### PR TITLE
Add generic conversation loop facade

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,9 @@ It provides generic contracts and value objects that product plugins can build o
 ## Layer Boundary
 
 ```text
-Abilities API  -> actions and tools
-wp-ai-client   -> provider/model prompt execution
-Agents API     -> durable agent runtime substrate
-Products       -> product-specific agent experiences
+wp-ai-client -> provider/model prompt execution and provider capabilities
+Agents API   -> identity, runtime contracts, orchestration contracts, tool mediation contracts, memory/transcripts/sessions
+Consumers    -> product UX, concrete tools, workflows, prompt policy, storage/materialization policy
 ```
 
 Agents API sits between tool/action discovery and product-specific automation. It owns the reusable agent runtime contracts; product plugins own the user-facing product experience.
@@ -26,8 +25,9 @@ Agents API sits between tool/action discovery and product-specific automation. I
 - Agent memory store contracts and value objects.
 - Conversation compaction policy and transcript transformation contracts.
 - Generic multi-turn conversation loop sequencing around caller-owned adapters.
+- Tool-call mediation contracts and runtime tool declaration value objects.
 - Conversation transcript store contracts.
-- Runtime tool declaration value objects.
+- Session and persistence contracts where they are provider-neutral.
 
 ## What Agents API Does Not Own
 
@@ -36,7 +36,7 @@ Agents API sits between tool/action discovery and product-specific automation. I
 - Product UI such as admin pages, settings screens, dashboards, or onboarding.
 - Product CLI commands beyond generic substrate needs.
 - Public REST controllers in v1 unless they are separately designed.
-- Product runner adapters that assemble prompts, choose tools, persist transcripts, or decide product policy.
+- Product runner adapters that assemble prompts, choose concrete tools, materialize storage, or decide product policy.
 
 Products can require Agents API because they build on the substrate. Agents API must not depend on any product plugin, import product classes, mirror a product source tree, or encode product vocabulary as generic runtime API.
 
@@ -140,14 +140,15 @@ Boundary selection preserves tool-call/tool-result integrity by default. If summ
 - Validating each runner response with `AgentConversationResult`.
 - Asking a caller-supplied continuation policy whether another turn is needed.
 
-It does not assemble prompts, select a provider/model, execute tools, choose durable storage, expose admin UI, or define product workflow semantics. Product plugins provide adapters for those concerns and pass them into the loop:
+It does not assemble prompts, select a provider/model, implement concrete tools, choose durable storage, expose admin UI, or define product workflow semantics. Consumers provide adapters for those concerns and pass them into the loop:
 
 ```php
 $result = AgentsAPI\AI\AgentConversationLoop::run(
 	$messages,
 	static function ( array $messages, array $context ): array {
-		// Product adapter assembles prompts, dispatches the model, executes tools,
-		// persists as needed, and returns an AgentConversationResult-shaped array.
+		// Consumer adapter assembles prompts, dispatches the model, invokes concrete
+		// tools through runtime contracts, materializes storage as needed, and
+		// returns an AgentConversationResult-shaped array.
 		return $runner->run_turn( $messages, $context );
 	},
 	array(

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ It provides generic contracts and value objects that product plugins can build o
 Abilities API  -> actions and tools
 wp-ai-client   -> provider/model prompt execution
 Agents API     -> durable agent runtime substrate
-Data Machine   -> automation product consumer
+Products       -> product-specific agent experiences
 ```
 
 Agents API sits between tool/action discovery and product-specific automation. It owns the reusable agent runtime contracts; product plugins own the user-facing product experience.
@@ -25,6 +25,7 @@ Agents API sits between tool/action discovery and product-specific automation. I
 - Agent package and package-artifact contracts.
 - Agent memory store contracts and value objects.
 - Conversation compaction policy and transcript transformation contracts.
+- Generic multi-turn conversation loop sequencing around caller-owned adapters.
 - Conversation transcript store contracts.
 - Runtime tool declaration value objects.
 
@@ -35,8 +36,9 @@ Agents API sits between tool/action discovery and product-specific automation. I
 - Product UI such as admin pages, settings screens, dashboards, or onboarding.
 - Product CLI commands beyond generic substrate needs.
 - Public REST controllers in v1 unless they are separately designed.
