### PR TITLE
Add conversation compaction contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Agents API sits between tool/action discovery and product-specific automation. I
 - Runtime message and result value objects.
 - Agent package and package-artifact contracts.
 - Agent memory store contracts and value objects.
+- Conversation compaction policy and transcript transformation contracts.
 - Conversation transcript store contracts.
 - Runtime tool declaration value objects.
 
@@ -65,10 +66,39 @@ Register agent definitions from inside a `wp_agents_api_init` callback. Reads su
 - `WP_Agents_Registry`
 - `WP_Agent_Package*` value objects and artifact registry helpers
 - `AgentsAPI\AI\AgentMessageEnvelope`
+- `AgentsAPI\AI\AgentConversationCompaction`
 - `AgentsAPI\AI\AgentConversationResult`
 - `AgentsAPI\AI\Tools\RuntimeToolDeclaration`
 - `AgentsAPI\Core\Database\Chat\ConversationTranscriptStoreInterface`
 - `AgentsAPI\Core\FilesRepository\AgentMemoryStoreInterface` and memory value objects
+
+## Conversation Compaction
+
+Agents can declare support for runtime conversation compaction without tying Agents API to a provider or model executor:
+
+```php
+wp_register_agent(
+	'example-agent',
+	array(
+		'supports_conversation_compaction' => true,
+		'conversation_compaction_policy'   => array(
+			'enabled'          => true,
+			'max_messages'     => 40,
+			'recent_messages'  => 12,
+			'summary_provider' => 'example-provider',
+			'summary_model'    => 'example-model',
+		),
+	)
+);
+```
+
+`AgentsAPI\AI\AgentConversationCompaction::compact()` transforms a transcript before model dispatch. The caller supplies a summarizer callable, keeping low-level model execution outside Agents API. The result includes:
+
+- `messages`: the transformed transcript, with a synthetic summary message followed by retained recent messages.
+- `metadata.compaction`: status, compacted boundary, retained count, and summary metadata for persisted transcripts.
+- `events`: `compaction_started`, `compaction_completed`, or `compaction_failed` lifecycle events that streaming clients can relay.
+
+Boundary selection preserves tool-call/tool-result integrity by default. If summarization fails, the original normalized transcript is returned unchanged and a failure event is emitted rather than silently dropping history.
 
 ## Tests
 

--- a/agents-api.php
+++ b/agents-api.php
@@ -37,6 +37,7 @@ require_once AGENTS_API_PATH . 'src/Registry/register-agents.php';
 require_once AGENTS_API_PATH . 'src/Packages/register-agent-package-artifacts.php';
 require_once AGENTS_API_PATH . 'src/Transcripts/ConversationTranscriptStoreInterface.php';
 require_once AGENTS_API_PATH . 'src/Runtime/AgentMessageEnvelope.php';
+require_once AGENTS_API_PATH . 'src/Runtime/AgentConversationCompaction.php';
 require_once AGENTS_API_PATH . 'src/Runtime/AgentConversationResult.php';
 require_once AGENTS_API_PATH . 'src/Tools/RuntimeToolDeclaration.php';
 require_once AGENTS_API_PATH . 'src/Memory/AgentMemoryScope.php';

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
   "scripts": {
     "test": [
       "php tests/bootstrap-smoke.php",
+      "php tests/conversation-compaction-smoke.php",
       "php tests/no-product-imports-smoke.php"
     ]
   }

