### PR TITLE
Add conversation runner contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ It provides generic contracts and value objects that product plugins can build o
 
 ```text
 Abilities API  -> actions and tools
-wp-ai-client   -> provider/model prompt execution
-Agents API     -> durable agent runtime substrate
-Data Machine   -> automation product consumer
+wp-ai-client   -> provider/model prompt execution and provider capabilities
+Agents API     -> agent runtime, orchestration, memory, transcript, and session contracts
+Consumers      -> product UX, concrete tools, workflows, prompt assembly, and storage policy
 ```
 
 Agents API sits between tool/action discovery and product-specific automation. It owns the reusable agent runtime contracts; product plugins own the user-facing product experience.
@@ -20,8 +20,10 @@ Agents API sits between tool/action discovery and product-specific automation. I
 ## What Agents API Owns
 
 - Agent registration and lookup.
-- Runtime message and result value objects.
+- Runtime message, result, and request value objects.
 - Agent execution principal/context value objects.
+- Multi-turn orchestration contracts.
+- Tool-call mediation contracts.
 - Agent package and package-artifact contracts.
 - Agent memory store contracts and value objects.
 - Conversation compaction policy and transcript transformation contracts.
@@ -35,8 +37,6 @@ Agents API sits between tool/action discovery and product-specific automation. I
 - Product UI such as admin pages, settings screens, dashboards, or onboarding.
 - Product CLI commands beyond generic substrate needs.
 - Public REST controllers in v1 unless they are separately designed.
-
-Data Machine is an example consumer and proving ground for these contracts. Agents API must not depend on Data Machine, import Data Machine classes, mirror Data Machine's source tree, or encode Data Machine vocabulary as generic runtime API. Data Machine can require Agents API because it is a product plugin built on the substrate.
 
 ## Consumer Integration
 
@@ -85,6 +85,12 @@ wp_register_agent(
 - `WP_Agent_Package*` value objects and artifact registry helpers
 - `AgentsAPI\AI\AgentMessageEnvelope`
 - `AgentsAPI\AI\AgentExecutionPrincipal`
+- `AgentsAPI\AI\AgentConversationRequest`
+- `AgentsAPI\AI\AgentConversationRunnerInterface`
+- `AgentsAPI\AI\AgentConversationCompletionDecision`
+- `AgentsAPI\AI\AgentConversationCompletionPolicyInterface`
+- `AgentsAPI\AI\AgentConversationTranscriptPersisterInterface`
+- `AgentsAPI\AI\NullAgentConversationTranscriptPersister`
 - `AgentsAPI\AI\AgentConversationCompaction`
 - `AgentsAPI\AI\AgentConversationResult`
 - `AgentsAPI\AI\Tools\RuntimeToolDeclaration`
@@ -126,11 +132,9 @@ wp_register_agent(
 	array(
 		'supports_conversation_compaction' => true,
 		'conversation_compaction_policy'   => array(
-			'enabled'          => true,
-			'max_messages'     => 40,
-			'recent_messages'  => 12,
-			'summary_provider' => 'example-provider',
-			'summary_model'    => 'example-model',
+			'enabled'         => true,
+			'max_messages'    => 40,
+			'recent_messages' => 12,
 		),
 	)
 );

--- a/agents-api.php
+++ b/agents-api.php
@@ -43,6 +43,12 @@ require_once AGENTS_API_PATH . 'src/Transcripts/ConversationTranscriptStoreInter
 require_once AGENTS_API_PATH . 'src/Runtime/AgentMessageEnvelope.php';
 require_once AGENTS_API_PATH . 'src/Runtime/AgentExecutionPrincipal.php';
 require_once AGENTS_API_PATH . 'src/Runtime/AgentCompactionItem.php';
+require_once AGENTS_API_PATH . 'src/Runtime/AgentConversationRequest.php';
+require_once AGENTS_API_PATH . 'src/Runtime/AgentConversationRunnerInterface.php';
+require_once AGENTS_API_PATH . 'src/Runtime/AgentConversationCompletionDecision.php';
+require_once AGENTS_API_PATH . 'src/Runtime/AgentConversationCompletionPolicyInterface.php';
+require_once AGENTS_API_PATH . 'src/Runtime/AgentConversationTranscriptPersisterInterface.php';
+require_once AGENTS_API_PATH . 'src/Runtime/NullAgentConversationTranscriptPersister.php';
 require_once AGENTS_API_PATH . 'src/Runtime/AgentConversationCompaction.php';
 require_once AGENTS_API_PATH . 'src/Runtime/AgentConversationResult.php';
 require_once AGENTS_API_PATH . 'src/Tools/RuntimeToolDeclaration.php';

--- a/agents-api.php
+++ b/agents-api.php
@@ -43,6 +43,7 @@ require_once AGENTS_API_PATH . 'src/Transcripts/ConversationTranscriptStoreInter
 require_once AGENTS_API_PATH . 'src/Runtime/AgentMessageEnvelope.php';
 require_once AGENTS_API_PATH . 'src/Runtime/AgentExecutionPrincipal.php';
 require_once AGENTS_API_PATH . 'src/Runtime/AgentCompactionItem.php';
+require_once AGENTS_API_PATH . 'src/Tools/RuntimeToolDeclaration.php';
 require_once AGENTS_API_PATH . 'src/Runtime/AgentConversationRequest.php';
 require_once AGENTS_API_PATH . 'src/Runtime/AgentConversationRunnerInterface.php';
 require_once AGENTS_API_PATH . 'src/Runtime/AgentConversationCompletionDecision.php';
@@ -51,7 +52,6 @@ require_once AGENTS_API_PATH . 'src/Runtime/AgentConversationTranscriptPersister
 require_once AGENTS_API_PATH . 'src/Runtime/NullAgentConversationTranscriptPersister.php';
 require_once AGENTS_API_PATH . 'src/Runtime/AgentConversationCompaction.php';
 require_once AGENTS_API_PATH . 'src/Runtime/AgentConversationResult.php';
-require_once AGENTS_API_PATH . 'src/Tools/RuntimeToolDeclaration.php';
 require_once AGENTS_API_PATH . 'src/Memory/AgentMemoryScope.php';
 require_once AGENTS_API_PATH . 'src/Memory/AgentMemoryListEntry.php';
 require_once AGENTS_API_PATH . 'src/Memory/AgentMemoryReadResult.php';

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
       "php tests/execution-principal-smoke.php",
       "php tests/identity-smoke.php",
       "php tests/compaction-item-smoke.php",
+      "php tests/conversation-runner-contracts-smoke.php",
       "php tests/conversation-compaction-smoke.php",
       "php tests/no-product-imports-smoke.php"
     ]

