### PR TITLE
Add generic compaction item contract

### DIFF
--- a/agents-api.php
+++ b/agents-api.php
@@ -41,6 +41,7 @@ require_once AGENTS_API_PATH . 'src/Identity/MaterializedAgentIdentityStoreInter
 require_once AGENTS_API_PATH . 'src/Transcripts/ConversationTranscriptStoreInterface.php';
 require_once AGENTS_API_PATH . 'src/Runtime/AgentMessageEnvelope.php';
 require_once AGENTS_API_PATH . 'src/Runtime/AgentExecutionPrincipal.php';
+require_once AGENTS_API_PATH . 'src/Runtime/AgentCompactionItem.php';
 require_once AGENTS_API_PATH . 'src/Runtime/AgentConversationCompaction.php';
 require_once AGENTS_API_PATH . 'src/Runtime/AgentConversationResult.php';
 require_once AGENTS_API_PATH . 'src/Tools/RuntimeToolDeclaration.php';

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
       "php tests/registry-smoke.php",
       "php tests/execution-principal-smoke.php",
       "php tests/identity-smoke.php",
+      "php tests/compaction-item-smoke.php",
       "php tests/conversation-compaction-smoke.php",
       "php tests/no-product-imports-smoke.php"
     ]

--- a/src/Runtime/AgentCompactionItem.php
+++ b/src/Runtime/AgentCompactionItem.php
@@ -1,0 +1,274 @@
+<?php
+/**
+ * Generic compaction item normalization contract.
+ *
+ * @package AgentsAPI
+ */
+
+namespace AgentsAPI\AI;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Normalizes ordered compaction inputs into a generic item shape.
+ */
+class AgentCompactionItem {
+
+	public const SCHEMA  = 'agents-api.compaction-item';
+	public const VERSION = 1;
+
+	/**
+	 * Normalize a raw item to the canonical compaction item shape.
+	 *
+	 * @param array    $item  Raw compaction item.
+	 * @param int|null $index Optional item position used for generated IDs.
+	 * @return array<string, mixed> Normalized compaction item.
+	 * @throws \InvalidArgumentException When the item is invalid.
+	 */
+	public static function normalize( array $item, ?int $index = null ): array {
+		$type     = self::normalize_string( $item['type'] ?? null, 'type' );
+		$content  = self::normalize_content( $item );
+		$metadata = self::normalize_metadata( $item['metadata'] ?? array() );
+		$group    = self::normalize_optional_string( $item['group'] ?? null, 'group' );
+		$boundary = self::normalize_boundary( $item['boundary'] ?? null );
+
+		$normalized = array(
+			'schema'   => self::SCHEMA,
+			'version'  => self::VERSION,
+			'id'       => self::normalize_id( $item['id'] ?? null, $type, $content, $metadata, $group, $boundary, $index ),
+			'type'     => $type,
+			'content'  => $content,
+			'metadata' => $metadata,
+		);
+
+		if ( null !== $group ) {
+			$normalized['group'] = $group;
+		}
+
+		if ( null !== $boundary ) {
+			$normalized['boundary'] = $boundary;
+		}
+
+		if ( false === self::json_encode( $normalized ) ) {
+			throw new \InvalidArgumentException( 'invalid_ai_compaction_item: item must be JSON serializable' );
+		}
+
+		return $normalized;
+	}
+
+	/**
+	 * Normalize an ordered list of compaction items.
+	 *
+	 * @param array $items Raw compaction items.
+	 * @return array<int, array<string, mixed>>
+	 * @throws \InvalidArgumentException When an item is invalid.
+	 */
+	public static function normalize_many( array $items ): array {
+		$normalized = array();
+		foreach ( $items as $index => $item ) {
+			if ( ! is_array( $item ) ) {
+				throw new \InvalidArgumentException( 'invalid_ai_compaction_item: item must be an array' );
+			}
+
+			$normalized[] = self::normalize( $item, is_int( $index ) ? $index : count( $normalized ) );
+		}
+
+		return $normalized;
+	}
+
+	/**
+	 * Project a message envelope into the generic compaction item contract.
+	 *
+	 * @param array    $message Message envelope or legacy message.
+	 * @param int|null $index   Optional item position used for generated IDs.
+	 * @return array<string, mixed> Normalized compaction item.
+	 */
+	public static function from_message( array $message, ?int $index = null ): array {
+		$envelope = AgentMessageEnvelope::normalize( $message );
+		$metadata = $envelope['metadata'];
+		$metadata['message'] = array(
+			'role'    => $envelope['role'],
+			'payload' => $envelope['payload'],
+		);
+
+		$item = array(
+			'type'     => 'message:' . $envelope['type'],
+			'content'  => $envelope['content'],
+			'metadata' => $metadata,
+		);
+
+		if ( isset( $envelope['id'] ) ) {
+			$item['id'] = $envelope['id'];
+		}
+
+		return self::normalize( $item, $index );
+	}
+
+	/**
+	 * Project message envelopes into ordered compaction items.
+	 *
+	 * @param array $messages Message envelopes or legacy messages.
+	 * @return array<int, array<string, mixed>>
+	 */
+	public static function from_messages( array $messages ): array {
+		$items = array();
+		foreach ( $messages as $index => $message ) {
+			if ( ! is_array( $message ) ) {
+				throw new \InvalidArgumentException( 'invalid_ai_message_envelope: message must be an array' );
+			}
+
+			$items[] = self::from_message( $message, is_int( $index ) ? $index : count( $items ) );
+		}
+
+		return $items;
+	}
+
+	/**
+	 * Normalize a required string field.
+	 *
+	 * @param mixed  $value Raw value.
+	 * @param string $field Field name.
+	 * @return string
+	 */
+	private static function normalize_string( $value, string $field ): string {
+		if ( ! is_string( $value ) || '' === trim( $value ) ) {
+			throw new \InvalidArgumentException( 'invalid_ai_compaction_item: ' . $field . ' must be a non-empty string' );
+		}
+
+		return trim( $value );
+	}
+
+	/**
+	 * Normalize an optional string field.
+	 *
+	 * @param mixed  $value Raw value.
+	 * @param string $field Field name.
+	 * @return string|null
+	 */
+	private static function normalize_optional_string( $value, string $field ): ?string {
+		if ( null === $value ) {
+			return null;
+		}
+
+		return self::normalize_string( $value, $field );
+	}
+
+	/**
+	 * Normalize item content.
+	 *
+	 * @param array $item Raw item.
+	 * @return string|array
+	 */
+	private static function normalize_content( array $item ) {
+		if ( ! array_key_exists( 'content', $item ) ) {
+			throw new \InvalidArgumentException( 'invalid_ai_compaction_item: content is required' );
+		}
+
+		$content = $item['content'];
+		if ( ! is_string( $content ) && ! is_array( $content ) ) {
+			throw new \InvalidArgumentException( 'invalid_ai_compaction_item: content must be a string or array' );
+		}
+
+		return $content;
+	}
+
+	/**
+	 * Normalize metadata.
+	 *
+	 * @param mixed $metadata Raw metadata.
+	 * @return array<string, mixed>
+	 */
+	private static function normalize_metadata( $metadata ): array {
+		if ( ! is_array( $metadata ) ) {
+			throw new \InvalidArgumentException( 'invalid_ai_compaction_item: metadata must be an array' );
+		}
+
+		return $metadata;
+	}
+
+	/**
+	 * Normalize optional grouping or boundary hints.
+	 *
+	 * @param mixed $boundary Raw boundary hints.
+	 * @return array<string, mixed>|null
+	 */
+	private static function normalize_boundary( $boundary ): ?array {
+		if ( null === $boundary ) {
+			return null;
+		}
+
+		if ( ! is_array( $boundary ) ) {
+			throw new \InvalidArgumentException( 'invalid_ai_compaction_item: boundary must be an array' );
+		}
+
+		return $boundary;
+	}
+
+	/**
+	 * Normalize or generate a stable item ID.
+	 *
+	 * @param mixed       $id       Raw ID.
+	 * @param string      $type     Item type.
+	 * @param string|array $content Item content.
+	 * @param array       $metadata Item metadata.
+	 * @param string|null $group    Item group.
+	 * @param array|null  $boundary Boundary hints.
+	 * @param int|null    $index    Item position.
+	 * @return string
+	 */
+	private static function normalize_id( $id, string $type, $content, array $metadata, ?string $group, ?array $boundary, ?int $index ): string {
+		if ( null !== $id ) {
+			return self::normalize_string( $id, 'id' );
+		}
+
+		$source = array(
+			'index'    => $index,
+			'type'     => $type,
+			'content'  => $content,
+			'metadata' => $metadata,
+			'group'    => $group,
+			'boundary' => $boundary,
+		);
+
+		return 'item-' . substr( hash( 'sha256', (string) self::json_encode( self::sort_recursive( $source ) ) ), 0, 16 );
+	}
+
+	/**
+	 * Sort associative array keys recursively for deterministic ID hashes.
+	 *
+	 * @param mixed $value Raw value.
+	 * @return mixed
+	 */
+	private static function sort_recursive( $value ) {
+		if ( ! is_array( $value ) ) {
+			return $value;
+		}
+
+		if ( array_keys( $value ) !== range( 0, count( $value ) - 1 ) ) {
+			ksort( $value );
+		}
+
+		foreach ( $value as $key => $nested_value ) {
+			$value[ $key ] = self::sort_recursive( $nested_value );
+		}
+
+		return $value;
+	}
+
+	/**
+	 * Encode data for serializability checks with a pure-PHP fallback for smokes.
+	 *
+	 * @param mixed $data Data to encode.
+	 * @return string|false Encoded JSON or false on failure.
+	 */
+	private static function json_encode( $data ) {
+		if ( function_exists( 'wp_json_encode' ) ) {
+			return wp_json_encode( $data );
+		}
+
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.json_encode_json_encode -- Pure-PHP smoke tests run without WordPress loaded.
+		return json_encode( $data );
+	}
+}

