### PR TITLE
Add guideline substrate polyfill

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Agents API sits between tool/action discovery and product-specific automation. I
 - Agent execution principal/context value objects.
 - Multi-turn orchestration contracts.
 - Agent package and package-artifact contracts.
+- Shared `wp_guideline` / `wp_guideline_type` storage substrate polyfill when Core/Gutenberg do not provide it.
 - Agent memory store contracts and value objects.
 - Conversation compaction policy and transcript transformation contracts.
 - Generic multi-turn conversation loop sequencing around caller-owned adapters.
@@ -88,6 +89,7 @@ wp_register_agent(
 - `WP_Agent`
 - `WP_Agents_Registry`
 - `WP_Agent_Package*` value objects and artifact registry helpers
+- `wp_guideline_types()` and `WP_Guidelines_Substrate`
 - `AgentsAPI\AI\AgentMessageEnvelope`
 - `AgentsAPI\AI\AgentExecutionPrincipal`
 - `AgentsAPI\AI\AgentConversationRequest`

--- a/agents-api.php
+++ b/agents-api.php
@@ -65,5 +65,8 @@ require_once AGENTS_API_PATH . 'src/Memory/AgentMemoryListEntry.php';
 require_once AGENTS_API_PATH . 'src/Memory/AgentMemoryReadResult.php';
 require_once AGENTS_API_PATH . 'src/Memory/AgentMemoryWriteResult.php';
 require_once AGENTS_API_PATH . 'src/Memory/AgentMemoryStoreInterface.php';
+require_once AGENTS_API_PATH . 'src/Guidelines/guidelines.php';
+require_once AGENTS_API_PATH . 'src/Guidelines/class-wp-guidelines-substrate.php';
 
 add_action( 'init', array( 'WP_Agents_Registry', 'init' ), 10 );
+add_action( 'init', array( 'WP_Guidelines_Substrate', 'register' ), 9 );

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
       "php tests/conversation-compaction-smoke.php",
       "php tests/markdown-section-compaction-smoke.php",
       "php tests/conversation-loop-smoke.php",
+      "php tests/guidelines-substrate-smoke.php",
       "php tests/no-product-imports-smoke.php"
     ]
   }

