### PR TITLE
Add materialized agent identity contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Agents API sits between tool/action discovery and product-specific automation. I
 ## What Agents API Owns
 
 - Agent registration and lookup.
+- Materialized agent identity lookup contracts.
 - Runtime message and result value objects.
 - Agent package and package-artifact contracts.
 - Agent memory store contracts and value objects.
@@ -64,6 +65,9 @@ Register agent definitions from inside a `wp_agents_api_init` callback. Reads su
 - `wp_register_agent()` / `wp_get_agent()` / `wp_get_agents()` / `wp_has_agent()` / `wp_unregister_agent()`
 - `WP_Agent`
 - `WP_Agents_Registry`
+- `AgentsAPI\Identity\MaterializedAgentIdentity`
+- `AgentsAPI\Identity\MaterializedAgentIdentityStoreInterface`
+- `wp_register_materialized_agent_identity_store()` / `wp_get_materialized_agent_identity()`
 - `WP_Agent_Package*` value objects and artifact registry helpers
 - `AgentsAPI\AI\AgentMessageEnvelope`
 - `AgentsAPI\AI\AgentConversationCompaction`

--- a/agents-api.php
+++ b/agents-api.php
@@ -25,6 +25,8 @@ define( 'AGENTS_API_PATH', __DIR__ . '/' );
 define( 'AGENTS_API_PLUGIN_FILE', __FILE__ );
 
 require_once AGENTS_API_PATH . 'src/Registry/class-wp-agent.php';
+require_once AGENTS_API_PATH . 'src/Identity/MaterializedAgentIdentity.php';
+require_once AGENTS_API_PATH . 'src/Identity/MaterializedAgentIdentityStoreInterface.php';
 require_once AGENTS_API_PATH . 'src/Packages/class-wp-agent-package-artifact.php';
 require_once AGENTS_API_PATH . 'src/Packages/class-wp-agent-package-artifact-type.php';
 require_once AGENTS_API_PATH . 'src/Packages/class-wp-agent-package-artifacts-registry.php';
@@ -34,6 +36,7 @@ require_once AGENTS_API_PATH . 'src/Packages/class-wp-agent-package-adoption-res
 require_once AGENTS_API_PATH . 'src/Packages/class-wp-agent-package-adopter-interface.php';
 require_once AGENTS_API_PATH . 'src/Registry/class-wp-agents-registry.php';
 require_once AGENTS_API_PATH . 'src/Registry/register-agents.php';
+require_once AGENTS_API_PATH . 'src/Identity/register-materialized-agent-identities.php';
 require_once AGENTS_API_PATH . 'src/Packages/register-agent-package-artifacts.php';
 require_once AGENTS_API_PATH . 'src/Transcripts/ConversationTranscriptStoreInterface.php';
 require_once AGENTS_API_PATH . 'src/Runtime/AgentMessageEnvelope.php';

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
     "test": [
       "php tests/bootstrap-smoke.php",
       "php tests/conversation-compaction-smoke.php",
+      "php tests/materialized-agent-identities-smoke.php",
       "php tests/no-product-imports-smoke.php"
     ]
   }

