### PR TITLE
Run CI through Homeboy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,22 +12,31 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  smoke-tests:
-    name: Composer smoke tests
+  homeboy:
+    name: Homeboy (${{ matrix.command }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        command: [lint, test]
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+      - uses: actions/checkout@v4
         with:
-          php-version: '8.1'
-          coverage: none
+          fetch-depth: 0
 
-      - name: Install dependencies
-        run: composer install --no-interaction --no-progress --prefer-dist
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        continue-on-error: true
+        with:
+          app-id: ${{ secrets.HOMEBOY_APP_ID }}
+          private-key: ${{ secrets.HOMEBOY_APP_PRIVATE_KEY }}
 
-      - name: Run smoke tests
-        run: composer test
+      - name: Run Homeboy ${{ matrix.command }}
+        uses: Extra-Chill/homeboy-action@v2
+        with:
+          commands: ${{ matrix.command }}
+          expected-commands: lint,test
+          app-token: ${{ steps.app-token.outputs.token || '' }}
+          autofix: 'false'

--- a/agents-api.php
+++ b/agents-api.php
@@ -6,6 +6,7 @@
  * Requires PHP: 8.1
  * Author: Automattic
  * License: GPL-2.0-or-later
+ * Text Domain: agents-api
  *
  * Agents API bootstrap.
  *

--- a/homeboy.json
+++ b/homeboy.json
@@ -1,0 +1,10 @@
+{
+  "auto_cleanup": false,
+  "extensions": {
+    "wordpress": {
+      "php": "8.1"
+    }
+  },
+  "id": "agents-api",
+  "remote_path": "wp-content/plugins/agents-api"
+}

--- a/src/Runtime/AgentConversationCompaction.php
+++ b/src/Runtime/AgentConversationCompaction.php
@@ -97,11 +97,11 @@ class AgentConversationCompaction {
 		}
 
 		$summary_context = array(
-			'policy'          => $policy,
-			'total_messages'  => $total_messages,
-			'compact_count'   => $cutoff,
-			'retained_count'  => $total_messages - $cutoff,
-			'boundary'        => array(
+			'policy'         => $policy,
+			'total_messages' => $total_messages,
+			'compact_count'  => $cutoff,
+			'retained_count' => $total_messages - $cutoff,
+			'boundary'       => array(
 				'compact_until' => $cutoff - 1,
 				'retain_from'   => $cutoff,
 			),
@@ -139,8 +139,8 @@ class AgentConversationCompaction {
 			)
 		);
 
-		$compacted_messages = array_merge( array( $summary_message ), array_slice( $normalized_messages, $cutoff ) );
-		$complete_context   = $summary_context;
+		$compacted_messages                  = array_merge( array( $summary_message ), array_slice( $normalized_messages, $cutoff ) );
+		$complete_context                    = $summary_context;
 		$complete_context['summary_message'] = $summary_message;
 
 		return self::result(
@@ -159,8 +159,9 @@ class AgentConversationCompaction {
 	 * @return int Boundary index.
 	 */
 	public static function select_boundary( array $messages, array $policy ): int {
-		$policy = self::normalize_policy( $policy );
-		$cutoff = max( 0, count( $messages ) - $policy['recent_messages'] );
+		$policy          = self::normalize_policy( $policy );
+		$recent_messages = (int) $policy['recent_messages'];
+		$cutoff          = max( 0, count( $messages ) - $recent_messages );
 
 		if ( ! $policy['preserve_tool_boundaries'] ) {
 			return $cutoff;
@@ -184,7 +185,7 @@ class AgentConversationCompaction {
 	 * @param string                           $status   Compaction status.
 	 * @param array<string, mixed>             $metadata Compaction metadata.
 	 * @param array<int, array<string, mixed>> $events   Lifecycle events.
-	 * @return array<string, mixed>
+	 * @return array{messages: array<int, array<string, mixed>>, metadata: array<string, mixed>, events: array<int, array<string, mixed>>}
 	 */
 	private static function result( array $messages, string $status, array $metadata, array $events ): array {
 		$metadata['status'] = $status;

--- a/src/Runtime/AgentExecutionPrincipal.php
+++ b/src/Runtime/AgentExecutionPrincipal.php
@@ -149,12 +149,12 @@ final class AgentExecutionPrincipal {
 	 */
 	public function to_array(): array {
 		return array(
-			'acting_user_id'       => $this->acting_user_id,
-			'effective_agent_id'   => $this->effective_agent_id,
-			'auth_source'          => $this->auth_source,
-			'request_context'      => $this->request_context,
-			'token_id'             => $this->token_id,
-			'request_metadata'     => $this->request_metadata,
+			'acting_user_id'     => $this->acting_user_id,
+			'effective_agent_id' => $this->effective_agent_id,
+			'auth_source'        => $this->auth_source,
+			'request_context'    => $this->request_context,
+			'token_id'           => $this->token_id,
+			'request_metadata'   => $this->request_metadata,
 		);
 	}
 
@@ -183,6 +183,7 @@ final class AgentExecutionPrincipal {
 	 */
 	private static function jsonEncode( $value ) {
 		try {
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.json_encode_json_encode -- This pure-PHP value object also runs outside WordPress in smoke tests.
 			return json_encode( $value, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR );
 		} catch ( \JsonException $e ) {
 			return false;


### PR DESCRIPTION
## Summary

- Replace the Composer-only CI workflow with a Homeboy `lint,test` matrix.
- Add minimal `homeboy.json` configuration for the WordPress extension and PHP 8.1 target.
- Fix existing lint/static-analysis findings that would otherwise block the new Homeboy lint gate.

## Notes

- `audit` is intentionally not part of CI yet; it can stay a local/manual check while the audit surface matures.
- `homeboy test` currently activates the plugin but does not discover the existing smoke scripts. Follow-up coverage issue: https://github.com/Automattic/agents-api/issues/27
- Existing Composer smoke coverage was run locally while making this change.

## Verification

- `composer test`
- `homeboy lint --path /Users/chubes/Developer/agents-api@chore-homeboy-ci --summary`
- `homeboy test --path /Users/chubes/Developer/agents-api@chore-homeboy-ci`

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafting the Homeboy CI configuration, fixing lint/static-analysis findings needed for the new gate, and running local verification. Chris remains responsible for review and merge.