--- a/src/Guidelines/class-wp-guidelines-substrate.php
+++ b/src/Guidelines/class-wp-guidelines-substrate.php
@@ -1,0 +1,153 @@
+<?php
+/**
+ * Guideline substrate registration.
+ *
+ * @package AgentsAPI
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Registers the shared guideline post type and taxonomy when Core/Gutenberg do not.
+ */
+class WP_Guidelines_Substrate {
+
+	/**
+	 * Post type slug used by the WordPress guideline substrate.
+	 *
+	 * @var string
+	 */
+	const POST_TYPE = 'wp_guideline';
+
+	/**
+	 * Taxonomy slug used to classify guideline posts.
+	 *
+	 * @var string
+	 */
+	const TAXONOMY = 'wp_guideline_type';
+
+	/**
+	 * Register the shared guideline substrate.
+	 */
+	public static function register(): void {
+		self::register_post_type();
+		self::register_taxonomy();
+
+		add_action( 'save_post_' . self::POST_TYPE, '_wp_guidelines_ensure_default_type_term' );
+		add_filter( 'wp_insert_term_data', '_wp_guidelines_maybe_map_term_label', 10, 2 );
+	}
+
+	/**
+	 * Register the guideline post type if no upstream provider has already done so.
+	 */
+	private static function register_post_type(): void {
+		if ( post_type_exists( self::POST_TYPE ) ) {
+			return;
+		}
+
+		register_post_type(
+			self::POST_TYPE,
+			array(
+				'labels'             => array(
+					'name'                     => _x( 'Guidelines', 'post type general name', 'agents-api' ),
+					'singular_name'            => _x( 'Guideline', 'post type singular name', 'agents-api' ),
+					'add_new'                  => __( 'Add Guideline', 'agents-api' ),
+					'add_new_item'             => __( 'Add Guideline', 'agents-api' ),
+					'all_items'                => __( 'All Guidelines', 'agents-api' ),
+					'edit_item'                => __( 'Edit Guideline', 'agents-api' ),
+					'filter_items_list'        => __( 'Filter guidelines list', 'agents-api' ),
+					'item_published'           => __( 'Guideline published.', 'agents-api' ),
+					'item_published_privately' => __( 'Guideline published privately.', 'agents-api' ),
+					'item_reverted_to_draft'   => __( 'Guideline reverted to draft.', 'agents-api' ),
+					'item_scheduled'           => __( 'Guideline scheduled.', 'agents-api' ),
+					'item_updated'             => __( 'Guideline updated.', 'agents-api' ),
+					'items_list'               => __( 'Guidelines list', 'agents-api' ),
+					'items_list_navigation'    => __( 'Guidelines list navigation', 'agents-api' ),
+					'new_item'                 => __( 'New Guideline', 'agents-api' ),
+					'not_found'                => __( 'No guidelines found.', 'agents-api' ),
+					'not_found_in_trash'       => __( 'No guidelines found in Trash.', 'agents-api' ),
+					'search_items'             => __( 'Search Guidelines', 'agents-api' ),
+					'view_item'                => __( 'View Guideline', 'agents-api' ),
+					'view_items'               => __( 'View Guidelines', 'agents-api' ),
+				),
+				'public'             => false,
+				'publicly_queryable' => false,
+				'show_ui'            => true,
+				'show_in_menu'       => false,
+				'show_in_rest'       => true,
+				'rest_base'          => 'guidelines',
+				'capability_type'    => 'guideline',
+				'map_meta_cap'       => true,
+				'capabilities'       => array(
+					'read'                   => 'edit_posts',
+					'create_posts'           => 'publish_posts',
+					'edit_posts'             => 'edit_posts',
+					'publish_posts'          => 'publish_posts',
+					'read_private_posts'     => 'read_private_posts',
+					'edit_private_posts'     => 'edit_private_posts',
+					'edit_published_posts'   => 'edit_published_posts',
+					'delete_private_posts'   => 'delete_private_posts',
+					'delete_published_posts' => 'delete_published_posts',
+					'delete_posts'           => 'delete_posts',
+					'edit_others_posts'      => 'edit_others_posts',
+					'delete_others_posts'    => 'delete_others_posts',
+				),
+				'supports'           => array( 'title', 'editor', 'excerpt', 'author', 'revisions' ),
+				'hierarchical'       => false,
+				'has_archive'        => false,
+				'rewrite'            => false,
+				'query_var'          => false,
+				'can_export'         => true,
+			)
+		);
+	}
+
+	/**
+	 * Register the guideline type taxonomy if no upstream provider has already done so.
+	 */
+	private static function register_taxonomy(): void {
+		if ( taxonomy_exists( self::TAXONOMY ) ) {
+			return;
+		}
+
+		register_taxonomy(
+			self::TAXONOMY,
+			self::POST_TYPE,
+			array(
+				'public'             => false,
+				'publicly_queryable' => false,
+				'hierarchical'       => true,
+				'labels'             => array(
+					'name'                  => _x( 'Guideline Types', 'taxonomy general name', 'agents-api' ),
+					'singular_name'         => _x( 'Guideline Type', 'taxonomy singular name', 'agents-api' ),
+					'add_new_item'          => __( 'Add Guideline Type', 'agents-api' ),
+					'add_or_remove_items'   => __( 'Add or remove guideline types', 'agents-api' ),
+					'back_to_items'         => __( '&larr; Go to Guideline Types', 'agents-api' ),
+					'edit_item'             => __( 'Edit Guideline Type', 'agents-api' ),
+					'item_link'             => __( 'Guideline Type Link', 'agents-api' ),
+					'item_link_description' => __( 'A link to a guideline type.', 'agents-api' ),
+					'items_list'            => __( 'Guideline Types list', 'agents-api' ),
+					'items_list_navigation' => __( 'Guideline Types list navigation', 'agents-api' ),
+					'new_item_name'         => __( 'New Guideline Type Name', 'agents-api' ),
+					'no_terms'              => __( 'No guideline types', 'agents-api' ),
+					'not_found'             => __( 'No guideline types found.', 'agents-api' ),
+					'search_items'          => __( 'Search Guideline Types', 'agents-api' ),
+					'update_item'           => __( 'Update Guideline Type', 'agents-api' ),
+					'view_item'             => __( 'View Guideline Type', 'agents-api' ),
+				),
+				'capabilities'       => array(
+					'manage_terms' => 'manage_categories',
+					'edit_terms'   => 'edit_posts',
+					'delete_terms' => 'delete_categories',
+					'assign_terms' => 'edit_posts',
+				),
+				'query_var'          => false,
+				'rewrite'            => false,
+				'show_ui'            => true,
+				'show_admin_column'  => true,
+				'show_in_nav_menus'  => false,
+				'show_in_rest'       => true,
+			)
+		);
+	}
+}