--- a/src/Runtime/AgentConversationCompletionDecision.php
+++ b/src/Runtime/AgentConversationCompletionDecision.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Runtime completion decision value.
+ *
+ * @package AgentsAPI
+ */
+
+namespace AgentsAPI\AI;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Immutable completion decision returned by runtime completion policies.
+ */
+class AgentConversationCompletionDecision {
+
+	/** @var bool Whether the current conversation should stop. */
+	private bool $complete;
+
+	/** @var string Optional diagnostic message. */
+	private string $message;
+
+	/** @var array<string, mixed> Optional diagnostic context. */
+	private array $context;
+
+	/**
+	 * @param bool   $complete Whether the current conversation should stop.
+	 * @param string $message  Optional diagnostic message.
+	 * @param array  $context  Optional diagnostic context.
+	 */
+	private function __construct( bool $complete, string $message = '', array $context = array() ) {
+		$this->complete = $complete;
+		$this->message  = $message;
+		$this->context  = $context;
+	}
+
+	/**
+	 * Build a non-completing decision.
+	 *
+	 * @param string $message Optional diagnostic message.
+	 * @param array  $context Optional diagnostic context.
+	 * @return self
+	 */
+	public static function incomplete( string $message = '', array $context = array() ): self {
+		return new self( false, $message, $context );
+	}
+
+	/**
+	 * Build a completing decision.
+	 *
+	 * @param string $message Optional diagnostic message.
+	 * @param array  $context Optional diagnostic context.
+	 * @return self
+	 */
+	public static function complete( string $message = '', array $context = array() ): self {
+		return new self( true, $message, $context );
+	}
+
+	/** @return bool Whether the current conversation should stop. */
+	public function isComplete(): bool {
+		return $this->complete;
+	}
+
+	/** @return string Optional diagnostic message. */
+	public function message(): string {
+		return $this->message;
+	}
+
+	/** @return array<string, mixed> Optional diagnostic context. */
+	public function context(): array {
+		return $this->context;
+	}
+
+	/**
+	 * Return a normalized array representation.
+	 *
+	 * @return array<string, mixed>
+	 */
+	public function to_array(): array {
+		return array(
+			'complete' => $this->complete,
+			'message'  => $this->message,
+			'context'  => $this->context,
+		);
+	}
+}

--- a/src/Runtime/AgentConversationCompletionPolicyInterface.php
+++ b/src/Runtime/AgentConversationCompletionPolicyInterface.php
@@ -17,12 +17,12 @@ interface AgentConversationCompletionPolicyInterface {
 	/**
 	 * Record a tool result and decide whether the runtime should stop.
 	 *
-	 * @param string     $tool_name   Tool name from the model response.
+	 * @param string     $tool_name       Tool name from the assistant response.
 	 * @param array|null $tool_def    Tool definition from the active tool set.
 	 * @param array      $tool_result Tool execution result.
-	 * @param string     $mode        Runtime mode.
-	 * @param int        $turn_count  Current turn count.
+	 * @param array      $runtime_context Caller-owned runtime context.
+	 * @param int        $turn_count      Current turn count.
 	 * @return AgentConversationCompletionDecision Completion decision.
 	 */
-	public function recordToolResult( string $tool_name, ?array $tool_def, array $tool_result, string $mode, int $turn_count ): AgentConversationCompletionDecision;
+	public function recordToolResult( string $tool_name, ?array $tool_def, array $tool_result, array $runtime_context, int $turn_count ): AgentConversationCompletionDecision;
 }

--- a/src/Runtime/AgentConversationCompletionPolicyInterface.php
+++ b/src/Runtime/AgentConversationCompletionPolicyInterface.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Runtime completion policy contract.
+ *
+ * @package AgentsAPI
+ */
+
+namespace AgentsAPI\AI;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Decides whether a tool result completes a conversation run.
+ */
+interface AgentConversationCompletionPolicyInterface {
+
+	/**
+	 * Record a tool result and decide whether the runtime should stop.
+	 *
+	 * @param string     $tool_name   Tool name from the model response.
+	 * @param array|null $tool_def    Tool definition from the active tool set.
+	 * @param array      $tool_result Tool execution result.
+	 * @param string     $mode        Runtime mode.
+	 * @param int        $turn_count  Current turn count.
+	 * @return AgentConversationCompletionDecision Completion decision.
+	 */
+	public function recordToolResult( string $tool_name, ?array $tool_def, array $tool_result, string $mode, int $turn_count ): AgentConversationCompletionDecision;
+}

