### PR TITLE
docs: define standalone Agents API boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,61 @@
 # Agents API
 
-WordPress-shaped backend substrate for durable agent runtime behavior.
+Agents API is a WordPress-shaped backend substrate for durable agent runtime behavior.
 
 Agents API is maintained by Automattic as a standalone WordPress substrate package.
 
-Agents API owns generic contracts and value objects for registering agents, describing runtime messages/results, declaring package artifacts, and persisting memory/transcripts. Product plugins own UI, workflows, orchestration, and domain behavior.
+It provides generic contracts and value objects that product plugins can build on without copying agent runtime primitives into every product. It is not a workflow product, an admin application, or a provider-specific AI client.
 
-## Boundary
+## Layer Boundary
 
 ```text
 Abilities API  -> actions and tools
 wp-ai-client   -> provider/model prompt execution
-Agents API     -> durable agent runtime behavior
-Data Machine   -> automation product built on those substrates
+Agents API     -> durable agent runtime substrate
+Data Machine   -> automation product consumer
 ```
 
-Agents API v1 is intentionally backend-only:
+Agents API sits between tool/action discovery and product-specific automation. It owns the reusable agent runtime contracts; product plugins own the user-facing product experience.
 
-- no admin pages
-- no REST controllers
-- no Data Machine flows, pipelines, jobs, handlers, queues, retention, pending actions, or content operations
-- no Intelligence wiki/briefing/domain-brain vocabulary
+## What Agents API Owns
+
+- Agent registration and lookup.
+- Runtime message and result value objects.
+- Agent package and package-artifact contracts.
+- Agent memory store contracts and value objects.
+- Conversation transcript store contracts.
+- Runtime tool declaration value objects.
+
+## What Agents API Does Not Own
+
+- Provider-specific request code. `wp-ai-client` owns provider/model prompt execution.
+- Product workflows such as flows, pipelines, jobs, handlers, queues, retention, and content operations.
+- Product UI such as admin pages, settings screens, dashboards, or onboarding.
+- Product CLI commands beyond generic substrate needs.
+- Public REST controllers in v1 unless they are separately designed.
+
+Data Machine is an example consumer and proving ground for these contracts. Agents API must not depend on Data Machine, import Data Machine classes, mirror Data Machine's source tree, or encode Data Machine vocabulary as generic runtime API. Data Machine can require Agents API because it is a product plugin built on the substrate.
+
+## Consumer Integration
+
+Product plugins should treat Agents API as an optional or required runtime dependency depending on their feature surface.
+
+For hard requirements, declare the plugin dependency using normal WordPress/plugin-distribution mechanisms and fail clearly when Agents API is unavailable.
+
+For optional integrations, feature-detect the public API before registering agent-backed features inside the registration hook:
+
+```php
+add_action(
+	'wp_agents_api_init',
+	static function () {
+		if ( function_exists( 'wp_register_agent' ) ) {
+			wp_register_agent( 'example-agent', array( /* ... */ ) );
+		}
+	}
+);
+```
+
+Register agent definitions from inside a `wp_agents_api_init` callback. Reads such as `wp_get_agent()` and `wp_has_agent()` are safe after WordPress `init` has fired.
 
 ## Public Surface
 


### PR DESCRIPTION
## Summary
- Rewrites the README around the standalone Agents API substrate boundary.
- Clarifies ownership across Abilities API, wp-ai-client, Agents API, and product consumers such as Data Machine.
- Adds consumer guidance for dependency handling and feature detection while keeping v1 backend-only.

## Tests
- composer test
- Manually verified README mentions Data Machine only as an example consumer/proving ground, not as a dependency or mirrored structure.

Closes #1

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafting and validating standalone Agents API boundary documentation under Chris's review.