### PR TITLE
Promote memory context registries

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Agents API sits between tool/action discovery and product-specific automation. I
 - Agent package and package-artifact contracts.
 - Shared `wp_guideline` / `wp_guideline_type` storage substrate polyfill when Core/Gutenberg do not provide it.
 - Agent memory store contracts and value objects.
+- Generic memory/context source registry, context section registry, injection policy vocabulary, and composable context value object.
 - Conversation compaction policy and transcript transformation contracts.
 - Generic multi-turn conversation loop sequencing around caller-owned adapters.
 - Iteration budget primitives for bounded execution across configurable dimensions.
@@ -45,6 +46,7 @@ Agents API sits between tool/action discovery and product-specific automation. I
 - Product runner adapters that assemble prompts, choose concrete tools, materialize storage, or decide product policy.
 - Concrete tool execution adapters, prompt assembly policy, or product storage/materialization policy.
 - Product-specific consent UX, support routing, escalation targets, or transcript-sharing policy.
+- Concrete memory retrieval, file projection, convention-path writing, or filesystem layout adapters.
 
 Products can require Agents API because they build on the substrate. Agents API must not depend on any product plugin, import product classes, mirror a product source tree, or encode product vocabulary as generic runtime API.
 
@@ -105,6 +107,11 @@ wp_register_agent(
 - `WP_Agent_Authorization_Policy_Interface`
 - `WP_Agent_WordPress_Authorization_Policy`
 - `WP_Agent_Capability_Ceiling`
+- `WP_Agent_Memory_Registry`
+- `WP_Agent_Memory_Layer`
+- `WP_Agent_Context_Section_Registry`
+- `WP_Agent_Context_Injection_Policy`
+- `WP_Agent_Composable_Context`
 - `wp_guideline_types()` and `WP_Guidelines_Substrate`
 - `AgentsAPI\AI\AgentMessageEnvelope`
 - `AgentsAPI\AI\AgentExecutionPrincipal`
@@ -266,6 +273,62 @@ Workspace-shared guidance is identified with `_wp_guideline_scope=workspace_shar
 The substrate maps private memory reads/edits through the explicit owner metadata, so editors and administrators do not gain access merely because they can read private posts. Workspace-shared guidance reads map to the editorial threshold (`edit_posts`), edits map to the publishing threshold (`publish_posts`), and promotion from private memory to shared guidance requires the owner plus the explicit `promote_agent_memory` capability.
 
 Hosts that provide their own guideline substrate can disable the polyfill with the `wp_guidelines_substrate_enabled` filter or register `wp_guideline` before Agents API does.
+
+## Memory And Context Registry
+
+Agents API separates memory identity, retrieval policy, composable context assembly, and storage projection:
+
+```text
+Memory/context source registry -> what can exist and when it is eligible
+Context section registry       -> ordered pieces that can compose a context
+Composable context             -> runtime assembly result
+Consumer adapters              -> file paths, database rows, guidelines, external stores
+```
+
+`WP_Agent_Memory_Registry` registers memory/context sources by layer and mode without assuming they are files. File conventions are metadata for adapters, not the identity model:
+
+```php
+WP_Agent_Memory_Registry::register(
+	'workspace/instructions',
+	array(
+		'layer'            => WP_Agent_Memory_Layer::WORKSPACE,
+		'priority'         => 20,
+		'protected'        => true,
+		'editable'         => false,
+		'modes'            => array( 'chat', 'pipeline' ),
+		'retrieval_policy' => WP_Agent_Context_Injection_Policy::ALWAYS,
+		'composable'       => true,
+		'context_slug'     => 'workspace-instructions',
+		'convention_path'  => 'AGENTS.md',
+	)
+);
+```
+
+Supported retrieval policies are `always`, `on_intent`, `on_tool_need`, `manual`, and `never`. Agents API only defines vocabulary and filtering; dynamic retrieval heuristics remain consumer/runtime policy.
+
+`WP_Agent_Context_Section_Registry` registers composable sections independently from any projection target:
+
+```php
+WP_Agent_Context_Section_Registry::register(
+	'workspace-instructions',
+	'agent-memory-policy',
+	20,
+	static function ( array $context, array $section ): string {
+		return "## Memory Policy\nUse only context sources allowed for " . ( $context['mode'] ?? 'runtime' ) . '.';
+	},
+	array(
+		'modes'            => array( 'chat' ),
+		'retrieval_policy' => WP_Agent_Context_Injection_Policy::ALWAYS,
+	)
+);
+
+$composed = WP_Agent_Context_Section_Registry::compose(
+	'workspace-instructions',
+	array( 'mode' => 'chat' )
+);
+```
+
+The generic layer vocabulary uses `workspace` rather than `site`. Products that need site or network files should map them through adapters or registration metadata such as `convention_path` or `external_projection_target`.
 
 ## Execution Principals
 

--- a/agents-api.php
+++ b/agents-api.php
@@ -41,6 +41,11 @@ require_once AGENTS_API_PATH . 'src/Auth/class-wp-agent-token-store-interface.ph
 require_once AGENTS_API_PATH . 'src/Auth/class-wp-agent-authorization-policy-interface.php';
 require_once AGENTS_API_PATH . 'src/Auth/class-wp-agent-token-authenticator.php';
 require_once AGENTS_API_PATH . 'src/Auth/class-wp-agent-wordpress-authorization-policy.php';
+require_once AGENTS_API_PATH . 'src/Context/class-wp-agent-context-injection-policy.php';
+require_once AGENTS_API_PATH . 'src/Context/class-wp-agent-memory-layer.php';
+require_once AGENTS_API_PATH . 'src/Context/class-wp-agent-memory-registry.php';
+require_once AGENTS_API_PATH . 'src/Context/class-wp-agent-composable-context.php';
+require_once AGENTS_API_PATH . 'src/Context/class-wp-agent-context-section-registry.php';
 require_once AGENTS_API_PATH . 'src/Registry/class-wp-agents-registry.php';
 require_once AGENTS_API_PATH . 'src/Registry/register-agents.php';
 require_once AGENTS_API_PATH . 'src/Packages/register-agent-package-artifacts.php';

--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,7 @@
       "php tests/conversation-runner-contracts-smoke.php",
       "php tests/conversation-compaction-smoke.php",
       "php tests/markdown-section-compaction-smoke.php",
+      "php tests/context-registry-smoke.php",
       "php tests/conversation-loop-smoke.php",
       "php tests/conversation-loop-tool-execution-smoke.php",
       "php tests/conversation-loop-completion-policy-smoke.php",

--- a/src/Context/class-wp-agent-composable-context.php
+++ b/src/Context/class-wp-agent-composable-context.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * Composable agent context value object.
+ *
+ * @package AgentsAPI
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+if ( ! class_exists( 'WP_Agent_Composable_Context' ) ) {
+	/**
+	 * Represents the result of composing context sections.
+	 */
+	final class WP_Agent_Composable_Context {
+
+		/**
+		 * @param string $slug     Context slug.
+		 * @param string $content  Composed content.
+		 * @param array  $sections Section metadata keyed by section slug.
+		 * @param array  $metadata Composition metadata.
+		 */
+		public function __construct(
+			public readonly string $slug,
+			public readonly string $content,
+			public readonly array $sections = array(),
+			public readonly array $metadata = array(),
+		) {}
+
+		/**
+		 * Compose context content from ordered section metadata.
+		 *
+		 * @param string $context_slug Context identifier.
+		 * @param array  $sections     Section metadata keyed by section slug.
+		 * @param array  $context      Runtime context passed to section callbacks.
+		 * @return self
+		 */
+		public static function compose( string $context_slug, array $sections, array $context = array() ): self {
+			$parts    = array();
+			$included = array();
+
+			foreach ( $sections as $slug => $section ) {
+				if ( ! is_array( $section ) || ! is_callable( $section['callback'] ?? null ) ) {
+					continue;
+				}
+
+				$output = call_user_func( $section['callback'], $context, $section );
+				if ( is_string( $output ) && '' !== trim( $output ) ) {
+					$parts[]    = trim( $output );
+					$included[] = is_string( $slug ) ? $slug : (string) ( $section['slug'] ?? '' );
+				}
+			}
+
+			$content = implode( "\n\n", $parts );
+			if ( function_exists( 'apply_filters' ) ) {
+				$filtered = apply_filters( 'agents_api_composable_context_content', $content, $context_slug, $sections, $context );
+				$content  = is_string( $filtered ) ? $filtered : $content;
+			}
+
+			return new self(
+				$context_slug,
+				$content,
+				$sections,
+				array(
+					'included_sections' => array_values( array_filter( $included ) ),
+					'section_count'     => count( $included ),
+				)
+			);
+		}
+
+		/**
+		 * Whether the composed context has non-empty content.
+		 *
+		 * @return bool
+		 */
+		public function has_content(): bool {
+			return '' !== trim( $this->content );
+		}
+
+		/**
+		 * Array representation for adapters and tests.
+		 *
+		 * @return array<string, mixed>
+		 */
+		public function to_array(): array {
+			return array(
+				'slug'     => $this->slug,
+				'content'  => $this->content,
+				'sections' => $this->sections,
+				'metadata' => $this->metadata,
+			);
+		}
+	}
+}

--- a/src/Context/class-wp-agent-context-injection-policy.php
+++ b/src/Context/class-wp-agent-context-injection-policy.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * Agent context injection policy vocabulary.
+ *
+ * @package AgentsAPI
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+if ( ! class_exists( 'WP_Agent_Context_Injection_Policy' ) ) {
+	/**
+	 * Canonical retrieval policy values for memory and context sources.
+	 */
+	final class WP_Agent_Context_Injection_Policy {
+
+		public const ALWAYS       = 'always';
+		public const ON_INTENT    = 'on_intent';
+		public const ON_TOOL_NEED = 'on_tool_need';
+		public const MANUAL       = 'manual';
+		public const NEVER        = 'never';
+
+		/**
+		 * Return the supported policy vocabulary.
+		 *
+		 * @return string[]
+		 */
+		public static function values(): array {
+			return array(
+				self::ALWAYS,
+				self::ON_INTENT,
+				self::ON_TOOL_NEED,
+				self::MANUAL,
+				self::NEVER,
+			);
+		}
+
+		/**
+		 * Normalize a raw policy string to a known vocabulary value.
+		 *
+		 * @param mixed  $policy  Raw policy value.
+		 * @param string $fallback_policy Default policy when the raw value is invalid.
+		 * @return string
+		 */
+		public static function normalize( $policy, string $fallback_policy = self::ALWAYS ): string {
+			$fallback_policy = in_array( $fallback_policy, self::values(), true ) ? $fallback_policy : self::ALWAYS;
+			$policy          = self::sanitize_slug( is_string( $policy ) ? $policy : '' );
+
+			return in_array( $policy, self::values(), true ) ? $policy : $fallback_policy;
+		}
+
+		/**
+		 * Whether a policy should be injected without runtime retrieval decisions.
+		 *
+		 * @param string $policy Policy value.
+		 * @return bool
+		 */
+		public static function is_always_injected( string $policy ): bool {
+			return self::ALWAYS === self::normalize( $policy );
+		}
+
+		/**
+		 * Whether a policy can be retrieved by a dynamic retrieval layer later.
+		 *
+		 * @param string $policy Policy value.
+		 * @return bool
+		 */
+		public static function is_retrievable( string $policy ): bool {
+			return in_array(
+				self::normalize( $policy ),
+				array( self::ALWAYS, self::ON_INTENT, self::ON_TOOL_NEED, self::MANUAL ),
+				true
+			);
+		}
+
+		/**
+		 * Small local sanitizer so the substrate can run in pure-PHP tests.
+		 *
+		 * @param string $value Raw slug.
+		 * @return string
+		 */
+		private static function sanitize_slug( string $value ): string {
+			$value = strtolower( $value );
+			$value = preg_replace( '/[^a-z0-9_\-]+/', '_', $value );
+
+			return trim( is_string( $value ) ? $value : '', '_' );
+		}
+	}
+}

--- a/src/Context/class-wp-agent-context-section-registry.php
+++ b/src/Context/class-wp-agent-context-section-registry.php
@@ -1,0 +1,193 @@
+<?php
+/**
+ * Generic agent context section registry.
+ *
+ * @package AgentsAPI
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+if ( ! class_exists( 'WP_Agent_Context_Section_Registry' ) ) {
+	/**
+	 * Registers composable context sections independently from files or stores.
+	 */
+	final class WP_Agent_Context_Section_Registry {
+
+		/**
+		 * Registered sections keyed by context slug then section slug.
+		 *
+		 * @var array<string, array<string, array<string, mixed>>>
+		 */
+		private static array $sections = array();
+
+		/**
+		 * Whether extension hooks have been fired.
+		 *
+		 * @var bool
+		 */
+		private static bool $hooks_fired = false;
+
+		/**
+		 * Register a section for a composable context.
+		 *
+		 * @param string   $context_slug Context identifier.
+		 * @param string   $section_slug Section identifier.
+		 * @param int      $priority     Sort priority. Lower numbers compose first.
+		 * @param callable $callback     Receives `(array $context, array $section)` and returns content.
+		 * @param array    $args         Section metadata.
+		 * @return array<string, mixed>|null Normalized section metadata, or null on invalid input.
+		 */
+		public static function register( string $context_slug, string $section_slug, int $priority, callable $callback, array $args = array() ): ?array {
+			$context_slug = self::sanitize_slug( $context_slug );
+			$section_slug = self::sanitize_slug( $section_slug );
+
+			if ( '' === $context_slug || '' === $section_slug ) {
+				return null;
+			}
+
+			if ( ! isset( self::$sections[ $context_slug ] ) ) {
+				self::$sections[ $context_slug ] = array();
+			}
+
+			$section = array(
+				'context_slug'     => $context_slug,
+				'slug'             => $section_slug,
+				'priority'         => $priority,
+				'callback'         => $callback,
+				'retrieval_policy' => WP_Agent_Context_Injection_Policy::normalize( $args['retrieval_policy'] ?? null ),
+				'modes'            => self::normalize_modes( $args['modes'] ?? array( WP_Agent_Memory_Registry::MODE_ALL ) ),
+				'label'            => is_string( $args['label'] ?? null ) ? $args['label'] : self::slug_to_label( $section_slug ),
+				'description'      => is_string( $args['description'] ?? null ) ? $args['description'] : '',
+				'meta'             => is_array( $args['meta'] ?? null ) ? $args['meta'] : array(),
+			);
+
+			self::$sections[ $context_slug ][ $section_slug ] = $section;
+
+			return $section;
+		}
+
+		/**
+		 * Remove a registered section.
+		 *
+		 * @param string $context_slug Context identifier.
+		 * @param string $section_slug Section identifier.
+		 * @return void
+		 */
+		public static function unregister( string $context_slug, string $section_slug ): void {
+			unset( self::$sections[ self::sanitize_slug( $context_slug ) ][ self::sanitize_slug( $section_slug ) ] );
+		}
+
+		/**
+		 * Return sections for a context in priority order.
+		 *
+		 * @param string $context_slug Context identifier.
+		 * @param array  $context      Runtime context, optionally including `mode`.
+		 * @return array<string, array<string, mixed>>
+		 */
+		public static function get_sections( string $context_slug, array $context = array() ): array {
+			self::ensure_hooks_fired();
+
+			$context_slug = self::sanitize_slug( $context_slug );
+			$mode         = self::sanitize_slug( is_string( $context['mode'] ?? null ) ? $context['mode'] : '' );
+			$sections     = self::$sections[ $context_slug ] ?? array();
+
+			$sections = array_filter(
+				$sections,
+				static function ( array $section ) use ( $mode ): bool {
+					$modes = $section['modes'] ?? array( WP_Agent_Memory_Registry::MODE_ALL );
+					return '' === $mode || in_array( WP_Agent_Memory_Registry::MODE_ALL, $modes, true ) || in_array( $mode, $modes, true );
+				}
+			);
+
+			uasort(
+				$sections,
+				static function ( array $a, array $b ): int {
+					$priority_order = $a['priority'] <=> $b['priority'];
+					return 0 !== $priority_order ? $priority_order : strcmp( $a['slug'], $b['slug'] );
+				}
+			);
+
+			return $sections;
+		}
+
+		/**
+		 * Compose a context from registered sections.
+		 *
+		 * @param string $context_slug Context identifier.
+		 * @param array  $context      Runtime context passed to callbacks.
+		 * @return WP_Agent_Composable_Context
+		 */
+		public static function compose( string $context_slug, array $context = array() ): WP_Agent_Composable_Context {
+			return WP_Agent_Composable_Context::compose( $context_slug, self::get_sections( $context_slug, $context ), $context );
+		}
+
+		/**
+		 * Return context slugs that currently have sections.
+		 *
+		 * @return string[]
+		 */
+		public static function get_context_slugs(): array {
+			self::ensure_hooks_fired();
+
+			return array_keys( array_filter( self::$sections ) );
+		}
+
+		/**
+		 * Reset registry state. Intended for tests.
+		 *
+		 * @return void
+		 */
+		public static function reset(): void {
+			self::$sections    = array();
+			self::$hooks_fired = false;
+		}
+
+		/**
+		 * Fire extension hook once.
+		 *
+		 * @return void
+		 */
+		private static function ensure_hooks_fired(): void {
+			if ( self::$hooks_fired ) {
+				return;
+			}
+
+			if ( function_exists( 'do_action' ) ) {
+				do_action( 'agents_api_context_sections', self::$sections );
+			}
+			self::$hooks_fired = true;
+		}
+
+		/**
+		 * @param mixed $modes Raw modes.
+		 * @return string[]
+		 */
+		private static function normalize_modes( $modes ): array {
+			if ( ! is_array( $modes ) || empty( $modes ) ) {
+				return array( WP_Agent_Memory_Registry::MODE_ALL );
+			}
+
+			$normalized = array_values( array_unique( array_filter( array_map( array( self::class, 'sanitize_slug' ), $modes ) ) ) );
+			return empty( $normalized ) ? array( WP_Agent_Memory_Registry::MODE_ALL ) : $normalized;
+		}
+
+		/**
+		 * @param string $slug Raw slug.
+		 * @return string
+		 */
+		private static function sanitize_slug( string $slug ): string {
+			$slug = strtolower( $slug );
+			$slug = preg_replace( '/[^a-z0-9_\-]+/', '-', $slug );
+
+			return trim( is_string( $slug ) ? $slug : '', '-' );
+		}
+
+		/**
+		 * @param string $slug Section slug.
+		 * @return string
+		 */
+		private static function slug_to_label( string $slug ): string {
+			return ucwords( str_replace( array( '-', '_' ), ' ', $slug ) );
+		}
+	}
+}

--- a/src/Context/class-wp-agent-memory-layer.php
+++ b/src/Context/class-wp-agent-memory-layer.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Agent memory layer vocabulary.
+ *
+ * @package AgentsAPI
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+if ( ! class_exists( 'WP_Agent_Memory_Layer' ) ) {
+	/**
+	 * Canonical memory/context source layers.
+	 */
+	final class WP_Agent_Memory_Layer {
+
+		public const WORKSPACE = 'workspace';
+		public const AGENT     = 'agent';
+		public const USER      = 'user';
+		public const NETWORK   = 'network';
+		public const SHARED    = 'shared';
+
+		/**
+		 * Return supported layer values.
+		 *
+		 * @return string[]
+		 */
+		public static function values(): array {
+			return array(
+				self::WORKSPACE,
+				self::AGENT,
+				self::USER,
+				self::NETWORK,
+				self::SHARED,
+			);
+		}
+
+		/**
+		 * Normalize a raw layer string.
+		 *
+		 * @param mixed  $layer   Raw layer value.
+		 * @param string $fallback_layer Default layer when invalid.
+		 * @return string
+		 */
+		public static function normalize( $layer, string $fallback_layer = self::WORKSPACE ): string {
+			$fallback_layer = in_array( $fallback_layer, self::values(), true ) ? $fallback_layer : self::WORKSPACE;
+			$layer          = self::sanitize_slug( is_string( $layer ) ? $layer : '' );
+
+			return in_array( $layer, self::values(), true ) ? $layer : $fallback_layer;
+		}
+
+		/**
+		 * Small local sanitizer so the substrate can run in pure-PHP tests.
+		 *
+		 * @param string $value Raw slug.
+		 * @return string
+		 */
+		private static function sanitize_slug( string $value ): string {
+			$value = strtolower( $value );
+			$value = preg_replace( '/[^a-z0-9_\-]+/', '_', $value );
+
+			return trim( is_string( $value ) ? $value : '', '_' );
+		}
+	}
+}

--- a/src/Context/class-wp-agent-memory-registry.php
+++ b/src/Context/class-wp-agent-memory-registry.php
@@ -1,0 +1,255 @@
+<?php
+/**
+ * Generic agent memory/context source registry.
+ *
+ * @package AgentsAPI
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+if ( ! class_exists( 'WP_Agent_Memory_Registry' ) ) {
+	/**
+	 * Registers memory and context sources without prescribing storage shape.
+	 */
+	final class WP_Agent_Memory_Registry {
+
+		public const MODE_ALL = 'all';
+
+		/**
+		 * Registered sources keyed by source ID.
+		 *
+		 * @var array<string, array<string, mixed>>
+		 */
+		private static array $sources = array();
+
+		/**
+		 * Whether extension hooks have been fired.
+		 *
+		 * @var bool
+		 */
+		private static bool $hooks_fired = false;
+
+		/**
+		 * Register a memory or context source.
+		 *
+		 * @param string $source_id Source identifier, e.g. `workspace/instructions`.
+		 * @param array  $args      Registration metadata.
+		 * @return array<string, mixed>|null Normalized source metadata, or null on invalid ID.
+		 */
+		public static function register( string $source_id, array $args = array() ): ?array {
+			$source_id = self::sanitize_source_id( $source_id );
+			if ( '' === $source_id ) {
+				return null;
+			}
+
+			$composable = (bool) ( $args['composable'] ?? false );
+			$editable   = $composable ? false : ( $args['editable'] ?? true );
+			if ( ! is_bool( $editable ) && ! is_string( $editable ) ) {
+				$editable = true;
+			}
+
+			$metadata = array(
+				'id'                         => $source_id,
+				'layer'                      => WP_Agent_Memory_Layer::normalize( $args['layer'] ?? null ),
+				'priority'                   => (int) ( $args['priority'] ?? 50 ),
+				'protected'                  => (bool) ( $args['protected'] ?? false ),
+				'editable'                   => $editable,
+				'capability'                 => isset( $args['capability'] ) && is_string( $args['capability'] ) ? $args['capability'] : '',
+				'modes'                      => self::normalize_modes( $args['modes'] ?? array( self::MODE_ALL ) ),
+				'retrieval_policy'           => WP_Agent_Context_Injection_Policy::normalize( $args['retrieval_policy'] ?? null ),
+				'composable'                 => $composable,
+				'context_slug'               => self::sanitize_source_id( (string) ( $args['context_slug'] ?? $source_id ) ),
+				'convention_path'            => self::normalize_relative_path( $args['convention_path'] ?? '' ),
+				'external_projection_target' => is_string( $args['external_projection_target'] ?? null ) ? $args['external_projection_target'] : '',
+				'label'                      => is_string( $args['label'] ?? null ) ? $args['label'] : self::id_to_label( $source_id ),
+				'description'                => is_string( $args['description'] ?? null ) ? $args['description'] : '',
+				'meta'                       => is_array( $args['meta'] ?? null ) ? $args['meta'] : array(),
+			);
+
+			self::$sources[ $source_id ] = $metadata;
+
+			return $metadata;
+		}
+
+		/**
+		 * Remove a registered source.
+		 *
+		 * @param string $source_id Source identifier.
+		 * @return void
+		 */
+		public static function unregister( string $source_id ): void {
+			unset( self::$sources[ self::sanitize_source_id( $source_id ) ] );
+		}
+
+		/**
+		 * Return a single registered source.
+		 *
+		 * @param string $source_id Source identifier.
+		 * @return array<string, mixed>|null
+		 */
+		public static function get( string $source_id ): ?array {
+			$sources = self::get_all();
+			return $sources[ self::sanitize_source_id( $source_id ) ] ?? null;
+		}
+
+		/**
+		 * Return all registered sources sorted by priority.
+		 *
+		 * @return array<string, array<string, mixed>>
+		 */
+		public static function get_all(): array {
+			return self::get_resolved();
+		}
+
+		/**
+		 * Return sources for a layer.
+		 *
+		 * @param string $layer Layer value.
+		 * @return array<string, array<string, mixed>>
+		 */
+		public static function get_by_layer( string $layer ): array {
+			$layer = WP_Agent_Memory_Layer::normalize( $layer );
+
+			return array_filter(
+				self::get_resolved(),
+				static function ( array $source ) use ( $layer ): bool {
+					return $layer === $source['layer'];
+				}
+			);
+		}
+
+		/**
+		 * Return sources applicable to a runtime mode and retrieval policy.
+		 *
+		 * @param string      $mode             Runtime mode slug.
+		 * @param string|null $retrieval_policy Optional policy filter.
+		 * @return array<string, array<string, mixed>>
+		 */
+		public static function get_for_mode( string $mode, ?string $retrieval_policy = null ): array {
+			$mode             = self::sanitize_slug( $mode );
+			$retrieval_policy = null === $retrieval_policy ? null : WP_Agent_Context_Injection_Policy::normalize( $retrieval_policy );
+
+			return array_filter(
+				self::get_resolved(),
+				static function ( array $source ) use ( $mode, $retrieval_policy ): bool {
+					$modes = $source['modes'] ?? array( self::MODE_ALL );
+					if ( '' !== $mode && ! in_array( self::MODE_ALL, $modes, true ) && ! in_array( $mode, $modes, true ) ) {
+						return false;
+					}
+
+					return null === $retrieval_policy || $retrieval_policy === $source['retrieval_policy'];
+				}
+			);
+		}
+
+		/**
+		 * Return sources that are injected without dynamic retrieval.
+		 *
+		 * @param string $mode Runtime mode slug.
+		 * @return array<string, array<string, mixed>>
+		 */
+		public static function get_always_injected( string $mode = '' ): array {
+			return self::get_for_mode( $mode, WP_Agent_Context_Injection_Policy::ALWAYS );
+		}
+
+		/**
+		 * Return composable sources.
+		 *
+		 * @return array<string, array<string, mixed>>
+		 */
+		public static function get_composable(): array {
+			return array_filter(
+				self::get_resolved(),
+				static function ( array $source ): bool {
+					return ! empty( $source['composable'] );
+				}
+			);
+		}
+
+		/**
+		 * Reset registry state. Intended for tests.
+		 *
+		 * @return void
+		 */
+		public static function reset(): void {
+			self::$sources     = array();
+			self::$hooks_fired = false;
+		}
+
+		/**
+		 * Resolve hooks and return sorted sources.
+		 *
+		 * @return array<string, array<string, mixed>>
+		 */
+		private static function get_resolved(): array {
+			if ( ! self::$hooks_fired ) {
+				if ( function_exists( 'do_action' ) ) {
+					do_action( 'agents_api_memory_sources', self::$sources );
+				}
+				self::$hooks_fired = true;
+			}
+
+			$sources = self::$sources;
+			uasort(
+				$sources,
+				static function ( array $a, array $b ): int {
+					$priority_order = $a['priority'] <=> $b['priority'];
+					return 0 !== $priority_order ? $priority_order : strcmp( $a['id'], $b['id'] );
+				}
+			);
+
+			return $sources;
+		}
+
+		/**
+		 * @param mixed $modes Raw modes.
+		 * @return string[]
+		 */
+		private static function normalize_modes( $modes ): array {
+			if ( ! is_array( $modes ) || empty( $modes ) ) {
+				return array( self::MODE_ALL );
+			}
+
+			$normalized = array_values( array_unique( array_filter( array_map( array( self::class, 'sanitize_slug' ), $modes ) ) ) );
+			return empty( $normalized ) ? array( self::MODE_ALL ) : $normalized;
+		}
+
+		/**
+		 * @param mixed $path Raw relative path.
+		 * @return string
+		 */
+		private static function normalize_relative_path( $path ): string {
+			return is_string( $path ) ? ltrim( $path, '/' ) : '';
+		}
+
+		/**
+		 * @param string $source_id Source identifier.
+		 * @return string
+		 */
+		private static function sanitize_source_id( string $source_id ): string {
+			$source_id = strtolower( $source_id );
+			$source_id = preg_replace( '/[^a-z0-9_\.\-\/]+/', '-', $source_id );
+
+			return trim( is_string( $source_id ) ? $source_id : '', '-/' );
+		}
+
+		/**
+		 * @param string $slug Raw slug.
+		 * @return string
+		 */
+		private static function sanitize_slug( string $slug ): string {
+			$slug = strtolower( $slug );
+			$slug = preg_replace( '/[^a-z0-9_\-]+/', '-', $slug );
+
+			return trim( is_string( $slug ) ? $slug : '', '-' );
+		}
+
+		/**
+		 * @param string $source_id Source identifier.
+		 * @return string
+		 */
+		private static function id_to_label( string $source_id ): string {
+			return ucwords( str_replace( array( '-', '_', '/', '.' ), ' ', $source_id ) );
+		}
+	}
+}

--- a/tests/bootstrap-smoke.php
+++ b/tests/bootstrap-smoke.php
@@ -76,6 +76,11 @@ agents_api_smoke_assert_equals( true, class_exists( 'WP_Agent_Token_Authenticato
 agents_api_smoke_assert_equals( true, interface_exists( 'WP_Agent_Authorization_Policy_Interface' ), 'WP_Agent_Authorization_Policy_Interface contract is available', $failures, $passes );
 agents_api_smoke_assert_equals( true, class_exists( 'WP_Agent_WordPress_Authorization_Policy' ), 'WP_Agent_WordPress_Authorization_Policy service is available', $failures, $passes );
 agents_api_smoke_assert_equals( true, class_exists( 'WP_Agent_Capability_Ceiling' ), 'WP_Agent_Capability_Ceiling value object is available', $failures, $passes );
+agents_api_smoke_assert_equals( true, class_exists( 'WP_Agent_Memory_Registry' ), 'WP_Agent_Memory_Registry facade is available', $failures, $passes );
+agents_api_smoke_assert_equals( true, class_exists( 'WP_Agent_Memory_Layer' ), 'WP_Agent_Memory_Layer vocabulary is available', $failures, $passes );
+agents_api_smoke_assert_equals( true, class_exists( 'WP_Agent_Context_Section_Registry' ), 'WP_Agent_Context_Section_Registry facade is available', $failures, $passes );
+agents_api_smoke_assert_equals( true, class_exists( 'WP_Agent_Context_Injection_Policy' ), 'WP_Agent_Context_Injection_Policy vocabulary is available', $failures, $passes );
+agents_api_smoke_assert_equals( true, class_exists( 'WP_Agent_Composable_Context' ), 'WP_Agent_Composable_Context value object is available', $failures, $passes );
 agents_api_smoke_assert_equals( true, defined( 'AGENTS_API_PLUGIN_FILE' ), 'plugin file constant is available', $failures, $passes );
 agents_api_smoke_assert_equals( true, class_exists( 'AgentsAPI\\AI\\AgentMarkdownSectionCompactionAdapter' ), 'AgentsAPI\\AI\\AgentMarkdownSectionCompactionAdapter contract is available', $failures, $passes );
 agents_api_smoke_assert_equals( true, class_exists( 'AgentsAPI\\AI\\AgentConversationLoop' ), 'AgentConversationLoop facade is available', $failures, $passes );
@@ -129,6 +134,7 @@ $expected_source_directories = array(
 	'Approvals',
 	'Auth',
 	'Consent',
+	'Context',
 	'Guidelines',
 	'Identity',
 	'Memory',

--- a/tests/context-registry-smoke.php
+++ b/tests/context-registry-smoke.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * Pure-PHP smoke test for context and memory registry contracts.
+ *
+ * Run with: php tests/context-registry-smoke.php
+ *
+ * @package AgentsAPI\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+$failures = array();
+$passes   = 0;
+
+echo "agents-api-context-registry-smoke\n";
+
+require_once __DIR__ . '/agents-api-smoke-helpers.php';
+agents_api_smoke_require_module();
+
+WP_Agent_Memory_Registry::reset();
+WP_Agent_Context_Section_Registry::reset();
+
+echo "\n[1] Memory sources normalize generic context metadata:\n";
+$workspace_source = WP_Agent_Memory_Registry::register(
+	'workspace/instructions',
+	array(
+		'layer'            => 'workspace',
+		'priority'         => 20,
+		'protected'        => true,
+		'editable'         => 'manage_options',
+		'modes'            => array( 'chat', 'pipeline' ),
+		'retrieval_policy' => 'always',
+		'composable'       => true,
+		'context_slug'     => 'workspace-instructions',
+		'convention_path'  => '/AGENTS.md',
+		'label'            => 'Workspace Instructions',
+	)
+);
+
+$manual_source = WP_Agent_Memory_Registry::register(
+	'user/project-notes',
+	array(
+		'layer'                      => 'user',
+		'priority'                   => 80,
+		'modes'                      => array( 'chat' ),
+		'retrieval_policy'           => 'manual',
+		'external_projection_target' => 'guideline:project-notes',
+	)
+);
+
+agents_api_smoke_assert_equals( 'workspace', $workspace_source['layer'] ?? null, 'workspace is the generic layer vocabulary', $failures, $passes );
+agents_api_smoke_assert_equals( false, $workspace_source['editable'] ?? null, 'composable sources are not hand editable', $failures, $passes );
+agents_api_smoke_assert_equals( 'AGENTS.md', $workspace_source['convention_path'] ?? null, 'convention path is metadata, not identity', $failures, $passes );
+agents_api_smoke_assert_equals( 'manual', $manual_source['retrieval_policy'] ?? null, 'manual retrieval policy is preserved', $failures, $passes );
+agents_api_smoke_assert_equals( array( 'always', 'on_intent', 'on_tool_need', 'manual', 'never' ), WP_Agent_Context_Injection_Policy::values(), 'policy vocabulary covers accepted values', $failures, $passes );
+
+$all_sources = WP_Agent_Memory_Registry::get_all();
+agents_api_smoke_assert_equals( array( 'workspace/instructions', 'user/project-notes' ), array_keys( $all_sources ), 'sources sort by priority', $failures, $passes );
+agents_api_smoke_assert_equals( array( 'workspace/instructions' ), array_keys( WP_Agent_Memory_Registry::get_by_layer( 'workspace' ) ), 'sources filter by layer', $failures, $passes );
+agents_api_smoke_assert_equals( array( 'workspace/instructions' ), array_keys( WP_Agent_Memory_Registry::get_always_injected( 'pipeline' ) ), 'always-injected sources filter by mode and policy', $failures, $passes );
+agents_api_smoke_assert_equals( array( 'workspace/instructions' ), array_keys( WP_Agent_Memory_Registry::get_composable() ), 'composable sources are discoverable', $failures, $passes );
+
+echo "\n[2] Context sections compose in priority order and respect modes:\n";
+WP_Agent_Context_Section_Registry::register(
+	'workspace-instructions',
+	'late-section',
+	50,
+	static function ( array $context, array $section ): string {
+		return '# ' . $section['label'] . "\nMode: " . ( $context['mode'] ?? 'none' );
+	},
+	array(
+		'label' => 'Late Section',
+		'modes' => array( 'chat' ),
+	)
+);
+
+WP_Agent_Context_Section_Registry::register(
+	'workspace-instructions',
+	'early-section',
+	10,
+	static function (): string {
+		return '# Early Section';
+	},
+	array(
+		'modes' => array( 'all' ),
+	)
+);
+
+$chat_context = WP_Agent_Context_Section_Registry::compose( 'workspace-instructions', array( 'mode' => 'chat' ) );
+$pipeline_context = WP_Agent_Context_Section_Registry::compose( 'workspace-instructions', array( 'mode' => 'pipeline' ) );
+
+agents_api_smoke_assert_equals( true, $chat_context instanceof WP_Agent_Composable_Context, 'compose returns value object', $failures, $passes );
+agents_api_smoke_assert_equals( "# Early Section\n\n# Late Section\nMode: chat", $chat_context->content, 'sections compose in priority order', $failures, $passes );
+agents_api_smoke_assert_equals( array( 'early-section', 'late-section' ), $chat_context->metadata['included_sections'] ?? array(), 'composition records included sections', $failures, $passes );
+agents_api_smoke_assert_equals( '# Early Section', $pipeline_context->content, 'mode-specific sections are filtered before compose', $failures, $passes );
+agents_api_smoke_assert_equals( true, $chat_context->has_content(), 'value object reports non-empty content', $failures, $passes );
+
+agents_api_smoke_finish( 'Agents API context registry', $failures, $passes );


### PR DESCRIPTION
## Summary
- Adds generic memory/context source registration with layer, mode, retrieval policy, composable, and projection metadata.
- Adds context section composition primitives plus a composable context value object.
- Documents the registry boundary and covers policy/layer/section composition behavior with smoke tests.

Fixes #63.

## Tests
- `composer test`
- `homeboy lint --path /Users/chubes/Developer/agents-api@chubes-memory-registry-context`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the generic memory/context registry substrate, docs, and smoke tests; Chris remains responsible for review and merge.