### PR TITLE
Add agent source provenance diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,23 @@ add_action(
 
 Register agent definitions from inside a `wp_agents_api_init` callback. Reads such as `wp_get_agent()` and `wp_has_agent()` are safe after WordPress `init` has fired.
 
+Agents can declare source provenance in `meta` so registration diagnostics can identify which plugin or package owns a slug:
+
+```php
+wp_register_agent(
+	'example-agent',
+	array(
+		'label' => 'Example Agent',
+		'meta'  => array(
+			'source_plugin'  => 'example-plugin/example-plugin.php',
+			'source_type'    => 'bundled-agent',
+			'source_package' => 'example-package',
+			'source_version' => '1.2.3',
+		),
+	)
+);
+```
+
 ## Public Surface
 
 - `wp_agents_api_init`

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
   "scripts": {
     "test": [
       "php tests/bootstrap-smoke.php",
+      "php tests/registry-smoke.php",
       "php tests/execution-principal-smoke.php",
       "php tests/identity-smoke.php",
       "php tests/conversation-compaction-smoke.php",

--- a/src/Registry/class-wp-agent.php
+++ b/src/Registry/class-wp-agent.php
@@ -76,6 +76,10 @@ if ( ! class_exists( 'WP_Agent' ) ) {
 		/**
 		 * Optional metadata.
 		 *
+		 * The following optional keys are reserved for source provenance so
+		 * diagnostics can identify where a registered agent came from:
+		 * source_plugin, source_type, source_package, and source_version.
+		 *
 		 * @var array<string, mixed>
 		 */
 		protected array $meta = array();

--- a/src/Registry/class-wp-agents-registry.php
+++ b/src/Registry/class-wp-agents-registry.php
@@ -50,7 +50,14 @@ if ( ! class_exists( 'WP_Agents_Registry' ) ) {
 			}
 
 			if ( $this->is_registered( $agent->get_slug() ) ) {
-				$this->notice_invalid_registration( __METHOD__, sprintf( 'Agent "%s" is already registered.', $agent->get_slug() ) );
+				$existing_agent = $this->registered_agents[ $agent->get_slug() ];
+				$message        = sprintf( 'Agent "%s" is already registered.', $agent->get_slug() );
+				$source         = $this->format_agent_source( $existing_agent );
+				if ( '' !== $source ) {
+					$message .= ' Existing source: ' . $source . '.';
+				}
+
+				$this->notice_invalid_registration( __METHOD__, $message );
 				return null;
 			}
 
@@ -212,6 +219,36 @@ if ( ! class_exists( 'WP_Agents_Registry' ) ) {
 				$message       = function_exists( 'esc_html' ) ? esc_html( $message ) : $message;
 				_doing_it_wrong( $function_name, $message, '0.71.0' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- _doing_it_wrong receives a message, not direct output.
 			}
+		}
+
+		/**
+		 * Format the registered agent source provenance for diagnostics.
+		 *
+		 * @param WP_Agent $agent Registered agent.
+		 * @return string Human-readable source, or an empty string when unavailable.
+		 */
+		private function format_agent_source( WP_Agent $agent ): string {
+			$meta        = $agent->get_meta();
+			$source_keys = array(
+				'source_plugin'  => 'plugin',
+				'source_type'    => 'type',
+				'source_package' => 'package',
+				'source_version' => 'version',
+			);
+			$parts       = array();
+
+			foreach ( $source_keys as $meta_key => $label ) {
+				if ( ! isset( $meta[ $meta_key ] ) || ! is_scalar( $meta[ $meta_key ] ) ) {
+					continue;
+				}
+
+				$value = trim( (string) $meta[ $meta_key ] );
+				if ( '' !== $value ) {
+					$parts[] = $label . '=' . $value;
+				}
+			}
+
+			return implode( ', ', $parts );
 		}
 	}
 }

--- a/src/Registry/register-agents.php
+++ b/src/Registry/register-agents.php
@@ -15,7 +15,9 @@ if ( ! function_exists( 'wp_register_agent' ) ) {
 	 * collects definitions without deciding whether they should be materialized.
 	 *
 	 * @param string|WP_Agent $agent Agent slug or definition object.
-	 * @param array           $args  Registration arguments.
+	 * @param array           $args  Registration arguments. Use `meta.source_plugin`,
+	 *                               `meta.source_type`, `meta.source_package`, and
+	 *                               `meta.source_version` to declare source provenance.
 	 * @return WP_Agent|null Registered agent, or null on invalid arguments.
 	 */
 	function wp_register_agent( $agent, array $args = array() ): ?WP_Agent {

--- a/tests/registry-smoke.php
+++ b/tests/registry-smoke.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Pure-PHP smoke test for agent registry behavior.
+ *
+ * Run with: php tests/registry-smoke.php
+ *
+ * @package AgentsAPI\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+$failures = array();
+$passes   = 0;
+
+echo "agents-api-registry-smoke\n";
+
+require_once __DIR__ . '/agents-api-smoke-helpers.php';
+agents_api_smoke_require_module();
+
+add_action(
+	'wp_agents_api_init',
+	static function () {
+		wp_register_agent(
+			'collision-agent',
+			array(
+				'label' => 'Collision Agent',
+				'meta'  => array(
+					'source_plugin'  => 'example-plugin/example-plugin.php',
+					'source_type'    => 'bundled-agent',
+					'source_package' => 'example-package',
+					'source_version' => '1.2.3',
+				),
+			)
+		);
+
+		wp_register_agent(
+			'collision-agent',
+			array(
+				'label' => 'Duplicate Collision Agent',
+			)
+		);
+	}
+);
+
+do_action( 'init' );
+
+$registered_agent = wp_get_agent( 'collision-agent' );
+$duplicate_notice = end( $GLOBALS['__agents_api_smoke_wrong'] );
+
+agents_api_smoke_assert_equals( true, $registered_agent instanceof WP_Agent, 'first agent remains registered after duplicate attempt', $failures, $passes );
+agents_api_smoke_assert_equals(
+	array(
+		'source_plugin'  => 'example-plugin/example-plugin.php',
+		'source_type'    => 'bundled-agent',
+		'source_package' => 'example-package',
+		'source_version' => '1.2.3',
+	),
+	$registered_agent instanceof WP_Agent ? $registered_agent->get_meta() : array(),
+	'agent provenance metadata is preserved',
+	$failures,
+	$passes
+);
+agents_api_smoke_assert_equals(
+	true,
+	is_array( $duplicate_notice ) && str_contains( $duplicate_notice['message'], 'Existing source: plugin=example-plugin/example-plugin.php, type=bundled-agent, package=example-package, version=1.2.3.' ),
+	'duplicate agent notice includes existing provenance',
+	$failures,
+	$passes
+);
+
+agents_api_smoke_finish( 'Agents API registry', $failures, $passes );


### PR DESCRIPTION
## Summary
- Documents standard agent source provenance keys under `meta` for `wp_register_agent()` callers.
- Includes existing agent source metadata in duplicate slug registration diagnostics when available.
- Adds a registry smoke test covering provenance preservation and duplicate diagnostic output.

## Tests
- `composer test`

Closes #29

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the provenance diagnostics update, focused smoke coverage, docs, and local verification; Chris remains responsible for review and merge.