--- a/src/Guidelines/guidelines.php
+++ b/src/Guidelines/guidelines.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * Guideline public API helpers.
+ *
+ * @package AgentsAPI
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+if ( ! function_exists( 'wp_guideline_types' ) ) {
+	/**
+	 * Returns registered guideline types keyed by slug.
+	 *
+	 * @return array<string, array{title: string}> Slug-keyed guideline type definitions.
+	 */
+	function wp_guideline_types(): array {
+		/**
+		 * Filters the guideline types available on this site.
+		 *
+		 * @param array<string, array{title: string}> $types Slug-keyed guideline type definitions.
+		 */
+		return apply_filters(
+			'wp_guideline_types',
+			array(
+				'artifact' => array(
+					'title' => __( 'Artifact', 'agents-api' ),
+				),
+				'content'  => array(
+					'title' => __( 'Content', 'agents-api' ),
+				),
+			)
+		);
+	}
+}
+
+if ( ! function_exists( '_wp_guidelines_ensure_default_type_term' ) ) {
+	/**
+	 * Assigns the artifact type to guideline posts saved without a type.
+	 *
+	 * @access private
+	 *
+	 * @param int $post_id Saved post ID.
+	 */
+	function _wp_guidelines_ensure_default_type_term( int $post_id ): void {
+		if ( wp_is_post_revision( $post_id ) ) {
+			return;
+		}
+
+		$terms = get_the_terms( $post_id, WP_Guidelines_Substrate::TAXONOMY );
+		if ( is_wp_error( $terms ) || ! empty( $terms ) ) {
+			return;
+		}
+
+		$term = term_exists( 'artifact', WP_Guidelines_Substrate::TAXONOMY );
+		if ( ! $term ) {
+			$term = wp_insert_term( 'artifact', WP_Guidelines_Substrate::TAXONOMY );
+			if ( is_wp_error( $term ) ) {
+				return;
+			}
+		}
+
+		wp_set_object_terms( $post_id, (int) $term['term_id'], WP_Guidelines_Substrate::TAXONOMY );
+	}
+}
+
+if ( ! function_exists( '_wp_guidelines_maybe_map_term_label' ) ) {
+	/**
+	 * Maps lazily-created guideline type slugs to human-readable labels.
+	 *
+	 * @access private
+	 *
+	 * @param array<string, mixed> $data     Term data to be inserted.
+	 * @param string               $taxonomy Taxonomy slug.
+	 * @return array<string, mixed> Possibly modified term data.
+	 */
+	function _wp_guidelines_maybe_map_term_label( array $data, string $taxonomy ): array {
+		if ( WP_Guidelines_Substrate::TAXONOMY !== $taxonomy ) {
+			return $data;
+		}
+
+		if ( ! isset( $data['name'], $data['slug'] ) || $data['name'] !== $data['slug'] ) {
+			return $data;
+		}
+
+		$types = wp_guideline_types();
+		if ( isset( $types[ $data['slug'] ] ) ) {
+			$data['name'] = $types[ $data['slug'] ]['title'];
+		}
+
+		return $data;
+	}
+}

--- a/tests/agents-api-smoke-helpers.php
+++ b/tests/agents-api-smoke-helpers.php
@@ -13,6 +13,19 @@ $GLOBALS['__agents_api_smoke_actions'] = array();
 $GLOBALS['__agents_api_smoke_wrong']   = array();
 $GLOBALS['__agents_api_smoke_current'] = array();
 $GLOBALS['__agents_api_smoke_done']    = array();
