### PR TITLE
Clarify conversation loop event observers

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ wp_register_agent(
 ## Public Surface
 
 - `wp_agents_api_init`
+- `agents_api_loop_event`
 - `wp_register_agent()` / `wp_get_agent()` / `wp_get_agents()` / `wp_has_agent()` / `wp_unregister_agent()`
 - `WP_Agent`
 - `WP_Agents_Registry`
@@ -158,6 +159,17 @@ wp_register_agent(
 - `AgentsAPI\Core\Workspace\AgentWorkspaceScope`
 - `AgentsAPI\Core\Database\Chat\ConversationTranscriptStoreInterface`
 - `AgentsAPI\Core\FilesRepository\AgentMemoryStoreInterface` and memory value objects, including provenance/trust metadata contracts
+
+## Conversation Loop Events
+
+`AgentConversationLoop` exposes lifecycle events through two observer surfaces:
+
+- The caller-owned `on_event` option: `fn( string $event, array $payload ): void`.
+- The WordPress `agents_api_loop_event` action: `do_action( 'agents_api_loop_event', $event, $payload )`.
+
+The callable sink is for the component that directly invokes the loop. The WordPress action is for independent observers such as logging, tracing, metrics, or transcript diagnostics.
+
+Event payloads are read-only snapshots. Observers must not rely on mutating payloads to affect loop behavior. Exceptions thrown by either observer surface are swallowed by the loop, so logging or tracing failures cannot break provider execution, tool mediation, budget enforcement, transcript persistence, or the returned result.
 
 ## Memory Provenance Metadata
 

--- a/src/Runtime/AgentConversationLoop.php
+++ b/src/Runtime/AgentConversationLoop.php
@@ -48,7 +48,7 @@ class AgentConversationLoop {
 	 * - `tool_declarations` (array|null): Tool declarations keyed by name.
 	 * - `completion_policy` (AgentConversationCompletionPolicyInterface|null): Typed completion policy.
 	 * - `transcript_persister` (AgentConversationTranscriptPersisterInterface|null): Transcript persister.
-	 * - `on_event` (callable|null): Lifecycle event sink `fn(string $event, array $payload)`.
+	 * - `on_event` (callable|null): Caller-owned lifecycle event sink `fn(string $event, array $payload)`.
 	 *
 	 * @param array    $messages    Initial transcript messages.
 	 * @param callable $turn_runner Caller-owned turn adapter.
@@ -410,24 +410,42 @@ class AgentConversationLoop {
 	}
 
 	/**
-	 * Emit a lifecycle event through the event sink.
+	 * Emit a lifecycle event through the caller sink and WordPress observers.
 	 *
-	 * Observer failures are swallowed to prevent changing loop results.
+	 * The caller-owned `on_event` sink and the `agents_api_loop_event` action are
+	 * observational surfaces. Event payloads are read-only snapshots for observers;
+	 * observer failures are swallowed to prevent changing loop results.
 	 *
 	 * @param callable|null $on_event Event sink.
 	 * @param string        $event    Event name.
 	 * @param array         $payload  Event payload.
 	 */
 	private static function emit_event( ?callable $on_event, string $event, array $payload = array() ): void {
-		if ( null === $on_event ) {
-			return;
+		if ( null !== $on_event ) {
+			try {
+				call_user_func( $on_event, $event, $payload );
+			} catch ( \Throwable $error ) {
+				// Observer failures must not change loop results.
+				unset( $error );
+			}
 		}
 
-		try {
-			call_user_func( $on_event, $event, $payload );
-		} catch ( \Throwable $error ) {
-			// Observer failures must not change loop results.
-			unset( $error );
+		if ( function_exists( 'do_action' ) ) {
+			try {
+				/**
+				 * Fires when AgentConversationLoop emits a lifecycle event.
+				 *
+				 * Observers receive read-only event snapshots. Exceptions thrown by
+				 * observers are swallowed and cannot change loop results.
+				 *
+				 * @param string $event   Event name.
+				 * @param array  $payload Event payload snapshot.
+				 */
+				do_action( 'agents_api_loop_event', $event, $payload );
+			} catch ( \Throwable $error ) {
+				// Observer failures must not change loop results.
+				unset( $error );
+			}
 		}
 	}
 

--- a/tests/conversation-loop-events-smoke.php
+++ b/tests/conversation-loop-events-smoke.php
@@ -146,7 +146,64 @@ $crashing_sink_result = AgentsAPI\AI\AgentConversationLoop::run(
 
 agents_api_smoke_assert_equals( 2, count( $crashing_sink_result['messages'] ), 'loop result is unaffected by event sink crash', $failures, $passes );
 
-echo "\n[4] No event sink = no events emitted (backwards compatible):\n";
+echo "\n[4] WordPress action observers receive events without caller sink:\n";
+$action_event_log = array();
+
+add_action(
+	'agents_api_loop_event',
+	static function ( string $event, array $payload ) use ( &$action_event_log ): void {
+		$action_event_log[] = array( 'event' => $event, 'payload' => $payload );
+	},
+	10,
+	2
+);
+
+$action_observed_result = AgentsAPI\AI\AgentConversationLoop::run(
+	array( array( 'role' => 'user', 'content' => 'observe' ) ),
+	static function ( array $messages ): array {
+		$messages[] = AgentsAPI\AI\AgentMessageEnvelope::text( 'assistant', 'observed' );
+
+		return array(
+			'messages'               => $messages,
+			'tool_execution_results' => array(),
+			'events'                 => array(),
+		);
+	},
+	array( 'max_turns' => 1 )
+);
+
+$action_event_names = array_column( $action_event_log, 'event' );
+agents_api_smoke_assert_equals( 2, count( $action_observed_result['messages'] ), 'loop works with action observer and no caller sink', $failures, $passes );
+agents_api_smoke_assert_equals( true, in_array( 'turn_started', $action_event_names, true ), 'action observer receives turn_started event', $failures, $passes );
+agents_api_smoke_assert_equals( true, in_array( 'completed', $action_event_names, true ), 'action observer receives completed event', $failures, $passes );
+
+echo "\n[5] WordPress action observer failure does not affect loop result:\n";
+add_action(
+	'agents_api_loop_event',
+	static function (): void {
+		throw new \RuntimeException( 'action observer crash' );
+	},
+	20,
+	2
+);
+
+$crashing_action_result = AgentsAPI\AI\AgentConversationLoop::run(
+	array( array( 'role' => 'user', 'content' => 'hello' ) ),
+	static function ( array $messages ): array {
+		$messages[] = AgentsAPI\AI\AgentMessageEnvelope::text( 'assistant', 'hi' );
+
+		return array(
+			'messages'               => $messages,
+			'tool_execution_results' => array(),
+			'events'                 => array(),
+		);
+	},
+	array( 'max_turns' => 1 )
+);
+
+agents_api_smoke_assert_equals( 2, count( $crashing_action_result['messages'] ), 'loop result is unaffected by action observer crash', $failures, $passes );
+
+echo "\n[6] No caller event sink remains optional:\n";
 $no_event_result = AgentsAPI\AI\AgentConversationLoop::run(
 	array( array( 'role' => 'user', 'content' => 'hello' ) ),
 	static function ( array $messages ): array {


### PR DESCRIPTION
## Summary
- Keep the caller-owned `on_event` callable and emit the same lifecycle events through a documented `agents_api_loop_event` WordPress action for independent observers.
- Document event payloads as read-only observational snapshots and make both callable/action observer failures non-fatal to loop execution.
- Cover action observer delivery and action observer failure behavior in the conversation loop event smoke test.

Closes #75.

## Tests
- `php -l src/Runtime/AgentConversationLoop.php`
- `php -l tests/conversation-loop-events-smoke.php`
- `php tests/conversation-loop-events-smoke.php`
- `composer test`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Inspecting `AgentConversationLoop` event behavior, drafting the substrate-level observer contract, implementing the change, and running validation. Chris remains responsible for review and merge decisions.