+- Product runner adapters that assemble prompts, choose tools, persist transcripts, or decide product policy.
 
-Data Machine is an example consumer and proving ground for these contracts. Agents API must not depend on Data Machine, import Data Machine classes, mirror Data Machine's source tree, or encode Data Machine vocabulary as generic runtime API. Data Machine can require Agents API because it is a product plugin built on the substrate.
+Products can require Agents API because they build on the substrate. Agents API must not depend on any product plugin, import product classes, mirror a product source tree, or encode product vocabulary as generic runtime API.
 
 ## Consumer Integration
 
@@ -70,6 +72,7 @@ Register agent definitions from inside a `wp_agents_api_init` callback. Reads su
 - `AgentsAPI\AI\AgentExecutionPrincipal`
 - `AgentsAPI\AI\AgentConversationCompaction`
 - `AgentsAPI\AI\AgentConversationResult`
+- `AgentsAPI\AI\AgentConversationLoop`
 - `AgentsAPI\AI\Tools\RuntimeToolDeclaration`
 - `AgentsAPI\Core\Database\Chat\ConversationTranscriptStoreInterface`
 - `AgentsAPI\Core\FilesRepository\AgentMemoryStoreInterface` and memory value objects
@@ -126,6 +129,39 @@ wp_register_agent(
 - `events`: `compaction_started`, `compaction_completed`, or `compaction_failed` lifecycle events that streaming clients can relay.
 
 Boundary selection preserves tool-call/tool-result integrity by default. If summarization fails, the original normalized transcript is returned unchanged and a failure event is emitted rather than silently dropping history.
+
+## Conversation Loop Boundary
+
+`AgentsAPI\AI\AgentConversationLoop` is a thin generic loop facade. It owns the reusable mechanics that every multi-turn agent run needs:
+
+- Normalizing inbound messages to `AgentMessageEnvelope`.
+- Optionally applying caller-supplied compaction before each turn.
+- Calling a runner adapter once per turn.
+- Validating each runner response with `AgentConversationResult`.
+- Asking a caller-supplied continuation policy whether another turn is needed.
+
+It does not assemble prompts, select a provider/model, execute tools, choose durable storage, expose admin UI, or define product workflow semantics. Product plugins provide adapters for those concerns and pass them into the loop:
+
+```php
+$result = AgentsAPI\AI\AgentConversationLoop::run(
+	$messages,
+	static function ( array $messages, array $context ): array {
+		// Product adapter assembles prompts, dispatches the model, executes tools,
+		// persists as needed, and returns an AgentConversationResult-shaped array.
+		return $runner->run_turn( $messages, $context );
+	},
+	array(
+		'max_turns'       => 4,
+		'should_continue' => static function ( array $turn_result, array $context ): bool {
+			return $policy->should_continue( $turn_result, $context );
+		},
+		'compaction_policy' => $agent->conversation_compaction_policy,
+		'summarizer'         => $summarizer,
+	)
+);
+```
+
+The loop treats all adapter inputs and outputs as JSON-friendly arrays so products can map them to their own storage, streaming, audit, and transport layers without Agents API owning those layers.
 
 ## Tests
 

--- a/agents-api.php
+++ b/agents-api.php
@@ -43,6 +43,7 @@ require_once AGENTS_API_PATH . 'src/Runtime/AgentMessageEnvelope.php';
 require_once AGENTS_API_PATH . 'src/Runtime/AgentExecutionPrincipal.php';
 require_once AGENTS_API_PATH . 'src/Runtime/AgentConversationCompaction.php';
 require_once AGENTS_API_PATH . 'src/Runtime/AgentConversationResult.php';
+require_once AGENTS_API_PATH . 'src/Runtime/AgentConversationLoop.php';
 require_once AGENTS_API_PATH . 'src/Tools/RuntimeToolDeclaration.php';
 require_once AGENTS_API_PATH . 'src/Memory/AgentMemoryScope.php';
 require_once AGENTS_API_PATH . 'src/Memory/AgentMemoryListEntry.php';

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
       "php tests/execution-principal-smoke.php",
       "php tests/identity-smoke.php",
       "php tests/conversation-compaction-smoke.php",
+      "php tests/conversation-loop-smoke.php",
       "php tests/no-product-imports-smoke.php"
     ]
   }

