### PR TITLE
Add deterministic overflow archive compaction

### DIFF
--- a/src/Runtime/AgentConversationCompaction.php
+++ b/src/Runtime/AgentConversationCompaction.php
@@ -36,13 +36,13 @@ class AgentConversationCompaction {
 	 */
 	public static function default_policy(): array {
 		return array(
-			'enabled'                  => false,
-			'max_messages'             => 40,
-			'recent_messages'          => 12,
-			'summary_role'             => 'system',
-			'summary_prefix'           => 'Earlier conversation summary:',
-			'summary_model'            => '',
-			'summary_provider'         => '',
+			'enabled'                    => false,
+			'max_messages'               => 40,
+			'recent_messages'            => 12,
+			'summary_role'               => 'system',
+			'summary_prefix'             => 'Earlier conversation summary:',
+			'summary_model'              => '',
+			'summary_provider'           => '',
 			'preserve_tool_boundaries'   => true,
 			'overflow_archive_enabled'   => false,
 			'overflow_threshold_bytes'   => 0,
@@ -63,13 +63,13 @@ class AgentConversationCompaction {
 	public static function normalize_policy( array $policy ): array {
 		$normalized = array_merge( self::default_policy(), $policy );
 
-		$normalized['enabled']                  = (bool) $normalized['enabled'];
-		$normalized['max_messages']             = max( 1, (int) $normalized['max_messages'] );
-		$normalized['recent_messages']          = max( 1, (int) $normalized['recent_messages'] );
-		$normalized['summary_role']             = self::normalize_string( $normalized['summary_role'], 'system' );
-		$normalized['summary_prefix']           = self::normalize_string( $normalized['summary_prefix'], 'Earlier conversation summary:' );
-		$normalized['summary_model']            = self::normalize_string( $normalized['summary_model'], '' );
-		$normalized['summary_provider']         = self::normalize_string( $normalized['summary_provider'], '' );
+		$normalized['enabled']                    = (bool) $normalized['enabled'];
+		$normalized['max_messages']               = max( 1, (int) $normalized['max_messages'] );
+		$normalized['recent_messages']            = max( 1, (int) $normalized['recent_messages'] );
+		$normalized['summary_role']               = self::normalize_string( $normalized['summary_role'], 'system' );
+		$normalized['summary_prefix']             = self::normalize_string( $normalized['summary_prefix'], 'Earlier conversation summary:' );
+		$normalized['summary_model']              = self::normalize_string( $normalized['summary_model'], '' );
+		$normalized['summary_provider']           = self::normalize_string( $normalized['summary_provider'], '' );
 		$normalized['preserve_tool_boundaries']   = (bool) $normalized['preserve_tool_boundaries'];
 		$normalized['overflow_archive_enabled']   = (bool) $normalized['overflow_archive_enabled'];
 		$normalized['overflow_threshold_bytes']   = max( 0, (int) $normalized['overflow_threshold_bytes'] );
@@ -195,19 +195,22 @@ class AgentConversationCompaction {
 	 * @param array<string, mixed>             $metadata Compaction metadata.
 	 * @param array<int, array<string, mixed>> $events   Lifecycle events.
 	 * @param array<string, mixed>             $extra    Extra result fields.
-	 * @return array<string, mixed>
+	 * @return array{messages: array<int, array<string, mixed>>, metadata: array<string, mixed>, events: array<int, array<string, mixed>>, archive_items?: array<int, array<string, mixed>>}
 	 */
 	private static function result( array $messages, string $status, array $metadata, array $events, array $extra = array() ): array {
 		$metadata['status'] = $status;
 
-		return array_merge(
-			array(
-				'messages' => $messages,
-				'metadata' => array( 'compaction' => $metadata ),
-				'events'   => $events,
-			),
-			$extra
+		$result = array(
+			'messages' => $messages,
+			'metadata' => array( 'compaction' => $metadata ),
+			'events'   => $events,
 		);
+
+		if ( isset( $extra['archive_items'] ) && is_array( $extra['archive_items'] ) ) {
+			$result['archive_items'] = $extra['archive_items'];
+		}
+
+		return $result;
 	}
 
 	/**
@@ -229,12 +232,12 @@ class AgentConversationCompaction {
 	 * @param array<int, array<string, mixed>> $source_messages     Original source messages.
 	 * @param array<int, array<string, mixed>> $normalized_messages Normalized messages.
 	 * @param array<string, mixed>             $policy              Normalized policy.
-	 * @return array<string, mixed>
+	 * @return array{messages: array<int, array<string, mixed>>, metadata: array<string, mixed>, events: array<int, array<string, mixed>>, archive_items?: array<int, array<string, mixed>>}
 	 */
 	private static function archive_overflow( array $source_messages, array $normalized_messages, array $policy ): array {
 		$total_messages = count( $normalized_messages );
-		$retain_count   = $policy['overflow_retained_messages'] > 0 ? $policy['overflow_retained_messages'] : $policy['recent_messages'];
-		$cutoff         = max( 0, $total_messages - $retain_count );
+		$retain_count   = (int) ( $policy['overflow_retained_messages'] > 0 ? $policy['overflow_retained_messages'] : $policy['recent_messages'] );
+		$cutoff         = (int) max( 0, $total_messages - $retain_count );
 
 		while ( $policy['overflow_retained_bytes'] > 0 && $cutoff < $total_messages - 1 && self::encoded_size( array_slice( $normalized_messages, $cutoff ) ) > $policy['overflow_retained_bytes'] ) {
 			++$cutoff;

--- a/src/Runtime/AgentConversationCompaction.php
+++ b/src/Runtime/AgentConversationCompaction.php
@@ -22,10 +22,12 @@ class AgentConversationCompaction {
 	public const EVENT_STARTED   = 'compaction_started';
 	public const EVENT_COMPLETED = 'compaction_completed';
 	public const EVENT_FAILED    = 'compaction_failed';
+	public const EVENT_ARCHIVED  = 'compaction_overflow_archived';
 
 	public const STATUS_SKIPPED   = 'skipped';
 	public const STATUS_COMPACTED = 'compacted';
 	public const STATUS_FAILED    = 'failed';
+	public const STATUS_ARCHIVED  = 'archived';
 
 	/**
 	 * Default declarative compaction policy.
@@ -42,6 +44,13 @@ class AgentConversationCompaction {
 			'summary_model'            => '',
 			'summary_provider'         => '',
 			'preserve_tool_boundaries' => true,
+			'overflow_archive_enabled'   => false,
+			'overflow_threshold_bytes'   => 0,
+			'overflow_retained_messages' => 0,
+			'overflow_retained_bytes'    => 0,
+			'overflow_archive_pointer'   => array(),
+			'overflow_stub_role'         => 'system',
+			'overflow_stub_prefix'       => 'Earlier conversation archived without summarization.',
 		);
 	}
 
@@ -62,6 +71,13 @@ class AgentConversationCompaction {
 		$normalized['summary_model']            = self::normalize_string( $normalized['summary_model'], '' );
 		$normalized['summary_provider']         = self::normalize_string( $normalized['summary_provider'], '' );
 		$normalized['preserve_tool_boundaries'] = (bool) $normalized['preserve_tool_boundaries'];
+		$normalized['overflow_archive_enabled']   = (bool) $normalized['overflow_archive_enabled'];
+		$normalized['overflow_threshold_bytes']   = max( 0, (int) $normalized['overflow_threshold_bytes'] );
+		$normalized['overflow_retained_messages'] = max( 0, (int) $normalized['overflow_retained_messages'] );
+		$normalized['overflow_retained_bytes']    = max( 0, (int) $normalized['overflow_retained_bytes'] );
+		$normalized['overflow_archive_pointer']   = is_array( $normalized['overflow_archive_pointer'] ) ? $normalized['overflow_archive_pointer'] : array();
+		$normalized['overflow_stub_role']         = self::normalize_string( $normalized['overflow_stub_role'], 'system' );
+		$normalized['overflow_stub_prefix']       = self::normalize_string( $normalized['overflow_stub_prefix'], 'Earlier conversation archived without summarization.' );
 
 		if ( $normalized['recent_messages'] >= $normalized['max_messages'] ) {
 			$normalized['recent_messages'] = max( 1, $normalized['max_messages'] - 1 );
@@ -80,12 +96,17 @@ class AgentConversationCompaction {
 	 * @param array    $messages   Complete transcript messages.
 	 * @param array    $policy     Compaction policy.
 	 * @param callable $summarizer Summary producer supplied by the runtime.
-	 * @return array{messages: array<int, array<string, mixed>>, metadata: array<string, mixed>, events: array<int, array<string, mixed>>}
+	 * @return array{messages: array<int, array<string, mixed>>, metadata: array<string, mixed>, events: array<int, array<string, mixed>>, archive_items?: array<int, array<string, mixed>>}
 	 */
 	public static function compact( array $messages, array $policy, callable $summarizer ): array {
 		$policy              = self::normalize_policy( $policy );
 		$normalized_messages = AgentMessageEnvelope::normalize_many( $messages );
 		$total_messages      = count( $normalized_messages );
+		$source_messages     = array_values( $messages );
+
+		if ( self::should_archive_overflow( $source_messages, $policy ) ) {
+			return self::archive_overflow( $source_messages, $normalized_messages, $policy );
+		}
 
 		if ( ! $policy['enabled'] || $total_messages <= $policy['max_messages'] ) {
 			return self::result( $normalized_messages, self::STATUS_SKIPPED, array(), array() );
@@ -162,10 +183,123 @@ class AgentConversationCompaction {
 		$policy = self::normalize_policy( $policy );
 		$cutoff = max( 0, count( $messages ) - $policy['recent_messages'] );
 
-		if ( ! $policy['preserve_tool_boundaries'] ) {
-			return $cutoff;
+		return $policy['preserve_tool_boundaries'] ? self::move_boundary_to_safe_index( $messages, $cutoff ) : $cutoff;
+	}
+
+	/**
+	 * Build a normalized result array.
+	 *
+	 * @param array<int, array<string, mixed>> $messages Messages.
+	 * @param string                           $status   Compaction status.
+	 * @param array<string, mixed>             $metadata Compaction metadata.
+	 * @param array<int, array<string, mixed>> $events   Lifecycle events.
+	 * @param array<string, mixed>             $extra    Extra result fields.
+	 * @return array<string, mixed>
+	 */
+	private static function result( array $messages, string $status, array $metadata, array $events, array $extra = array() ): array {
+		$metadata['status'] = $status;
+
+		return array_merge(
+			array(
+				'messages' => $messages,
+				'metadata' => array( 'compaction' => $metadata ),
+				'events'   => $events,
+			),
+			$extra
+		);
+	}
+
+	/**
+	 * Determine whether deterministic overflow archiving should run.
+	 *
+	 * @param array<int, array<string, mixed>> $messages Source messages.
+	 * @param array<string, mixed>             $policy   Normalized policy.
+	 * @return bool
+	 */
+	private static function should_archive_overflow( array $messages, array $policy ): bool {
+		return $policy['overflow_archive_enabled']
+			&& $policy['overflow_threshold_bytes'] > 0
+			&& self::encoded_size( $messages ) > $policy['overflow_threshold_bytes'];
+	}
+
+	/**
+	 * Deterministically split oversized input into retained messages and archive items.
+	 *
+	 * @param array<int, array<string, mixed>> $source_messages     Original source messages.
+	 * @param array<int, array<string, mixed>> $normalized_messages Normalized messages.
+	 * @param array<string, mixed>             $policy              Normalized policy.
+	 * @return array<string, mixed>
+	 */
+	private static function archive_overflow( array $source_messages, array $normalized_messages, array $policy ): array {
+		$total_messages = count( $normalized_messages );
+		$retain_count   = $policy['overflow_retained_messages'] > 0 ? $policy['overflow_retained_messages'] : $policy['recent_messages'];
+		$cutoff         = max( 0, $total_messages - $retain_count );
+
+		while ( $policy['overflow_retained_bytes'] > 0 && $cutoff < $total_messages - 1 && self::encoded_size( array_slice( $normalized_messages, $cutoff ) ) > $policy['overflow_retained_bytes'] ) {
+			++$cutoff;
 		}
 
+		if ( $policy['preserve_tool_boundaries'] ) {
+			$cutoff = self::move_boundary_to_safe_index( $normalized_messages, $cutoff );
+		}
+
+		if ( $cutoff <= 0 ) {
+			return self::result(
+				$normalized_messages,
+				self::STATUS_SKIPPED,
+				array(
+					'policy' => $policy,
+					'reason' => 'overflow_input_unsplittable',
+					'total_messages' => $total_messages,
+					'total_bytes' => self::encoded_size( $source_messages ),
+				),
+				array()
+			);
+		}
+
+		$archive_items = array_slice( $source_messages, 0, $cutoff );
+		$retained      = array_slice( $normalized_messages, $cutoff );
+		$archive_id    = 'agents-api-overflow-' . substr( hash( 'sha256', self::encoded_json( $archive_items ) ), 0, 16 );
+		$archive_meta  = array(
+			'strategy'       => 'deterministic_overflow_archive',
+			'archive_id'     => $archive_id,
+			'archive_pointer' => $policy['overflow_archive_pointer'],
+			'archive_count'  => count( $archive_items ),
+			'retained_count' => count( $retained ),
+			'total_messages' => $total_messages,
+			'total_bytes'    => self::encoded_size( $source_messages ),
+			'boundary'       => array(
+				'archive_until' => $cutoff - 1,
+				'retain_from'   => $cutoff,
+			),
+			'policy'         => $policy,
+		);
+
+		$stub_message = AgentMessageEnvelope::text(
+			$policy['overflow_stub_role'],
+			$policy['overflow_stub_prefix'] . "\n\nArchive ID: " . $archive_id . "\nArchived messages: " . count( $archive_items ),
+			array(
+				'agents_api_compaction_archive' => $archive_meta,
+			)
+		);
+
+		return self::result(
+			array_merge( array( $stub_message ), $retained ),
+			self::STATUS_ARCHIVED,
+			$archive_meta,
+			array( self::event( self::EVENT_ARCHIVED, $archive_meta ) ),
+			array( 'archive_items' => $archive_items )
+		);
+	}
+
+	/**
+	 * Move a split boundary so tool-call/tool-result pairs stay together.
+	 *
+	 * @param array<int, array<string, mixed>> $messages Normalized messages.
+	 * @param int                              $cutoff   Candidate boundary.
+	 * @return int Safe boundary.
+	 */
+	private static function move_boundary_to_safe_index( array $messages, int $cutoff ): int {
 		while ( $cutoff > 0 && isset( $messages[ $cutoff ] ) && AgentMessageEnvelope::TYPE_TOOL_RESULT === AgentMessageEnvelope::type( $messages[ $cutoff ] ) ) {
 			--$cutoff;
 		}
@@ -178,22 +312,30 @@ class AgentConversationCompaction {
 	}
 
 	/**
-	 * Build a normalized result array.
+	 * Return the byte length of the deterministic JSON encoding for data.
 	 *
-	 * @param array<int, array<string, mixed>> $messages Messages.
-	 * @param string                           $status   Compaction status.
-	 * @param array<string, mixed>             $metadata Compaction metadata.
-	 * @param array<int, array<string, mixed>> $events   Lifecycle events.
-	 * @return array<string, mixed>
+	 * @param mixed $data Data to measure.
+	 * @return int Encoded byte count.
 	 */
-	private static function result( array $messages, string $status, array $metadata, array $events ): array {
-		$metadata['status'] = $status;
+	private static function encoded_size( $data ): int {
+		return strlen( self::encoded_json( $data ) );
+	}
 
-		return array(
-			'messages' => $messages,
-			'metadata' => array( 'compaction' => $metadata ),
-			'events'   => $events,
-		);
+	/**
+	 * Encode data consistently for sizing and deterministic archive IDs.
+	 *
+	 * @param mixed $data Data to encode.
+	 * @return string Encoded JSON.
+	 */
+	private static function encoded_json( $data ): string {
+		if ( function_exists( 'wp_json_encode' ) ) {
+			$encoded = wp_json_encode( $data );
+		} else {
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.json_encode_json_encode -- Pure-PHP smoke tests run without WordPress loaded.
+			$encoded = json_encode( $data );
+		}
+
+		return is_string( $encoded ) ? $encoded : '';
 	}
 
 	/**

--- a/tests/conversation-compaction-smoke.php
+++ b/tests/conversation-compaction-smoke.php
@@ -114,4 +114,106 @@ agents_api_smoke_assert_equals( true, $agent->supports_conversation_compaction()
 agents_api_smoke_assert_equals( 10, $agent->get_conversation_compaction_policy()['max_messages'], 'agent exposes normalized compaction policy', $failures, $passes );
 agents_api_smoke_assert_equals( true, $agent->to_array()['supports_conversation_compaction'], 'agent array includes compaction capability', $failures, $passes );
 
+echo "\n[6] Oversized transcripts archive deterministically without summarizer calls:\n";
+$overflow_policy = array(
+	'enabled'                    => true,
+	'max_messages'               => 100,
+	'recent_messages'            => 2,
+	'overflow_archive_enabled'   => true,
+	'overflow_threshold_bytes'   => 180,
+	'overflow_retained_messages' => 2,
+	'overflow_archive_pointer'   => array( 'destination' => 'memory://daily/2026/05/01.md' ),
+);
+$overflow_messages = array();
+for ( $i = 1; $i <= 6; ++$i ) {
+	$overflow_messages[] = array(
+		'id'       => 'message-' . $i,
+		'role'     => 0 === $i % 2 ? 'assistant' : 'user',
+		'content'  => 'message ' . $i . ' ' . str_repeat( 'x', 40 ),
+		'metadata' => array(
+			'position' => $i,
+			'source'   => 'overflow-smoke',
+		),
+	);
+}
+
+$overflow_summarizer_calls = 0;
+$overflow_result           = AgentsAPI\AI\AgentConversationCompaction::compact(
+	$overflow_messages,
+	$overflow_policy,
+	static function () use ( &$overflow_summarizer_calls ): string {
+		++$overflow_summarizer_calls;
+		return 'should not run';
+	}
+);
+$archive_metadata = $overflow_result['metadata']['compaction'];
+agents_api_smoke_assert_equals( AgentsAPI\AI\AgentConversationCompaction::STATUS_ARCHIVED, $archive_metadata['status'], 'oversized transcript uses archive status', $failures, $passes );
+agents_api_smoke_assert_equals( 0, $overflow_summarizer_calls, 'overflow archive does not call summarizer', $failures, $passes );
+agents_api_smoke_assert_equals( 3, count( $overflow_result['messages'] ), 'overflow result retains stub plus active subset', $failures, $passes );
+agents_api_smoke_assert_equals( 4, count( $overflow_result['archive_items'] ), 'overflow result returns archived items', $failures, $passes );
+agents_api_smoke_assert_equals( $overflow_messages[1], $overflow_result['archive_items'][1], 'archived items retain original IDs and metadata verbatim', $failures, $passes );
+agents_api_smoke_assert_equals( $overflow_policy['overflow_archive_pointer'], $archive_metadata['archive_pointer'], 'archive metadata includes consumer pointer', $failures, $passes );
+agents_api_smoke_assert_equals( $archive_metadata['archive_id'], $overflow_result['messages'][0]['metadata']['agents_api_compaction_archive']['archive_id'], 'stub metadata includes archive ID', $failures, $passes );
+
+echo "\n[7] Small overflow-enabled transcripts are unchanged:\n";
+$small_overflow_calls = 0;
+$small_overflow       = AgentsAPI\AI\AgentConversationCompaction::compact(
+	$messages,
+	array(
+		'enabled'                    => true,
+		'max_messages'               => 100,
+		'overflow_archive_enabled'   => true,
+		'overflow_threshold_bytes'   => 100000,
+		'overflow_retained_messages' => 2,
+	),
+	static function () use ( &$small_overflow_calls ): string {
+		++$small_overflow_calls;
+		return 'should not run';
+	}
+);
+agents_api_smoke_assert_equals( AgentsAPI\AI\AgentConversationCompaction::STATUS_SKIPPED, $small_overflow['metadata']['compaction']['status'], 'small overflow-enabled transcript is skipped', $failures, $passes );
+agents_api_smoke_assert_equals( 0, $small_overflow_calls, 'small overflow-enabled transcript does not call summarizer', $failures, $passes );
+agents_api_smoke_assert_equals( false, array_key_exists( 'archive_items', $small_overflow ), 'small overflow-enabled transcript has no archive items', $failures, $passes );
+
+echo "\n[8] Single oversized items remain intact when they cannot be split safely:\n";
+$single_overflow_calls = 0;
+$single_oversized      = AgentsAPI\AI\AgentConversationCompaction::compact(
+	array(
+		array(
+			'id'       => 'single-large-message',
+			'role'     => 'user',
+			'content'  => str_repeat( 'single ', 80 ),
+			'metadata' => array( 'keep' => 'verbatim' ),
+		),
+	),
+	array(
+		'enabled'                    => true,
+		'max_messages'               => 100,
+		'overflow_archive_enabled'   => true,
+		'overflow_threshold_bytes'   => 40,
+		'overflow_retained_messages' => 1,
+	),
+	static function () use ( &$single_overflow_calls ): string {
+		++$single_overflow_calls;
+		return 'should not run';
+	}
+);
+agents_api_smoke_assert_equals( AgentsAPI\AI\AgentConversationCompaction::STATUS_SKIPPED, $single_oversized['metadata']['compaction']['status'], 'single oversized item is skipped', $failures, $passes );
+agents_api_smoke_assert_equals( 'overflow_input_unsplittable', $single_oversized['metadata']['compaction']['reason'], 'single oversized item records unsplittable reason', $failures, $passes );
+agents_api_smoke_assert_equals( 0, $single_overflow_calls, 'single oversized item does not call summarizer', $failures, $passes );
+agents_api_smoke_assert_equals( 'single-large-message', $single_oversized['messages'][0]['id'], 'single oversized item ID is preserved', $failures, $passes );
+agents_api_smoke_assert_equals( array( 'keep' => 'verbatim' ), $single_oversized['messages'][0]['metadata'], 'single oversized item metadata is preserved', $failures, $passes );
+
+echo "\n[9] Overflow archive output is deterministic:\n";
+$overflow_result_again = AgentsAPI\AI\AgentConversationCompaction::compact(
+	$overflow_messages,
+	$overflow_policy,
+	static function (): string {
+		return 'should not run';
+	}
+);
+agents_api_smoke_assert_equals( $overflow_result['metadata']['compaction']['archive_id'], $overflow_result_again['metadata']['compaction']['archive_id'], 'archive IDs are deterministic', $failures, $passes );
+agents_api_smoke_assert_equals( $overflow_result['archive_items'], $overflow_result_again['archive_items'], 'archive item output is deterministic', $failures, $passes );
+agents_api_smoke_assert_equals( $overflow_result['messages'], $overflow_result_again['messages'], 'retained message output is deterministic', $failures, $passes );
+
 agents_api_smoke_finish( 'Agents API conversation compaction', $failures, $passes );

--- a/tests/conversation-compaction-smoke.php
+++ b/tests/conversation-compaction-smoke.php
@@ -147,11 +147,12 @@ $overflow_result           = AgentsAPI\AI\AgentConversationCompaction::compact(
 	}
 );
 $archive_metadata = $overflow_result['metadata']['compaction'];
+$archive_items    = $overflow_result['archive_items'] ?? array();
 agents_api_smoke_assert_equals( AgentsAPI\AI\AgentConversationCompaction::STATUS_ARCHIVED, $archive_metadata['status'], 'oversized transcript uses archive status', $failures, $passes );
 agents_api_smoke_assert_equals( 0, $overflow_summarizer_calls, 'overflow archive does not call summarizer', $failures, $passes );
 agents_api_smoke_assert_equals( 3, count( $overflow_result['messages'] ), 'overflow result retains stub plus active subset', $failures, $passes );
-agents_api_smoke_assert_equals( 4, count( $overflow_result['archive_items'] ), 'overflow result returns archived items', $failures, $passes );
-agents_api_smoke_assert_equals( $overflow_messages[1], $overflow_result['archive_items'][1], 'archived items retain original IDs and metadata verbatim', $failures, $passes );
+agents_api_smoke_assert_equals( 4, count( $archive_items ), 'overflow result returns archived items', $failures, $passes );
+agents_api_smoke_assert_equals( $overflow_messages[1], $archive_items[1], 'archived items retain original IDs and metadata verbatim', $failures, $passes );
 agents_api_smoke_assert_equals( $overflow_policy['overflow_archive_pointer'], $archive_metadata['archive_pointer'], 'archive metadata includes consumer pointer', $failures, $passes );
 agents_api_smoke_assert_equals( $archive_metadata['archive_id'], $overflow_result['messages'][0]['metadata']['agents_api_compaction_archive']['archive_id'], 'stub metadata includes archive ID', $failures, $passes );
 
@@ -212,8 +213,9 @@ $overflow_result_again = AgentsAPI\AI\AgentConversationCompaction::compact(
 		return 'should not run';
 	}
 );
+$archive_items_again = $overflow_result_again['archive_items'] ?? array();
 agents_api_smoke_assert_equals( $overflow_result['metadata']['compaction']['archive_id'], $overflow_result_again['metadata']['compaction']['archive_id'], 'archive IDs are deterministic', $failures, $passes );
-agents_api_smoke_assert_equals( $overflow_result['archive_items'], $overflow_result_again['archive_items'], 'archive item output is deterministic', $failures, $passes );
+agents_api_smoke_assert_equals( $archive_items, $archive_items_again, 'archive item output is deterministic', $failures, $passes );
 agents_api_smoke_assert_equals( $overflow_result['messages'], $overflow_result_again['messages'], 'retained message output is deterministic', $failures, $passes );
 
 agents_api_smoke_finish( 'Agents API conversation compaction', $failures, $passes );


### PR DESCRIPTION
## Summary
- Add an overflow archive branch to conversation compaction that splits oversized ordered inputs deterministically before any summarizer call.
- Return archive items verbatim alongside retained messages with a synthetic archive stub and pointer metadata for consumer persistence.
- Extend smoke coverage for large input, no-op small input, single unsplittable input, and deterministic output.

## Testing
- composer test
- php -l src/Runtime/AgentConversationCompaction.php
- php -l tests/conversation-compaction-smoke.php

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the implementation and smoke tests; Chris remains responsible for review and merge.

Fixes #15