### PR TITLE
Add pending action store contract

### DIFF
--- a/agents-api.php
+++ b/agents-api.php
@@ -40,6 +40,7 @@ require_once AGENTS_API_PATH . 'src/Identity/AgentIdentityScope.php';
 require_once AGENTS_API_PATH . 'src/Identity/MaterializedAgentIdentity.php';
 require_once AGENTS_API_PATH . 'src/Identity/MaterializedAgentIdentityStoreInterface.php';
 require_once AGENTS_API_PATH . 'src/Transcripts/ConversationTranscriptStoreInterface.php';
+require_once AGENTS_API_PATH . 'src/Approvals/PendingActionStoreInterface.php';
 require_once AGENTS_API_PATH . 'src/Runtime/AgentMessageEnvelope.php';
 require_once AGENTS_API_PATH . 'src/Runtime/AgentExecutionPrincipal.php';
 require_once AGENTS_API_PATH . 'src/Runtime/AgentCompactionItem.php';

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
       "php tests/registry-smoke.php",
       "php tests/execution-principal-smoke.php",
       "php tests/tool-runtime-smoke.php",
+      "php tests/pending-action-store-contract-smoke.php",
       "php tests/identity-smoke.php",
       "php tests/compaction-item-smoke.php",
       "php tests/conversation-runner-contracts-smoke.php",

--- a/src/Approvals/PendingActionStoreInterface.php
+++ b/src/Approvals/PendingActionStoreInterface.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Pending Action Store Interface
+ *
+ * Generic persistence contract for actions that must be resumed after an
+ * external approval or rejection. The contract deliberately describes only the
+ * pending-action payload lifecycle; concrete storage, routing, UI, and
+ * scheduling behavior stay in consumers.
+ *
+ * Payloads MUST remain JSON-serializable. Consumers may store richer payloads
+ * when they need additional context for approval prompts, diffs, audit data, or
+ * continuation state.
+ *
+ * @package AgentsAPI
+ * @since   next
+ */
+
+namespace AgentsAPI\AI\Approvals;
+
+defined( 'ABSPATH' ) || exit;
+
+interface PendingActionStoreInterface {
+
+	/**
+	 * Persist a pending action payload under a caller-provided action ID.
+	 *
+	 * @param string              $action_id Durable action identifier.
+	 * @param array<string,mixed> $payload   JSON-serializable pending action payload.
+	 * @return bool Whether the payload was stored successfully.
+	 */
+	public function store( string $action_id, array $payload ): bool;
+
+	/**
+	 * Retrieve a pending action payload by action ID.
+	 *
+	 * @param string $action_id Durable action identifier.
+	 * @return array<string,mixed>|null Pending action payload, or null when not found.
+	 */
+	public function get( string $action_id ): ?array;
+
+	/**
+	 * Delete a pending action payload by action ID.
+	 *
+	 * Implementations SHOULD make delete idempotent for missing action IDs.
+	 *
+	 * @param string $action_id Durable action identifier.
+	 * @return bool Whether the delete operation completed successfully.
+	 */
+	public function delete( string $action_id ): bool;
+}