--- a/tests/compaction-item-smoke.php
+++ b/tests/compaction-item-smoke.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * Pure-PHP smoke test for the Agents API generic compaction item contract.
+ *
+ * Run with: php tests/compaction-item-smoke.php
+ *
+ * @package AgentsAPI\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+$failures = array();
+$passes   = 0;
+
+echo "agents-api-compaction-item-smoke\n";
+
+require_once __DIR__ . '/agents-api-smoke-helpers.php';
+agents_api_smoke_require_module();
+
+echo "\n[1] Valid items normalize to the public contract:\n";
+$item = AgentsAPI\AI\AgentCompactionItem::normalize(
+	array(
+		'id'       => 'section-intro',
+		'type'     => 'markdown_section',
+		'content'  => 'Intro text',
+		'metadata' => array(
+			'source' => 'handbook',
+			'level'  => 2,
+		),
+		'group'    => 'handbook-page',
+		'boundary' => array( 'starts_group' => true ),
+	)
+);
+agents_api_smoke_assert_equals( AgentsAPI\AI\AgentCompactionItem::SCHEMA, $item['schema'], 'item schema is public', $failures, $passes );
+agents_api_smoke_assert_equals( AgentsAPI\AI\AgentCompactionItem::VERSION, $item['version'], 'item version is public', $failures, $passes );
+agents_api_smoke_assert_equals( 'section-intro', $item['id'], 'caller-provided id is preserved', $failures, $passes );
+agents_api_smoke_assert_equals( 'markdown_section', $item['type'], 'type is preserved', $failures, $passes );
+agents_api_smoke_assert_equals( 'Intro text', $item['content'], 'content is preserved', $failures, $passes );
+agents_api_smoke_assert_equals( array( 'source' => 'handbook', 'level' => 2 ), $item['metadata'], 'metadata is preserved', $failures, $passes );
+agents_api_smoke_assert_equals( 'handbook-page', $item['group'], 'group hint is preserved', $failures, $passes );
+agents_api_smoke_assert_equals( array( 'starts_group' => true ), $item['boundary'], 'boundary hint is preserved', $failures, $passes );
+
+echo "\n[2] Ordered item lists retain order and metadata:\n";
+$ordered = AgentsAPI\AI\AgentCompactionItem::normalize_many(
+	array(
+		array(
+			'id'       => 'first',
+			'type'     => 'record',
+			'content'  => 'one',
+			'metadata' => array( 'ordinal' => 1 ),
+		),
+		array(
+			'id'       => 'second',
+			'type'     => 'record',
+			'content'  => 'two',
+			'metadata' => array( 'ordinal' => 2 ),
+		),
+	)
+);
+agents_api_smoke_assert_equals( 'first', $ordered[0]['id'], 'first item remains first', $failures, $passes );
+agents_api_smoke_assert_equals( 'second', $ordered[1]['id'], 'second item remains second', $failures, $passes );
+agents_api_smoke_assert_equals( array( 'ordinal' => 2 ), $ordered[1]['metadata'], 'ordered item metadata is preserved', $failures, $passes );
+
+echo "\n[3] Missing IDs are generated deterministically:\n";
+$without_id = array(
+	'type'     => 'memory_record',
+	'content'  => array( 'text' => 'Remember this' ),
+	'metadata' => array( 'source' => 'runtime' ),
+);
+$generated_one = AgentsAPI\AI\AgentCompactionItem::normalize( $without_id, 3 );
+$generated_two = AgentsAPI\AI\AgentCompactionItem::normalize( $without_id, 3 );
+agents_api_smoke_assert_equals( $generated_one['id'], $generated_two['id'], 'generated id is stable for the same item and index', $failures, $passes );
+agents_api_smoke_assert_equals( 'item-', substr( $generated_one['id'], 0, 5 ), 'generated id uses item prefix', $failures, $passes );
+
+echo "\n[4] Invalid or missing fields are rejected:\n";
+$invalid_cases = array(
+	'missing type'     => array( 'content' => 'text', 'metadata' => array() ),
+	'missing content'  => array( 'type' => 'record', 'metadata' => array() ),
+	'invalid content'  => array( 'type' => 'record', 'content' => 12, 'metadata' => array() ),
+	'invalid metadata' => array( 'type' => 'record', 'content' => 'text', 'metadata' => 'nope' ),
+	'invalid id'       => array( 'id' => '', 'type' => 'record', 'content' => 'text', 'metadata' => array() ),
+	'invalid boundary' => array( 'type' => 'record', 'content' => 'text', 'metadata' => array(), 'boundary' => 'nope' ),
+);
+
+foreach ( $invalid_cases as $name => $invalid_item ) {
+	$thrown = false;
+	try {
+		AgentsAPI\AI\AgentCompactionItem::normalize( $invalid_item );
+	} catch ( InvalidArgumentException $error ) {
+		$thrown = 0 === strpos( $error->getMessage(), 'invalid_ai_compaction_item:' );
+	}
+	agents_api_smoke_assert_equals( true, $thrown, $name . ' throws contract exception', $failures, $passes );
+}
+
+echo "\n[5] Message envelopes can be projected without fake chat-message inputs:\n";
+$message_item = AgentsAPI\AI\AgentCompactionItem::from_message(
+	array(
+		'id'       => 'message-1',
+		'role'     => 'assistant',
+		'content'  => 'Answer',
+		'metadata' => array( 'trace' => 'abc' ),
+	),
+	0
+);
+agents_api_smoke_assert_equals( 'message-1', $message_item['id'], 'message id is preserved in compaction item', $failures, $passes );
+agents_api_smoke_assert_equals( 'message:text', $message_item['type'], 'message item type is namespaced', $failures, $passes );
+agents_api_smoke_assert_equals( 'abc', $message_item['metadata']['trace'], 'message metadata is preserved', $failures, $passes );
+agents_api_smoke_assert_equals( 'assistant', $message_item['metadata']['message']['role'], 'message role is retained as metadata', $failures, $passes );
+
+agents_api_smoke_finish( 'Agents API compaction item', $failures, $passes );


### PR DESCRIPTION
## Summary
- Adds `AgentCompactionItem` as a generic compaction input normalization contract with stable generated IDs, metadata preservation, and optional grouping/boundary hints.
- Keeps conversation compaction on existing message envelopes while adding projection helpers for callers that want generic compaction items.
- Adds focused smoke coverage for valid items, invalid/missing fields, deterministic IDs, ordering, and metadata preservation.

## Testing
- `composer test`
- `php tests/compaction-item-smoke.php`
- `php -l src/Runtime/AgentCompactionItem.php && php -l agents-api.php && php -l tests/compaction-item-smoke.php`

Closes #16.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the compaction item contract, smoke tests, and PR description; Chris remains responsible for review and merge.