### PR TITLE
Add pending approval action value object

### DIFF
--- a/agents-api.php
+++ b/agents-api.php
@@ -41,6 +41,7 @@ require_once AGENTS_API_PATH . 'src/Identity/MaterializedAgentIdentity.php';
 require_once AGENTS_API_PATH . 'src/Identity/MaterializedAgentIdentityStoreInterface.php';
 require_once AGENTS_API_PATH . 'src/Transcripts/ConversationTranscriptStoreInterface.php';
 require_once AGENTS_API_PATH . 'src/Approvals/PendingActionStoreInterface.php';
+require_once AGENTS_API_PATH . 'src/Approvals/PendingAction.php';
 require_once AGENTS_API_PATH . 'src/Runtime/AgentMessageEnvelope.php';
 require_once AGENTS_API_PATH . 'src/Runtime/AgentExecutionPrincipal.php';
 require_once AGENTS_API_PATH . 'src/Runtime/AgentCompactionItem.php';

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
       "php tests/tool-runtime-smoke.php",
       "php tests/pending-action-store-contract-smoke.php",
       "php tests/identity-smoke.php",
+      "php tests/approval-action-value-shape-smoke.php",
       "php tests/compaction-item-smoke.php",
       "php tests/conversation-runner-contracts-smoke.php",
       "php tests/conversation-compaction-smoke.php",