--- a/src/Identity/MaterializedAgentIdentity.php
+++ b/src/Identity/MaterializedAgentIdentity.php
@@ -1,0 +1,201 @@
+<?php
+/**
+ * Materialized agent identity value object.
+ *
+ * @package AgentsAPI
+ */
+
+namespace AgentsAPI\Identity;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Durable agent instance identity.
+ */
+final class MaterializedAgentIdentity {
+
+	/**
+	 * Durable identity ID.
+	 *
+	 * @var int
+	 */
+	private int $id;
+
+	/**
+	 * Registered agent slug.
+	 *
+	 * @var string
+	 */
+	private string $slug;
+
+	/**
+	 * Human-readable label.
+	 *
+	 * @var string
+	 */
+	private string $label;
+
+	/**
+	 * Owner WordPress user ID.
+	 *
+	 * @var int
+	 */
+	private int $owner_user_id;
+
+	/**
+	 * Persisted agent configuration.
+	 *
+	 * @var array<string, mixed>
+	 */
+	private array $config;
+
+	/**
+	 * Created timestamp, when known.
+	 *
+	 * @var string|null
+	 */
+	private ?string $created_at;
+
+	/**
+	 * Updated timestamp, when known.
+	 *
+	 * @var string|null
+	 */
+	private ?string $updated_at;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param int                  $id            Durable identity ID.
+	 * @param string               $slug          Registered agent slug.
+	 * @param string               $label         Human-readable label.
+	 * @param int                  $owner_user_id Owner WordPress user ID.
+	 * @param array<string, mixed> $config        Persisted agent configuration.
+	 * @param string|null          $created_at    Created timestamp, when known.
+	 * @param string|null          $updated_at    Updated timestamp, when known.
+	 */
+	public function __construct( int $id, string $slug, string $label, int $owner_user_id, array $config = array(), ?string $created_at = null, ?string $updated_at = null ) {
+		$slug = sanitize_title( $slug );
+		if ( $id <= 0 ) {
+			throw new \InvalidArgumentException( 'Materialized agent identity ID must be positive.' );
+		}
+		if ( '' === $slug ) {
+			throw new \InvalidArgumentException( 'Materialized agent identity slug cannot be empty.' );
+		}
+		if ( $owner_user_id <= 0 ) {
+			throw new \InvalidArgumentException( 'Materialized agent identity owner user ID must be positive.' );
+		}
+
+		$this->id            = $id;
+		$this->slug          = $slug;
+		$this->label         = '' !== $label ? $label : $slug;
+		$this->owner_user_id = $owner_user_id;
+		$this->config        = $config;
+		$this->created_at    = $created_at;
+		$this->updated_at    = $updated_at;
+	}
+
+	/**
+	 * Create an identity from a storage row.
+	 *
+	 * @param array<string, mixed> $row Storage row.
+	 * @return self
+	 */
+	public static function from_array( array $row ): self {
+		$config = $row['config'] ?? array();
+		if ( is_string( $config ) && '' !== $config ) {
+			$decoded = json_decode( $config, true );
+			$config  = is_array( $decoded ) ? $decoded : array();
+		}
+
+		return new self(
+			(int) ( $row['id'] ?? 0 ),
+			(string) ( $row['slug'] ?? '' ),
+			(string) ( $row['label'] ?? '' ),
+			(int) ( $row['owner_user_id'] ?? 0 ),
+			is_array( $config ) ? $config : array(),
+			isset( $row['created_at'] ) ? (string) $row['created_at'] : null,
+			isset( $row['updated_at'] ) ? (string) $row['updated_at'] : null
+		);
+	}
+
+	/**
+	 * Get the durable identity ID.
+	 *
+	 * @return int
+	 */
+	public function get_id(): int {
+		return $this->id;
+	}
+
+	/**
+	 * Get the registered agent slug.
+	 *
+	 * @return string
+	 */
+	public function get_slug(): string {
+		return $this->slug;
+	}
+
+	/**
+	 * Get the human-readable label.
+	 *
+	 * @return string
+	 */
+	public function get_label(): string {
+		return $this->label;
+	}
+
+	/**
+	 * Get the owner WordPress user ID.
+	 *
+	 * @return int
+	 */
+	public function get_owner_user_id(): int {
+		return $this->owner_user_id;
+	}
+
+	/**
+	 * Get persisted agent configuration.
+	 *
+	 * @return array<string, mixed>
+	 */
+	public function get_config(): array {
+		return $this->config;
+	}
+
+	/**
+	 * Get created timestamp, when known.
+	 *
+	 * @return string|null
+	 */
+	public function get_created_at(): ?string {
+		return $this->created_at;
+	}
+
+	/**
+	 * Get updated timestamp, when known.
+	 *
+	 * @return string|null
+	 */
+	public function get_updated_at(): ?string {
+		return $this->updated_at;
+	}
+
+	/**
+	 * Convert the identity to generic array form.
+	 *
+	 * @return array{id:int,slug:string,label:string,owner_user_id:int,config:array<string,mixed>,created_at:string|null,updated_at:string|null}
+	 */
+	public function to_array(): array {
+		return array(
+			'id'            => $this->id,
+			'slug'          => $this->slug,
+			'label'         => $this->label,
+			'owner_user_id' => $this->owner_user_id,
+			'config'        => $this->config,
+			'created_at'    => $this->created_at,
+			'updated_at'    => $this->updated_at,
+		);
+	}
+}

