### PR TITLE
Add execution principal context

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Agents API sits between tool/action discovery and product-specific automation. I
 
 - Agent registration and lookup.
 - Runtime message and result value objects.
+- Agent execution principal/context value objects.
 - Agent package and package-artifact contracts.
 - Agent memory store contracts and value objects.
 - Conversation compaction policy and transcript transformation contracts.
@@ -66,6 +67,7 @@ Register agent definitions from inside a `wp_agents_api_init` callback. Reads su
 - `WP_Agents_Registry`
 - `WP_Agent_Package*` value objects and artifact registry helpers
 - `AgentsAPI\AI\AgentMessageEnvelope`
+- `AgentsAPI\AI\AgentExecutionPrincipal`
 - `AgentsAPI\AI\AgentConversationCompaction`
 - `AgentsAPI\AI\AgentConversationResult`
 - `AgentsAPI\AI\Tools\RuntimeToolDeclaration`

--- a/README.md
+++ b/README.md
@@ -74,6 +74,31 @@ Register agent definitions from inside a `wp_agents_api_init` callback. Reads su
 - `AgentsAPI\Core\Database\Chat\ConversationTranscriptStoreInterface`
 - `AgentsAPI\Core\FilesRepository\AgentMemoryStoreInterface` and memory value objects
 
+## Execution Principals
+
+`AgentsAPI\AI\AgentExecutionPrincipal` represents the actor and agent context for one runtime request. It records the acting WordPress user ID, effective agent ID/slug, auth source, request context, optional token ID, and JSON-friendly request metadata.
+
+Host plugins can resolve the current principal from REST, CLI, cron, bearer-token, or session state through the `agents_api_execution_principal` filter:
+
+```php
+add_filter(
+	'agents_api_execution_principal',
+	static function ( $principal, array $context ) {
+		if ( 'rest' !== ( $context['request_context'] ?? '' ) ) {
+			return $principal;
+		}
+
+		return AgentsAPI\AI\AgentExecutionPrincipal::user_session(
+			get_current_user_id(),
+			(string) ( $context['agent_id'] ?? '' ),
+			'rest'
+		);
+	},
+	10,
+	2
+);
+```
+
 ## Conversation Compaction
 
 Agents can declare support for runtime conversation compaction without tying Agents API to a provider or model executor:

--- a/agents-api.php
+++ b/agents-api.php
@@ -37,6 +37,7 @@ require_once AGENTS_API_PATH . 'src/Registry/register-agents.php';
 require_once AGENTS_API_PATH . 'src/Packages/register-agent-package-artifacts.php';
 require_once AGENTS_API_PATH . 'src/Transcripts/ConversationTranscriptStoreInterface.php';
 require_once AGENTS_API_PATH . 'src/Runtime/AgentMessageEnvelope.php';
