### PR TITLE
Add materialized agent identity contracts

### DIFF
--- a/agents-api.php
+++ b/agents-api.php
@@ -35,6 +35,9 @@ require_once AGENTS_API_PATH . 'src/Packages/class-wp-agent-package-adopter-inte
 require_once AGENTS_API_PATH . 'src/Registry/class-wp-agents-registry.php';
 require_once AGENTS_API_PATH . 'src/Registry/register-agents.php';
 require_once AGENTS_API_PATH . 'src/Packages/register-agent-package-artifacts.php';
+require_once AGENTS_API_PATH . 'src/Identity/AgentIdentityScope.php';
+require_once AGENTS_API_PATH . 'src/Identity/MaterializedAgentIdentity.php';
+require_once AGENTS_API_PATH . 'src/Identity/MaterializedAgentIdentityStoreInterface.php';
 require_once AGENTS_API_PATH . 'src/Transcripts/ConversationTranscriptStoreInterface.php';
 require_once AGENTS_API_PATH . 'src/Runtime/AgentMessageEnvelope.php';
 require_once AGENTS_API_PATH . 'src/Runtime/AgentConversationCompaction.php';

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
   "scripts": {
     "test": [
       "php tests/bootstrap-smoke.php",
+      "php tests/identity-smoke.php",
       "php tests/conversation-compaction-smoke.php",
       "php tests/no-product-imports-smoke.php"
     ]

--- a/src/Identity/AgentIdentityScope.php
+++ b/src/Identity/AgentIdentityScope.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * Agent Identity Scope
+ *
+ * Store-neutral value object for resolving a durable materialized agent
+ * instance from a declarative agent slug, owner, and product-defined key.
+ *
+ * @package AgentsAPI
+ * @since   next
+ */
+
+namespace AgentsAPI\Core\Identity;
+
+defined( 'ABSPATH' ) || exit;
+
+final class AgentIdentityScope {
+
+	/**
+	 * @param string $agent_slug    Declarative agent slug registered with Agents API.
+	 * @param int    $owner_user_id Effective WordPress owner user ID. 0 = shared/no owner.
+	 * @param string $instance_key  Product-defined stable instance key. Defaults to 'default'.
+	 */
+	public function __construct(
+		public readonly string $agent_slug,
+		public readonly int $owner_user_id = 0,
+		public readonly string $instance_key = 'default',
+	) {
+		if ( '' === self::normalize_agent_slug( $this->agent_slug ) ) {
+			throw new \InvalidArgumentException( 'Agent identity scope agent_slug cannot be empty.' );
+		}
+
+		if ( 0 > $this->owner_user_id ) {
+			throw new \InvalidArgumentException( 'Agent identity scope owner_user_id cannot be negative.' );
+		}
+
+		if ( '' === self::normalize_instance_key( $this->instance_key ) ) {
+			throw new \InvalidArgumentException( 'Agent identity scope instance_key cannot be empty.' );
+		}
+	}
+
+	/**
+	 * Creates a normalized copy of the scope.
+	 *
+	 * @return self
+	 */
+	public function normalize(): self {
+		return new self(
+			self::normalize_agent_slug( $this->agent_slug ),
+			$this->owner_user_id,
+			self::normalize_instance_key( $this->instance_key )
+		);
+	}
+
+	/**
+	 * Stable string key for cache/map lookups.
+	 *
+	 * @return string
+	 */
+	public function key(): string {
+		$normalized = $this->normalize();
+
+		return sprintf( '%s:%d:%s', $normalized->agent_slug, $normalized->owner_user_id, $normalized->instance_key );
+	}
+
+	/**
+	 * Normalizes a registered agent slug.
+	 *
+	 * @param string $agent_slug Raw slug.
+	 * @return string
+	 */
+	public static function normalize_agent_slug( string $agent_slug ): string {
+		if ( function_exists( 'sanitize_title' ) ) {
+			return sanitize_title( $agent_slug );
+		}
+
+		$agent_slug = strtolower( $agent_slug );
+		$agent_slug = preg_replace( '/[^a-z0-9]+/', '-', $agent_slug );
+
+		return trim( (string) $agent_slug, '-' );
+	}
+
+	/**
+	 * Normalizes a product-defined materialized instance key.
+	 *
+	 * @param string $instance_key Raw instance key.
+	 * @return string
+	 */
+	public static function normalize_instance_key( string $instance_key ): string {
+		$instance_key = strtolower( trim( $instance_key ) );
+		$instance_key = preg_replace( '/\s*\/\s*/', '/', $instance_key );
+		$instance_key = preg_replace( '/[^a-z0-9_.:\/-]+/', '-', $instance_key );
+
+		return trim( (string) $instance_key, '-/' );
+	}
+}

--- a/src/Identity/MaterializedAgentIdentity.php
+++ b/src/Identity/MaterializedAgentIdentity.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * Materialized Agent Identity
+ *
+ * Immutable value object describing a durable agent instance already resolved
+ * by an identity store.
+ *
+ * @package AgentsAPI
+ * @since   next
+ */
+
+namespace AgentsAPI\Core\Identity;
+
+defined( 'ABSPATH' ) || exit;
+
+final class MaterializedAgentIdentity {
+
+	/**
+	 * @param int                 $id            Durable identity store ID.
+	 * @param AgentIdentityScope  $scope         Logical identity scope.
+	 * @param array<string,mixed> $config        Materialized agent configuration.
+	 * @param array<string,mixed> $meta          Store/product metadata.
+	 * @param int|null            $created_at    Unix timestamp of first materialization, or null if unknown.
+	 * @param int|null            $updated_at    Unix timestamp of last update, or null if unknown.
+	 */
+	public function __construct(
+		public readonly int $id,
+		public readonly AgentIdentityScope $scope,
+		public readonly array $config = array(),
+		public readonly array $meta = array(),
+		public readonly ?int $created_at = null,
+		public readonly ?int $updated_at = null,
+	) {
+		if ( 1 > $this->id ) {
+			throw new \InvalidArgumentException( 'Materialized agent identity id must be a positive integer.' );
+		}
+	}
+
+	/**
+	 * Returns a copy with replacement configuration.
+	 *
+	 * @param array<string,mixed> $config Replacement configuration.
+	 * @return self
+	 */
+	public function with_config( array $config ): self {
+		return new self( $this->id, $this->scope, $config, $this->meta, $this->created_at, $this->updated_at );
+	}
+
+	/**
+	 * Returns a copy with replacement metadata.
+	 *
+	 * @param array<string,mixed> $meta Replacement metadata.
+	 * @return self
+	 */
+	public function with_meta( array $meta ): self {
+		return new self( $this->id, $this->scope, $this->config, $meta, $this->created_at, $this->updated_at );
+	}
+
+	/**
+	 * Stable string key for cache/map lookups.
+	 *
+	 * @return string
+	 */
+	public function key(): string {
+		return (string) $this->id;
+	}
+
+	/**
+	 * Exports the normalized identity payload.
+	 *
+	 * @return array<string,mixed>
+	 */
+	public function to_array(): array {
+		$normalized_scope = $this->scope->normalize();
+
+		return array(
+			'id'            => $this->id,
+			'agent_slug'    => $normalized_scope->agent_slug,
+			'owner_user_id' => $normalized_scope->owner_user_id,
+			'instance_key'  => $normalized_scope->instance_key,
+			'config'        => $this->config,
+			'meta'          => $this->meta,
+			'created_at'    => $this->created_at,
+			'updated_at'    => $this->updated_at,
+		);
+	}
+}

--- a/src/Identity/MaterializedAgentIdentityStoreInterface.php
+++ b/src/Identity/MaterializedAgentIdentityStoreInterface.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Materialized Agent Identity Store Interface
+ *
+ * Generic persistence contract for durable agent instances. The contract only
+ * resolves identity records; access grants, scoped policy, token binding, and
+ * product-specific runtime behavior stay in higher-level callers.
+ *
+ * @package AgentsAPI
+ * @since   next
+ */
+
+namespace AgentsAPI\Core\Identity;
+
+defined( 'ABSPATH' ) || exit;
+
+interface MaterializedAgentIdentityStoreInterface {
+
+	/**
+	 * Resolve an already-materialized identity by logical scope.
+	 *
+	 * @param AgentIdentityScope $scope Logical identity scope.
+	 * @return MaterializedAgentIdentity|null Identity, or null when not materialized.
+	 */
+	public function resolve( AgentIdentityScope $scope ): ?MaterializedAgentIdentity;
+
+	/**
+	 * Retrieve a materialized identity by durable store ID.
+	 *
+	 * @param int $identity_id Durable identity store ID.
+	 * @return MaterializedAgentIdentity|null Identity, or null when not found.
+	 */
+	public function get( int $identity_id ): ?MaterializedAgentIdentity;
+
+	/**
+	 * Resolve an existing identity or create the durable identity record.
+	 *
+	 * Implementations MUST make this operation idempotent for the same normalized
+	 * `(agent_slug, owner_user_id, instance_key)` tuple.
+	 *
+	 * @param AgentIdentityScope  $scope          Logical identity scope.
+	 * @param array<string,mixed> $default_config Initial config for first materialization only.
+	 * @param array<string,mixed> $meta           Optional metadata for first materialization only.
+	 * @return MaterializedAgentIdentity
+	 */
+	public function materialize( AgentIdentityScope $scope, array $default_config = array(), array $meta = array() ): MaterializedAgentIdentity;
+
+	/**
+	 * Persist replacement config and metadata for an existing identity.
+	 *
+	 * @param MaterializedAgentIdentity $identity Replacement identity value.
+	 * @return MaterializedAgentIdentity Updated persisted value.
+	 */
+	public function update( MaterializedAgentIdentity $identity ): MaterializedAgentIdentity;
+
+	/**
+	 * Delete a materialized identity. Idempotent for non-existent identities.
+	 *
+	 * @param AgentIdentityScope $scope Logical identity scope.
+	 * @return bool Whether the operation succeeded.
+	 */
+	public function delete( AgentIdentityScope $scope ): bool;
+}

--- a/tests/bootstrap-smoke.php
+++ b/tests/bootstrap-smoke.php
@@ -25,6 +25,9 @@ $namespace_map = array(
 	'DataMachine\\Engine\\AI\\AgentConversationResult'                      => 'AgentsAPI\\AI\\AgentConversationResult',
 	'DataMachine\\Engine\\AI\\Tools\\RuntimeToolDeclaration'                => 'AgentsAPI\\AI\\Tools\\RuntimeToolDeclaration',
 	'DataMachine\\Core\\Database\\Chat\\ConversationTranscriptStoreInterface' => 'AgentsAPI\\Core\\Database\\Chat\\ConversationTranscriptStoreInterface',
+	'DataMachine\\Core\\Identity\\AgentIdentityScope'                         => 'AgentsAPI\\Core\\Identity\\AgentIdentityScope',
+	'DataMachine\\Core\\Identity\\MaterializedAgentIdentity'                  => 'AgentsAPI\\Core\\Identity\\MaterializedAgentIdentity',
+	'DataMachine\\Core\\Identity\\MaterializedAgentIdentityStoreInterface'     => 'AgentsAPI\\Core\\Identity\\MaterializedAgentIdentityStoreInterface',
 	'DataMachine\\Core\\FilesRepository\\AgentMemoryStoreInterface'           => 'AgentsAPI\\Core\\FilesRepository\\AgentMemoryStoreInterface',
 	'DataMachine\\Core\\FilesRepository\\AgentMemoryScope'                    => 'AgentsAPI\\Core\\FilesRepository\\AgentMemoryScope',
 );
@@ -91,6 +94,7 @@ agents_api_smoke_assert_equals( false, false !== strpos( $bootstrap_source, 'Dat
 
 echo "\n[3] Module source tree uses Agents API vocabulary:\n";
 $expected_source_directories = array(
+	'Identity',
 	'Memory',
 	'Packages',
 	'Registry',

--- a/tests/identity-smoke.php
+++ b/tests/identity-smoke.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Pure-PHP smoke test for the Agents API materialized identity contract.
+ *
+ * Run with: php tests/identity-smoke.php
+ *
+ * @package AgentsAPI\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+$failures = array();
+$passes   = 0;
+
+echo "agents-api-identity-smoke\n";
+
+require_once __DIR__ . '/agents-api-smoke-helpers.php';
+agents_api_smoke_require_module();
+
+echo "\n[1] Agent identity scope normalizes logical identity tuples:\n";
+$scope            = new AgentsAPI\Core\Identity\AgentIdentityScope( 'Research Assistant', 12, ' Site:42 / Primary ' );
+$normalized_scope = $scope->normalize();
+agents_api_smoke_assert_equals( 'research-assistant', $normalized_scope->agent_slug, 'agent slug is normalized like registered agents', $failures, $passes );
+agents_api_smoke_assert_equals( 12, $normalized_scope->owner_user_id, 'owner user ID is preserved', $failures, $passes );
+agents_api_smoke_assert_equals( 'site:42/primary', $normalized_scope->instance_key, 'instance key is normalized but product-addressable', $failures, $passes );
+agents_api_smoke_assert_equals( 'research-assistant:12:site:42/primary', $scope->key(), 'scope key is stable', $failures, $passes );
+
+echo "\n[2] Materialized identity exposes durable store identity without backend coupling:\n";
+$identity = new AgentsAPI\Core\Identity\MaterializedAgentIdentity(
+	23,
+	$scope,
+	array( 'temperature' => 0.2 ),
+	array( 'source' => 'smoke' ),
+	1713370000,
+	1713370500
+);
+agents_api_smoke_assert_equals( '23', $identity->key(), 'identity key uses durable store ID', $failures, $passes );
+agents_api_smoke_assert_equals(
+	array(
+		'id'            => 23,
+		'agent_slug'    => 'research-assistant',
+		'owner_user_id' => 12,
+		'instance_key'  => 'site:42/primary',
+		'config'        => array( 'temperature' => 0.2 ),
+		'meta'          => array( 'source' => 'smoke' ),
+		'created_at'    => 1713370000,
+		'updated_at'    => 1713370500,
+	),
+	$identity->to_array(),
+	'identity exports normalized payload',
+	$failures,
+	$passes
+);
+
+$updated = $identity->with_config( array( 'temperature' => 0.5 ) )->with_meta( array( 'source' => 'updated' ) );
+agents_api_smoke_assert_equals( array( 'temperature' => 0.5 ), $updated->config, 'with_config returns replacement config copy', $failures, $passes );
+agents_api_smoke_assert_equals( array( 'source' => 'updated' ), $updated->meta, 'with_meta returns replacement metadata copy', $failures, $passes );
+agents_api_smoke_assert_equals( array( 'temperature' => 0.2 ), $identity->config, 'original identity remains immutable', $failures, $passes );
+
+echo "\n[3] Identity store contract is available without a concrete backend:\n";
+agents_api_smoke_assert_equals( true, interface_exists( 'AgentsAPI\\Core\\Identity\\MaterializedAgentIdentityStoreInterface' ), 'materialized identity store interface is available', $failures, $passes );
+agents_api_smoke_assert_equals( false, class_exists( 'DataMachine\\Core\\Identity\\MaterializedAgentIdentityStoreInterface', false ) || interface_exists( 'DataMachine\\Core\\Identity\\MaterializedAgentIdentityStoreInterface', false ), 'Data Machine identity store alias is not loaded', $failures, $passes );
+
+agents_api_smoke_finish( 'Agents API materialized identity', $failures, $passes );


### PR DESCRIPTION
## Summary
- Adds Agents API materialized identity primitives: `AgentIdentityScope`, `MaterializedAgentIdentity`, and `MaterializedAgentIdentityStoreInterface`.
- Wires the primitives into the plugin bootstrap and standalone smoke coverage.
- Keeps scope limited to contracts/value objects; no persistence backend, access grants, scoped policy, token binding, schema migration, or consumer migration.

## Source
- Closes https://github.com/Automattic/agents-api/issues/10

## Tests
- `composer test` - passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implementing and validating the materialized identity contract/value object primitives and smoke coverage; Chris remains responsible for review and merge.

## Blockers
- None.
