### PR TITLE
chore: bump WordPress floor to 7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ Agents API sits between tool/action discovery and product-specific automation. I
 
 Products can require Agents API because they build on the substrate. Agents API must not depend on any product plugin, import product classes, mirror a product source tree, or encode product vocabulary as generic runtime API.
 
+## Requirements
+
+Agents API requires **WordPress 7.0 or higher**. The substrate itself is provider-agnostic and loads on earlier versions, but every realistic consumer needs an AI provider. The only WordPress-native provider story is `wp-ai-client`, which ships in WordPress 7.0 core. Sites running 6.8–6.9 can install Agents API without errors but won't have a working AI provider unless they manually install the deprecated `wp-ai-client` plugin.
+
 ## Consumer Integration
 
 Product plugins should treat Agents API as an optional or required runtime dependency depending on their feature surface.

--- a/agents-api.php
+++ b/agents-api.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Agents API
  * Description: WordPress-shaped agent runtime substrate.
- * Requires at least: 6.8
+ * Requires at least: 7.0
  * Requires PHP: 8.1
  * Author: Automattic
  * License: GPL-2.0-or-later


### PR DESCRIPTION
Closes #40.

Aligns with Extra-Chill/extrachill-ai-adventure#2 which declared 7.0 as its floor and merged today.

## Rationale

The substrate is provider-agnostic by design, but every realistic consumer needs an AI provider. The only WordPress-native provider is wp-ai-client, which is shipping in WordPress 7.0 core. The effective floor is already 7.0 — the header should be honest about it.

## Changes

- `agents-api.php`: `Requires at least: 6.8` → `7.0`
- `README.md`: Added Requirements section explaining the 7.0 floor + wp-ai-client rationale.

## Out of scope

- Composer's `require` constraint (stays `php: >=8.1`)
- Hard-coupling substrate to wp-ai-client (boundary stays as documented)