### PR TITLE
chore: prepare repo for Automattic ownership

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  smoke-tests:
+    name: Composer smoke tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.1'
+          coverage: none
+
+      - name: Install dependencies
+        run: composer install --no-interaction --no-progress --prefer-dist
+
+      - name: Run smoke tests
+        run: composer test

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 WordPress-shaped backend substrate for durable agent runtime behavior.
 
+Agents API is maintained by Automattic as a standalone WordPress substrate package.
+
 Agents API owns generic contracts and value objects for registering agents, describing runtime messages/results, declaring package artifacts, and persisting memory/transcripts. Product plugins own UI, workflows, orchestration, and domain behavior.
 
 ## Boundary

--- a/agents-api.php
+++ b/agents-api.php
@@ -4,7 +4,7 @@
  * Description: WordPress-shaped agent runtime substrate.
  * Requires at least: 6.8
  * Requires PHP: 8.1
- * Author: Extra Chill
+ * Author: Automattic
  * License: GPL-2.0-or-later
  *
  * Agents API bootstrap.

--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,13 @@
 {
-  "name": "extra-chill/agents-api",
+  "name": "automattic/agents-api",
   "description": "WordPress-shaped agent runtime substrate.",
   "type": "wordpress-plugin",
   "license": "GPL-2.0-or-later",
+  "homepage": "https://github.com/Automattic/agents-api",
+  "support": {
+    "issues": "https://github.com/Automattic/agents-api/issues",
+    "source": "https://github.com/Automattic/agents-api"
+  },
   "require": {
     "php": ">=8.1"
   },


### PR DESCRIPTION
## Summary
- Updates Composer metadata, plugin header ownership, and README wording for the Automattic-owned repository.
- Adds a minimal GitHub Actions workflow that runs the existing Composer smoke-test coverage on PRs and main pushes.

## Tests
- `composer test`
- `composer validate --strict`

Closes #2

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafting and testing repository metadata/CI readiness changes under Chris's review.
