### PR TITLE
feat(runtime): add IterationBudget primitive for bounded iteration

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Agents API sits between tool/action discovery and product-specific automation. I
 - Agent memory store contracts and value objects.
 - Conversation compaction policy and transcript transformation contracts.
 - Generic multi-turn conversation loop sequencing around caller-owned adapters.
+- Iteration budget primitives for bounded execution across configurable dimensions.
 - Tool-call mediation contracts and runtime tool declaration value objects.
 - Conversation transcript store contracts.
 - Tool source registration, parameter normalization, tool-call mediation, and execution result contracts.
@@ -103,6 +104,7 @@ wp_register_agent(
 - `AgentsAPI\AI\AgentConversationTranscriptPersisterInterface`
 - `AgentsAPI\AI\NullAgentConversationTranscriptPersister`
 - `AgentsAPI\AI\AgentConversationCompaction`
+- `AgentsAPI\AI\IterationBudget`
 - `AgentsAPI\AI\AgentConversationResult`
 - `AgentsAPI\AI\AgentConversationLoop`
 - `AgentsAPI\AI\Tools\RuntimeToolDeclaration`
@@ -234,9 +236,15 @@ $result = AgentsAPI\AI\AgentConversationLoop::run(
 		// Transcript persistence (#43)
 		'transcript_persister' => $my_persister,        // AgentConversationTranscriptPersisterInterface
 
+		// Iteration budgets (#47)
+		'budgets' => array(
+			new AgentsAPI\AI\IterationBudget( 'tool_calls', 20 ),
+			new AgentsAPI\AI\IterationBudget( 'tool_calls_progress_story', 5 ),
+		),
+
 		// Lifecycle events (#44)
 		'on_event' => static function ( string $event, array $payload ): void {
-			// Events: turn_started, tool_call, tool_result, completed, failed
+			// Events: turn_started, tool_call, tool_result, budget_exceeded, completed, failed
 			$logger->log( $event, $payload );
 		},
 
@@ -258,6 +266,64 @@ $result = AgentsAPI\AI\AgentConversationLoop::run(
 All new options are opt-in. Existing callers passing only the original options continue to work identically.
 
 The loop treats all adapter inputs and outputs as JSON-friendly arrays so products can map them to their own storage, streaming, audit, and transport layers without Agents API owning those layers.
+
+## Iteration Budgets
+
+`AgentsAPI\AI\IterationBudget` is a generic bounded-iteration primitive. It counts a named dimension (turns, tool calls, chain depth, retries) and exposes a uniform API for checking exceedance. A budget is a stateful value object — call `increment()` at each iteration, then `exceeded()` to decide whether to continue.
+
+```php
+$budget = new AgentsAPI\AI\IterationBudget( 'chain_depth', 3 );
+
+$budget->name();      // 'chain_depth'
+$budget->ceiling();   // 3
+$budget->current();   // 0
+$budget->exceeded();  // false
+$budget->remaining(); // 3
+
+$budget->increment();
+$budget->current();   // 1
+$budget->exceeded();  // false
+
+$budget->increment();
+$budget->increment();
+$budget->exceeded();  // true (current >= ceiling)
+$budget->remaining(); // 0
+```
+
+### Loop integration
+
+Pass budgets to `AgentConversationLoop::run()` via the `budgets` option. The loop enforces them at the appropriate seams:
+
+- **`turns`** — incremented after each turn. When an explicit `IterationBudget('turns', N)` is provided, it overrides `max_turns` and produces a `budget_exceeded` status when tripped.
+- **`tool_calls`** — incremented after each tool call when tool mediation is enabled.
+- **`tool_calls_<name>`** — incremented per tool name for ping-pong protection (e.g. `tool_calls_progress_story`).
+
+```php
+$result = AgentsAPI\AI\AgentConversationLoop::run(
+	$messages,
+	$turn_runner,
+	array(
+		'max_turns' => 10,
+		'budgets'   => array(
+			new AgentsAPI\AI\IterationBudget( 'tool_calls', 20 ),
+			new AgentsAPI\AI\IterationBudget( 'tool_calls_progress_story', 5 ),
+		),
+		'tool_executor'     => $executor,
+		'tool_declarations' => $tools,
+	)
+);
+
+if ( ( $result['status'] ?? null ) === 'budget_exceeded' ) {
+	// $result['budget'] contains the name of the exceeded budget.
+	$logger->warn( 'Budget exceeded: ' . $result['budget'] );
+}
+```
+
+When a budget trips, the loop returns early with `status: 'budget_exceeded'` and `budget: '<name>'` in the result. A `budget_exceeded` event is also emitted through the `on_event` sink with `budget`, `current`, and `ceiling` in the payload.
+
+External observers tracking exotic dimensions (token cost, wall-clock, custom chain depth) can use the `on_event` hook to increment their own `IterationBudget` instances and signal the loop through the existing `should_continue` or completion policy escape hatches.
+
+The substrate ships only the per-execution value object. Registries, configuration persistence, and ceiling policies are consumer concerns.
 
 ## Tests
 

--- a/agents-api.php
+++ b/agents-api.php
@@ -52,6 +52,7 @@ require_once AGENTS_API_PATH . 'src/Runtime/AgentConversationTranscriptPersister
 require_once AGENTS_API_PATH . 'src/Runtime/NullAgentConversationTranscriptPersister.php';
 require_once AGENTS_API_PATH . 'src/Runtime/AgentConversationCompaction.php';
 require_once AGENTS_API_PATH . 'src/Runtime/AgentMarkdownSectionCompactionAdapter.php';
+require_once AGENTS_API_PATH . 'src/Runtime/IterationBudget.php';
 require_once AGENTS_API_PATH . 'src/Runtime/AgentConversationResult.php';
 require_once AGENTS_API_PATH . 'src/Runtime/AgentConversationLoop.php';
 require_once AGENTS_API_PATH . 'src/Tools/ToolCall.php';

--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,8 @@
       "php tests/conversation-loop-completion-policy-smoke.php",
       "php tests/conversation-loop-transcript-persister-smoke.php",
       "php tests/conversation-loop-events-smoke.php",
+      "php tests/iteration-budget-smoke.php",
+      "php tests/conversation-loop-budgets-smoke.php",
       "php tests/guidelines-substrate-smoke.php",
       "php tests/no-product-imports-smoke.php"
     ]

--- a/src/Runtime/AgentConversationLoop.php
+++ b/src/Runtime/AgentConversationLoop.php
@@ -36,7 +36,7 @@ class AgentConversationLoop {
 	 * and the loop handles execution internally. Otherwise the turn runner must
 	 * return an `AgentConversationResult`-compatible array as before.
 	 *
- 	 * Supported options:
+	 * Supported options:
 	 *
 	 * - `max_turns` (int): Maximum turns to run. Defaults to 1.
 	 * - `budgets` (IterationBudget[]): Named iteration budgets for bounded execution.

--- a/src/Runtime/AgentConversationLoop.php
+++ b/src/Runtime/AgentConversationLoop.php
@@ -36,9 +36,10 @@ class AgentConversationLoop {
 	 * and the loop handles execution internally. Otherwise the turn runner must
 	 * return an `AgentConversationResult`-compatible array as before.
 	 *
-	 * Supported options:
+ 	 * Supported options:
 	 *
 	 * - `max_turns` (int): Maximum turns to run. Defaults to 1.
+	 * - `budgets` (IterationBudget[]): Named iteration budgets for bounded execution.
 	 * - `context` (array): Caller-owned context passed to adapters.
 	 * - `should_continue` (callable|null): Caller-owned continuation policy.
 	 * - `compaction_policy` (array|null): Optional compaction policy.
@@ -63,11 +64,13 @@ class AgentConversationLoop {
 		$completion_policy     = self::resolve_completion_policy( $options );
 		$transcript_persister  = self::resolve_transcript_persister( $options );
 		$on_event              = self::resolve_event_sink( $options );
+		$budgets               = self::resolve_budgets( $options, $max_turns );
 		$mediation_enabled     = null !== $tool_executor && ! empty( $tool_declarations );
 		$messages              = AgentMessageEnvelope::normalize_many( $messages );
 		$events                = array();
 		$tool_results          = array();
 		$conversation_complete = false;
+		$exceeded_budget       = null;
 
 		for ( $turn = 1; $turn <= $max_turns; ++$turn ) {
 			$turn_context         = $context;
@@ -128,13 +131,15 @@ class AgentConversationLoop {
 					$completion_policy,
 					$turn_context,
 					$turn,
-					$on_event
+					$on_event,
+					$budgets
 				);
 
 				$messages              = $mediation_result['messages'];
 				$tool_results          = array_merge( $tool_results, $mediation_result['tool_execution_results'] );
 				$events                = array_merge( $events, $mediation_result['events'] );
 				$conversation_complete = $mediation_result['conversation_complete'];
+				$exceeded_budget       = $mediation_result['exceeded_budget'];
 			} else {
 				// Legacy path: turn runner handles everything internally.
 				$result       = AgentConversationResult::normalize( $result );
@@ -163,8 +168,18 @@ class AgentConversationLoop {
 				}
 			}
 
-			// Stop conditions: completion policy said stop, or legacy should_continue.
+			// Stop conditions: budget exceeded, completion policy, or legacy should_continue.
+			if ( null !== $exceeded_budget ) {
+				break;
+			}
+
 			if ( $conversation_complete ) {
+				break;
+			}
+
+			// Increment the turns budget after a completed turn.
+			$exceeded_budget = self::increment_budget( $budgets, 'turns', $on_event );
+			if ( null !== $exceeded_budget ) {
 				break;
 			}
 
@@ -173,11 +188,18 @@ class AgentConversationLoop {
 			}
 		}
 
-		$final_result = AgentConversationResult::normalize( array(
+		$final_result_data = array(
 			'messages'               => $messages,
 			'tool_execution_results' => $tool_results,
 			'events'                 => $events,
-		) );
+		);
+
+		if ( null !== $exceeded_budget ) {
+			$final_result_data['status'] = 'budget_exceeded';
+			$final_result_data['budget'] = $exceeded_budget;
+		}
+
+		$final_result = AgentConversationResult::normalize( $final_result_data );
 
 		self::persist_transcript( $transcript_persister, $messages, $options, $final_result );
 
@@ -202,7 +224,8 @@ class AgentConversationLoop {
 	 * @param array                                             $turn_context    Turn context.
 	 * @param int                                               $turn            Current turn number.
 	 * @param callable|null                                     $on_event        Event sink.
-	 * @return array{messages: array, tool_execution_results: array, events: array, conversation_complete: bool}
+	 * @param array<string, IterationBudget>                    $budgets         Named iteration budgets.
+	 * @return array{messages: array, tool_execution_results: array, events: array, conversation_complete: bool, exceeded_budget: string|null}
 	 */
 	private static function mediate_tool_calls(
 		array $result,
@@ -211,7 +234,8 @@ class AgentConversationLoop {
 		?AgentConversationCompletionPolicyInterface $policy,
 		array $turn_context,
 		int $turn,
-		?callable $on_event
+		?callable $on_event,
+		array $budgets = array()
 	): array {
 		$core                   = new ToolExecutionCore();
 		$messages               = isset( $result['messages'] ) && is_array( $result['messages'] )
@@ -221,6 +245,7 @@ class AgentConversationLoop {
 		$tool_execution_results = array();
 		$events                 = array();
 		$complete               = false;
+		$exceeded_budget        = null;
 
 		// If the turn runner returned text content, add it as an assistant message.
 		if ( isset( $result['content'] ) && is_string( $result['content'] ) && '' !== $result['content'] ) {
@@ -285,6 +310,17 @@ class AgentConversationLoop {
 				$exec_result
 			);
 
+			// Increment tool-call budgets: total and per-tool-name.
+			$exceeded_budget = self::increment_budget( $budgets, 'tool_calls', $on_event );
+			if ( null === $exceeded_budget ) {
+				$exceeded_budget = self::increment_budget( $budgets, 'tool_calls_' . $tool_name, $on_event );
+			}
+
+			if ( null !== $exceeded_budget ) {
+				$complete = true;
+				break;
+			}
+
 			// Consult completion policy.
 			if ( null !== $policy ) {
 				$decision = $policy->recordToolResult(
@@ -321,6 +357,7 @@ class AgentConversationLoop {
 			'tool_execution_results' => $tool_execution_results,
 			'events'                 => $events,
 			'conversation_complete'  => $complete,
+			'exceeded_budget'        => $exceeded_budget,
 		);
 	}
 
@@ -439,6 +476,68 @@ class AgentConversationLoop {
 	private static function resolve_event_sink( array $options ): ?callable {
 		$sink = $options['on_event'] ?? null;
 		return is_callable( $sink ) ? $sink : null;
+	}
+
+	/**
+	 * Resolve iteration budgets from options.
+	 *
+	 * Synthesizes a `turns` budget from `max_turns` when no explicit `turns`
+	 * budget is provided, preserving backwards compatibility.
+	 *
+	 * @param array $options   Loop options.
+	 * @param int   $max_turns Resolved max turns value.
+	 * @return array<string, IterationBudget> Budgets keyed by name.
+	 */
+	private static function resolve_budgets( array $options, int $max_turns ): array {
+		$raw     = $options['budgets'] ?? array();
+		$budgets = array();
+
+		if ( is_array( $raw ) ) {
+			foreach ( $raw as $budget ) {
+				if ( $budget instanceof IterationBudget ) {
+					$budgets[ $budget->name() ] = $budget;
+				}
+			}
+		}
+
+		// Synthesize a turns budget from max_turns when none was explicitly provided.
+		if ( ! isset( $budgets['turns'] ) ) {
+			$budgets['turns'] = new IterationBudget( 'turns', $max_turns );
+		}
+
+		return $budgets;
+	}
+
+	/**
+	 * Increment a named budget and check for exceedance.
+	 *
+	 * When the budget is exceeded, emits a `budget_exceeded` event and returns
+	 * the budget name. Returns null when the budget is not exceeded or does not exist.
+	 *
+	 * @param array<string, IterationBudget> $budgets  Named budgets.
+	 * @param string                         $name     Budget name to increment.
+	 * @param callable|null                  $on_event Event sink.
+	 * @return string|null Exceeded budget name, or null.
+	 */
+	private static function increment_budget( array $budgets, string $name, ?callable $on_event ): ?string {
+		if ( ! isset( $budgets[ $name ] ) ) {
+			return null;
+		}
+
+		$budget = $budgets[ $name ];
+		$budget->increment();
+
+		if ( $budget->exceeded() ) {
+			self::emit_event( $on_event, 'budget_exceeded', array(
+				'budget'  => $name,
+				'current' => $budget->current(),
+				'ceiling' => $budget->ceiling(),
+			) );
+
+			return $name;
+		}
+
+		return null;
 	}
 
 	/**

--- a/src/Runtime/AgentConversationLoop.php
+++ b/src/Runtime/AgentConversationLoop.php
@@ -64,7 +64,9 @@ class AgentConversationLoop {
 		$completion_policy     = self::resolve_completion_policy( $options );
 		$transcript_persister  = self::resolve_transcript_persister( $options );
 		$on_event              = self::resolve_event_sink( $options );
-		$budgets               = self::resolve_budgets( $options, $max_turns );
+		$budget_resolution     = self::resolve_budgets( $options, $max_turns );
+		$budgets               = $budget_resolution['budgets'];
+		$has_explicit_turns    = $budget_resolution['has_explicit_turns'];
 		$mediation_enabled     = null !== $tool_executor && ! empty( $tool_declarations );
 		$messages              = AgentMessageEnvelope::normalize_many( $messages );
 		$events                = array();
@@ -178,8 +180,14 @@ class AgentConversationLoop {
 			}
 
 			// Increment the turns budget after a completed turn.
-			$exceeded_budget = self::increment_budget( $budgets, 'turns', $on_event );
-			if ( null !== $exceeded_budget ) {
+			// Synthesized turns budgets (from max_turns) break the loop silently
+			// to preserve backwards compatibility. Explicit turns budgets signal
+			// budget_exceeded so callers know the stop reason.
+			$turns_exceeded = self::increment_budget( $budgets, 'turns', $has_explicit_turns ? $on_event : null );
+			if ( null !== $turns_exceeded ) {
+				if ( $has_explicit_turns ) {
+					$exceeded_budget = $turns_exceeded;
+				}
 				break;
 			}
 
@@ -486,7 +494,7 @@ class AgentConversationLoop {
 	 *
 	 * @param array $options   Loop options.
 	 * @param int   $max_turns Resolved max turns value.
-	 * @return array<string, IterationBudget> Budgets keyed by name.
+	 * @return array{budgets: array<string, IterationBudget>, has_explicit_turns: bool}
 	 */
 	private static function resolve_budgets( array $options, int $max_turns ): array {
 		$raw     = $options['budgets'] ?? array();
@@ -500,12 +508,17 @@ class AgentConversationLoop {
 			}
 		}
 
+		$has_explicit_turns = isset( $budgets['turns'] );
+
 		// Synthesize a turns budget from max_turns when none was explicitly provided.
-		if ( ! isset( $budgets['turns'] ) ) {
+		if ( ! $has_explicit_turns ) {
 			$budgets['turns'] = new IterationBudget( 'turns', $max_turns );
 		}
 
-		return $budgets;
+		return array(
+			'budgets'            => $budgets,
+			'has_explicit_turns' => $has_explicit_turns,
+		);
 	}
 
 	/**

--- a/src/Runtime/AgentConversationResult.php
+++ b/src/Runtime/AgentConversationResult.php
@@ -88,6 +88,15 @@ class AgentConversationResult {
 			}
 		}
 
+		// Validate optional budget-exceeded status fields.
+		if ( array_key_exists( 'status', $result ) && ! is_string( $result['status'] ) ) {
+			throw self::invalid( 'status', 'must be a string when present' );
+		}
+
+		if ( array_key_exists( 'budget', $result ) && ! is_string( $result['budget'] ) ) {
+			throw self::invalid( 'budget', 'must be a string when present' );
+		}
+
 		return $result;
 	}
 

--- a/src/Runtime/IterationBudget.php
+++ b/src/Runtime/IterationBudget.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * Iteration Budget — generic bounded-iteration primitive.
+ *
+ * Counts a named dimension (turns, tool calls, chain depth, retries)
+ * and exposes a uniform API for checking exceedance. A budget is a
+ * stateful value object — call {@see increment()} at each iteration,
+ * then {@see exceeded()} to decide whether to continue.
+ *
+ * The substrate ships only the per-execution value object. Registries,
+ * configuration persistence, and ceiling policies are consumer concerns.
+ *
+ * @package AgentsAPI
+ */
+
+namespace AgentsAPI\AI;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+final class IterationBudget {
+
+	/**
+	 * Budget name (e.g. "turns", "tool_calls", "chain_depth").
+	 *
+	 * @var string
+	 */
+	private string $name;
+
+	/**
+	 * Maximum allowed value (inclusive ceiling — exceeded when current >= ceiling).
+	 *
+	 * @var int
+	 */
+	private int $ceiling;
+
+	/**
+	 * Current counter value.
+	 *
+	 * @var int
+	 */
+	private int $current;
+
+	/**
+	 * @param string $name    Budget name. Used in result status and event payloads.
+	 * @param int    $ceiling Maximum allowed value (must be >= 1).
+	 * @param int    $current Starting counter value (default 0). Negative values are clamped to 0.
+	 */
+	public function __construct( string $name, int $ceiling, int $current = 0 ) {
+		$this->name    = $name;
+		$this->ceiling = max( 1, $ceiling );
+		$this->current = max( 0, $current );
+	}
+
+	/**
+	 * Increment the counter by one.
+	 */
+	public function increment(): void {
+		++$this->current;
+	}
+
+	/**
+	 * Whether the counter has reached or exceeded the ceiling.
+	 *
+	 * @return bool True when current >= ceiling.
+	 */
+	public function exceeded(): bool {
+		return $this->current >= $this->ceiling;
+	}
+
+	/**
+	 * Remaining iterations before exceedance.
+	 *
+	 * @return int Zero when exceeded, otherwise ceiling - current.
+	 */
+	public function remaining(): int {
+		return max( 0, $this->ceiling - $this->current );
+	}
+
+	/**
+	 * Budget name.
+	 */
+	public function name(): string {
+		return $this->name;
+	}
+
+	/**
+	 * Current counter value.
+	 */
+	public function current(): int {
+		return $this->current;
+	}
+
+	/**
+	 * Ceiling for this budget.
+	 */
+	public function ceiling(): int {
+		return $this->ceiling;
+	}
+}

--- a/tests/conversation-loop-budgets-smoke.php
+++ b/tests/conversation-loop-budgets-smoke.php
@@ -1,0 +1,302 @@
+<?php
+/**
+ * Pure-PHP smoke test for IterationBudget enforcement in AgentConversationLoop.
+ *
+ * Run with: php tests/conversation-loop-budgets-smoke.php
+ *
+ * @package AgentsAPI\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+$failures = array();
+$passes   = 0;
+
+echo "agents-api-conversation-loop-budgets-smoke\n";
+
+require_once __DIR__ . '/agents-api-smoke-helpers.php';
+agents_api_smoke_require_module();
+
+// Reusable tool executor for mediated tests.
+$executor = new class() implements AgentsAPI\AI\Tools\ToolExecutorInterface {
+	public function executeToolCall( array $tool_call, array $tool_definition, array $context = array() ): array {
+		return array(
+			'success'   => true,
+			'tool_name' => $tool_call['tool_name'],
+			'result'    => array( 'ok' => true ),
+		);
+	}
+};
+
+$tools = array(
+	'client/work' => array(
+		'name'        => 'client/work',
+		'source'      => 'client',
+		'description' => 'Do work.',
+		'parameters'  => array(),
+		'executor'    => 'client',
+		'scope'       => 'run',
+	),
+	'client/ping' => array(
+		'name'        => 'client/ping',
+		'source'      => 'client',
+		'description' => 'Ping.',
+		'parameters'  => array(),
+		'executor'    => 'client',
+		'scope'       => 'run',
+	),
+);
+
+echo "\n[1] max_turns only — existing behavior preserved:\n";
+$turn_count = 0;
+$result     = AgentsAPI\AI\AgentConversationLoop::run(
+	array( array( 'role' => 'user', 'content' => 'go' ) ),
+	static function ( array $messages, array $context ) use ( &$turn_count ): array {
+		++$turn_count;
+		$messages[] = AgentsAPI\AI\AgentMessageEnvelope::text( 'assistant', 'turn ' . $context['turn'] );
+
+		return array(
+			'messages'               => $messages,
+			'tool_execution_results' => array(),
+			'events'                 => array(),
+		);
+	},
+	array(
+		'max_turns'       => 3,
+		'should_continue' => static function (): bool {
+			return true;
+		},
+	)
+);
+
+agents_api_smoke_assert_equals( 3, $turn_count, 'loop runs exactly max_turns turns', $failures, $passes );
+agents_api_smoke_assert_equals( false, isset( $result['status'] ), 'no budget_exceeded status for max_turns exit', $failures, $passes );
+
+echo "\n[2] Explicit turns budget stops loop with budget_exceeded status:\n";
+$turn_count = 0;
+$result     = AgentsAPI\AI\AgentConversationLoop::run(
+	array( array( 'role' => 'user', 'content' => 'go' ) ),
+	static function ( array $messages, array $context ) use ( &$turn_count ): array {
+		++$turn_count;
+		$messages[] = AgentsAPI\AI\AgentMessageEnvelope::text( 'assistant', 'turn ' . $context['turn'] );
+
+		return array(
+			'messages'               => $messages,
+			'tool_execution_results' => array(),
+			'events'                 => array(),
+		);
+	},
+	array(
+		'max_turns'       => 10,
+		'budgets'         => array(
+			new AgentsAPI\AI\IterationBudget( 'turns', 2 ),
+		),
+		'should_continue' => static function (): bool {
+			return true;
+		},
+	)
+);
+
+agents_api_smoke_assert_equals( 2, $turn_count, 'loop stops after turns budget ceiling', $failures, $passes );
+agents_api_smoke_assert_equals( 'budget_exceeded', $result['status'] ?? null, 'result has budget_exceeded status', $failures, $passes );
+agents_api_smoke_assert_equals( 'turns', $result['budget'] ?? null, 'result identifies turns budget', $failures, $passes );
+
+echo "\n[3] tool_calls budget stops loop mid-execution:\n";
+$tool_call_count = 0;
+$event_log       = array();
+$result          = AgentsAPI\AI\AgentConversationLoop::run(
+	array( array( 'role' => 'user', 'content' => 'go' ) ),
+	static function ( array $messages, array $context ) use ( &$tool_call_count ): array {
+		++$tool_call_count;
+
+		return array(
+			'messages'   => $messages,
+			'tool_calls' => array(
+				array( 'name' => 'client/work', 'parameters' => array() ),
+				array( 'name' => 'client/work', 'parameters' => array() ),
+				array( 'name' => 'client/work', 'parameters' => array() ),
+			),
+		);
+	},
+	array(
+		'max_turns'         => 10,
+		'tool_executor'     => $executor,
+		'tool_declarations' => $tools,
+		'budgets'           => array(
+			new AgentsAPI\AI\IterationBudget( 'tool_calls', 2 ),
+		),
+		'should_continue'   => static function (): bool {
+			return true;
+		},
+		'on_event'          => static function ( string $event, array $payload ) use ( &$event_log ): void {
+			$event_log[] = array( 'event' => $event, 'payload' => $payload );
+		},
+	)
+);
+
+agents_api_smoke_assert_equals( 'budget_exceeded', $result['status'] ?? null, 'tool_calls budget stops with budget_exceeded', $failures, $passes );
+agents_api_smoke_assert_equals( 'tool_calls', $result['budget'] ?? null, 'result identifies tool_calls budget', $failures, $passes );
+agents_api_smoke_assert_equals( 2, count( $result['tool_execution_results'] ), 'only 2 tool calls executed before budget exceeded', $failures, $passes );
+
+// Verify budget_exceeded event was emitted.
+$budget_events = array_filter( $event_log, static function ( array $e ): bool {
+	return 'budget_exceeded' === $e['event'];
+} );
+agents_api_smoke_assert_equals( 1, count( $budget_events ), 'budget_exceeded event was emitted', $failures, $passes );
+$budget_event = array_values( $budget_events )[0];
+agents_api_smoke_assert_equals( 'tool_calls', $budget_event['payload']['budget'], 'budget_exceeded event carries budget name', $failures, $passes );
+agents_api_smoke_assert_equals( 2, $budget_event['payload']['current'], 'budget_exceeded event carries current count', $failures, $passes );
+agents_api_smoke_assert_equals( 2, $budget_event['payload']['ceiling'], 'budget_exceeded event carries ceiling', $failures, $passes );
+
+echo "\n[4] Per-tool-name budget stops specific tool ping-pong:\n";
+$result = AgentsAPI\AI\AgentConversationLoop::run(
+	array( array( 'role' => 'user', 'content' => 'go' ) ),
+	static function ( array $messages, array $context ): array {
+		return array(
+			'messages'   => $messages,
+			'tool_calls' => array(
+				array( 'name' => 'client/ping', 'parameters' => array() ),
+				array( 'name' => 'client/work', 'parameters' => array() ),
+				array( 'name' => 'client/ping', 'parameters' => array() ),
+				array( 'name' => 'client/ping', 'parameters' => array() ),
+			),
+		);
+	},
+	array(
+		'max_turns'         => 10,
+		'tool_executor'     => $executor,
+		'tool_declarations' => $tools,
+		'budgets'           => array(
+			new AgentsAPI\AI\IterationBudget( 'tool_calls_client/ping', 2 ),
+		),
+		'should_continue'   => static function (): bool {
+			return true;
+		},
+	)
+);
+
+agents_api_smoke_assert_equals( 'budget_exceeded', $result['status'] ?? null, 'per-tool budget stops with budget_exceeded', $failures, $passes );
+agents_api_smoke_assert_equals( 'tool_calls_client/ping', $result['budget'] ?? null, 'result identifies per-tool budget', $failures, $passes );
+// Should have executed: ping(1), work(1), ping(2) = 3 calls before budget exceeded on 2nd ping.
+agents_api_smoke_assert_equals( 3, count( $result['tool_execution_results'] ), 'per-tool budget stops after the tool hits ceiling', $failures, $passes );
+
+echo "\n[5] Multiple budgets — any one exceeded stops the loop:\n";
+$result = AgentsAPI\AI\AgentConversationLoop::run(
+	array( array( 'role' => 'user', 'content' => 'go' ) ),
+	static function ( array $messages, array $context ): array {
+		return array(
+			'messages'   => $messages,
+			'tool_calls' => array(
+				array( 'name' => 'client/work', 'parameters' => array() ),
+				array( 'name' => 'client/work', 'parameters' => array() ),
+				array( 'name' => 'client/work', 'parameters' => array() ),
+			),
+		);
+	},
+	array(
+		'max_turns'         => 10,
+		'tool_executor'     => $executor,
+		'tool_declarations' => $tools,
+		'budgets'           => array(
+			new AgentsAPI\AI\IterationBudget( 'tool_calls', 10 ),
+			new AgentsAPI\AI\IterationBudget( 'tool_calls_client/work', 2 ),
+		),
+		'should_continue'   => static function (): bool {
+			return true;
+		},
+	)
+);
+
+agents_api_smoke_assert_equals( 'budget_exceeded', $result['status'] ?? null, 'first exceeded budget stops loop', $failures, $passes );
+agents_api_smoke_assert_equals( 'tool_calls_client/work', $result['budget'] ?? null, 'result identifies the per-tool budget that exceeded', $failures, $passes );
+
+echo "\n[6] Budget works alongside completion policy (budget checked first):\n";
+$policy = new class() implements AgentsAPI\AI\AgentConversationCompletionPolicyInterface {
+	public function recordToolResult(
+		string $tool_name,
+		?array $tool_definition,
+		array $result,
+		array $context,
+		int $turn
+	): AgentsAPI\AI\AgentConversationCompletionDecision {
+		return AgentsAPI\AI\AgentConversationCompletionDecision::notComplete();
+	}
+};
+
+$result = AgentsAPI\AI\AgentConversationLoop::run(
+	array( array( 'role' => 'user', 'content' => 'go' ) ),
+	static function ( array $messages ): array {
+		return array(
+			'messages'   => $messages,
+			'tool_calls' => array(
+				array( 'name' => 'client/work', 'parameters' => array() ),
+			),
+		);
+	},
+	array(
+		'max_turns'         => 10,
+		'tool_executor'     => $executor,
+		'tool_declarations' => $tools,
+		'completion_policy' => $policy,
+		'budgets'           => array(
+			new AgentsAPI\AI\IterationBudget( 'tool_calls', 1 ),
+		),
+		'should_continue'   => static function (): bool {
+			return true;
+		},
+	)
+);
+
+agents_api_smoke_assert_equals( 'budget_exceeded', $result['status'] ?? null, 'budget stops even with completion policy present', $failures, $passes );
+agents_api_smoke_assert_equals( 'tool_calls', $result['budget'] ?? null, 'budget identified even with completion policy', $failures, $passes );
+
+echo "\n[7] No budgets and no max_turns — default 1-turn behavior unchanged:\n";
+$turn_count = 0;
+$result     = AgentsAPI\AI\AgentConversationLoop::run(
+	array( array( 'role' => 'user', 'content' => 'go' ) ),
+	static function ( array $messages ) use ( &$turn_count ): array {
+		++$turn_count;
+
+		return array(
+			'messages'               => $messages,
+			'tool_execution_results' => array(),
+			'events'                 => array(),
+		);
+	}
+);
+
+agents_api_smoke_assert_equals( 1, $turn_count, 'default loop runs exactly 1 turn', $failures, $passes );
+agents_api_smoke_assert_equals( false, isset( $result['status'] ), 'no budget_exceeded status for default exit', $failures, $passes );
+
+echo "\n[8] Explicit turns budget overrides max_turns:\n";
+$turn_count = 0;
+$result     = AgentsAPI\AI\AgentConversationLoop::run(
+	array( array( 'role' => 'user', 'content' => 'go' ) ),
+	static function ( array $messages, array $context ) use ( &$turn_count ): array {
+		++$turn_count;
+		$messages[] = AgentsAPI\AI\AgentMessageEnvelope::text( 'assistant', 'turn ' . $context['turn'] );
+
+		return array(
+			'messages'               => $messages,
+			'tool_execution_results' => array(),
+			'events'                 => array(),
+		);
+	},
+	array(
+		'max_turns'       => 10,
+		'budgets'         => array(
+			new AgentsAPI\AI\IterationBudget( 'turns', 3 ),
+		),
+		'should_continue' => static function (): bool {
+			return true;
+		},
+	)
+);
+
+agents_api_smoke_assert_equals( 3, $turn_count, 'explicit turns budget overrides higher max_turns', $failures, $passes );
+agents_api_smoke_assert_equals( 'budget_exceeded', $result['status'] ?? null, 'explicit turns budget produces budget_exceeded status', $failures, $passes );
+agents_api_smoke_assert_equals( 'turns', $result['budget'] ?? null, 'explicit turns budget identified in result', $failures, $passes );
+
+agents_api_smoke_finish( 'Agents API conversation loop budgets', $failures, $passes );

--- a/tests/iteration-budget-smoke.php
+++ b/tests/iteration-budget-smoke.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Pure-PHP smoke test for the IterationBudget value object.
+ *
+ * Run with: php tests/iteration-budget-smoke.php
+ *
+ * @package AgentsAPI\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+$failures = array();
+$passes   = 0;
+
+echo "agents-api-iteration-budget-smoke\n";
+
+require_once __DIR__ . '/agents-api-smoke-helpers.php';
+agents_api_smoke_require_module();
+
+echo "\n[1] Budget initializes with correct defaults:\n";
+$budget = new AgentsAPI\AI\IterationBudget( 'turns', 5 );
+agents_api_smoke_assert_equals( 'turns', $budget->name(), 'name returns budget name', $failures, $passes );
+agents_api_smoke_assert_equals( 5, $budget->ceiling(), 'ceiling returns configured maximum', $failures, $passes );
+agents_api_smoke_assert_equals( 0, $budget->current(), 'current starts at zero', $failures, $passes );
+agents_api_smoke_assert_equals( false, $budget->exceeded(), 'new budget is not exceeded', $failures, $passes );
+agents_api_smoke_assert_equals( 5, $budget->remaining(), 'remaining equals ceiling when current is zero', $failures, $passes );
+
+echo "\n[2] Increment ticks current and exceeded triggers at ceiling:\n";
+$budget = new AgentsAPI\AI\IterationBudget( 'tool_calls', 3 );
+$budget->increment();
+agents_api_smoke_assert_equals( 1, $budget->current(), 'current ticks after first increment', $failures, $passes );
+agents_api_smoke_assert_equals( false, $budget->exceeded(), 'budget not exceeded below ceiling', $failures, $passes );
+agents_api_smoke_assert_equals( 2, $budget->remaining(), 'remaining decreases after increment', $failures, $passes );
+
+$budget->increment();
+agents_api_smoke_assert_equals( 2, $budget->current(), 'current ticks after second increment', $failures, $passes );
+agents_api_smoke_assert_equals( false, $budget->exceeded(), 'budget not exceeded one below ceiling', $failures, $passes );
+
+$budget->increment();
+agents_api_smoke_assert_equals( 3, $budget->current(), 'current reaches ceiling', $failures, $passes );
+agents_api_smoke_assert_equals( true, $budget->exceeded(), 'budget exceeded at ceiling', $failures, $passes );
+agents_api_smoke_assert_equals( 0, $budget->remaining(), 'remaining is zero when exceeded', $failures, $passes );
+
+echo "\n[3] Budget exceeded stays true past ceiling:\n";
+$budget->increment();
+agents_api_smoke_assert_equals( 4, $budget->current(), 'current can exceed ceiling', $failures, $passes );
+agents_api_smoke_assert_equals( true, $budget->exceeded(), 'budget stays exceeded past ceiling', $failures, $passes );
+agents_api_smoke_assert_equals( 0, $budget->remaining(), 'remaining clamps to zero past ceiling', $failures, $passes );
+
+echo "\n[4] Ceiling clamps to minimum of 1:\n";
+$small = new AgentsAPI\AI\IterationBudget( 'edge', 0 );
+agents_api_smoke_assert_equals( 1, $small->ceiling(), 'zero ceiling clamps to 1', $failures, $passes );
+
+$negative = new AgentsAPI\AI\IterationBudget( 'edge', -5 );
+agents_api_smoke_assert_equals( 1, $negative->ceiling(), 'negative ceiling clamps to 1', $failures, $passes );
+
+echo "\n[5] Starting current clamps negative to zero:\n";
+$preloaded = new AgentsAPI\AI\IterationBudget( 'retries', 5, -3 );
+agents_api_smoke_assert_equals( 0, $preloaded->current(), 'negative starting current clamps to zero', $failures, $passes );
+
+echo "\n[6] Starting current at or above ceiling is already exceeded:\n";
+$pre_exceeded = new AgentsAPI\AI\IterationBudget( 'depth', 3, 3 );
+agents_api_smoke_assert_equals( true, $pre_exceeded->exceeded(), 'budget starting at ceiling is exceeded', $failures, $passes );
+agents_api_smoke_assert_equals( 0, $pre_exceeded->remaining(), 'remaining is zero for pre-exceeded budget', $failures, $passes );
+
+$above = new AgentsAPI\AI\IterationBudget( 'depth', 3, 5 );
+agents_api_smoke_assert_equals( true, $above->exceeded(), 'budget starting above ceiling is exceeded', $failures, $passes );
+
+agents_api_smoke_finish( 'Agents API iteration budget', $failures, $passes );


### PR DESCRIPTION
## Summary

Adds a generic `IterationBudget` value object to the agents-api runtime and wires it into `AgentConversationLoop::run()` so consumers can hard-stop runaway loops on dimensions beyond just turns.

Closes #47. Built on the substrate foundation from #46. Driven by [data-machine#1716](https://github.com/Extra-Chill/data-machine/issues/1716).

## Design decisions (from #47 leans)

1. **Multiple named budgets composable** — `budgets` option accepts an array of `IterationBudget` instances
2. **Enforcement inside `AgentConversationLoop::run()`** for native dimensions; existing event hook as escape hatch for external observers
3. **Native dimensions:** `turns`, `tool_calls` (total), `tool_calls_<name>` (per-tool-name)
4. **Soft signal at exceeded** — returns early with `status: 'budget_exceeded'` and `budget: '<name>'` in the result, does not throw
5. **Lift only the value object** — no registry, consumers build their own

## What changed

### Value object (`src/Runtime/IterationBudget.php`)
- Mirrors DM's battle-tested API: `name()`, `ceiling()`, `current()`, `increment()`, `exceeded()`, `remaining()`
- Drops DM-specific vocabulary (`toResponseFlag()`, `toWarning()`) — substrate stays minimal
- ~100 LOC, namespace `AgentsAPI\AI`

### Loop wiring (`src/Runtime/AgentConversationLoop.php`)
- New `budgets` option on `run()` accepts `IterationBudget[]`
- Internally synthesizes a `turns` budget from `max_turns` — existing callers see no behavior change (BC)
- Increments `tool_calls` and `tool_calls_<name>` budgets during mediated tool execution
- Emits `budget_exceeded` event with `budget`, `current`, `ceiling` payload
- Returns early with `status: 'budget_exceeded'`, `budget: '<name>'` when any budget trips

### Result contract (`src/Runtime/AgentConversationResult.php`)
- Passes through optional `status` and `budget` string fields

### Tests
- `tests/iteration-budget-smoke.php` — 22 assertions covering value object API, edge cases
- `tests/conversation-loop-budgets-smoke.php` — 24 assertions covering BC, turns budget, tool_calls budget, per-tool budget, multiple budgets, completion policy coexistence

### Docs
- README updated with public surface entry, "What Agents API Owns" entry, full IterationBudget section with usage examples

## Backwards compatibility

- Callers passing only `max_turns` see identical behavior (no `budget_exceeded` status, no events)
- Callers passing no `budgets` and no `max_turns` get default 1-turn behavior
- All 18 existing test suites pass unchanged (445 total assertions)

## Commits

| Prefix | Description |
|--------|-------------|
| `feat:` | Add IterationBudget value object |
| `feat:` | Wire IterationBudget enforcement into AgentConversationLoop |
| `test:` | Smoke coverage for IterationBudget and loop integration |
| `docs:` | Document IterationBudget primitive |
| `fix:` | Preserve BC for synthesized turns budget from max_turns |
| `style:` | Fix indentation in loop doc comment |