--- a/src/Identity/MaterializedAgentIdentityStoreInterface.php
+++ b/src/Identity/MaterializedAgentIdentityStoreInterface.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Materialized agent identity store contract.
+ *
+ * @package AgentsAPI
+ */
+
+namespace AgentsAPI\Identity;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Read-only lookup surface for durable agent instances.
+ */
+interface MaterializedAgentIdentityStoreInterface {
+
+	/**
+	 * Get a materialized agent identity by durable ID.
+	 *
+	 * @param int $id Durable identity ID.
+	 * @return MaterializedAgentIdentity|null Identity, or null when not found.
+	 */
+	public function get_by_id( int $id ): ?MaterializedAgentIdentity;
+
+	/**
+	 * Get a materialized agent identity by registered slug.
+	 *
+	 * @param string $slug Registered agent slug.
+	 * @return MaterializedAgentIdentity|null Identity, or null when not found.
+	 */
+	public function get_by_slug( string $slug ): ?MaterializedAgentIdentity;
+
+	/**
+	 * Get materialized agent identities owned by a WordPress user.
+	 *
+	 * @param int $owner_user_id Owner WordPress user ID.
+	 * @return MaterializedAgentIdentity[] Identities owned by the user.
+	 */
+	public function get_by_owner_user_id( int $owner_user_id ): array;
+}

--- a/src/Identity/register-materialized-agent-identities.php
+++ b/src/Identity/register-materialized-agent-identities.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * Materialized agent identity helpers.
+ *
+ * @package AgentsAPI
+ */
+
+use AgentsAPI\Identity\MaterializedAgentIdentity;
+use AgentsAPI\Identity\MaterializedAgentIdentityStoreInterface;
+
+defined( 'ABSPATH' ) || exit;
+
+if ( ! function_exists( 'wp_register_materialized_agent_identity_store' ) ) {
+	/**
+	 * Register the backing store for durable agent identities.
+	 *
+	 * @param MaterializedAgentIdentityStoreInterface $store Backing store.
+	 * @return void
+	 */
+	function wp_register_materialized_agent_identity_store( MaterializedAgentIdentityStoreInterface $store ): void {
+		$GLOBALS['wp_materialized_agent_identity_store'] = $store;
+	}
+}
+
+if ( ! function_exists( 'wp_get_materialized_agent_identity_store' ) ) {
+	/**
+	 * Get the registered backing store for durable agent identities.
+	 *
+	 * @return MaterializedAgentIdentityStoreInterface|null Backing store, or null when none is registered.
+	 */
+	function wp_get_materialized_agent_identity_store(): ?MaterializedAgentIdentityStoreInterface {
+		$store = $GLOBALS['wp_materialized_agent_identity_store'] ?? null;
+		if ( function_exists( 'apply_filters' ) ) {
+			$store = apply_filters( 'wp_materialized_agent_identity_store', $store );
+		}
+
+		return $store instanceof MaterializedAgentIdentityStoreInterface ? $store : null;
+	}
+}
+
+if ( ! function_exists( 'wp_get_materialized_agent_identity_by_id' ) ) {
+	/**
+	 * Get a materialized agent identity by durable ID.
+	 *
+	 * @param int $id Durable identity ID.
+	 * @return MaterializedAgentIdentity|null Identity, or null when not found.
+	 */
+	function wp_get_materialized_agent_identity_by_id( int $id ): ?MaterializedAgentIdentity {
+		$store = wp_get_materialized_agent_identity_store();
+		if ( null === $store ) {
+			return null;
+		}
+
+		return $store->get_by_id( $id );
+	}
+}
+
+if ( ! function_exists( 'wp_get_materialized_agent_identity' ) ) {
+	/**
+	 * Resolve a registered agent definition to its durable identity.
+	 *
+	 * @param string|WP_Agent $agent Agent slug or registered definition object.
+	 * @return MaterializedAgentIdentity|null Identity, or null when not registered/materialized.
+	 */
+	function wp_get_materialized_agent_identity( $agent ): ?MaterializedAgentIdentity {
+		$slug = $agent instanceof WP_Agent ? $agent->get_slug() : sanitize_title( (string) $agent );
+		if ( '' === $slug || ! wp_has_agent( $slug ) ) {
+			return null;
+		}
+
+		$store = wp_get_materialized_agent_identity_store();
+		if ( null === $store ) {
+			return null;
+		}
+
+		return $store->get_by_slug( $slug );
+	}
+}
+
+if ( ! function_exists( 'wp_get_materialized_agent_identities_by_owner_user_id' ) ) {
+	/**
+	 * Get materialized agent identities owned by a WordPress user.
+	 *
+	 * @param int $owner_user_id Owner WordPress user ID.
+	 * @return MaterializedAgentIdentity[] Identities owned by the user.
+	 */
+	function wp_get_materialized_agent_identities_by_owner_user_id( int $owner_user_id ): array {
+		$store = wp_get_materialized_agent_identity_store();
+		if ( null === $store ) {
+			return array();
+		}
+
+		return $store->get_by_owner_user_id( $owner_user_id );
+	}
+}

