### PR TITLE
Add approval-required envelope builder

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
   "scripts": {
     "test": [
       "php tests/bootstrap-smoke.php",
+      "php tests/message-envelope-smoke.php",
       "php tests/registry-smoke.php",
       "php tests/execution-principal-smoke.php",
       "php tests/tool-runtime-smoke.php",

--- a/src/Runtime/AgentMessageEnvelope.php
+++ b/src/Runtime/AgentMessageEnvelope.php
@@ -103,6 +103,21 @@ class AgentMessageEnvelope {
 	}
 
 	/**
+	 * Build a canonical approval-required envelope.
+	 *
+	 * The payload is intentionally generic so consumers can describe any pending
+	 * action without coupling the envelope contract to a specific runtime.
+	 *
+	 * @param string $content  Human-readable approval request content.
+	 * @param array  $payload  Approval payload, for example action_id, kind, summary, preview, resolve, expires_at.
+	 * @param array  $metadata Extension metadata.
+	 * @return array<string, mixed>
+	 */
+	public static function approvalRequired( string $content, array $payload, array $metadata = array() ): array {
+		return self::buildEnvelope( self::roleForType( self::TYPE_APPROVAL_REQUIRED ), $content, self::TYPE_APPROVAL_REQUIRED, $payload, $metadata, array() );
+	}
+
+	/**
 	 * Normalize a legacy message or typed envelope to the canonical envelope.
 	 *
 	 * @param array $message Message array.

--- a/tests/message-envelope-smoke.php
+++ b/tests/message-envelope-smoke.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Pure-PHP smoke test for generic message envelopes.
+ *
+ * Run with: php tests/message-envelope-smoke.php
+ *
+ * @package AgentsAPI\Tests
+ */
+
+$failures = array();
+$passes   = 0;
+
+echo "agents-api-message-envelope-smoke\n";
+
+require_once __DIR__ . '/agents-api-smoke-helpers.php';
+agents_api_smoke_require_module();
+
+echo "\n[1] Approval-required envelopes carry generic pending action payloads:\n";
+$payload  = array(
+	'action_id'  => 'approve-diff-123',
+	'kind'       => 'diff',
+	'summary'    => 'Review generated changes before they are applied.',
+	'preview'    => array(
+		'format' => 'unified_diff',
+		'value'  => "--- a/example.txt\n+++ b/example.txt\n@@\n-old\n+new\n",
+	),
+	'resolve'    => array(
+		'approve' => array( 'label' => 'Approve' ),
+		'reject'  => array( 'label' => 'Reject' ),
+	),
+	'expires_at' => '2026-05-03T12:00:00Z',
+);
+$metadata = array(
+	'source' => 'smoke',
+);
+
+$envelope = AgentsAPI\AI\AgentMessageEnvelope::approvalRequired( 'Approval required before applying changes.', $payload, $metadata );
+agents_api_smoke_assert_equals( AgentsAPI\AI\AgentMessageEnvelope::SCHEMA, $envelope['schema'], 'approval envelope uses canonical schema', $failures, $passes );
+agents_api_smoke_assert_equals( AgentsAPI\AI\AgentMessageEnvelope::TYPE_APPROVAL_REQUIRED, $envelope['type'], 'approval envelope has approval_required type', $failures, $passes );
+agents_api_smoke_assert_equals( 'tool', $envelope['role'], 'approval envelope uses action role', $failures, $passes );
+agents_api_smoke_assert_equals( $payload, $envelope['payload'], 'approval envelope preserves generic payload', $failures, $passes );
+agents_api_smoke_assert_equals( $metadata, $envelope['metadata'], 'approval envelope preserves metadata', $failures, $passes );
+
+echo "\n[2] Normalization and provider projection preserve the typed envelope:\n";
+$normalized = AgentsAPI\AI\AgentMessageEnvelope::normalize( $envelope );
+agents_api_smoke_assert_equals( $envelope, $normalized, 'normalization preserves approval envelope', $failures, $passes );
+
+$provider_message = AgentsAPI\AI\AgentMessageEnvelope::to_provider_message( $envelope );
+agents_api_smoke_assert_equals( 'tool', $provider_message['role'], 'provider projection preserves role', $failures, $passes );
+agents_api_smoke_assert_equals( 'Approval required before applying changes.', $provider_message['content'], 'provider projection preserves content', $failures, $passes );
+agents_api_smoke_assert_equals( AgentsAPI\AI\AgentMessageEnvelope::TYPE_APPROVAL_REQUIRED, $provider_message['metadata']['type'], 'provider projection preserves type metadata', $failures, $passes );
+agents_api_smoke_assert_equals( 'approve-diff-123', $provider_message['metadata']['action_id'], 'provider projection exposes action_id metadata', $failures, $passes );
+agents_api_smoke_assert_equals( $payload['preview'], $provider_message['metadata']['preview'], 'provider projection exposes preview metadata', $failures, $passes );
+agents_api_smoke_assert_equals( 'smoke', $provider_message['metadata']['source'], 'provider projection keeps extension metadata', $failures, $passes );
+
+agents_api_smoke_finish( 'message envelope smoke', $failures, $passes );


### PR DESCRIPTION
## Summary
- Adds `AgentMessageEnvelope::approvalRequired()` for generic pending-action approval messages.
- Covers approval-required envelope normalization and provider projection with a focused smoke test.
- Includes the new focused smoke in the composer smoke suite.

## Testing
- `php tests/message-envelope-smoke.php`
- `composer test`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** drafted the focused implementation and tests; Chris reviews before merge.