--- a/tests/bootstrap-smoke.php
+++ b/tests/bootstrap-smoke.php
@@ -66,6 +66,7 @@ agents_api_smoke_assert_equals( true, class_exists( 'WP_Agent_Package_Artifacts_
 agents_api_smoke_assert_equals( true, defined( 'AGENTS_API_PLUGIN_FILE' ), 'plugin file constant is available', $failures, $passes );
 agents_api_smoke_assert_equals( true, class_exists( 'AgentsAPI\\AI\\AgentMarkdownSectionCompactionAdapter' ), 'AgentsAPI\\AI\\AgentMarkdownSectionCompactionAdapter contract is available', $failures, $passes );
 agents_api_smoke_assert_equals( true, class_exists( 'AgentsAPI\\AI\\AgentConversationLoop' ), 'AgentConversationLoop facade is available', $failures, $passes );
+agents_api_smoke_assert_equals( true, interface_exists( 'AgentsAPI\\AI\\Approvals\\PendingActionStoreInterface' ), 'AgentsAPI\\AI\\Approvals\\PendingActionStoreInterface contract is available', $failures, $passes );
 foreach ( $namespace_map as $legacy_class => $target_class ) {
 	agents_api_smoke_assert_equals( true, class_exists( $target_class ) || interface_exists( $target_class ), $target_class . ' contract is available', $failures, $passes );
 	agents_api_smoke_assert_equals( false, class_exists( $legacy_class, false ) || interface_exists( $legacy_class, false ), $legacy_class . ' compatibility alias is not loaded', $failures, $passes );
@@ -108,6 +109,7 @@ agents_api_smoke_assert_equals( false, false !== strpos( $bootstrap_source, 'Dat
 
 echo "\n[3] Module source tree uses Agents API vocabulary:\n";
 $expected_source_directories = array(
+	'Approvals',
 	'Guidelines',
 	'Identity',
 	'Memory',

--- a/tests/pending-action-store-contract-smoke.php
+++ b/tests/pending-action-store-contract-smoke.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Pure-PHP smoke test for the Agents API pending action store contract.
+ *
+ * Run with: php tests/pending-action-store-contract-smoke.php
+ *
+ * @package AgentsAPI\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+$failures = array();
+$passes   = 0;
+
+echo "agents-api-pending-action-store-contract-smoke\n";
+
+require_once __DIR__ . '/agents-api-smoke-helpers.php';
+agents_api_smoke_require_module();
+
+echo "\n[1] Pending action store contract is available without a concrete backend:\n";
+agents_api_smoke_assert_equals( true, interface_exists( 'AgentsAPI\\AI\\Approvals\\PendingActionStoreInterface' ), 'pending action store interface is available', $failures, $passes );
+
+$reflection = new ReflectionClass( 'AgentsAPI\\AI\\Approvals\\PendingActionStoreInterface' );
+$methods    = array();
+foreach ( $reflection->getMethods() as $method ) {
+	$methods[ $method->getName() ] = $method;
+}
+
+echo "\n[2] Pending action store exposes the minimal generic lifecycle:\n";
+agents_api_smoke_assert_equals( array( 'store', 'get', 'delete' ), array_keys( $methods ), 'contract exposes only store/get/delete', $failures, $passes );
+agents_api_smoke_assert_equals( 'bool', (string) $methods['store']->getReturnType(), 'store returns bool', $failures, $passes );
+agents_api_smoke_assert_equals( '?array', (string) $methods['get']->getReturnType(), 'get returns nullable array', $failures, $passes );
+agents_api_smoke_assert_equals( 'bool', (string) $methods['delete']->getReturnType(), 'delete returns bool', $failures, $passes );
+
+$store_parameters  = $methods['store']->getParameters();
+$get_parameters    = $methods['get']->getParameters();
+$delete_parameters = $methods['delete']->getParameters();
+agents_api_smoke_assert_equals( array( 'action_id', 'payload' ), array_map( static fn( ReflectionParameter $parameter ): string => $parameter->getName(), $store_parameters ), 'store accepts action ID and payload', $failures, $passes );
+agents_api_smoke_assert_equals( 'string', (string) $store_parameters[0]->getType(), 'store action ID is string', $failures, $passes );
+agents_api_smoke_assert_equals( 'array', (string) $store_parameters[1]->getType(), 'store payload is array', $failures, $passes );
+agents_api_smoke_assert_equals( array( 'action_id' ), array_map( static fn( ReflectionParameter $parameter ): string => $parameter->getName(), $get_parameters ), 'get accepts action ID only', $failures, $passes );
+agents_api_smoke_assert_equals( 'string', (string) $get_parameters[0]->getType(), 'get action ID is string', $failures, $passes );
+agents_api_smoke_assert_equals( array( 'action_id' ), array_map( static fn( ReflectionParameter $parameter ): string => $parameter->getName(), $delete_parameters ), 'delete accepts action ID only', $failures, $passes );
+agents_api_smoke_assert_equals( 'string', (string) $delete_parameters[0]->getType(), 'delete action ID is string', $failures, $passes );
+
+agents_api_smoke_finish( 'Agents API pending action store contract', $failures, $passes );


### PR DESCRIPTION
## Summary
- Add a generic `AgentsAPI\AI\Approvals\PendingActionStoreInterface` for storing, retrieving, and deleting JSON-serializable pending action payloads.
- Wire the contract into the plugin bootstrap and smoke suite without adding a concrete backend or product-specific approval behavior.

## Testing
- `php tests/pending-action-store-contract-smoke.php`
- `composer test`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** drafted the focused implementation and tests; Chris reviews before merge.