--- a/tests/agents-api-smoke-helpers.php
+++ b/tests/agents-api-smoke-helpers.php
@@ -10,6 +10,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 $GLOBALS['__agents_api_smoke_actions'] = array();
+$GLOBALS['__agents_api_smoke_filters'] = array();
 $GLOBALS['__agents_api_smoke_wrong']   = array();
 $GLOBALS['__agents_api_smoke_current'] = array();
 $GLOBALS['__agents_api_smoke_done']    = array();
@@ -27,6 +28,24 @@ function sanitize_file_name( string $value ): string {
 function add_action( string $hook, callable $callback, int $priority = 10, int $accepted_args = 1 ): void {
 	unset( $accepted_args );
 	$GLOBALS['__agents_api_smoke_actions'][ $hook ][ $priority ][] = $callback;
+}
+
+function add_filter( string $hook, callable $callback, int $priority = 10, int $accepted_args = 1 ): void {
+	unset( $accepted_args );
+	$GLOBALS['__agents_api_smoke_filters'][ $hook ][ $priority ][] = $callback;
+}
+
+function apply_filters( string $hook, $value ) {
+	$callbacks = $GLOBALS['__agents_api_smoke_filters'][ $hook ] ?? array();
+	ksort( $callbacks );
+
+	foreach ( $callbacks as $priority_callbacks ) {
+		foreach ( $priority_callbacks as $callback ) {
+			$value = call_user_func( $callback, $value );
+		}
+	}
+
+	return $value;
 }
 
 function do_action( string $hook, ...$args ): void {

--- a/tests/bootstrap-smoke.php
+++ b/tests/bootstrap-smoke.php
@@ -38,6 +38,11 @@ agents_api_smoke_assert_equals( true, function_exists( 'wp_get_agent' ), 'wp_get
 agents_api_smoke_assert_equals( true, function_exists( 'wp_get_agents' ), 'wp_get_agents helper is available', $failures, $passes );
 agents_api_smoke_assert_equals( true, function_exists( 'wp_has_agent' ), 'wp_has_agent helper is available', $failures, $passes );
 agents_api_smoke_assert_equals( true, function_exists( 'wp_unregister_agent' ), 'wp_unregister_agent helper is available', $failures, $passes );
+agents_api_smoke_assert_equals( true, function_exists( 'wp_register_materialized_agent_identity_store' ), 'wp_register_materialized_agent_identity_store helper is available', $failures, $passes );
+agents_api_smoke_assert_equals( true, function_exists( 'wp_get_materialized_agent_identity_store' ), 'wp_get_materialized_agent_identity_store helper is available', $failures, $passes );
+agents_api_smoke_assert_equals( true, function_exists( 'wp_get_materialized_agent_identity_by_id' ), 'wp_get_materialized_agent_identity_by_id helper is available', $failures, $passes );
+agents_api_smoke_assert_equals( true, function_exists( 'wp_get_materialized_agent_identity' ), 'wp_get_materialized_agent_identity helper is available', $failures, $passes );
+agents_api_smoke_assert_equals( true, function_exists( 'wp_get_materialized_agent_identities_by_owner_user_id' ), 'wp_get_materialized_agent_identities_by_owner_user_id helper is available', $failures, $passes );
 agents_api_smoke_assert_equals( true, function_exists( 'wp_register_agent_package_artifact_type' ), 'wp_register_agent_package_artifact_type helper is available', $failures, $passes );
 agents_api_smoke_assert_equals( true, function_exists( 'wp_get_agent_package_artifact_type' ), 'wp_get_agent_package_artifact_type helper is available', $failures, $passes );
 agents_api_smoke_assert_equals( true, function_exists( 'wp_get_agent_package_artifact_types' ), 'wp_get_agent_package_artifact_types helper is available', $failures, $passes );
@@ -45,6 +50,8 @@ agents_api_smoke_assert_equals( true, function_exists( 'wp_has_agent_package_art
 agents_api_smoke_assert_equals( true, function_exists( 'wp_unregister_agent_package_artifact_type' ), 'wp_unregister_agent_package_artifact_type helper is available', $failures, $passes );
 agents_api_smoke_assert_equals( true, class_exists( 'WP_Agent' ), 'WP_Agent value object is available', $failures, $passes );
 agents_api_smoke_assert_equals( true, class_exists( 'WP_Agents_Registry' ), 'WP_Agents_Registry facade is available', $failures, $passes );
+agents_api_smoke_assert_equals( true, class_exists( 'AgentsAPI\\Identity\\MaterializedAgentIdentity' ), 'MaterializedAgentIdentity value object is available', $failures, $passes );
+agents_api_smoke_assert_equals( true, interface_exists( 'AgentsAPI\\Identity\\MaterializedAgentIdentityStoreInterface' ), 'MaterializedAgentIdentityStoreInterface contract is available', $failures, $passes );
 agents_api_smoke_assert_equals( true, class_exists( 'WP_Agent_Package_Artifact' ), 'WP_Agent_Package_Artifact value object is available', $failures, $passes );
 agents_api_smoke_assert_equals( true, class_exists( 'WP_Agent_Package_Artifact_Type' ), 'WP_Agent_Package_Artifact_Type value object is available', $failures, $passes );
 agents_api_smoke_assert_equals( true, class_exists( 'WP_Agent_Package_Artifacts_Registry' ), 'WP_Agent_Package_Artifacts_Registry facade is available', $failures, $passes );
@@ -91,6 +98,7 @@ agents_api_smoke_assert_equals( false, false !== strpos( $bootstrap_source, 'Dat
 
 echo "\n[3] Module source tree uses Agents API vocabulary:\n";
 $expected_source_directories = array(
+	'Identity',
 	'Memory',
 	'Packages',
 	'Registry',

--- a/tests/materialized-agent-identities-smoke.php
+++ b/tests/materialized-agent-identities-smoke.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * Pure-PHP smoke test for materialized agent identity contracts.
+ *
+ * Run with: php tests/materialized-agent-identities-smoke.php
+ *
+ * @package AgentsAPI\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+$failures = array();
+$passes   = 0;
+
+echo "agents-api-materialized-agent-identities-smoke\n";
+
+require_once __DIR__ . '/agents-api-smoke-helpers.php';
+agents_api_smoke_require_module();
+
+final class Agents_API_Fake_Materialized_Agent_Identity_Store implements AgentsAPI\Identity\MaterializedAgentIdentityStoreInterface {
+	/**
+	 * @var array<int, AgentsAPI\Identity\MaterializedAgentIdentity>
+	 */
+	private array $identities = array();
+
+	/**
+	 * @param AgentsAPI\Identity\MaterializedAgentIdentity[] $identities Identities.
+	 */
+	public function __construct( array $identities ) {
+		foreach ( $identities as $identity ) {
+			$this->identities[ $identity->get_id() ] = $identity;
+		}
+	}
+
+	public function get_by_id( int $id ): ?AgentsAPI\Identity\MaterializedAgentIdentity {
+		return $this->identities[ $id ] ?? null;
+	}
+
+	public function get_by_slug( string $slug ): ?AgentsAPI\Identity\MaterializedAgentIdentity {
+		$slug = sanitize_title( $slug );
+		foreach ( $this->identities as $identity ) {
+			if ( $slug === $identity->get_slug() ) {
+				return $identity;
+			}
+		}
+
+		return null;
+	}
+
+	public function get_by_owner_user_id( int $owner_user_id ): array {
+		$matches = array();
+		foreach ( $this->identities as $identity ) {
+			if ( $owner_user_id === $identity->get_owner_user_id() ) {
+				$matches[] = $identity;
+			}
+		}
+
+		return $matches;
+	}
+}
+
+do_action( 'init' );
+
+add_action(
+	'wp_agents_api_init',
+	static function (): void {
+		wp_register_agent(
+			'Support Chef',
+			array(
+				'label'          => 'Support Chef',
+				'default_config' => array( 'temperature' => 0.2 ),
+			)
+		);
+	}
+);
+
+WP_Agents_Registry::reset_for_tests();
+WP_Agents_Registry::init();
+
+$identity = AgentsAPI\Identity\MaterializedAgentIdentity::from_array(
+	array(
+		'id'            => 123,
+		'slug'          => 'support-chef',
+		'label'         => 'Support Chef',
+		'owner_user_id' => 45,
+		'config'        => '{"temperature":0.2}',
+		'created_at'    => '2026-05-01 00:00:00',
+		'updated_at'    => '2026-05-01 00:00:00',
+	)
+);
+
+$store = new Agents_API_Fake_Materialized_Agent_Identity_Store( array( $identity ) );
+wp_register_materialized_agent_identity_store( $store );
+
+$by_slug  = wp_get_materialized_agent_identity( 'support-chef' );
+$by_owner = wp_get_materialized_agent_identities_by_owner_user_id( 45 );
+
+agents_api_smoke_assert_equals( $store, wp_get_materialized_agent_identity_store(), 'registered identity store is returned', $failures, $passes );
+agents_api_smoke_assert_equals( 123, wp_get_materialized_agent_identity_by_id( 123 )->get_id(), 'identity resolves by durable ID', $failures, $passes );
+agents_api_smoke_assert_equals( 123, $by_slug instanceof AgentsAPI\Identity\MaterializedAgentIdentity ? $by_slug->get_id() : null, 'registered definition resolves to identity by slug', $failures, $passes );
+agents_api_smoke_assert_equals( 45, $by_slug instanceof AgentsAPI\Identity\MaterializedAgentIdentity ? $by_slug->get_owner_user_id() : null, 'identity exposes owner user ID', $failures, $passes );
+agents_api_smoke_assert_equals( array( 'temperature' => 0.2 ), $by_slug instanceof AgentsAPI\Identity\MaterializedAgentIdentity ? $by_slug->get_config() : null, 'identity normalizes persisted config', $failures, $passes );
+agents_api_smoke_assert_equals( 1, count( $by_owner ), 'identity store resolves identities by owner user ID', $failures, $passes );
+agents_api_smoke_assert_equals( 123, $by_owner[0]->get_id(), 'owner user ID lookup returns matching identity', $failures, $passes );
+agents_api_smoke_assert_equals( null, wp_get_materialized_agent_identity( 'not-registered' ), 'unregistered slug does not resolve to materialized identity', $failures, $passes );
+
+agents_api_smoke_finish( 'Agents API materialized agent identities', $failures, $passes );


### PR DESCRIPTION
## Summary
- Add a generic `MaterializedAgentIdentity` value object and read-only `MaterializedAgentIdentityStoreInterface` for durable agent instances.
- Add public helpers for registering/filtering the backing identity store and resolving registered agent definitions to materialized identities.
- Add focused smoke coverage for slug and owner-user-ID lookup through the generic contract.

## Notes
- No Data Machine-backed implementation is included in this repo because Agents API currently has no product adapter location and its standalone boundary tests reject Data Machine imports. The new store registration/filter seam lets Data Machine register a backing implementation from the product plugin without changing Agents API's product-free boundary.
- No access grants, scoped policy, token binding, storage migrations, or Data Machine consumer migrations are included.

## Testing
- `composer test`

Closes https://github.com/Automattic/agents-api/issues/10

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the minimal contract/value-object implementation, smoke tests, and PR description; Chris remains responsible for review and merge.