+$GLOBALS['__agents_api_smoke_post_types'] = array();
+$GLOBALS['__agents_api_smoke_taxonomies'] = array();
+$GLOBALS['__agents_api_smoke_terms']      = array();
+
+function __( string $text, string $domain = 'default' ): string {
+	unset( $domain );
+	return $text;
+}
+
+function _x( string $text, string $context, string $domain = 'default' ): string {
+	unset( $context, $domain );
+	return $text;
+}
 
 function sanitize_title( string $value ): string {
 	$value = strtolower( $value );
@@ -87,6 +100,66 @@ function _doing_it_wrong( string $function_name, string $message, string $versio
 		'message'  => $message,
 		'version'  => $version,
 	);
+}
+
+function post_type_exists( string $post_type ): bool {
+	return isset( $GLOBALS['__agents_api_smoke_post_types'][ $post_type ] );
+}
+
+function register_post_type( string $post_type, array $args = array() ) {
+	$GLOBALS['__agents_api_smoke_post_types'][ $post_type ] = $args;
+	return (object) array(
+		'name' => $post_type,
+		'args' => $args,
+	);
+}
+
+function taxonomy_exists( string $taxonomy ): bool {
+	return isset( $GLOBALS['__agents_api_smoke_taxonomies'][ $taxonomy ] );
+}
+
+function register_taxonomy( string $taxonomy, $object_type, array $args = array() ) {
+	$GLOBALS['__agents_api_smoke_taxonomies'][ $taxonomy ] = array(
+		'object_type' => $object_type,
+		'args'        => $args,
+	);
+	return (object) array(
+		'name' => $taxonomy,
+		'args' => $args,
+	);
+}
+
+function wp_is_post_revision( int $post_id ) {
+	unset( $post_id );
+	return false;
+}
+
+function get_the_terms( int $post_id, string $taxonomy ) {
+	return $GLOBALS['__agents_api_smoke_object_terms'][ $post_id ][ $taxonomy ] ?? array();
+}
+
+function term_exists( string $term, string $taxonomy ) {
+	return $GLOBALS['__agents_api_smoke_terms'][ $taxonomy ][ $term ] ?? null;
+}
+
+function wp_insert_term( string $term, string $taxonomy, array $args = array() ) {
+	$slug    = isset( $args['slug'] ) ? (string) $args['slug'] : sanitize_title( $term );
+	$term_id = count( $GLOBALS['__agents_api_smoke_terms'][ $taxonomy ] ?? array() ) + 1;
+	$created = array(
+		'term_id' => $term_id,
+		'slug'    => $slug,
+		'name'    => $term,
+	);
+	$GLOBALS['__agents_api_smoke_terms'][ $taxonomy ][ $slug ] = $created;
+	return $created;
+}
+
+function wp_set_object_terms( int $post_id, $terms, string $taxonomy ): void {
+	$GLOBALS['__agents_api_smoke_object_terms'][ $post_id ][ $taxonomy ] = (array) $terms;
+}
+
+function is_wp_error( $value ): bool {
+	return false;
 }
 
 function agents_api_smoke_assert_equals( $expected, $actual, string $name, array &$failures, int &$passes ): void {

--- a/tests/bootstrap-smoke.php
+++ b/tests/bootstrap-smoke.php
@@ -108,6 +108,7 @@ agents_api_smoke_assert_equals( false, false !== strpos( $bootstrap_source, 'Dat
 
 echo "\n[3] Module source tree uses Agents API vocabulary:\n";
 $expected_source_directories = array(
+	'Guidelines',
 	'Identity',
 	'Memory',
 	'Packages',
@@ -129,5 +130,15 @@ agents_api_smoke_assert_equals( $expected_source_directories, $actual_source_dir
 agents_api_smoke_assert_equals( false, is_dir( AGENTS_API_PATH . 'inc/Core' ), 'copied inc/Core tree is absent', $failures, $passes );
 agents_api_smoke_assert_equals( false, is_dir( AGENTS_API_PATH . 'inc/AI' ), 'copied inc/AI tree is absent', $failures, $passes );
 agents_api_smoke_assert_equals( false, is_dir( AGENTS_API_PATH . 'inc' ), 'legacy inc source root is absent', $failures, $passes );
+
+echo "\n[4] Module owns the generic guideline substrate polyfill:\n";
+agents_api_smoke_assert_equals( true, class_exists( 'WP_Guidelines_Substrate' ), 'guideline substrate class is available', $failures, $passes );
+agents_api_smoke_assert_equals( true, function_exists( 'wp_guideline_types' ), 'wp_guideline_types helper is available', $failures, $passes );
+
+do_action( 'init' );
+agents_api_smoke_assert_equals( true, post_type_exists( 'wp_guideline' ), 'wp_guideline post type is registered on init', $failures, $passes );
+agents_api_smoke_assert_equals( true, taxonomy_exists( 'wp_guideline_type' ), 'wp_guideline_type taxonomy is registered on init', $failures, $passes );
+agents_api_smoke_assert_equals( 'guidelines', $GLOBALS['__agents_api_smoke_post_types']['wp_guideline']['rest_base'] ?? null, 'guideline post type exposes the shared REST base', $failures, $passes );
+agents_api_smoke_assert_equals( array( 'artifact', 'content' ), array_keys( wp_guideline_types() ), 'default guideline types match the shared substrate', $failures, $passes );
 
 agents_api_smoke_finish( 'Agents API bootstrap', $failures, $passes );

--- a/tests/guidelines-substrate-smoke.php
+++ b/tests/guidelines-substrate-smoke.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Pure-PHP smoke test for the shared guideline substrate polyfill.
+ *
+ * Run with: php tests/guidelines-substrate-smoke.php
+ *
+ * @package AgentsAPI\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+$failures = array();
+$passes   = 0;
+
+echo "agents-api-guidelines-substrate-smoke\n";
+
+require_once __DIR__ . '/agents-api-smoke-helpers.php';
+agents_api_smoke_require_module();
+
+echo "\n[1] Guideline substrate registers compatible storage primitives:\n";
+do_action( 'init' );
+
+$post_type_args = $GLOBALS['__agents_api_smoke_post_types']['wp_guideline'] ?? array();
+$taxonomy_entry = $GLOBALS['__agents_api_smoke_taxonomies']['wp_guideline_type'] ?? array();
+$taxonomy_args  = $taxonomy_entry['args'] ?? array();
+
+agents_api_smoke_assert_equals( true, post_type_exists( 'wp_guideline' ), 'wp_guideline post type exists', $failures, $passes );
+agents_api_smoke_assert_equals( false, $post_type_args['public'] ?? null, 'wp_guideline is non-public', $failures, $passes );
+agents_api_smoke_assert_equals( true, $post_type_args['show_in_rest'] ?? null, 'wp_guideline is REST-visible', $failures, $passes );
+agents_api_smoke_assert_equals( 'guidelines', $post_type_args['rest_base'] ?? null, 'wp_guideline uses shared REST base', $failures, $passes );
+agents_api_smoke_assert_equals( 'guideline', $post_type_args['capability_type'] ?? null, 'wp_guideline uses guideline capability type', $failures, $passes );
+agents_api_smoke_assert_equals( true, taxonomy_exists( 'wp_guideline_type' ), 'wp_guideline_type taxonomy exists', $failures, $passes );
+agents_api_smoke_assert_equals( 'wp_guideline', $taxonomy_entry['object_type'] ?? null, 'taxonomy is attached to wp_guideline', $failures, $passes );
+agents_api_smoke_assert_equals( true, $taxonomy_args['hierarchical'] ?? null, 'guideline type taxonomy is hierarchical', $failures, $passes );
+agents_api_smoke_assert_equals( true, $taxonomy_args['show_in_rest'] ?? null, 'guideline type taxonomy is REST-visible', $failures, $passes );
+
+echo "\n[2] Guideline type helper and default term behavior are available:\n";
+$types = wp_guideline_types();
+agents_api_smoke_assert_equals( 'Artifact', $types['artifact']['title'] ?? null, 'artifact guideline type is declared', $failures, $passes );
+agents_api_smoke_assert_equals( 'Content', $types['content']['title'] ?? null, 'content guideline type is declared', $failures, $passes );
+
+$term_data = apply_filters(
+	'wp_insert_term_data',
+	array(
+		'name' => 'artifact',
+		'slug' => 'artifact',
+	),
+	'wp_guideline_type'
+);
+agents_api_smoke_assert_equals( 'Artifact', $term_data['name'] ?? null, 'raw artifact slug maps to the guideline type label', $failures, $passes );
+
+do_action( 'save_post_wp_guideline', 123 );
+agents_api_smoke_assert_equals( true, (bool) term_exists( 'artifact', 'wp_guideline_type' ), 'saving an untyped guideline creates artifact term', $failures, $passes );
+
+agents_api_smoke_finish( 'Agents API guideline substrate', $failures, $passes );


### PR DESCRIPTION
## Summary
- Adds the shared `wp_guideline` / `wp_guideline_type` substrate polyfill to Agents API when Core/Gutenberg have not already registered it.
- Exposes `wp_guideline_types()` plus default guideline type behavior compatible with the Gutenberg substrate.
- Documents the substrate as part of Agents API's public surface so product plugins can consume it instead of owning their own polyfills.

## Tests
- `composer test`

## Related
- Blocks Automattic/intelligence#333 until this upstream substrate lands.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the upstream substrate implementation, smoke tests, and PR description; Chris remains responsible for review and merge.