--- a/src/Approvals/PendingAction.php
+++ b/src/Approvals/PendingAction.php
@@ -1,0 +1,295 @@
+<?php
+/**
+ * Generic pending approval action value object.
+ *
+ * @package AgentsAPI
+ */
+
+namespace AgentsAPI\AI\Approvals;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Represents a proposed action awaiting approval.
+ */
+// phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Validation exceptions are not rendered output.
+class PendingAction {
+
+	/** @var string */
+	private $action_id;
+
+	/** @var string */
+	private $kind;
+
+	/** @var string */
+	private $summary;
+
+	/** @var mixed */
+	private $preview;
+
+	/** @var mixed */
+	private $apply_input;
+
+	/** @var string|null */
+	private $created_by;
+
+	/** @var string|null */
+	private $agent_id;
+
+	/** @var array<string, mixed> */
+	private $context;
+
+	/** @var string */
+	private $created_at;
+
+	/** @var string|null */
+	private $expires_at;
+
+	/**
+	 * @param string               $action_id   Stable action identifier.
+	 * @param string               $kind        Generic action kind.
+	 * @param string               $summary     Human-readable summary.
+	 * @param mixed                $preview     JSON-serializable preview payload.
+	 * @param mixed                $apply_input JSON-serializable apply payload.
+	 * @param string|null          $created_by  Optional creator identifier.
+	 * @param string|null          $agent_id    Optional agent identifier.
+	 * @param mixed                $context     Optional JSON-serializable context array.
+	 * @param string               $created_at  Creation timestamp string.
+	 * @param string|null          $expires_at  Optional expiration timestamp string.
+	 */
+	public function __construct(
+		$action_id,
+		$kind,
+		$summary,
+		$preview,
+		$apply_input,
+		$created_by,
+		$agent_id,
+		$context,
+		$created_at,
+		$expires_at
+	) {
+		$this->action_id   = self::normalize_string( $action_id, 'action_id' );
+		$this->kind        = self::normalize_string( $kind, 'kind' );
+		$this->summary     = self::normalize_string( $summary, 'summary' );
+		$this->preview     = self::normalize_json_value( $preview, 'preview' );
+		$this->apply_input = self::normalize_json_value( $apply_input, 'apply_input' );
+		$this->created_by  = self::normalize_optional_string( $created_by, 'created_by' );
+		$this->agent_id    = self::normalize_optional_string( $agent_id, 'agent_id' );
+		$this->context     = self::normalize_json_array( $context, 'context' );
+		$this->created_at  = self::normalize_string( $created_at, 'created_at' );
+		$this->expires_at  = self::normalize_optional_string( $expires_at, 'expires_at' );
+	}
+
+	/**
+	 * Build a pending action from an array shape.
+	 *
+	 * @param array<string, mixed> $action Raw action data.
+	 * @return self
+	 */
+	public static function from_array( array $action ): self {
+		return new self(
+			self::required_value( $action, 'action_id' ),
+			self::required_value( $action, 'kind' ),
+			self::required_value( $action, 'summary' ),
+			self::required_value( $action, 'preview' ),
+			self::required_value( $action, 'apply_input' ),
+			$action['created_by'] ?? null,
+			$action['agent_id'] ?? null,
+			$action['context'] ?? array(),
+			self::required_value( $action, 'created_at' ),
+			$action['expires_at'] ?? null
+		);
+	}
+
+	/**
+	 * Convert the action to its canonical public shape.
+	 *
+	 * @return array<string, mixed>
+	 */
+	public function to_array(): array {
+		return array(
+			'action_id'   => $this->action_id,
+			'kind'        => $this->kind,
+			'summary'     => $this->summary,
+			'preview'     => $this->preview,
+			'apply_input' => $this->apply_input,
+			'created_by'  => $this->created_by,
+			'agent_id'    => $this->agent_id,
+			'context'     => $this->context,
+			'created_at'  => $this->created_at,
+			'expires_at'  => $this->expires_at,
+		);
+	}
+
+	/**
+	 * @return string
+	 */
+	public function get_action_id(): string {
+		return $this->action_id;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function get_kind(): string {
+		return $this->kind;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function get_summary(): string {
+		return $this->summary;
+	}
+
+	/**
+	 * @return mixed
+	 */
+	public function get_preview() {
+		return $this->preview;
+	}
+
+	/**
+	 * @return mixed
+	 */
+	public function get_apply_input() {
+		return $this->apply_input;
+	}
+
+	/**
+	 * @return string|null
+	 */
+	public function get_created_by(): ?string {
+		return $this->created_by;
+	}
+
+	/**
+	 * @return string|null
+	 */
+	public function get_agent_id(): ?string {
+		return $this->agent_id;
+	}
+
+	/**
+	 * @return array<string, mixed>
+	 */
+	public function get_context(): array {
+		return $this->context;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function get_created_at(): string {
+		return $this->created_at;
+	}
+
+	/**
+	 * @return string|null
+	 */
+	public function get_expires_at(): ?string {
+		return $this->expires_at;
+	}
+
+	/**
+	 * Read a required array value.
+	 *
+	 * @param array<string, mixed> $source Source data.
+	 * @param string               $field  Field name.
+	 * @return mixed
+	 */
+	private static function required_value( array $source, string $field ) {
+		if ( ! array_key_exists( $field, $source ) ) {
+			throw new \InvalidArgumentException( 'invalid_ai_pending_action: ' . $field . ' is required' );
+		}
+
+		return $source[ $field ];
+	}
+
+	/**
+	 * Normalize a required string field.
+	 *
+	 * @param mixed  $value Raw value.
+	 * @param string $field Field name.
+	 * @return string
+	 */
+	private static function normalize_string( $value, string $field ): string {
+		if ( ! is_string( $value ) || '' === trim( $value ) ) {
+			throw new \InvalidArgumentException( 'invalid_ai_pending_action: ' . $field . ' must be a non-empty string' );
+		}
+
+		return trim( $value );
+	}
+
+	/**
+	 * Normalize an optional string field.
+	 *
+	 * @param mixed  $value Raw value.
+	 * @param string $field Field name.
+	 * @return string|null
+	 */
+	private static function normalize_optional_string( $value, string $field ): ?string {
+		if ( null === $value ) {
+			return null;
+		}
+
+		return self::normalize_string( $value, $field );
+	}
+
+	/**
+	 * Normalize a JSON-serializable array.
+	 *
+	 * @param mixed  $value Raw value.
+	 * @param string $field Field name.
+	 * @return array<string, mixed>
+	 */
+	private static function normalize_json_array( $value, string $field ): array {
+		if ( ! is_array( $value ) ) {
+			throw new \InvalidArgumentException( 'invalid_ai_pending_action: ' . $field . ' must be an array' );
+		}
+
+		self::assert_json_serializable( $value, $field );
+		return $value;
+	}
+
+	/**
+	 * Normalize any JSON-serializable value.
+	 *
+	 * @param mixed  $value Raw value.
+	 * @param string $field Field name.
+	 * @return mixed
+	 */
+	private static function normalize_json_value( $value, string $field ) {
+		self::assert_json_serializable( $value, $field );
+		return $value;
+	}
+
+	/**
+	 * Validate JSON serializability with a pure-PHP fallback for smokes.
+	 *
+	 * @param mixed  $value Raw value.
+	 * @param string $field Field name.
+	 */
+	private static function assert_json_serializable( $value, string $field ): void {
+		$encoded = self::json_encode( $value );
+		if ( false === $encoded || JSON_ERROR_NONE !== json_last_error() ) {
+			throw new \InvalidArgumentException( 'invalid_ai_pending_action: ' . $field . ' must be JSON serializable' );
+		}
+	}
+
+	/**
+	 * Encode data with a WordPress-aware fallback.
+	 *
+	 * @param mixed $data Data to encode.
+	 * @return string|false Encoded JSON or false on failure.
+	 */
+	private static function json_encode( $data ) {
+		if ( function_exists( 'wp_json_encode' ) ) {
+			return wp_json_encode( $data );
+		}
+
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.json_encode_json_encode -- Pure-PHP smoke tests run without WordPress loaded.
+		return json_encode( $data );
+	}
+}

--- a/tests/approval-action-value-shape-smoke.php
+++ b/tests/approval-action-value-shape-smoke.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * Pure-PHP smoke test for the Agents API pending approval action value shape.
+ *
+ * Run with: php tests/approval-action-value-shape-smoke.php
+ *
+ * @package AgentsAPI\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+$failures = array();
+$passes   = 0;
+
+echo "agents-api-approval-action-value-shape-smoke\n";
+
+require_once __DIR__ . '/agents-api-smoke-helpers.php';
+agents_api_smoke_require_module();
+
+echo "\n[1] Array input round-trips through the pending action shape:\n";
+$raw = array(
+	'action_id'   => 'approve-123',
+	'kind'        => 'content_update',
+	'summary'     => 'Update the public content summary.',
+	'preview'     => array(
+		'before' => 'Old summary',
+		'after'  => 'New summary',
+	),
+	'apply_input' => array(
+		'target_id' => 'content-42',
+		'changes'   => array( 'summary' => 'New summary' ),
+	),
+	'created_by'  => 'user-7',
+	'agent_id'    => 'agent-reviewer',
+	'context'     => array(
+		'source' => 'runtime',
+		'trace'  => array( 'request_id' => 'req-abc' ),
+	),
+	'created_at'  => '2026-05-03T15:00:00Z',
+	'expires_at'  => '2026-05-04T15:00:00Z',
+);
+
+$action = AgentsAPI\AI\Approvals\PendingAction::from_array( $raw );
+$array  = $action->to_array();
+
+agents_api_smoke_assert_equals( $raw, $array, 'canonical array preserves all public fields', $failures, $passes );
+agents_api_smoke_assert_equals( 'approve-123', $action->get_action_id(), 'action id getter returns canonical id', $failures, $passes );
+agents_api_smoke_assert_equals( 'content_update', $action->get_kind(), 'kind getter returns generic kind', $failures, $passes );
+agents_api_smoke_assert_equals( array( 'source' => 'runtime', 'trace' => array( 'request_id' => 'req-abc' ) ), $action->get_context(), 'context getter returns context', $failures, $passes );
+
+echo "\n[2] Optional identity and expiration fields can be absent:\n";
+$minimal = AgentsAPI\AI\Approvals\PendingAction::from_array(
+	array(
+		'action_id'   => 'approve-124',
+		'kind'        => 'file_patch',
+		'summary'     => 'Review a proposed patch.',
+		'preview'     => 'diff --git a/example b/example',
+		'apply_input' => array( 'patch' => '...' ),
+		'created_at'  => '2026-05-03T15:10:00Z',
+	)
+)->to_array();
+
+agents_api_smoke_assert_equals( null, $minimal['created_by'], 'created_by defaults to null', $failures, $passes );
+agents_api_smoke_assert_equals( null, $minimal['agent_id'], 'agent_id defaults to null', $failures, $passes );
+agents_api_smoke_assert_equals( array(), $minimal['context'], 'context defaults to empty array', $failures, $passes );
+agents_api_smoke_assert_equals( null, $minimal['expires_at'], 'expires_at defaults to null', $failures, $passes );
+
+echo "\n[3] Invalid fields are rejected generically:\n";
+$invalid_cases = array(
+	'missing action_id'       => array( 'kind' => 'update', 'summary' => 'Summary', 'preview' => array(), 'apply_input' => array(), 'created_at' => 'now' ),
+	'invalid action_id'       => array( 'action_id' => 123, 'kind' => 'update', 'summary' => 'Summary', 'preview' => array(), 'apply_input' => array(), 'created_at' => 'now' ),
+	'empty kind'              => array( 'action_id' => 'approve-1', 'kind' => '', 'summary' => 'Summary', 'preview' => array(), 'apply_input' => array(), 'created_at' => 'now' ),
+	'invalid context'         => array( 'action_id' => 'approve-1', 'kind' => 'update', 'summary' => 'Summary', 'preview' => array(), 'apply_input' => array(), 'context' => 'nope', 'created_at' => 'now' ),
+	'non-serializable input'  => array( 'action_id' => 'approve-1', 'kind' => 'update', 'summary' => 'Summary', 'preview' => array(), 'apply_input' => tmpfile(), 'created_at' => 'now' ),
+	'invalid optional string' => array( 'action_id' => 'approve-1', 'kind' => 'update', 'summary' => 'Summary', 'preview' => array(), 'apply_input' => array(), 'created_by' => '', 'created_at' => 'now' ),
+);
+
+foreach ( $invalid_cases as $name => $invalid_action ) {
+	$thrown = false;
+	try {
+		AgentsAPI\AI\Approvals\PendingAction::from_array( $invalid_action );
+	} catch ( InvalidArgumentException $error ) {
+		$thrown = 0 === strpos( $error->getMessage(), 'invalid_ai_pending_action:' );
+	}
+	agents_api_smoke_assert_equals( true, $thrown, $name . ' throws contract exception', $failures, $passes );
+}
+
+agents_api_smoke_finish( 'Agents API approval action value shape', $failures, $passes );


### PR DESCRIPTION
## Summary
- Adds a generic `AgentsAPI\AI\Approvals\PendingAction` value object for proposed actions awaiting approval.
- Validates only generic JSON-serializable action payloads and exposes `from_array()` / `to_array()` plus getters.
- Adds a focused pure-PHP smoke test and wires it into the Composer smoke suite.

## Testing
- `php tests/approval-action-value-shape-smoke.php`
- `composer test`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** drafted the focused implementation and tests; Chris reviews before merge.