--- a/src/Registry/class-wp-agent.php
+++ b/src/Registry/class-wp-agent.php
@@ -60,6 +60,20 @@ if ( ! class_exists( 'WP_Agent' ) ) {
 		protected array $default_config = array();
 
 		/**
+		 * Whether this agent opts into runtime conversation compaction.
+		 *
+		 * @var bool
+		 */
+		protected bool $supports_conversation_compaction = false;
+
+		/**
+		 * Declarative conversation compaction policy.
+		 *
+		 * @var array<string, mixed>
+		 */
+		protected array $conversation_compaction_policy = array();
+
+		/**
 		 * Optional metadata.
 		 *
 		 * @var array<string, mixed>
@@ -128,6 +142,18 @@ if ( ! class_exists( 'WP_Agent' ) ) {
 				}
 
 				$properties['default_config'] = $args['default_config'];
+			}
+
+			if ( isset( $args['supports_conversation_compaction'] ) ) {
+				$properties['supports_conversation_compaction'] = (bool) $args['supports_conversation_compaction'];
+			}
+
+			if ( isset( $args['conversation_compaction_policy'] ) ) {
+				if ( ! is_array( $args['conversation_compaction_policy'] ) ) {
+					throw new InvalidArgumentException( 'Agent conversation_compaction_policy property must be an array.' );
+				}
+
+				$properties['conversation_compaction_policy'] = \AgentsAPI\AI\AgentConversationCompaction::normalize_policy( $args['conversation_compaction_policy'] );
 			}
 
 			if ( isset( $args['meta'] ) ) {
@@ -222,6 +248,24 @@ if ( ! class_exists( 'WP_Agent' ) ) {
 		}
 
 		/**
+		 * Whether this agent opts into runtime conversation compaction.
+		 *
+		 * @return bool
+		 */
+		public function supports_conversation_compaction(): bool {
+			return $this->supports_conversation_compaction;
+		}
+
+		/**
+		 * Retrieves declarative conversation compaction policy.
+		 *
+		 * @return array<string, mixed>
+		 */
+		public function get_conversation_compaction_policy(): array {
+			return $this->conversation_compaction_policy;
+		}
+
+		/**
 		 * Retrieves optional metadata.
 		 *
 		 * @return array<string, mixed>
@@ -237,13 +281,15 @@ if ( ! class_exists( 'WP_Agent' ) ) {
 		 */
 		public function to_array(): array {
 			return array(
-				'slug'           => $this->slug,
-				'label'          => $this->label,
-				'description'    => $this->description,
-				'memory_seeds'   => $this->memory_seeds,
-				'owner_resolver' => $this->owner_resolver,
-				'default_config' => $this->default_config,
-				'meta'           => $this->meta,
+				'slug'                             => $this->slug,
+				'label'                            => $this->label,
+				'description'                      => $this->description,
+				'memory_seeds'                     => $this->memory_seeds,
+				'owner_resolver'                   => $this->owner_resolver,
+				'default_config'                   => $this->default_config,
+				'supports_conversation_compaction' => $this->supports_conversation_compaction,
+				'conversation_compaction_policy'   => $this->conversation_compaction_policy,
+				'meta'                             => $this->meta,
 			);
 		}
 

--- a/src/Runtime/AgentConversationCompaction.php
+++ b/src/Runtime/AgentConversationCompaction.php
@@ -1,0 +1,228 @@
+<?php
+/**
+ * Agent conversation compaction contract.
+ *
+ * @package AgentsAPI
+ */
+
+namespace AgentsAPI\AI;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Normalizes compaction policy and applies transcript compaction safely.
+ *
+ * This class defines the runtime contract only. Callers provide the summarizer
+ * callable, so provider/model execution stays outside Agents API.
+ */
+class AgentConversationCompaction {
+
+	public const EVENT_STARTED   = 'compaction_started';
+	public const EVENT_COMPLETED = 'compaction_completed';
+	public const EVENT_FAILED    = 'compaction_failed';
+
+	public const STATUS_SKIPPED   = 'skipped';
+	public const STATUS_COMPACTED = 'compacted';
+	public const STATUS_FAILED    = 'failed';
+
+	/**
+	 * Default declarative compaction policy.
+	 *
+	 * @return array<string, mixed>
+	 */
+	public static function default_policy(): array {
+		return array(
+			'enabled'                  => false,
+			'max_messages'             => 40,
+			'recent_messages'          => 12,
+			'summary_role'             => 'system',
+			'summary_prefix'           => 'Earlier conversation summary:',
+			'summary_model'            => '',
+			'summary_provider'         => '',
+			'preserve_tool_boundaries' => true,
+		);
+	}
+
+	/**
+	 * Normalize caller-provided compaction policy.
+	 *
+	 * @param array<string, mixed> $policy Raw policy.
+	 * @return array<string, mixed>
+	 */
+	public static function normalize_policy( array $policy ): array {
+		$normalized = array_merge( self::default_policy(), $policy );
+
+		$normalized['enabled']                  = (bool) $normalized['enabled'];
+		$normalized['max_messages']             = max( 1, (int) $normalized['max_messages'] );
+		$normalized['recent_messages']          = max( 1, (int) $normalized['recent_messages'] );
+		$normalized['summary_role']             = self::normalize_string( $normalized['summary_role'], 'system' );
+		$normalized['summary_prefix']           = self::normalize_string( $normalized['summary_prefix'], 'Earlier conversation summary:' );
+		$normalized['summary_model']            = self::normalize_string( $normalized['summary_model'], '' );
+		$normalized['summary_provider']         = self::normalize_string( $normalized['summary_provider'], '' );
+		$normalized['preserve_tool_boundaries'] = (bool) $normalized['preserve_tool_boundaries'];
+
+		if ( $normalized['recent_messages'] >= $normalized['max_messages'] ) {
+			$normalized['recent_messages'] = max( 1, $normalized['max_messages'] - 1 );
+		}
+
+		return $normalized;
+	}
+
+	/**
+	 * Compact a transcript before model dispatch.
+	 *
+	 * The summarizer receives `(array $messages_to_summarize, array $context)` and
+	 * must return a summary string. On failure the original transcript is returned
+	 * unchanged with a `compaction_failed` lifecycle event.
+	 *
+	 * @param array    $messages   Complete transcript messages.
+	 * @param array    $policy     Compaction policy.
+	 * @param callable $summarizer Summary producer supplied by the runtime.
+	 * @return array{messages: array<int, array<string, mixed>>, metadata: array<string, mixed>, events: array<int, array<string, mixed>>}
+	 */
+	public static function compact( array $messages, array $policy, callable $summarizer ): array {
+		$policy              = self::normalize_policy( $policy );
+		$normalized_messages = AgentMessageEnvelope::normalize_many( $messages );
+		$total_messages      = count( $normalized_messages );
+
+		if ( ! $policy['enabled'] || $total_messages <= $policy['max_messages'] ) {
+			return self::result( $normalized_messages, self::STATUS_SKIPPED, array(), array() );
+		}
+
+		$cutoff = self::select_boundary( $normalized_messages, $policy );
+		if ( $cutoff <= 0 ) {
+			return self::result( $normalized_messages, self::STATUS_SKIPPED, array(), array() );
+		}
+
+		$summary_context = array(
+			'policy'          => $policy,
+			'total_messages'  => $total_messages,
+			'compact_count'   => $cutoff,
+			'retained_count'  => $total_messages - $cutoff,
+			'boundary'        => array(
+				'compact_until' => $cutoff - 1,
+				'retain_from'   => $cutoff,
+			),
+		);
+
+		$started_event = self::event( self::EVENT_STARTED, $summary_context );
+
+		try {
+			$summary = call_user_func( $summarizer, array_slice( $normalized_messages, 0, $cutoff ), $summary_context );
+			if ( ! is_string( $summary ) || '' === trim( $summary ) ) {
+				throw new \RuntimeException( 'Summary must be a non-empty string.' );
+			}
+		} catch ( \Throwable $error ) {
+			$failure_context          = $summary_context;
+			$failure_context['error'] = $error->getMessage();
+
+			return self::result(
+				$normalized_messages,
+				self::STATUS_FAILED,
+				$failure_context,
+				array( $started_event, self::event( self::EVENT_FAILED, $failure_context ) )
+			);
+		}
+
+		$summary_message = AgentMessageEnvelope::text(
+			$policy['summary_role'],
+			$policy['summary_prefix'] . "\n\n" . trim( $summary ),
+			array(
+				'agents_api_compaction' => array(
+					'compacted_message_count' => $cutoff,
+					'retained_message_count'  => $total_messages - $cutoff,
+					'summary_provider'        => $policy['summary_provider'],
+					'summary_model'           => $policy['summary_model'],
+				),
+			)
+		);
+
+		$compacted_messages = array_merge( array( $summary_message ), array_slice( $normalized_messages, $cutoff ) );
+		$complete_context   = $summary_context;
+		$complete_context['summary_message'] = $summary_message;
+
+		return self::result(
+			$compacted_messages,
+			self::STATUS_COMPACTED,
+			$complete_context,
+			array( $started_event, self::event( self::EVENT_COMPLETED, $complete_context ) )
+		);
+	}
+
+	/**
+	 * Select the first retained message index without cutting tool boundaries.
+	 *
+	 * @param array<int, array<string, mixed>> $messages Normalized messages.
+	 * @param array<string, mixed>             $policy   Normalized policy.
+	 * @return int Boundary index.
+	 */
+	public static function select_boundary( array $messages, array $policy ): int {
+		$policy = self::normalize_policy( $policy );
+		$cutoff = max( 0, count( $messages ) - $policy['recent_messages'] );
+
+		if ( ! $policy['preserve_tool_boundaries'] ) {
+			return $cutoff;
+		}
+
+		while ( $cutoff > 0 && isset( $messages[ $cutoff ] ) && AgentMessageEnvelope::TYPE_TOOL_RESULT === AgentMessageEnvelope::type( $messages[ $cutoff ] ) ) {
+			--$cutoff;
+		}
+
+		while ( $cutoff > 0 && isset( $messages[ $cutoff - 1 ] ) && AgentMessageEnvelope::TYPE_TOOL_CALL === AgentMessageEnvelope::type( $messages[ $cutoff - 1 ] ) ) {
+			--$cutoff;
+		}
+
+		return $cutoff;
+	}
+
+	/**
+	 * Build a normalized result array.
+	 *
+	 * @param array<int, array<string, mixed>> $messages Messages.
+	 * @param string                           $status   Compaction status.
+	 * @param array<string, mixed>             $metadata Compaction metadata.
+	 * @param array<int, array<string, mixed>> $events   Lifecycle events.
+	 * @return array<string, mixed>
+	 */
+	private static function result( array $messages, string $status, array $metadata, array $events ): array {
+		$metadata['status'] = $status;
+
+		return array(
+			'messages' => $messages,
+			'metadata' => array( 'compaction' => $metadata ),
+			'events'   => $events,
+		);
+	}
+
+	/**
+	 * Build a lifecycle event payload for streaming clients.
+	 *
+	 * @param string               $type Event type.
+	 * @param array<string, mixed> $data Event data.
+	 * @return array<string, mixed>
+	 */
+	private static function event( string $type, array $data ): array {
+		return array(
+			'type'     => $type,
+			'metadata' => $data,
+		);
+	}
+
+	/**
+	 * Normalize string policy fields.
+	 *
+	 * @param mixed  $value    Raw value.
+	 * @param string $fallback Fallback value.
+	 * @return string
+	 */
+	private static function normalize_string( $value, string $fallback ): string {
+		if ( ! is_string( $value ) ) {
+			return $fallback;
+		}
+
+		$value = trim( $value );
+		return '' === $value ? $fallback : $value;
+	}
+}

--- a/tests/bootstrap-smoke.php
+++ b/tests/bootstrap-smoke.php
@@ -21,6 +21,7 @@ agents_api_smoke_require_module();
 
 $namespace_map = array(
 	'DataMachine\\Engine\\AI\\AgentMessageEnvelope'                         => 'AgentsAPI\\AI\\AgentMessageEnvelope',
+	'DataMachine\\Engine\\AI\\AgentConversationCompaction'                  => 'AgentsAPI\\AI\\AgentConversationCompaction',
 	'DataMachine\\Engine\\AI\\AgentConversationResult'                      => 'AgentsAPI\\AI\\AgentConversationResult',
 	'DataMachine\\Engine\\AI\\Tools\\RuntimeToolDeclaration'                => 'AgentsAPI\\AI\\Tools\\RuntimeToolDeclaration',
 	'DataMachine\\Core\\Database\\Chat\\ConversationTranscriptStoreInterface' => 'AgentsAPI\\Core\\Database\\Chat\\ConversationTranscriptStoreInterface',

--- a/tests/conversation-compaction-smoke.php
+++ b/tests/conversation-compaction-smoke.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ * Pure-PHP smoke test for the Agents API conversation compaction contract.
+ *
+ * Run with: php tests/conversation-compaction-smoke.php
+ *
+ * @package AgentsAPI\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+$failures = array();
+$passes   = 0;
+
+echo "agents-api-conversation-compaction-smoke\n";
+
+require_once __DIR__ . '/agents-api-smoke-helpers.php';
+agents_api_smoke_require_module();
+
+$policy = array(
+	'enabled'         => true,
+	'max_messages'    => 5,
+	'recent_messages' => 2,
+);
+
+$messages = array(
+	array( 'role' => 'user', 'content' => 'one' ),
+	array( 'role' => 'assistant', 'content' => 'two' ),
+	array( 'role' => 'user', 'content' => 'three' ),
+	array( 'role' => 'assistant', 'content' => 'four' ),
+);
+
+echo "\n[1] Below-threshold transcripts are unchanged:\n";
+$below_threshold = AgentsAPI\AI\AgentConversationCompaction::compact(
+	$messages,
+	$policy,
+	static function (): string {
+		return 'should not run';
+	}
+);
+agents_api_smoke_assert_equals( AgentsAPI\AI\AgentConversationCompaction::STATUS_SKIPPED, $below_threshold['metadata']['compaction']['status'], 'below-threshold compaction is skipped', $failures, $passes );
+agents_api_smoke_assert_equals( 4, count( $below_threshold['messages'] ), 'below-threshold message count is unchanged', $failures, $passes );
+agents_api_smoke_assert_equals( array(), $below_threshold['events'], 'below-threshold compaction emits no lifecycle events', $failures, $passes );
+
+echo "\n[2] Successful compaction returns a synthetic summary and lifecycle events:\n";
+$long_messages = array_merge(
+	$messages,
+	array(
+		array( 'role' => 'user', 'content' => 'five' ),
+		array( 'role' => 'assistant', 'content' => 'six' ),
+	)
+);
+
+$compacted = AgentsAPI\AI\AgentConversationCompaction::compact(
+	$long_messages,
+	$policy,
+	static function ( array $messages_to_summarize, array $context ): string {
+		return 'Summarized ' . count( $messages_to_summarize ) . ' of ' . $context['total_messages'] . ' messages.';
+	}
+);
+agents_api_smoke_assert_equals( AgentsAPI\AI\AgentConversationCompaction::STATUS_COMPACTED, $compacted['metadata']['compaction']['status'], 'long transcript is compacted', $failures, $passes );
+agents_api_smoke_assert_equals( 3, count( $compacted['messages'] ), 'compacted transcript contains summary plus retained messages', $failures, $passes );
+agents_api_smoke_assert_equals( 'system', $compacted['messages'][0]['role'], 'summary message uses policy role', $failures, $passes );
+agents_api_smoke_assert_equals( 4, $compacted['messages'][0]['metadata']['agents_api_compaction']['compacted_message_count'], 'summary metadata records compacted boundary', $failures, $passes );
+agents_api_smoke_assert_equals( AgentsAPI\AI\AgentConversationCompaction::EVENT_STARTED, $compacted['events'][0]['type'], 'compaction start event is emitted', $failures, $passes );
+agents_api_smoke_assert_equals( AgentsAPI\AI\AgentConversationCompaction::EVENT_COMPLETED, $compacted['events'][1]['type'], 'compaction completed event is emitted', $failures, $passes );
+
+echo "\n[3] Summarizer failures retain the original transcript:\n";
+$failed = AgentsAPI\AI\AgentConversationCompaction::compact(
+	$long_messages,
+	$policy,
+	static function (): string {
+		throw new RuntimeException( 'summary backend unavailable' );
+	}
+);
+agents_api_smoke_assert_equals( AgentsAPI\AI\AgentConversationCompaction::STATUS_FAILED, $failed['metadata']['compaction']['status'], 'summarizer failure is reported', $failures, $passes );
+agents_api_smoke_assert_equals( count( $long_messages ), count( $failed['messages'] ), 'summarizer failure keeps original transcript length', $failures, $passes );
+agents_api_smoke_assert_equals( AgentsAPI\AI\AgentConversationCompaction::EVENT_FAILED, $failed['events'][1]['type'], 'summarizer failure emits failed event', $failures, $passes );
+
+echo "\n[4] Boundary selection does not split tool-call/tool-result pairs:\n";
+$tool_messages = array(
+	array( 'role' => 'user', 'content' => 'question' ),
+	AgentsAPI\AI\AgentMessageEnvelope::toolCall( 'call weather', 'weather', array( 'city' => 'New York' ), 1 ),
+	AgentsAPI\AI\AgentMessageEnvelope::toolResult( 'weather result', 'weather', array( 'success' => true, 'turn' => 1 ) ),
+	array( 'role' => 'assistant', 'content' => 'answer' ),
+	array( 'role' => 'user', 'content' => 'follow up' ),
+);
+
+$boundary = AgentsAPI\AI\AgentConversationCompaction::select_boundary(
+	AgentsAPI\AI\AgentMessageEnvelope::normalize_many( $tool_messages ),
+	array(
+		'enabled'         => true,
+		'max_messages'    => 4,
+		'recent_messages' => 3,
+	)
+);
+agents_api_smoke_assert_equals( 1, $boundary, 'boundary moves before retained tool result', $failures, $passes );
+
+echo "\n[5] WP_Agent exposes declarative compaction capability and policy:\n";
+$agent = new WP_Agent(
+	'compacting-agent',
+	array(
+		'supports_conversation_compaction' => true,
+		'conversation_compaction_policy'   => array(
+			'enabled'         => true,
+			'max_messages'    => 10,
+			'recent_messages' => 4,
+		),
+	)
+);
+agents_api_smoke_assert_equals( true, $agent->supports_conversation_compaction(), 'agent declares compaction support', $failures, $passes );
+agents_api_smoke_assert_equals( 10, $agent->get_conversation_compaction_policy()['max_messages'], 'agent exposes normalized compaction policy', $failures, $passes );
+agents_api_smoke_assert_equals( true, $agent->to_array()['supports_conversation_compaction'], 'agent array includes compaction capability', $failures, $passes );
+
+agents_api_smoke_finish( 'Agents API conversation compaction', $failures, $passes );


### PR DESCRIPTION
## Summary
- Adds a public `AgentConversationCompaction` runtime contract for declarative policy normalization, safe transcript boundary selection, lifecycle event payloads, and summarizer-supplied compaction.
- Adds `WP_Agent` capability/config fields for conversation compaction support and policy discovery.
- Documents the public compaction surface and adds smoke coverage for no-op, success, failure, and tool-call/tool-result boundary behavior.

Fixes #7

## Tests
- `php -l agents-api.php && php -l src/Registry/class-wp-agent.php && php -l src/Runtime/AgentConversationCompaction.php && php -l tests/bootstrap-smoke.php && php -l tests/conversation-compaction-smoke.php && php -l tests/no-product-imports-smoke.php`
- `composer test`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the public compaction contract, documentation, and smoke tests; Chris remains responsible for review and validation.