+require_once AGENTS_API_PATH . 'src/Runtime/AgentExecutionPrincipal.php';
 require_once AGENTS_API_PATH . 'src/Runtime/AgentConversationCompaction.php';
 require_once AGENTS_API_PATH . 'src/Runtime/AgentConversationResult.php';
 require_once AGENTS_API_PATH . 'src/Tools/RuntimeToolDeclaration.php';

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
   "scripts": {
     "test": [
       "php tests/bootstrap-smoke.php",
+      "php tests/execution-principal-smoke.php",
       "php tests/conversation-compaction-smoke.php",
       "php tests/no-product-imports-smoke.php"
     ]

--- a/src/Runtime/AgentExecutionPrincipal.php
+++ b/src/Runtime/AgentExecutionPrincipal.php
@@ -1,0 +1,133 @@
+<?php
+/**
+ * Agent execution principal context.
+ *
+ * @package AgentsAPI
+ */
+
+namespace AgentsAPI\AI;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Immutable identity context for one agent execution.
+ *
+ * This class records who is acting, which agent is effective for the run, and
+ * how the request was authenticated. It intentionally does not decide access,
+ * grant scoped resources, or persist tokens.
+ */
+// phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Validation exceptions are not rendered output.
+final class AgentExecutionPrincipal {
+
+	public const AUTH_SOURCE_USER                 = 'user';
+	public const AUTH_SOURCE_APPLICATION_PASSWORD = 'application_password';
+	public const AUTH_SOURCE_AGENT_TOKEN          = 'agent_token';
+	public const AUTH_SOURCE_SYSTEM               = 'system';
+
+	/**
+	 * @param int         $acting_user_id       WordPress user ID on whose behalf the run executes. 0 = system/anonymous context.
+	 * @param string      $effective_agent_slug Registered agent slug effective for the run.
+	 * @param string      $auth_source          Authentication source identifier.
+	 * @param int|null    $token_id             Optional caller-owned token identifier. Agents API does not load or store the token.
+	 * @param array       $request_metadata     JSON-serializable request metadata supplied by the caller.
+	 */
+	public function __construct(
+		public readonly int $acting_user_id,
+		public readonly string $effective_agent_slug,
+		public readonly string $auth_source,
+		public readonly ?int $token_id = null,
+		public readonly array $request_metadata = array(),
+	) {
+		if ( $this->acting_user_id < 0 ) {
+			throw self::invalid( 'acting_user_id', 'must be zero or a positive integer' );
+		}
+
+		if ( '' === $this->effective_agent_slug ) {
+			throw self::invalid( 'effective_agent_slug', 'must be a non-empty string' );
+		}
+
+		if ( '' === $this->auth_source ) {
+			throw self::invalid( 'auth_source', 'must be a non-empty string' );
+		}
+
+		if ( null !== $this->token_id && $this->token_id <= 0 ) {
+			throw self::invalid( 'token_id', 'must be null or a positive integer' );
+		}
+
+		if ( false === self::jsonEncode( $this->request_metadata ) ) {
+			throw self::invalid( 'request_metadata', 'must be JSON serializable' );
+		}
+	}
+
+	/**
+	 * Build a principal from a request/context array.
+	 *
+	 * @param array $principal Raw principal fields.
+	 * @return self
+	 */
+	public static function from_array( array $principal ): self {
+		return new self(
+			isset( $principal['acting_user_id'] ) ? (int) $principal['acting_user_id'] : 0,
+			isset( $principal['effective_agent_slug'] ) ? (string) $principal['effective_agent_slug'] : '',
+			isset( $principal['auth_source'] ) ? (string) $principal['auth_source'] : '',
+			isset( $principal['token_id'] ) ? (int) $principal['token_id'] : null,
+			isset( $principal['request_metadata'] ) && is_array( $principal['request_metadata'] ) ? $principal['request_metadata'] : array()
+		);
+	}
+
+	/**
+	 * Export the principal to a stable, JSON-friendly shape.
+	 *
+	 * @return array<string, mixed>
+	 */
+	public function to_array(): array {
+		return array(
+			'acting_user_id'       => $this->acting_user_id,
+			'effective_agent_slug' => $this->effective_agent_slug,
+			'auth_source'          => $this->auth_source,
+			'token_id'             => $this->token_id,
+			'request_metadata'     => $this->request_metadata,
+		);
+	}
+
+	/**
+	 * Return a copy with additional request metadata.
+	 *
+	 * @param array $request_metadata Replacement request metadata.
+	 * @return self
+	 */
+	public function with_request_metadata( array $request_metadata ): self {
+		return new self(
+			$this->acting_user_id,
+			$this->effective_agent_slug,
+			$this->auth_source,
+			$this->token_id,
+			$request_metadata
+		);
+	}
+
+	/**
+	 * Encode JSON without throwing on older PHP configurations.
+	 *
+	 * @param mixed $value Value to encode.
+	 * @return string|false
+	 */
+	private static function jsonEncode( $value ) {
+		try {
+			return json_encode( $value, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR );
+		} catch ( \JsonException $e ) {
+			return false;
+		}
+	}
+
+	/**
+	 * Build a machine-readable validation exception.
+	 *
+	 * @param string $path Field path.
+	 * @param string $reason Failure reason.
+	 * @return \InvalidArgumentException Validation exception.
+	 */
+	private static function invalid( string $path, string $reason ): \InvalidArgumentException {
+		return new \InvalidArgumentException( 'invalid_agent_execution_principal: ' . $path . ' ' . $reason );
+	}
+}

--- a/src/Runtime/AgentExecutionPrincipal.php
+++ b/src/Runtime/AgentExecutionPrincipal.php
@@ -24,17 +24,24 @@ final class AgentExecutionPrincipal {
 	public const AUTH_SOURCE_AGENT_TOKEN          = 'agent_token';
 	public const AUTH_SOURCE_SYSTEM               = 'system';
 
+	public const REQUEST_CONTEXT_REST = 'rest';
+	public const REQUEST_CONTEXT_CLI  = 'cli';
+	public const REQUEST_CONTEXT_CRON = 'cron';
+	public const REQUEST_CONTEXT_CHAT = 'chat';
+
 	/**
-	 * @param int         $acting_user_id       WordPress user ID on whose behalf the run executes. 0 = system/anonymous context.
-	 * @param string      $effective_agent_slug Registered agent slug effective for the run.
-	 * @param string      $auth_source          Authentication source identifier.
-	 * @param int|null    $token_id             Optional caller-owned token identifier. Agents API does not load or store the token.
-	 * @param array       $request_metadata     JSON-serializable request metadata supplied by the caller.
+	 * @param int         $acting_user_id    WordPress user ID on whose behalf the run executes. 0 = system/anonymous context.
+	 * @param string      $effective_agent_id Registered agent ID/slug effective for the run.
+	 * @param string      $auth_source       Authentication source identifier.
+	 * @param string      $request_context   Request context such as rest, cli, cron, or chat.
+	 * @param int|null    $token_id          Optional caller-owned token identifier. Agents API does not load or store the token.
+	 * @param array       $request_metadata  JSON-serializable request metadata supplied by the caller.
 	 */
 	public function __construct(
 		public readonly int $acting_user_id,
-		public readonly string $effective_agent_slug,
+		public readonly string $effective_agent_id,
 		public readonly string $auth_source,
+		public readonly string $request_context,
 		public readonly ?int $token_id = null,
 		public readonly array $request_metadata = array(),
 	) {
@@ -42,12 +49,16 @@ final class AgentExecutionPrincipal {
 			throw self::invalid( 'acting_user_id', 'must be zero or a positive integer' );
 		}
 
-		if ( '' === $this->effective_agent_slug ) {
-			throw self::invalid( 'effective_agent_slug', 'must be a non-empty string' );
+		if ( '' === $this->effective_agent_id ) {
+			throw self::invalid( 'effective_agent_id', 'must be a non-empty string' );
 		}
 
 		if ( '' === $this->auth_source ) {
 			throw self::invalid( 'auth_source', 'must be a non-empty string' );
+		}
+
+		if ( '' === $this->request_context ) {
+			throw self::invalid( 'request_context', 'must be a non-empty string' );
 		}
 
 		if ( null !== $this->token_id && $this->token_id <= 0 ) {
@@ -60,6 +71,61 @@ final class AgentExecutionPrincipal {
 	}
 
 	/**
+	 * Resolve a principal through host-provided request hooks.
+	 *
+	 * Host plugins can derive principals from REST, CLI, cron, bearer-token, or
+	 * user-session state by returning either an AgentExecutionPrincipal instance
+	 * or a raw principal array from the `agents_api_execution_principal` filter.
+	 *
+	 * @param array<string, mixed> $request_context Request-specific context for resolvers.
+	 * @return self|null Principal when a resolver provides one.
+	 */
+	public static function resolve( array $request_context = array() ): ?self {
+		$principal = null;
+
+		if ( function_exists( 'apply_filters' ) ) {
+			$principal = apply_filters( 'agents_api_execution_principal', $principal, $request_context );
+		}
+
+		if ( null === $principal || $principal instanceof self ) {
+			return $principal;
+		}
+
+		if ( is_array( $principal ) ) {
+			return self::from_array( $principal );
+		}
+
+		throw self::invalid( 'principal', 'resolver must return null, an array, or an AgentExecutionPrincipal' );
+	}
+
+	/**
+	 * Build a principal from a user-session request shape.
+	 *
+	 * @param int    $acting_user_id    WordPress user ID.
+	 * @param string $effective_agent_id Registered agent ID/slug.
+	 * @param string $request_context   Request context.
+	 * @param array  $request_metadata  Request metadata.
+	 * @return self
+	 */
+	public static function user_session( int $acting_user_id, string $effective_agent_id, string $request_context = self::REQUEST_CONTEXT_REST, array $request_metadata = array() ): self {
+		return new self( $acting_user_id, $effective_agent_id, self::AUTH_SOURCE_USER, $request_context, null, $request_metadata );
+	}
+
+	/**
+	 * Build a principal from a caller-owned agent token shape.
+	 *
+	 * @param int    $acting_user_id    WordPress user ID represented by the token.
+	 * @param string $effective_agent_id Registered agent ID/slug.
+	 * @param int    $token_id          Caller-owned token identifier.
+	 * @param string $request_context   Request context.
+	 * @param array  $request_metadata  Request metadata.
+	 * @return self
+	 */
+	public static function agent_token( int $acting_user_id, string $effective_agent_id, int $token_id, string $request_context = self::REQUEST_CONTEXT_REST, array $request_metadata = array() ): self {
+		return new self( $acting_user_id, $effective_agent_id, self::AUTH_SOURCE_AGENT_TOKEN, $request_context, $token_id, $request_metadata );
+	}
+
+	/**
 	 * Build a principal from a request/context array.
 	 *
 	 * @param array $principal Raw principal fields.
@@ -68,8 +134,9 @@ final class AgentExecutionPrincipal {
 	public static function from_array( array $principal ): self {
 		return new self(
 			isset( $principal['acting_user_id'] ) ? (int) $principal['acting_user_id'] : 0,
-			isset( $principal['effective_agent_slug'] ) ? (string) $principal['effective_agent_slug'] : '',
+			isset( $principal['effective_agent_id'] ) ? (string) $principal['effective_agent_id'] : '',
 			isset( $principal['auth_source'] ) ? (string) $principal['auth_source'] : '',
+			isset( $principal['request_context'] ) ? (string) $principal['request_context'] : '',
 			isset( $principal['token_id'] ) ? (int) $principal['token_id'] : null,
 			isset( $principal['request_metadata'] ) && is_array( $principal['request_metadata'] ) ? $principal['request_metadata'] : array()
 		);
@@ -83,8 +150,9 @@ final class AgentExecutionPrincipal {
 	public function to_array(): array {
 		return array(
 			'acting_user_id'       => $this->acting_user_id,
-			'effective_agent_slug' => $this->effective_agent_slug,
+			'effective_agent_id'   => $this->effective_agent_id,
 			'auth_source'          => $this->auth_source,
+			'request_context'      => $this->request_context,
 			'token_id'             => $this->token_id,
 			'request_metadata'     => $this->request_metadata,
 		);
@@ -99,8 +167,9 @@ final class AgentExecutionPrincipal {
 	public function with_request_metadata( array $request_metadata ): self {
 		return new self(
 			$this->acting_user_id,
-			$this->effective_agent_slug,
+			$this->effective_agent_id,
 			$this->auth_source,
+			$this->request_context,
 			$this->token_id,
 			$request_metadata
 		);

--- a/tests/agents-api-smoke-helpers.php
+++ b/tests/agents-api-smoke-helpers.php
@@ -44,6 +44,27 @@ function do_action( string $hook, ...$args ): void {
 	$GLOBALS['__agents_api_smoke_done'][ $hook ] = ( $GLOBALS['__agents_api_smoke_done'][ $hook ] ?? 0 ) + 1;
 }
 
+function add_filter( string $hook, callable $callback, int $priority = 10, int $accepted_args = 1 ): void {
+	add_action( $hook, $callback, $priority, $accepted_args );
+}
+
+function apply_filters( string $hook, $value, ...$args ) {
+	$GLOBALS['__agents_api_smoke_current'][] = $hook;
+	$callbacks = $GLOBALS['__agents_api_smoke_actions'][ $hook ] ?? array();
+	ksort( $callbacks );
+
+	foreach ( $callbacks as $priority_callbacks ) {
+		foreach ( $priority_callbacks as $callback ) {
+			$value = call_user_func_array( $callback, array_merge( array( $value ), $args ) );
+		}
+	}
+
+	array_pop( $GLOBALS['__agents_api_smoke_current'] );
+	$GLOBALS['__agents_api_smoke_done'][ $hook ] = ( $GLOBALS['__agents_api_smoke_done'][ $hook ] ?? 0 ) + 1;
+
+	return $value;
+}
+
 function doing_action( string $hook ): bool {
 	return in_array( $hook, $GLOBALS['__agents_api_smoke_current'], true );
 }

--- a/tests/bootstrap-smoke.php
+++ b/tests/bootstrap-smoke.php
@@ -21,6 +21,7 @@ agents_api_smoke_require_module();
 
 $namespace_map = array(
 	'DataMachine\\Engine\\AI\\AgentMessageEnvelope'                         => 'AgentsAPI\\AI\\AgentMessageEnvelope',
+	'DataMachine\\Engine\\AI\\AgentExecutionPrincipal'                      => 'AgentsAPI\\AI\\AgentExecutionPrincipal',
 	'DataMachine\\Engine\\AI\\AgentConversationCompaction'                  => 'AgentsAPI\\AI\\AgentConversationCompaction',
 	'DataMachine\\Engine\\AI\\AgentConversationResult'                      => 'AgentsAPI\\AI\\AgentConversationResult',
 	'DataMachine\\Engine\\AI\\Tools\\RuntimeToolDeclaration'                => 'AgentsAPI\\AI\\Tools\\RuntimeToolDeclaration',

--- a/tests/execution-principal-smoke.php
+++ b/tests/execution-principal-smoke.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * Pure-PHP smoke test for execution principal primitives.
+ *
+ * Run with: php tests/execution-principal-smoke.php
+ *
+ * @package AgentsAPI\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+$failures = array();
+$passes   = 0;
+
+echo "agents-api-execution-principal-smoke\n";
+
+require_once __DIR__ . '/agents-api-smoke-helpers.php';
+agents_api_smoke_require_module();
+
+$principal = new AgentsAPI\AI\AgentExecutionPrincipal(
+	123,
+	'content-helper',
+	AgentsAPI\AI\AgentExecutionPrincipal::AUTH_SOURCE_AGENT_TOKEN,
+	456,
+	array(
+		'request_id' => 'req-abc',
+		'transport'  => 'rest',
+	)
+);
+
+agents_api_smoke_assert_equals( 123, $principal->acting_user_id, 'principal records acting user id', $failures, $passes );
+agents_api_smoke_assert_equals( 'content-helper', $principal->effective_agent_slug, 'principal records effective agent slug', $failures, $passes );
+agents_api_smoke_assert_equals( AgentsAPI\AI\AgentExecutionPrincipal::AUTH_SOURCE_AGENT_TOKEN, $principal->auth_source, 'principal records auth source', $failures, $passes );
+agents_api_smoke_assert_equals( 456, $principal->token_id, 'principal records optional token id', $failures, $passes );
+agents_api_smoke_assert_equals( 'req-abc', $principal->request_metadata['request_id'], 'principal records request metadata', $failures, $passes );
+
+$principal_array = $principal->to_array();
+agents_api_smoke_assert_equals( 123, $principal_array['acting_user_id'], 'principal exports acting user id', $failures, $passes );
+agents_api_smoke_assert_equals( 'content-helper', $principal_array['effective_agent_slug'], 'principal exports effective agent slug', $failures, $passes );
+agents_api_smoke_assert_equals( AgentsAPI\AI\AgentExecutionPrincipal::AUTH_SOURCE_AGENT_TOKEN, $principal_array['auth_source'], 'principal exports auth source', $failures, $passes );
+agents_api_smoke_assert_equals( 456, $principal_array['token_id'], 'principal exports token id without token contents', $failures, $passes );
+
+$from_array = AgentsAPI\AI\AgentExecutionPrincipal::from_array(
+	array(
+		'acting_user_id'       => '7',
+		'effective_agent_slug' => 'support-agent',
+		'auth_source'          => AgentsAPI\AI\AgentExecutionPrincipal::AUTH_SOURCE_USER,
+		'request_metadata'     => array( 'ip_hash' => 'abc123' ),
+	)
+);
+agents_api_smoke_assert_equals( 7, $from_array->acting_user_id, 'from_array normalizes acting user id', $failures, $passes );
+agents_api_smoke_assert_equals( null, $from_array->token_id, 'from_array allows absent token id', $failures, $passes );
+agents_api_smoke_assert_equals( array( 'ip_hash' => 'abc123' ), $from_array->request_metadata, 'from_array keeps metadata array', $failures, $passes );
+
+$with_metadata = $from_array->with_request_metadata( array( 'request_id' => 'req-next' ) );
+agents_api_smoke_assert_equals( array( 'request_id' => 'req-next' ), $with_metadata->request_metadata, 'metadata replacement returns updated copy', $failures, $passes );
+agents_api_smoke_assert_equals( array( 'ip_hash' => 'abc123' ), $from_array->request_metadata, 'metadata replacement leaves original immutable', $failures, $passes );
+
+try {
+	new AgentsAPI\AI\AgentExecutionPrincipal( -1, 'agent', AgentsAPI\AI\AgentExecutionPrincipal::AUTH_SOURCE_USER );
+	agents_api_smoke_assert_equals( true, false, 'negative user id is rejected', $failures, $passes );
+} catch ( InvalidArgumentException $e ) {
+	agents_api_smoke_assert_equals( true, str_contains( $e->getMessage(), 'acting_user_id' ), 'negative user id is rejected', $failures, $passes );
+}
+
+try {
+	new AgentsAPI\AI\AgentExecutionPrincipal( 1, '', AgentsAPI\AI\AgentExecutionPrincipal::AUTH_SOURCE_USER );
+	agents_api_smoke_assert_equals( true, false, 'empty effective agent is rejected', $failures, $passes );
+} catch ( InvalidArgumentException $e ) {
+	agents_api_smoke_assert_equals( true, str_contains( $e->getMessage(), 'effective_agent_slug' ), 'empty effective agent is rejected', $failures, $passes );
+}
+
+try {
+	new AgentsAPI\AI\AgentExecutionPrincipal( 1, 'agent', AgentsAPI\AI\AgentExecutionPrincipal::AUTH_SOURCE_USER, 0 );
+	agents_api_smoke_assert_equals( true, false, 'zero token id is rejected', $failures, $passes );
+} catch ( InvalidArgumentException $e ) {
+	agents_api_smoke_assert_equals( true, str_contains( $e->getMessage(), 'token_id' ), 'zero token id is rejected', $failures, $passes );
+}
+
+$resource = fopen( 'php://memory', 'r' );
+try {
+	new AgentsAPI\AI\AgentExecutionPrincipal( 1, 'agent', AgentsAPI\AI\AgentExecutionPrincipal::AUTH_SOURCE_USER, null, array( 'resource' => $resource ) );
+	agents_api_smoke_assert_equals( true, false, 'non-serializable metadata is rejected', $failures, $passes );
+} catch ( InvalidArgumentException $e ) {
+	agents_api_smoke_assert_equals( true, str_contains( $e->getMessage(), 'request_metadata' ), 'non-serializable metadata is rejected', $failures, $passes );
+} finally {
+	if ( is_resource( $resource ) ) {
+		fclose( $resource );
+	}
+}
+
+agents_api_smoke_finish( 'Agents API execution principal', $failures, $passes );

--- a/tests/execution-principal-smoke.php
+++ b/tests/execution-principal-smoke.php
@@ -19,61 +19,105 @@ echo "agents-api-execution-principal-smoke\n";
 require_once __DIR__ . '/agents-api-smoke-helpers.php';
 agents_api_smoke_require_module();
 
-$principal = new AgentsAPI\AI\AgentExecutionPrincipal(
+$principal = AgentsAPI\AI\AgentExecutionPrincipal::agent_token(
 	123,
 	'content-helper',
-	AgentsAPI\AI\AgentExecutionPrincipal::AUTH_SOURCE_AGENT_TOKEN,
 	456,
+	AgentsAPI\AI\AgentExecutionPrincipal::REQUEST_CONTEXT_REST,
 	array(
 		'request_id' => 'req-abc',
-		'transport'  => 'rest',
+		'transport'  => AgentsAPI\AI\AgentExecutionPrincipal::REQUEST_CONTEXT_REST,
 	)
 );
 
 agents_api_smoke_assert_equals( 123, $principal->acting_user_id, 'principal records acting user id', $failures, $passes );
-agents_api_smoke_assert_equals( 'content-helper', $principal->effective_agent_slug, 'principal records effective agent slug', $failures, $passes );
+agents_api_smoke_assert_equals( 'content-helper', $principal->effective_agent_id, 'principal records effective agent id', $failures, $passes );
 agents_api_smoke_assert_equals( AgentsAPI\AI\AgentExecutionPrincipal::AUTH_SOURCE_AGENT_TOKEN, $principal->auth_source, 'principal records auth source', $failures, $passes );
+agents_api_smoke_assert_equals( AgentsAPI\AI\AgentExecutionPrincipal::REQUEST_CONTEXT_REST, $principal->request_context, 'principal records request context', $failures, $passes );
 agents_api_smoke_assert_equals( 456, $principal->token_id, 'principal records optional token id', $failures, $passes );
 agents_api_smoke_assert_equals( 'req-abc', $principal->request_metadata['request_id'], 'principal records request metadata', $failures, $passes );
 
 $principal_array = $principal->to_array();
 agents_api_smoke_assert_equals( 123, $principal_array['acting_user_id'], 'principal exports acting user id', $failures, $passes );
-agents_api_smoke_assert_equals( 'content-helper', $principal_array['effective_agent_slug'], 'principal exports effective agent slug', $failures, $passes );
+agents_api_smoke_assert_equals( 'content-helper', $principal_array['effective_agent_id'], 'principal exports effective agent id', $failures, $passes );
 agents_api_smoke_assert_equals( AgentsAPI\AI\AgentExecutionPrincipal::AUTH_SOURCE_AGENT_TOKEN, $principal_array['auth_source'], 'principal exports auth source', $failures, $passes );
+agents_api_smoke_assert_equals( AgentsAPI\AI\AgentExecutionPrincipal::REQUEST_CONTEXT_REST, $principal_array['request_context'], 'principal exports request context', $failures, $passes );
 agents_api_smoke_assert_equals( 456, $principal_array['token_id'], 'principal exports token id without token contents', $failures, $passes );
 
 $from_array = AgentsAPI\AI\AgentExecutionPrincipal::from_array(
 	array(
 		'acting_user_id'       => '7',
-		'effective_agent_slug' => 'support-agent',
+		'effective_agent_id'   => 'support-agent',
 		'auth_source'          => AgentsAPI\AI\AgentExecutionPrincipal::AUTH_SOURCE_USER,
+		'request_context'      => AgentsAPI\AI\AgentExecutionPrincipal::REQUEST_CONTEXT_CHAT,
 		'request_metadata'     => array( 'ip_hash' => 'abc123' ),
 	)
 );
 agents_api_smoke_assert_equals( 7, $from_array->acting_user_id, 'from_array normalizes acting user id', $failures, $passes );
+agents_api_smoke_assert_equals( 'support-agent', $from_array->effective_agent_id, 'from_array normalizes effective agent id', $failures, $passes );
 agents_api_smoke_assert_equals( null, $from_array->token_id, 'from_array allows absent token id', $failures, $passes );
+agents_api_smoke_assert_equals( AgentsAPI\AI\AgentExecutionPrincipal::REQUEST_CONTEXT_CHAT, $from_array->request_context, 'from_array normalizes request context', $failures, $passes );
 agents_api_smoke_assert_equals( array( 'ip_hash' => 'abc123' ), $from_array->request_metadata, 'from_array keeps metadata array', $failures, $passes );
+
+$user_session = AgentsAPI\AI\AgentExecutionPrincipal::user_session(
+	99,
+	'editor-agent',
+	AgentsAPI\AI\AgentExecutionPrincipal::REQUEST_CONTEXT_REST,
+	array( 'route' => '/agents/v1/run' )
+);
+agents_api_smoke_assert_equals( 99, $user_session->acting_user_id, 'user_session records acting user id', $failures, $passes );
+agents_api_smoke_assert_equals( 'editor-agent', $user_session->effective_agent_id, 'user_session records effective agent id', $failures, $passes );
+agents_api_smoke_assert_equals( AgentsAPI\AI\AgentExecutionPrincipal::AUTH_SOURCE_USER, $user_session->auth_source, 'user_session records user auth source', $failures, $passes );
+agents_api_smoke_assert_equals( null, $user_session->token_id, 'user_session omits token id', $failures, $passes );
+
+add_filter(
+	'agents_api_execution_principal',
+	static function ( $principal, array $context ) {
+		if ( AgentsAPI\AI\AgentExecutionPrincipal::REQUEST_CONTEXT_REST !== ( $context['request_context'] ?? '' ) ) {
+			return $principal;
+		}
+
+		return array(
+			'acting_user_id'       => 42,
+			'effective_agent_id'   => 'token-agent',
+			'auth_source'          => AgentsAPI\AI\AgentExecutionPrincipal::AUTH_SOURCE_AGENT_TOKEN,
+			'request_context'      => $context['request_context'],
+			'token_id'             => 321,
+			'request_metadata'     => array( 'credential' => 'bearer' ),
+		);
+	},
+	10,
+	2
+);
+
+$resolved = AgentsAPI\AI\AgentExecutionPrincipal::resolve(
+	array( 'request_context' => AgentsAPI\AI\AgentExecutionPrincipal::REQUEST_CONTEXT_REST )
+);
+agents_api_smoke_assert_equals( 42, $resolved->acting_user_id, 'resolve accepts filter-provided array principal', $failures, $passes );
+agents_api_smoke_assert_equals( 'token-agent', $resolved->effective_agent_id, 'resolve records token effective agent id', $failures, $passes );
+agents_api_smoke_assert_equals( AgentsAPI\AI\AgentExecutionPrincipal::AUTH_SOURCE_AGENT_TOKEN, $resolved->auth_source, 'resolve records token auth source', $failures, $passes );
+agents_api_smoke_assert_equals( 321, $resolved->token_id, 'resolve records token id', $failures, $passes );
 
 $with_metadata = $from_array->with_request_metadata( array( 'request_id' => 'req-next' ) );
 agents_api_smoke_assert_equals( array( 'request_id' => 'req-next' ), $with_metadata->request_metadata, 'metadata replacement returns updated copy', $failures, $passes );
 agents_api_smoke_assert_equals( array( 'ip_hash' => 'abc123' ), $from_array->request_metadata, 'metadata replacement leaves original immutable', $failures, $passes );
 
 try {
-	new AgentsAPI\AI\AgentExecutionPrincipal( -1, 'agent', AgentsAPI\AI\AgentExecutionPrincipal::AUTH_SOURCE_USER );
+	new AgentsAPI\AI\AgentExecutionPrincipal( -1, 'agent', AgentsAPI\AI\AgentExecutionPrincipal::AUTH_SOURCE_USER, AgentsAPI\AI\AgentExecutionPrincipal::REQUEST_CONTEXT_REST );
 	agents_api_smoke_assert_equals( true, false, 'negative user id is rejected', $failures, $passes );
 } catch ( InvalidArgumentException $e ) {
 	agents_api_smoke_assert_equals( true, str_contains( $e->getMessage(), 'acting_user_id' ), 'negative user id is rejected', $failures, $passes );
 }
 
 try {
-	new AgentsAPI\AI\AgentExecutionPrincipal( 1, '', AgentsAPI\AI\AgentExecutionPrincipal::AUTH_SOURCE_USER );
-	agents_api_smoke_assert_equals( true, false, 'empty effective agent is rejected', $failures, $passes );
+	new AgentsAPI\AI\AgentExecutionPrincipal( 1, '', AgentsAPI\AI\AgentExecutionPrincipal::AUTH_SOURCE_USER, AgentsAPI\AI\AgentExecutionPrincipal::REQUEST_CONTEXT_REST );
+	agents_api_smoke_assert_equals( true, false, 'empty effective agent id is rejected', $failures, $passes );
 } catch ( InvalidArgumentException $e ) {
-	agents_api_smoke_assert_equals( true, str_contains( $e->getMessage(), 'effective_agent_slug' ), 'empty effective agent is rejected', $failures, $passes );
+	agents_api_smoke_assert_equals( true, str_contains( $e->getMessage(), 'effective_agent_id' ), 'empty effective agent id is rejected', $failures, $passes );
 }
 
 try {
-	new AgentsAPI\AI\AgentExecutionPrincipal( 1, 'agent', AgentsAPI\AI\AgentExecutionPrincipal::AUTH_SOURCE_USER, 0 );
+	new AgentsAPI\AI\AgentExecutionPrincipal( 1, 'agent', AgentsAPI\AI\AgentExecutionPrincipal::AUTH_SOURCE_USER, AgentsAPI\AI\AgentExecutionPrincipal::REQUEST_CONTEXT_REST, 0 );
 	agents_api_smoke_assert_equals( true, false, 'zero token id is rejected', $failures, $passes );
 } catch ( InvalidArgumentException $e ) {
 	agents_api_smoke_assert_equals( true, str_contains( $e->getMessage(), 'token_id' ), 'zero token id is rejected', $failures, $passes );
@@ -81,7 +125,7 @@ try {
 
 $resource = fopen( 'php://memory', 'r' );
 try {
-	new AgentsAPI\AI\AgentExecutionPrincipal( 1, 'agent', AgentsAPI\AI\AgentExecutionPrincipal::AUTH_SOURCE_USER, null, array( 'resource' => $resource ) );
+	new AgentsAPI\AI\AgentExecutionPrincipal( 1, 'agent', AgentsAPI\AI\AgentExecutionPrincipal::AUTH_SOURCE_USER, AgentsAPI\AI\AgentExecutionPrincipal::REQUEST_CONTEXT_REST, null, array( 'resource' => $resource ) );
 	agents_api_smoke_assert_equals( true, false, 'non-serializable metadata is rejected', $failures, $passes );
 } catch ( InvalidArgumentException $e ) {
 	agents_api_smoke_assert_equals( true, str_contains( $e->getMessage(), 'request_metadata' ), 'non-serializable metadata is rejected', $failures, $passes );


### PR DESCRIPTION
## Summary
- Add `AgentsAPI\AI\AgentExecutionPrincipal` as an immutable runtime context for acting user, effective agent ID/slug, auth source, request context, optional token ID, and request metadata.
- Add user-session and agent-token construction helpers plus the `agents_api_execution_principal` resolver filter for host plugins.
- Expose and document the primitive while keeping access policy, scoped grants, token storage, and conversation-loop behavior out of scope.

## Source
- Fixes https://github.com/Automattic/agents-api/issues/12

## Tests
- `composer test` - passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the execution principal primitive, resolver hook, smoke tests, and docs; Chris remains responsible for review and validation.