--- a/src/Runtime/AgentConversationLoop.php
+++ b/src/Runtime/AgentConversationLoop.php
@@ -103,7 +103,7 @@ class AgentConversationLoop {
 		$compaction = AgentConversationCompaction::compact( $messages, $policy, $summarizer );
 		return array(
 			'messages' => $compaction['messages'],
-			'events'   => self::normalize_events( $compaction['events'] ?? array() ),
+			'events'   => self::normalize_events( $compaction['events'] ),
 		);
 	}
 

--- a/src/Runtime/AgentConversationLoop.php
+++ b/src/Runtime/AgentConversationLoop.php
@@ -1,0 +1,141 @@
+<?php
+/**
+ * Generic agent conversation loop facade.
+ *
+ * @package AgentsAPI
+ */
+
+namespace AgentsAPI\AI;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Sequences multi-turn agent execution around caller-owned adapters.
+ *
+ * The loop owns only neutral transcript normalization, optional compaction,
+ * turn sequencing, result validation, and stop-condition dispatch. Product
+ * plugins supply prompt assembly, model dispatch, tool execution, persistence,
+ * and policy decisions through callables.
+ */
+class AgentConversationLoop {
+
+	/**
+	 * Run a conversation loop.
+	 *
+	 * The turn runner receives `(array $messages, array $context)` and must return
+	 * an `AgentConversationResult`-compatible array. The optional continuation
+	 * policy receives `(array $result, array $context)` and returns true when the
+	 * loop should run another turn.
+	 *
+	 * Supported options:
+	 *
+	 * - `max_turns` (int): Maximum turns to run. Defaults to 1.
+	 * - `context` (array): Caller-owned context passed to adapters.
+	 * - `should_continue` (callable|null): Caller-owned continuation policy.
+	 * - `compaction_policy` (array|null): Optional compaction policy.
+	 * - `summarizer` (callable|null): Optional compaction summarizer.
+	 *
+	 * @param array    $messages    Initial transcript messages.
+	 * @param callable $turn_runner Caller-owned turn adapter.
+	 * @param array    $options     Loop options.
+	 * @return array Normalized conversation result.
+	 */
+	public static function run( array $messages, callable $turn_runner, array $options = array() ): array {
+		$max_turns       = self::max_turns( $options['max_turns'] ?? 1 );
+		$context         = isset( $options['context'] ) && is_array( $options['context'] ) ? $options['context'] : array();
+		$should_continue = $options['should_continue'] ?? null;
+		$messages        = AgentMessageEnvelope::normalize_many( $messages );
+		$events          = array();
+		$tool_results    = array();
+
+		for ( $turn = 1; $turn <= $max_turns; ++$turn ) {
+			$turn_context         = $context;
+			$turn_context['turn'] = $turn;
+
+			$compaction = self::maybe_compact( $messages, $options );
+			$messages   = $compaction['messages'];
+			$events     = array_merge( $events, $compaction['events'] );
+
+			$result = call_user_func( $turn_runner, $messages, $turn_context );
+			if ( ! is_array( $result ) ) {
+				throw new \InvalidArgumentException( 'invalid_agent_conversation_loop: turn runner must return an array' );
+			}
+
+			$result       = AgentConversationResult::normalize( $result );
+			$messages     = $result['messages'];
+			$tool_results = array_merge( $tool_results, $result['tool_execution_results'] );
+			$events       = array_merge( $events, self::normalize_events( $result['events'] ?? array() ) );
+
+			if ( ! is_callable( $should_continue ) || ! call_user_func( $should_continue, $result, $turn_context ) ) {
+				break;
+			}
+		}
+
+		return AgentConversationResult::normalize(
+			array(
+				'messages'               => $messages,
+				'tool_execution_results' => $tool_results,
+				'events'                 => $events,
+			)
+		);
+	}
+
+	/**
+	 * Apply optional transcript compaction through caller-owned summarization.
+	 *
+	 * @param array $messages Current messages.
+	 * @param array $options  Loop options.
+	 * @return array{messages: array<int, array<string, mixed>>, events: array<int, array<string, mixed>>}
+	 */
+	private static function maybe_compact( array $messages, array $options ): array {
+		$policy     = $options['compaction_policy'] ?? null;
+		$summarizer = $options['summarizer'] ?? null;
+
+		if ( ! is_array( $policy ) || ! is_callable( $summarizer ) ) {
+			return array(
+				'messages' => $messages,
+				'events'   => array(),
+			);
+		}
+
+		$compaction = AgentConversationCompaction::compact( $messages, $policy, $summarizer );
+		return array(
+			'messages' => $compaction['messages'],
+			'events'   => self::normalize_events( $compaction['events'] ?? array() ),
+		);
+	}
+
+	/**
+	 * Normalize the max turn option.
+	 *
+	 * @param mixed $value Raw option.
+	 * @return int
+	 */
+	private static function max_turns( $value ): int {
+		return max( 1, (int) $value );
+	}
+
+	/**
+	 * Normalize caller-owned lifecycle events.
+	 *
+	 * @param mixed $events Raw events.
+	 * @return array<int, array<string, mixed>>
+	 */
+	private static function normalize_events( $events ): array {
+		if ( ! is_array( $events ) ) {
+			throw new \InvalidArgumentException( 'invalid_agent_conversation_loop: events must be an array' );
+		}
+
+		$normalized = array();
+		foreach ( $events as $event ) {
+			if ( ! is_array( $event ) ) {
+				throw new \InvalidArgumentException( 'invalid_agent_conversation_loop: event must be an array' );
+			}
+			$normalized[] = $event;
+		}
+
+		return $normalized;
+	}
+}