--- a/src/Runtime/AgentConversationRequest.php
+++ b/src/Runtime/AgentConversationRequest.php
@@ -165,7 +165,7 @@ class AgentConversationRequest {
 	 */
 	private static function jsonEncode( $value ) {
 		try {
-			return json_encode( $value, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR );
+			return wp_json_encode( $value, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR );
 		} catch ( \JsonException $e ) {
 			return false;
 		}

--- a/src/Runtime/AgentConversationRequest.php
+++ b/src/Runtime/AgentConversationRequest.php
@@ -7,11 +7,14 @@
 
 namespace AgentsAPI\AI;
 
+use AgentsAPI\AI\Tools\RuntimeToolDeclaration;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
  * Neutral request object for conversation runner implementations.
  */
+// phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Validation exceptions are not rendered output.
 class AgentConversationRequest {
 
 	public const DEFAULT_MAX_TURNS = 10;
@@ -19,86 +22,49 @@ class AgentConversationRequest {
 	/** @var array<int, array<string, mixed>> Initial conversation messages. */
 	private array $messages;
 
-	/** @var array<int, array<string, mixed>> Available tools. */
+	/** @var array<int, array<string, mixed>> Runtime tool declarations available to the run. */
 	private array $tools;
 
-	/** @var array<string, mixed> Provider/model configuration. */
-	private array $model_config;
+	/** @var AgentExecutionPrincipal|null Execution principal for the run. */
+	private ?AgentExecutionPrincipal $principal;
 
-	/** @var string Execution mode. */
-	private string $mode;
+	/** @var array<string, mixed> Caller-owned runtime context. */
+	private array $runtime_context;
 
-	/** @var array<string, mixed> Runtime payload. */
-	private array $payload;
+	/** @var array<string, mixed> Caller-owned metadata. */
+	private array $metadata;
 
 	/** @var int Maximum turn budget requested by caller. */
 	private int $max_turns;
 
-	/** @var bool Whether to stop after one model turn. */
+	/** @var bool Whether to stop after one orchestration turn. */
 	private bool $single_turn;
 
 	/**
-	 * Build a request from a common runner argument list.
-	 *
-	 * @param array  $messages    Initial conversation messages.
-	 * @param array  $tools       Available tools.
-	 * @param string $provider    Provider identifier.
-	 * @param string $model       Model identifier.
-	 * @param string $mode        Execution mode.
-	 * @param array  $payload     Runtime payload.
-	 * @param int    $max_turns   Maximum conversation turns.
-	 * @param bool   $single_turn Single-turn mode flag.
-	 * @return self Request object.
-	 */
-	public static function fromRunArgs(
-		array $messages,
-		array $tools,
-		string $provider,
-		string $model,
-		string $mode,
-		array $payload = array(),
-		int $max_turns = self::DEFAULT_MAX_TURNS,
-		bool $single_turn = false
-	): self {
-		return new self(
-			$messages,
-			$tools,
-			array(
-				'provider' => $provider,
-				'model'    => $model,
-			),
-			$mode,
-			$payload,
-			$max_turns,
-			$single_turn
-		);
-	}
-
-	/**
-	 * @param array  $messages     Initial conversation messages.
-	 * @param array  $tools        Available tools.
-	 * @param array  $model_config Provider/model configuration.
-	 * @param string $mode         Execution mode.
-	 * @param array  $payload      Runtime payload.
-	 * @param int    $max_turns    Maximum conversation turns.
-	 * @param bool   $single_turn  Single-turn mode flag.
+	 * @param array                         $messages        Initial conversation messages.
+	 * @param array                         $tools           Runtime tool declarations available to the run.
+	 * @param AgentExecutionPrincipal|null  $principal       Execution principal for the run.
+	 * @param array<string, mixed>          $runtime_context Caller-owned runtime context.
+	 * @param array<string, mixed>          $metadata        Caller-owned metadata.
+	 * @param int                           $max_turns       Maximum conversation turns.
+	 * @param bool                          $single_turn     Single-turn orchestration flag.
 	 */
 	public function __construct(
 		array $messages,
 		array $tools,
-		array $model_config,
-		string $mode,
-		array $payload = array(),
+		?AgentExecutionPrincipal $principal = null,
+		array $runtime_context = array(),
+		array $metadata = array(),
 		int $max_turns = self::DEFAULT_MAX_TURNS,
 		bool $single_turn = false
 	) {
-		$this->messages     = AgentMessageEnvelope::normalize_many( $messages );
-		$this->tools        = self::normalize_list_of_arrays( $tools, 'tools' );
-		$this->model_config = self::normalize_model_config( $model_config );
-		$this->mode         = self::normalize_string( $mode, 'mode' );
-		$this->payload      = $payload;
-		$this->max_turns    = max( 1, $max_turns );
-		$this->single_turn  = $single_turn;
+		$this->messages        = AgentMessageEnvelope::normalize_many( $messages );
+		$this->tools           = self::normalize_tools( $tools );
+		$this->principal       = $principal;
+		$this->runtime_context = self::normalize_json_array( $runtime_context, 'runtime_context' );
+		$this->metadata        = self::normalize_json_array( $metadata, 'metadata' );
+		$this->max_turns       = max( 1, $max_turns );
+		$this->single_turn     = $single_turn;
 	}
 
 	/** @return array<int, array<string, mixed>> Initial conversation messages. */
@@ -106,34 +72,24 @@ class AgentConversationRequest {
 		return $this->messages;
 	}
 
-	/** @return array<int, array<string, mixed>> Available tools. */
+	/** @return array<int, array<string, mixed>> Runtime tool declarations available to the run. */
 	public function tools(): array {
 		return $this->tools;
 	}
 
-	/** @return array<string, mixed> Provider/model configuration. */
-	public function modelConfig(): array {
-		return $this->model_config;
+	/** @return AgentExecutionPrincipal|null Execution principal for the run. */
+	public function principal(): ?AgentExecutionPrincipal {
+		return $this->principal;
 	}
 
-	/** @return string Provider identifier. */
-	public function provider(): string {
-		return $this->model_config['provider'];
+	/** @return array<string, mixed> Caller-owned runtime context. */
+	public function runtimeContext(): array {
+		return $this->runtime_context;
 	}
 
-	/** @return string Model identifier. */
-	public function model(): string {
-		return $this->model_config['model'];
-	}
-
-	/** @return string Execution mode. */
-	public function mode(): string {
-		return $this->mode;
-	}
-
-	/** @return array<string, mixed> Runtime payload. */
-	public function payload(): array {
-		return $this->payload;
+	/** @return array<string, mixed> Caller-owned metadata. */
+	public function metadata(): array {
+		return $this->metadata;
 	}
 
 	/** @return int Maximum turn budget requested by caller. */
@@ -141,7 +97,7 @@ class AgentConversationRequest {
 		return $this->max_turns;
 	}
 
-	/** @return bool Whether to stop after one model turn. */
+	/** @return bool Whether to stop after one orchestration turn. */
 	public function singleTurn(): bool {
 		return $this->single_turn;
 	}
@@ -153,60 +109,76 @@ class AgentConversationRequest {
 	 */
 	public function to_array(): array {
 		return array(
-			'messages'     => $this->messages,
-			'tools'        => $this->tools,
-			'model_config' => $this->model_config,
-			'mode'         => $this->mode,
-			'payload'      => $this->payload,
-			'max_turns'    => $this->max_turns,
-			'single_turn'  => $this->single_turn,
+			'messages'        => $this->messages,
+			'tools'           => $this->tools,
+			'principal'       => $this->principal ? $this->principal->to_array() : null,
+			'runtime_context' => $this->runtime_context,
+			'metadata'        => $this->metadata,
+			'max_turns'       => $this->max_turns,
+			'single_turn'     => $this->single_turn,
 		);
 	}
 
 	/**
-	 * Normalize a list whose entries must be arrays.
+	 * Normalize runtime tool declarations.
 	 *
-	 * @param array  $items List items.
-	 * @param string $path  Field path for validation errors.
+	 * @param array $tools Runtime tool declarations.
 	 * @return array<int, array<string, mixed>>
 	 */
-	private static function normalize_list_of_arrays( array $items, string $path ): array {
+	private static function normalize_tools( array $tools ): array {
 		$normalized = array();
-		foreach ( $items as $index => $item ) {
-			if ( ! is_array( $item ) ) {
-				throw new \InvalidArgumentException( 'invalid_agent_conversation_request: ' . $path . '[' . $index . '] must be an array' );
+		foreach ( $tools as $index => $tool ) {
+			if ( ! is_array( $tool ) ) {
+				throw self::invalid( 'tools[' . $index . ']', 'must be an array' );
 			}
-			$normalized[] = $item;
+
+			try {
+				$normalized[] = RuntimeToolDeclaration::normalize( $tool );
+			} catch ( \InvalidArgumentException $error ) {
+				throw self::invalid( 'tools[' . $index . ']', $error->getMessage() );
+			}
 		}
 
 		return $normalized;
 	}
 
 	/**
-	 * Normalize provider/model configuration.
+	 * Validate that a caller-owned array is JSON-serializable.
 	 *
-	 * @param array $model_config Raw model configuration.
+	 * @param array  $value Raw array.
+	 * @param string $path  Field path.
 	 * @return array<string, mixed>
 	 */
-	private static function normalize_model_config( array $model_config ): array {
-		$model_config['provider'] = self::normalize_string( $model_config['provider'] ?? '', 'model_config.provider' );
-		$model_config['model']    = self::normalize_string( $model_config['model'] ?? '', 'model_config.model' );
+	private static function normalize_json_array( array $value, string $path ): array {
+		if ( false === self::jsonEncode( $value ) ) {
+			throw self::invalid( $path, 'must be JSON serializable' );
+		}
 
-		return $model_config;
+		return $value;
 	}
 
 	/**
-	 * Normalize a required non-empty string.
+	 * Encode JSON without throwing on older PHP configurations.
 	 *
-	 * @param mixed  $value Raw value.
-	 * @param string $path  Field path.
-	 * @return string
+	 * @param mixed $value Value to encode.
+	 * @return string|false
 	 */
-	private static function normalize_string( $value, string $path ): string {
-		if ( ! is_string( $value ) || '' === trim( $value ) ) {
-			throw new \InvalidArgumentException( 'invalid_agent_conversation_request: ' . $path . ' must be a non-empty string' );
+	private static function jsonEncode( $value ) {
+		try {
+			return json_encode( $value, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR );
+		} catch ( \JsonException $e ) {
+			return false;
 		}
+	}
 
-		return trim( $value );
+	/**
+	 * Build a machine-readable validation exception.
+	 *
+	 * @param string $path Field path.
+	 * @param string $reason Failure reason.
+	 * @return \InvalidArgumentException Validation exception.
+	 */
+	private static function invalid( string $path, string $reason ): \InvalidArgumentException {
+		return new \InvalidArgumentException( 'invalid_agent_conversation_request: ' . $path . ' ' . $reason );
 	}
 }

--- a/src/Runtime/AgentConversationRequest.php
+++ b/src/Runtime/AgentConversationRequest.php
@@ -1,0 +1,212 @@
+<?php
+/**
+ * Agent conversation runner request contract.
+ *
+ * @package AgentsAPI
+ */
+
+namespace AgentsAPI\AI;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Neutral request object for conversation runner implementations.
+ */
+class AgentConversationRequest {
+
+	public const DEFAULT_MAX_TURNS = 10;
+
+	/** @var array<int, array<string, mixed>> Initial conversation messages. */
+	private array $messages;
+
+	/** @var array<int, array<string, mixed>> Available tools. */
+	private array $tools;
+
+	/** @var array<string, mixed> Provider/model configuration. */
+	private array $model_config;
+
+	/** @var string Execution mode. */
+	private string $mode;
+
+	/** @var array<string, mixed> Runtime payload. */
+	private array $payload;
+
+	/** @var int Maximum turn budget requested by caller. */
+	private int $max_turns;
+
+	/** @var bool Whether to stop after one model turn. */
+	private bool $single_turn;
+
+	/**
+	 * Build a request from a common runner argument list.
+	 *
+	 * @param array  $messages    Initial conversation messages.
+	 * @param array  $tools       Available tools.
+	 * @param string $provider    Provider identifier.
+	 * @param string $model       Model identifier.
+	 * @param string $mode        Execution mode.
+	 * @param array  $payload     Runtime payload.
+	 * @param int    $max_turns   Maximum conversation turns.
+	 * @param bool   $single_turn Single-turn mode flag.
+	 * @return self Request object.
+	 */
+	public static function fromRunArgs(
+		array $messages,
+		array $tools,
+		string $provider,
+		string $model,
+		string $mode,
+		array $payload = array(),
+		int $max_turns = self::DEFAULT_MAX_TURNS,
+		bool $single_turn = false
+	): self {
+		return new self(
+			$messages,
+			$tools,
+			array(
+				'provider' => $provider,
+				'model'    => $model,
+			),
+			$mode,
+			$payload,
+			$max_turns,
+			$single_turn
+		);
+	}
+
+	/**
+	 * @param array  $messages     Initial conversation messages.
+	 * @param array  $tools        Available tools.
+	 * @param array  $model_config Provider/model configuration.
+	 * @param string $mode         Execution mode.
+	 * @param array  $payload      Runtime payload.
+	 * @param int    $max_turns    Maximum conversation turns.
+	 * @param bool   $single_turn  Single-turn mode flag.
+	 */
+	public function __construct(
+		array $messages,
+		array $tools,
+		array $model_config,
+		string $mode,
+		array $payload = array(),
+		int $max_turns = self::DEFAULT_MAX_TURNS,
+		bool $single_turn = false
+	) {
+		$this->messages     = AgentMessageEnvelope::normalize_many( $messages );
+		$this->tools        = self::normalize_list_of_arrays( $tools, 'tools' );
+		$this->model_config = self::normalize_model_config( $model_config );
+		$this->mode         = self::normalize_string( $mode, 'mode' );
+		$this->payload      = $payload;
+		$this->max_turns    = max( 1, $max_turns );
+		$this->single_turn  = $single_turn;
+	}
+
+	/** @return array<int, array<string, mixed>> Initial conversation messages. */
+	public function messages(): array {
+		return $this->messages;
+	}
+
+	/** @return array<int, array<string, mixed>> Available tools. */
+	public function tools(): array {
+		return $this->tools;
+	}
+
+	/** @return array<string, mixed> Provider/model configuration. */
+	public function modelConfig(): array {
+		return $this->model_config;
+	}
+
+	/** @return string Provider identifier. */
+	public function provider(): string {
+		return $this->model_config['provider'];
+	}
+
+	/** @return string Model identifier. */
+	public function model(): string {
+		return $this->model_config['model'];
+	}
+
+	/** @return string Execution mode. */
+	public function mode(): string {
+		return $this->mode;
+	}
+
+	/** @return array<string, mixed> Runtime payload. */
+	public function payload(): array {
+		return $this->payload;
+	}
+
+	/** @return int Maximum turn budget requested by caller. */
+	public function maxTurns(): int {
+		return $this->max_turns;
+	}
+
+	/** @return bool Whether to stop after one model turn. */
+	public function singleTurn(): bool {
+		return $this->single_turn;
+	}
+
+	/**
+	 * Return a normalized array representation.
+	 *
+	 * @return array<string, mixed>
+	 */
+	public function to_array(): array {
+		return array(
+			'messages'     => $this->messages,
+			'tools'        => $this->tools,
+			'model_config' => $this->model_config,
+			'mode'         => $this->mode,
+			'payload'      => $this->payload,
+			'max_turns'    => $this->max_turns,
+			'single_turn'  => $this->single_turn,
+		);
+	}
+
+	/**
+	 * Normalize a list whose entries must be arrays.
+	 *
+	 * @param array  $items List items.
+	 * @param string $path  Field path for validation errors.
+	 * @return array<int, array<string, mixed>>
+	 */
+	private static function normalize_list_of_arrays( array $items, string $path ): array {
+		$normalized = array();
+		foreach ( $items as $index => $item ) {
+			if ( ! is_array( $item ) ) {
+				throw new \InvalidArgumentException( 'invalid_agent_conversation_request: ' . $path . '[' . $index . '] must be an array' );
+			}
+			$normalized[] = $item;
+		}
+
+		return $normalized;
+	}
+
+	/**
+	 * Normalize provider/model configuration.
+	 *
+	 * @param array $model_config Raw model configuration.
+	 * @return array<string, mixed>
+	 */
+	private static function normalize_model_config( array $model_config ): array {
+		$model_config['provider'] = self::normalize_string( $model_config['provider'] ?? '', 'model_config.provider' );
+		$model_config['model']    = self::normalize_string( $model_config['model'] ?? '', 'model_config.model' );
+
+		return $model_config;
+	}
+
+	/**
+	 * Normalize a required non-empty string.
+	 *
+	 * @param mixed  $value Raw value.
+	 * @param string $path  Field path.
+	 * @return string
+	 */
+	private static function normalize_string( $value, string $path ): string {
+		if ( ! is_string( $value ) || '' === trim( $value ) ) {
+			throw new \InvalidArgumentException( 'invalid_agent_conversation_request: ' . $path . ' must be a non-empty string' );
+		}
+
+		return trim( $value );
+	}
+}

--- a/src/Runtime/AgentConversationRunnerInterface.php
+++ b/src/Runtime/AgentConversationRunnerInterface.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Agent conversation runner interface.
+ *
+ * @package AgentsAPI
+ */
+
+namespace AgentsAPI\AI;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Transport-neutral runner boundary for conversation execution.
+ */
+interface AgentConversationRunnerInterface {
+
+	/**
+	 * Run an agent conversation request.
+	 *
+	 * @param AgentConversationRequest $request Conversation request.
+	 * @return array<string, mixed> Raw conversation result shape.
+	 */
+	public function run( AgentConversationRequest $request ): array;
+}

--- a/src/Runtime/AgentConversationTranscriptPersisterInterface.php
+++ b/src/Runtime/AgentConversationTranscriptPersisterInterface.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Runtime transcript persistence contract.
+ *
+ * @package AgentsAPI
+ */
+
+namespace AgentsAPI\AI;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Persists a completed or failed conversation transcript when requested.
+ */
+interface AgentConversationTranscriptPersisterInterface {
+
+	/**
+	 * Persist a runtime transcript.
+	 *
+	 * @param array  $messages Final conversation messages.
+	 * @param string $provider Provider identifier.
+	 * @param string $model    Model identifier.
+	 * @param array  $payload  Runtime payload.
+	 * @param array  $result   Conversation result so far.
+	 * @return string Transcript ID on success, empty string when not persisted.
+	 */
+	public function persist( array $messages, string $provider, string $model, array $payload, array $result ): string;
+}

--- a/src/Runtime/AgentConversationTranscriptPersisterInterface.php
+++ b/src/Runtime/AgentConversationTranscriptPersisterInterface.php
@@ -17,12 +17,10 @@ interface AgentConversationTranscriptPersisterInterface {
 	/**
 	 * Persist a runtime transcript.
 	 *
-	 * @param array  $messages Final conversation messages.
-	 * @param string $provider Provider identifier.
-	 * @param string $model    Model identifier.
-	 * @param array  $payload  Runtime payload.
-	 * @param array  $result   Conversation result so far.
+	 * @param array                    $messages Final conversation messages.
+	 * @param AgentConversationRequest $request  Original conversation request.
+	 * @param array                    $result   Conversation result so far.
 	 * @return string Transcript ID on success, empty string when not persisted.
 	 */
-	public function persist( array $messages, string $provider, string $model, array $payload, array $result ): string;
+	public function persist( array $messages, AgentConversationRequest $request, array $result ): string;
 }

--- a/src/Runtime/NullAgentConversationTranscriptPersister.php
+++ b/src/Runtime/NullAgentConversationTranscriptPersister.php
@@ -17,8 +17,8 @@ class NullAgentConversationTranscriptPersister implements AgentConversationTrans
 	/**
 	 * @inheritDoc
 	 */
-	public function persist( array $messages, string $provider, string $model, array $payload, array $result ): string {
-		unset( $messages, $provider, $model, $payload, $result );
+	public function persist( array $messages, AgentConversationRequest $request, array $result ): string {
+		unset( $messages, $request, $result );
 
 		return '';
 	}

--- a/src/Runtime/NullAgentConversationTranscriptPersister.php
+++ b/src/Runtime/NullAgentConversationTranscriptPersister.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Null transcript persister.
+ *
+ * @package AgentsAPI
+ */
+
+namespace AgentsAPI\AI;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * No-op transcript persistence implementation.
+ */
+class NullAgentConversationTranscriptPersister implements AgentConversationTranscriptPersisterInterface {
+
+	/**
+	 * @inheritDoc
+	 */
+	public function persist( array $messages, string $provider, string $model, array $payload, array $result ): string {
+		unset( $messages, $provider, $model, $payload, $result );
+
+		return '';
+	}
+}

--- a/tests/agents-api-smoke-helpers.php
+++ b/tests/agents-api-smoke-helpers.php
@@ -77,6 +77,10 @@ function esc_html( string $value ): string {
 	return htmlspecialchars( $value, ENT_QUOTES, 'UTF-8' );
 }
 
+function wp_json_encode( $value, int $flags = 0, int $depth = 512 ) {
+	return json_encode( $value, $flags, $depth );
+}
+
 function _doing_it_wrong( string $function_name, string $message, string $version ): void {
 	$GLOBALS['__agents_api_smoke_wrong'][] = array(
 		'function' => $function_name,

--- a/tests/bootstrap-smoke.php
+++ b/tests/bootstrap-smoke.php
@@ -22,6 +22,12 @@ agents_api_smoke_require_module();
 $namespace_map = array(
 	'DataMachine\\Engine\\AI\\AgentMessageEnvelope'                         => 'AgentsAPI\\AI\\AgentMessageEnvelope',
 	'DataMachine\\Engine\\AI\\AgentExecutionPrincipal'                      => 'AgentsAPI\\AI\\AgentExecutionPrincipal',
+	'DataMachine\\Engine\\AI\\AgentConversationRequest'                    => 'AgentsAPI\\AI\\AgentConversationRequest',
+	'DataMachine\\Engine\\AI\\AgentConversationRunnerInterface'            => 'AgentsAPI\\AI\\AgentConversationRunnerInterface',
+	'DataMachine\\Engine\\AI\\AgentConversationCompletionDecision'         => 'AgentsAPI\\AI\\AgentConversationCompletionDecision',
+	'DataMachine\\Engine\\AI\\AgentConversationCompletionPolicyInterface'  => 'AgentsAPI\\AI\\AgentConversationCompletionPolicyInterface',
+	'DataMachine\\Engine\\AI\\AgentConversationTranscriptPersisterInterface' => 'AgentsAPI\\AI\\AgentConversationTranscriptPersisterInterface',
+	'DataMachine\\Engine\\AI\\NullAgentConversationTranscriptPersister'     => 'AgentsAPI\\AI\\NullAgentConversationTranscriptPersister',
 	'DataMachine\\Engine\\AI\\AgentConversationCompaction'                  => 'AgentsAPI\\AI\\AgentConversationCompaction',
 	'DataMachine\\Engine\\AI\\AgentConversationResult'                      => 'AgentsAPI\\AI\\AgentConversationResult',
 	'DataMachine\\Engine\\AI\\Tools\\RuntimeToolDeclaration'                => 'AgentsAPI\\AI\\Tools\\RuntimeToolDeclaration',

--- a/tests/conversation-runner-contracts-smoke.php
+++ b/tests/conversation-runner-contracts-smoke.php
@@ -20,29 +20,40 @@ require_once __DIR__ . '/agents-api-smoke-helpers.php';
 agents_api_smoke_require_module();
 
 echo "\n[1] Conversation requests normalize runner inputs:\n";
-$request = AgentsAPI\AI\AgentConversationRequest::fromRunArgs(
+$principal = AgentsAPI\AI\AgentExecutionPrincipal::user_session( 123, 'example-agent', AgentsAPI\AI\AgentExecutionPrincipal::REQUEST_CONTEXT_REST );
+$request   = new AgentsAPI\AI\AgentConversationRequest(
 	array(
 		array( 'role' => 'user', 'content' => 'Hello' ),
 	),
 	array(
-		array( 'name' => 'lookup', 'description' => 'Look up something.' ),
+		array(
+			'name'        => 'client/lookup',
+			'description' => 'Look up something.',
+			'executor'    => AgentsAPI\AI\Tools\RuntimeToolDeclaration::EXECUTOR_CLIENT,
+			'scope'       => AgentsAPI\AI\Tools\RuntimeToolDeclaration::SCOPE_RUN,
+		),
 	),
-	'example-provider',
-	'example-model',
-	'chat',
+	$principal,
+	array( 'request_kind' => 'interactive' ),
 	array( 'trace_id' => 'abc123' ),
 	0,
 	true
 );
 
 agents_api_smoke_assert_equals( AgentsAPI\AI\AgentMessageEnvelope::SCHEMA, $request->messages()[0]['schema'], 'request messages normalize to envelopes', $failures, $passes );
-agents_api_smoke_assert_equals( 'example-provider', $request->provider(), 'request exposes provider', $failures, $passes );
-agents_api_smoke_assert_equals( 'example-model', $request->model(), 'request exposes model', $failures, $passes );
-agents_api_smoke_assert_equals( 'chat', $request->mode(), 'request exposes mode', $failures, $passes );
+agents_api_smoke_assert_equals( $principal, $request->principal(), 'request exposes execution principal', $failures, $passes );
+agents_api_smoke_assert_equals( 'interactive', $request->runtimeContext()['request_kind'], 'request preserves caller runtime context', $failures, $passes );
 agents_api_smoke_assert_equals( 1, $request->maxTurns(), 'request enforces a positive turn budget', $failures, $passes );
 agents_api_smoke_assert_equals( true, $request->singleTurn(), 'request preserves single-turn flag', $failures, $passes );
-agents_api_smoke_assert_equals( 'abc123', $request->payload()['trace_id'], 'request preserves runtime payload', $failures, $passes );
-agents_api_smoke_assert_equals( 'lookup', $request->tools()[0]['name'], 'request preserves normalized tool list', $failures, $passes );
+agents_api_smoke_assert_equals( 'abc123', $request->metadata()['trace_id'], 'request preserves caller metadata', $failures, $passes );
+agents_api_smoke_assert_equals( 'client/lookup', $request->tools()[0]['name'], 'request preserves normalized tool list', $failures, $passes );
+agents_api_smoke_assert_equals(
+	array( 'messages', 'tools', 'principal', 'runtime_context', 'metadata', 'max_turns', 'single_turn' ),
+	array_keys( $request->to_array() ),
+	'request array exposes only neutral runner keys',
+	$failures,
+	$passes
+);
 
 echo "\n[2] Runner interfaces accept request value objects and result arrays:\n";
 $runner = new class() implements AgentsAPI\AI\AgentConversationRunnerInterface {
@@ -61,40 +72,40 @@ agents_api_smoke_assert_equals( array(), $runner_result['tool_execution_results'
 
 echo "\n[3] Completion decisions and policies are immutable value contracts:\n";
 $policy = new class() implements AgentsAPI\AI\AgentConversationCompletionPolicyInterface {
-	public function recordToolResult( string $tool_name, ?array $tool_def, array $tool_result, string $mode, int $turn_count ): AgentsAPI\AI\AgentConversationCompletionDecision {
-		unset( $tool_def, $mode );
+	public function recordToolResult( string $tool_name, ?array $tool_def, array $tool_result, array $runtime_context, int $turn_count ): AgentsAPI\AI\AgentConversationCompletionDecision {
+		unset( $tool_def );
 
 		return AgentsAPI\AI\AgentConversationCompletionDecision::complete(
 			'tool completed',
 			array(
-				'tool_name'  => $tool_name,
-				'turn_count' => $turn_count,
-				'success'    => $tool_result['success'] ?? false,
+				'tool_name'    => $tool_name,
+				'turn_count'   => $turn_count,
+				'success'      => $tool_result['success'] ?? false,
+				'request_kind' => $runtime_context['request_kind'] ?? '',
 			)
 		);
 	}
 };
 
-$decision = $policy->recordToolResult( 'lookup', null, array( 'success' => true ), 'chat', 2 );
+$decision = $policy->recordToolResult( 'client/lookup', null, array( 'success' => true ), $request->runtimeContext(), 2 );
 agents_api_smoke_assert_equals( true, $decision->isComplete(), 'completion decision marks complete', $failures, $passes );
 agents_api_smoke_assert_equals( 'tool completed', $decision->message(), 'completion decision exposes message', $failures, $passes );
 agents_api_smoke_assert_equals( 2, $decision->context()['turn_count'], 'completion decision exposes context', $failures, $passes );
+agents_api_smoke_assert_equals( 'interactive', $decision->context()['request_kind'], 'completion policy receives runtime context', $failures, $passes );
 agents_api_smoke_assert_equals( true, $decision->to_array()['complete'], 'completion decision has array projection', $failures, $passes );
 agents_api_smoke_assert_equals( false, AgentsAPI\AI\AgentConversationCompletionDecision::incomplete()->isComplete(), 'incomplete decision marks incomplete', $failures, $passes );
 
 echo "\n[4] Transcript persisters expose a no-op implementation:\n";
 $persister = new AgentsAPI\AI\NullAgentConversationTranscriptPersister();
 agents_api_smoke_assert_equals( true, $persister instanceof AgentsAPI\AI\AgentConversationTranscriptPersisterInterface, 'null persister implements contract', $failures, $passes );
-agents_api_smoke_assert_equals( '', $persister->persist( $request->messages(), $request->provider(), $request->model(), $request->payload(), $runner_result ), 'null persister declines persistence with empty ID', $failures, $passes );
+agents_api_smoke_assert_equals( '', $persister->persist( $request->messages(), $request, $runner_result ), 'null persister declines persistence with empty ID', $failures, $passes );
 
 echo "\n[5] Invalid request inputs fail early:\n";
 $threw = false;
 try {
 	new AgentsAPI\AI\AgentConversationRequest(
 		array( array( 'role' => 'user', 'content' => 'Hello' ) ),
-		array( 'not-a-tool-array' ),
-		array( 'provider' => 'example-provider', 'model' => 'example-model' ),
-		'chat'
+		array( 'not-a-tool-array' )
 	);
 } catch ( InvalidArgumentException $error ) {
 	$threw = str_starts_with( $error->getMessage(), 'invalid_agent_conversation_request:' );

--- a/tests/conversation-runner-contracts-smoke.php
+++ b/tests/conversation-runner-contracts-smoke.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * Pure-PHP smoke test for the Agents API conversation runner contracts.
+ *
+ * Run with: php tests/conversation-runner-contracts-smoke.php
+ *
+ * @package AgentsAPI\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+$failures = array();
+$passes   = 0;
+
+echo "agents-api-conversation-runner-contracts-smoke\n";
+
+require_once __DIR__ . '/agents-api-smoke-helpers.php';
+agents_api_smoke_require_module();
+
+echo "\n[1] Conversation requests normalize runner inputs:\n";
+$request = AgentsAPI\AI\AgentConversationRequest::fromRunArgs(
+	array(
+		array( 'role' => 'user', 'content' => 'Hello' ),
+	),
+	array(
+		array( 'name' => 'lookup', 'description' => 'Look up something.' ),
+	),
+	'example-provider',
+	'example-model',
+	'chat',
+	array( 'trace_id' => 'abc123' ),
+	0,
+	true
+);
+
+agents_api_smoke_assert_equals( AgentsAPI\AI\AgentMessageEnvelope::SCHEMA, $request->messages()[0]['schema'], 'request messages normalize to envelopes', $failures, $passes );
+agents_api_smoke_assert_equals( 'example-provider', $request->provider(), 'request exposes provider', $failures, $passes );
+agents_api_smoke_assert_equals( 'example-model', $request->model(), 'request exposes model', $failures, $passes );
+agents_api_smoke_assert_equals( 'chat', $request->mode(), 'request exposes mode', $failures, $passes );
+agents_api_smoke_assert_equals( 1, $request->maxTurns(), 'request enforces a positive turn budget', $failures, $passes );
+agents_api_smoke_assert_equals( true, $request->singleTurn(), 'request preserves single-turn flag', $failures, $passes );
+agents_api_smoke_assert_equals( 'abc123', $request->payload()['trace_id'], 'request preserves runtime payload', $failures, $passes );
+agents_api_smoke_assert_equals( 'lookup', $request->tools()[0]['name'], 'request preserves normalized tool list', $failures, $passes );
+
+echo "\n[2] Runner interfaces accept request value objects and result arrays:\n";
+$runner = new class() implements AgentsAPI\AI\AgentConversationRunnerInterface {
+	public function run( AgentsAPI\AI\AgentConversationRequest $request ): array {
+		return AgentsAPI\AI\AgentConversationResult::normalize(
+			array(
+				'messages' => $request->messages(),
+			)
+		);
+	}
+};
+
+$runner_result = $runner->run( $request );
+agents_api_smoke_assert_equals( 1, count( $runner_result['messages'] ), 'runner returns normalized messages', $failures, $passes );
+agents_api_smoke_assert_equals( array(), $runner_result['tool_execution_results'], 'runner result normalization provides empty tool results', $failures, $passes );
+
+echo "\n[3] Completion decisions and policies are immutable value contracts:\n";
+$policy = new class() implements AgentsAPI\AI\AgentConversationCompletionPolicyInterface {
+	public function recordToolResult( string $tool_name, ?array $tool_def, array $tool_result, string $mode, int $turn_count ): AgentsAPI\AI\AgentConversationCompletionDecision {
+		unset( $tool_def, $mode );
+
+		return AgentsAPI\AI\AgentConversationCompletionDecision::complete(
+			'tool completed',
+			array(
+				'tool_name'  => $tool_name,
+				'turn_count' => $turn_count,
+				'success'    => $tool_result['success'] ?? false,
+			)
+		);
+	}
+};
+
+$decision = $policy->recordToolResult( 'lookup', null, array( 'success' => true ), 'chat', 2 );
+agents_api_smoke_assert_equals( true, $decision->isComplete(), 'completion decision marks complete', $failures, $passes );
+agents_api_smoke_assert_equals( 'tool completed', $decision->message(), 'completion decision exposes message', $failures, $passes );
+agents_api_smoke_assert_equals( 2, $decision->context()['turn_count'], 'completion decision exposes context', $failures, $passes );
+agents_api_smoke_assert_equals( true, $decision->to_array()['complete'], 'completion decision has array projection', $failures, $passes );
+agents_api_smoke_assert_equals( false, AgentsAPI\AI\AgentConversationCompletionDecision::incomplete()->isComplete(), 'incomplete decision marks incomplete', $failures, $passes );
+
+echo "\n[4] Transcript persisters expose a no-op implementation:\n";
+$persister = new AgentsAPI\AI\NullAgentConversationTranscriptPersister();
+agents_api_smoke_assert_equals( true, $persister instanceof AgentsAPI\AI\AgentConversationTranscriptPersisterInterface, 'null persister implements contract', $failures, $passes );
+agents_api_smoke_assert_equals( '', $persister->persist( $request->messages(), $request->provider(), $request->model(), $request->payload(), $runner_result ), 'null persister declines persistence with empty ID', $failures, $passes );
+
+echo "\n[5] Invalid request inputs fail early:\n";
+$threw = false;
+try {
+	new AgentsAPI\AI\AgentConversationRequest(
+		array( array( 'role' => 'user', 'content' => 'Hello' ) ),
+		array( 'not-a-tool-array' ),
+		array( 'provider' => 'example-provider', 'model' => 'example-model' ),
+		'chat'
+	);
+} catch ( InvalidArgumentException $error ) {
+	$threw = str_starts_with( $error->getMessage(), 'invalid_agent_conversation_request:' );
+}
+agents_api_smoke_assert_equals( true, $threw, 'request rejects non-array tool declarations', $failures, $passes );
+
+agents_api_smoke_finish( 'Agents API conversation runner contracts', $failures, $passes );

--- a/tests/conversation-runner-contracts-smoke.php
+++ b/tests/conversation-runner-contracts-smoke.php
@@ -97,7 +97,6 @@ agents_api_smoke_assert_equals( false, AgentsAPI\AI\AgentConversationCompletionD
 
 echo "\n[4] Transcript persisters expose a no-op implementation:\n";
 $persister = new AgentsAPI\AI\NullAgentConversationTranscriptPersister();
-agents_api_smoke_assert_equals( true, $persister instanceof AgentsAPI\AI\AgentConversationTranscriptPersisterInterface, 'null persister implements contract', $failures, $passes );
 agents_api_smoke_assert_equals( '', $persister->persist( $request->messages(), $request, $runner_result ), 'null persister declines persistence with empty ID', $failures, $passes );
 
 echo "\n[5] Invalid request inputs fail early:\n";


### PR DESCRIPTION
## Summary
- Add neutral conversation request, runner, completion policy, completion decision, and transcript persister contracts.
- Add a null transcript persister and bootstrap the new runtime contracts from the plugin entry point.
- Cover request/result normalization and interface/value-object behavior with a focused smoke test.

## Tests
- composer test

Closes #30

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the contract extraction implementation and smoke tests; Chris remains responsible for review and final acceptance.