### PR TITLE
Fix compaction item lint

### DIFF
--- a/src/Runtime/AgentCompactionItem.php
+++ b/src/Runtime/AgentCompactionItem.php
@@ -14,6 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Normalizes ordered compaction inputs into a generic item shape.
  */
+// phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Validation exceptions are not rendered output.
 class AgentCompactionItem {
 
 	public const SCHEMA  = 'agents-api.compaction-item';
@@ -86,8 +87,8 @@ class AgentCompactionItem {
 	 * @return array<string, mixed> Normalized compaction item.
 	 */
 	public static function from_message( array $message, ?int $index = null ): array {
-		$envelope = AgentMessageEnvelope::normalize( $message );
-		$metadata = $envelope['metadata'];
+		$envelope            = AgentMessageEnvelope::normalize( $message );
+		$metadata            = $envelope['metadata'];
 		$metadata['message'] = array(
 			'role'    => $envelope['role'],
 			'payload' => $envelope['payload'],


### PR DESCRIPTION
## Summary

- Align compaction item assignments with the WordPress lint profile.
- Mark validation exception messages as non-rendered output so PHPCS does not treat field names as escaped UI output.

## Verification

- `homeboy lint --path /Users/chubes/Developer/agents-api@fix-compaction-item-lint --summary`
- `composer test`

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Identifying the Homeboy lint regression and drafting the minimal lint-only fix. Chris remains responsible for review and merge.