--- a/src/Runtime/AgentConversationLoop.php
+++ b/src/Runtime/AgentConversationLoop.php
@@ -15,9 +15,9 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Sequences multi-turn agent execution around caller-owned adapters.
  *
  * The loop owns only neutral transcript normalization, optional compaction,
- * turn sequencing, result validation, and stop-condition dispatch. Product
- * plugins supply prompt assembly, model dispatch, tool execution, persistence,
- * and policy decisions through callables.
+ * turn sequencing, result validation, and stop-condition dispatch. Callers
+ * supply prompt assembly, provider/model dispatch, concrete tool execution,
+ * persistence, and product policy through adapters.
  */
 class AgentConversationLoop {
 

--- a/tests/bootstrap-smoke.php
+++ b/tests/bootstrap-smoke.php
@@ -53,6 +53,7 @@ agents_api_smoke_assert_equals( true, class_exists( 'WP_Agent_Package_Artifact' 
 agents_api_smoke_assert_equals( true, class_exists( 'WP_Agent_Package_Artifact_Type' ), 'WP_Agent_Package_Artifact_Type value object is available', $failures, $passes );
 agents_api_smoke_assert_equals( true, class_exists( 'WP_Agent_Package_Artifacts_Registry' ), 'WP_Agent_Package_Artifacts_Registry facade is available', $failures, $passes );
 agents_api_smoke_assert_equals( true, defined( 'AGENTS_API_PLUGIN_FILE' ), 'plugin file constant is available', $failures, $passes );
+agents_api_smoke_assert_equals( true, class_exists( 'AgentsAPI\\AI\\AgentConversationLoop' ), 'AgentConversationLoop facade is available', $failures, $passes );
 foreach ( $namespace_map as $legacy_class => $target_class ) {
 	agents_api_smoke_assert_equals( true, class_exists( $target_class ) || interface_exists( $target_class ), $target_class . ' contract is available', $failures, $passes );
 	agents_api_smoke_assert_equals( false, class_exists( $legacy_class, false ) || interface_exists( $legacy_class, false ), $legacy_class . ' compatibility alias is not loaded', $failures, $passes );

--- a/tests/conversation-loop-smoke.php
+++ b/tests/conversation-loop-smoke.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * Pure-PHP smoke test for the Agents API conversation loop facade.
+ *
+ * Run with: php tests/conversation-loop-smoke.php
+ *
+ * @package AgentsAPI\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+$failures = array();
+$passes   = 0;
+
+echo "agents-api-conversation-loop-smoke\n";
+
+require_once __DIR__ . '/agents-api-smoke-helpers.php';
+agents_api_smoke_require_module();
+
+echo "\n[1] Loop delegates turn execution and continuation policy to callers:\n";
+$turns  = array();
+$result = AgentsAPI\AI\AgentConversationLoop::run(
+	array( array( 'role' => 'user', 'content' => 'hello' ) ),
+	static function ( array $messages, array $context ) use ( &$turns ): array {
+		$turns[]    = $context['turn'];
+		$messages[] = AgentsAPI\AI\AgentMessageEnvelope::text( 'assistant', 'turn ' . $context['turn'] );
+
+		return array(
+			'messages'               => $messages,
+			'tool_execution_results' => array(),
+			'events'                 => array(
+				array(
+					'type'     => 'turn_completed',
+					'metadata' => array( 'turn' => $context['turn'] ),
+				),
+			),
+		);
+	},
+	array(
+		'max_turns'       => 2,
+		'should_continue' => static function ( array $turn_result, array $context ): bool {
+			unset( $turn_result );
+			return 1 === $context['turn'];
+		},
+	)
+);
+
+agents_api_smoke_assert_equals( array( 1, 2 ), $turns, 'loop runs until caller policy stops', $failures, $passes );
+agents_api_smoke_assert_equals( 3, count( $result['messages'] ), 'loop returns the final normalized transcript', $failures, $passes );
+agents_api_smoke_assert_equals( 2, count( $result['events'] ), 'loop preserves caller lifecycle events', $failures, $passes );
+
+echo "\n[2] Loop can apply caller-supplied compaction without owning model dispatch:\n";
+$summarized_messages = array();
+$compacted_result    = AgentsAPI\AI\AgentConversationLoop::run(
+	array(
+		array( 'role' => 'user', 'content' => 'one' ),
+		array( 'role' => 'assistant', 'content' => 'two' ),
+		array( 'role' => 'user', 'content' => 'three' ),
+	),
+	static function ( array $messages ) use ( &$summarized_messages ): array {
+		$summarized_messages = $messages;
+		return array(
+			'messages'               => $messages,
+			'tool_execution_results' => array(),
+		);
+	},
+	array(
+		'compaction_policy' => array(
+			'enabled'         => true,
+			'max_messages'    => 2,
+			'recent_messages' => 1,
+		),
+		'summarizer'         => static function ( array $messages ): string {
+			return 'summary of ' . count( $messages ) . ' messages';
+		},
+	)
+);
+
+agents_api_smoke_assert_equals( 2, count( $summarized_messages ), 'turn runner receives compacted transcript', $failures, $passes );
+agents_api_smoke_assert_equals( AgentsAPI\AI\AgentConversationCompaction::EVENT_COMPLETED, $compacted_result['events'][1]['type'], 'loop surfaces compaction lifecycle events', $failures, $passes );
+
+echo "\n[3] Loop validates adapter result shape:\n";
+$threw = false;
+try {
+	AgentsAPI\AI\AgentConversationLoop::run(
+		array( array( 'role' => 'user', 'content' => 'hello' ) ),
+		static function (): string {
+			return 'not an array';
+		}
+	);
+} catch ( InvalidArgumentException $e ) {
+	$threw = str_starts_with( $e->getMessage(), 'invalid_agent_conversation_loop:' );
+}
+agents_api_smoke_assert_equals( true, $threw, 'loop rejects non-array adapter results', $failures, $passes );
+
+agents_api_smoke_finish( 'Agents API conversation loop', $failures, $passes );


### PR DESCRIPTION
## Summary
- Defines the generic loop ownership boundary in the README with product-owned adapters for prompts, tools, storage, and policy.
- Adds `AgentsAPI\AI\AgentConversationLoop` as a thin neutral facade for message normalization, optional compaction, turn sequencing, result validation, and caller-owned continuation policy.
- Covers the loop facade with a focused pure-PHP smoke test.

Closes #32

## Tests
- `composer test`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the loop facade, boundary documentation, smoke tests, and validation steps; Chris remains responsible for review and merge.