### PR TITLE
Add action policy vocabulary

### DIFF
--- a/agents-api.php
+++ b/agents-api.php
@@ -56,6 +56,7 @@ require_once AGENTS_API_PATH . 'src/Runtime/IterationBudget.php';
 require_once AGENTS_API_PATH . 'src/Runtime/AgentConversationResult.php';
 require_once AGENTS_API_PATH . 'src/Runtime/AgentConversationLoop.php';
 require_once AGENTS_API_PATH . 'src/Tools/ToolCall.php';
+require_once AGENTS_API_PATH . 'src/Tools/ActionPolicy.php';
 require_once AGENTS_API_PATH . 'src/Tools/ToolParameters.php';
 require_once AGENTS_API_PATH . 'src/Tools/ToolExecutionResult.php';
 require_once AGENTS_API_PATH . 'src/Tools/ToolExecutorInterface.php';

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
       "php tests/bootstrap-smoke.php",
       "php tests/registry-smoke.php",
       "php tests/execution-principal-smoke.php",
+      "php tests/action-policy-values-smoke.php",
       "php tests/tool-runtime-smoke.php",
       "php tests/identity-smoke.php",
       "php tests/compaction-item-smoke.php",

--- a/src/Tools/ActionPolicy.php
+++ b/src/Tools/ActionPolicy.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * Tool action policy vocabulary.
+ *
+ * @package AgentsAPI
+ */
+
+namespace AgentsAPI\AI\Tools;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Normalizes generic tool action policy values.
+ */
+final class ActionPolicy {
+
+	/** Execute the tool call immediately. */
+	public const DIRECT = 'direct';
+
+	/** Stage the tool call for user review before execution. */
+	public const PREVIEW = 'preview';
+
+	/** Refuse the tool call without execution. */
+	public const FORBIDDEN = 'forbidden';
+
+	/**
+	 * Return all valid policy values.
+	 *
+	 * @return string[]
+	 */
+	public static function all(): array {
+		return array(
+			self::DIRECT,
+			self::PREVIEW,
+			self::FORBIDDEN,
+		);
+	}
+
+	/**
+	 * Determine whether a raw value is a recognized action policy.
+	 *
+	 * @param mixed $value Raw policy value.
+	 * @return bool
+	 */
+	public static function isValid( $value ): bool {
+		return null !== self::normalize( $value );
+	}
+
+	/**
+	 * Normalize a raw policy value.
+	 *
+	 * @param mixed       $value    Raw policy value.
+	 * @param string|null $fallback Optional fallback used when value is invalid.
+	 * @return string|null One of the policy constants, or null when invalid.
+	 */
+	public static function normalize( $value, ?string $fallback = null ): ?string {
+		if ( is_string( $value ) ) {
+			$normalized = strtolower( trim( $value ) );
+			if ( in_array( $normalized, self::all(), true ) ) {
+				return $normalized;
+			}
+		}
+
+		if ( null === $fallback ) {
+			return null;
+		}
+
+		return self::normalize( $fallback );
+	}
+
+	/**
+	 * Whether the policy allows immediate execution.
+	 *
+	 * @param mixed $policy Raw or normalized policy value.
+	 * @return bool
+	 */
+	public static function allowsDirectExecution( $policy ): bool {
+		return self::DIRECT === self::normalize( $policy );
+	}
+
+	/**
+	 * Whether the policy stages execution for approval.
+	 *
+	 * @param mixed $policy Raw or normalized policy value.
+	 * @return bool
+	 */
+	public static function stagesApproval( $policy ): bool {
+		return self::PREVIEW === self::normalize( $policy );
+	}
+
+	/**
+	 * Whether the policy refuses execution.
+	 *
+	 * @param mixed $policy Raw or normalized policy value.
+	 * @return bool
+	 */
+	public static function refusesExecution( $policy ): bool {
+		return self::FORBIDDEN === self::normalize( $policy );
+	}
+}

--- a/tests/action-policy-values-smoke.php
+++ b/tests/action-policy-values-smoke.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Pure-PHP smoke test for generic action policy values.
+ *
+ * Run with: php tests/action-policy-values-smoke.php
+ *
+ * @package AgentsAPI\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+$failures = array();
+$passes   = 0;
+
+echo "agents-api-action-policy-values-smoke\n";
+
+require_once __DIR__ . '/agents-api-smoke-helpers.php';
+agents_api_smoke_require_module();
+
+$policy_class = AgentsAPI\AI\Tools\ActionPolicy::class;
+
+agents_api_smoke_assert_equals(
+	array( 'direct', 'preview', 'forbidden' ),
+	$policy_class::all(),
+	'action policy exposes stable generic values',
+	$failures,
+	$passes
+);
+
+agents_api_smoke_assert_equals( 'direct', $policy_class::normalize( ' Direct ' ), 'action policy normalizes direct values', $failures, $passes );
+agents_api_smoke_assert_equals( 'preview', $policy_class::normalize( 'PREVIEW' ), 'action policy normalizes preview values', $failures, $passes );
+agents_api_smoke_assert_equals( 'forbidden', $policy_class::normalize( ' forbidden ' ), 'action policy normalizes forbidden values', $failures, $passes );
+agents_api_smoke_assert_equals( null, $policy_class::normalize( 'approve' ), 'action policy rejects unknown values', $failures, $passes );
+agents_api_smoke_assert_equals( 'direct', $policy_class::normalize( 'approve', $policy_class::DIRECT ), 'action policy applies valid fallback', $failures, $passes );
+agents_api_smoke_assert_equals( null, $policy_class::normalize( 'approve', 'also-invalid' ), 'action policy rejects invalid fallback', $failures, $passes );
+agents_api_smoke_assert_equals( true, $policy_class::isValid( 'preview' ), 'action policy validates known values', $failures, $passes );
+agents_api_smoke_assert_equals( false, $policy_class::isValid( 'review' ), 'action policy invalidates unknown values', $failures, $passes );
+agents_api_smoke_assert_equals( true, $policy_class::allowsDirectExecution( 'direct' ), 'direct policy permits immediate execution', $failures, $passes );
+agents_api_smoke_assert_equals( true, $policy_class::stagesApproval( 'preview' ), 'preview policy stages approval', $failures, $passes );
+agents_api_smoke_assert_equals( true, $policy_class::refusesExecution( 'forbidden' ), 'forbidden policy refuses execution', $failures, $passes );
+
+agents_api_smoke_finish( 'Agents API action policy values', $failures, $passes );


### PR DESCRIPTION
## Summary
- Adds a generic `AgentsAPI\AI\Tools\ActionPolicy` vocabulary for `direct`, `preview`, and `forbidden` tool action policies.
- Provides normalization and decision helpers for runtimes that execute immediately, stage approval, or refuse a tool call.
- Adds focused smoke coverage and wires it into the existing Composer smoke suite.

## Testing
- `php tests/action-policy-values-smoke.php`
- `composer test`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** drafted the focused implementation and tests; Chris reviews before merge.