### PR TITLE
Add caller context primitive

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,7 +461,7 @@ The generic layer vocabulary uses `workspace` rather than `site`. Products that 
 
 ## Execution Principals
 
-`AgentsAPI\AI\AgentExecutionPrincipal` represents the actor and agent context for one runtime request. It records the acting WordPress user ID, effective agent ID/slug, auth source, request context, optional token ID, workspace ID, client ID, capability ceiling, and JSON-friendly request metadata.
+`AgentsAPI\AI\AgentExecutionPrincipal` represents the actor and agent context for one runtime request. It records the acting WordPress user ID, effective agent ID/slug, auth source, request context, optional token ID, workspace ID, client ID, capability ceiling, optional caller context, and JSON-friendly request metadata.
 
 Host plugins can resolve the current principal from REST, CLI, cron, bearer-token, or session state through the `agents_api_execution_principal` filter:
 
@@ -502,6 +502,36 @@ request bearer token
 `WP_Agent_Token` models token metadata for bearer-token authentication. It stores token hash, prefix, label, expiry, last-used timestamp, optional client/workspace identifiers, and optional capability restrictions. It never exposes raw token material in metadata exports.
 
 `WP_Agent_Token_Authenticator` accepts a raw bearer token at the request edge, hashes it, asks a host token store to resolve the hash, rejects expired tokens, touches successful tokens, and returns an `AgentExecutionPrincipal` populated with token/client/workspace context.
+
+## Caller Context
+
+`WP_Agent_Caller_Context` carries cross-site agent-to-agent caller claims alongside an execution principal. It is a value object and parser only; hosts remain responsible for deciding whether the caller host and token are trusted.
+
+Canonical inbound header names:
+
+- `X-Agents-Api-Caller-Agent` — agent ID/slug on the caller host.
+- `X-Agents-Api-Caller-User` — user ID on the caller host, or `0` when no caller-host user applies.
+- `X-Agents-Api-Caller-Host` — `self` or an absolute URL for the remote caller host.
+- `X-Agents-Api-Chain-Depth` — non-negative chain depth, where `0` is top-of-chain.
+- `X-Agents-Api-Chain-Root` — stable identifier for the originating request.
+
+Requests with no caller headers parse as a top-of-chain context: no caller agent, caller user `0`, caller host `self`, chain depth `0`, and a generated chain root request ID. Requests with malformed caller headers are rejected fail-closed by `WP_Agent_Token_Authenticator` before the token is touched.
+
+```php
+$principal = $authenticator->authenticate_bearer_token(
+	$raw_token,
+	AgentsAPI\AI\AgentExecutionPrincipal::REQUEST_CONTEXT_REST,
+	array(),
+	$request // WP_REST_Request or array of request headers.
+);
+
+if ( $principal && $principal->caller_context?->is_cross_site() ) {
+	// Host-owned trust policy: verify caller_host through shared keys, mTLS,
+	// allow-lists, or another product-specific mechanism before honoring claims.
+}
+```
+
+The default parser depth ceiling is `WP_Agent_Caller_Context::DEFAULT_MAX_CHAIN_DEPTH` (`16`). Hosts can pass a stricter maximum to `authenticate_bearer_token()` or parse with `WP_Agent_Caller_Context::from_headers( $headers, $max_depth )` before applying their own loop policy.
 
 `WP_Agent_WordPress_Authorization_Policy` is the default WordPress-shaped policy. It denies a capability unless both are true:
 

--- a/agents-api.php
+++ b/agents-api.php
@@ -38,6 +38,7 @@ require_once AGENTS_API_PATH . 'src/Auth/class-wp-agent-access-grant.php';
 require_once AGENTS_API_PATH . 'src/Auth/class-wp-agent-access-store-interface.php';
 require_once AGENTS_API_PATH . 'src/Auth/class-wp-agent-token.php';
 require_once AGENTS_API_PATH . 'src/Auth/class-wp-agent-token-store-interface.php';
+require_once AGENTS_API_PATH . 'src/Auth/class-wp-agent-caller-context.php';
 require_once AGENTS_API_PATH . 'src/Auth/class-wp-agent-authorization-policy-interface.php';
 require_once AGENTS_API_PATH . 'src/Auth/class-wp-agent-token-authenticator.php';
 require_once AGENTS_API_PATH . 'src/Auth/class-wp-agent-wordpress-authorization-policy.php';

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
       "php tests/message-envelope-smoke.php",
       "php tests/registry-smoke.php",
       "php tests/execution-principal-smoke.php",
+      "php tests/caller-context-smoke.php",
       "php tests/authorization-smoke.php",
       "php tests/action-policy-values-smoke.php",
       "php tests/consent-policy-smoke.php",

--- a/src/Auth/class-wp-agent-caller-context.php
+++ b/src/Auth/class-wp-agent-caller-context.php
@@ -77,7 +77,9 @@ if ( ! class_exists( 'WP_Agent_Caller_Context' ) ) {
 		 * @return self
 		 */
 		public static function top_of_chain( ?string $chain_root_request_id = null ): self {
-			return new self( '', 0, self::SELF_HOST, 0, $chain_root_request_id ?: self::generate_request_id() );
+			$chain_root_request_id = null !== $chain_root_request_id && '' !== $chain_root_request_id ? $chain_root_request_id : self::generate_request_id();
+
+			return new self( '', 0, self::SELF_HOST, 0, $chain_root_request_id );
 		}
 
 		/**
@@ -97,10 +99,10 @@ if ( ! class_exists( 'WP_Agent_Caller_Context' ) ) {
 
 			$get = self::header_accessor( $source );
 			$raw = array(
-				'caller_agent_id'      => trim( $get( self::HEADER_CALLER_AGENT ) ),
-				'caller_user_id'       => trim( $get( self::HEADER_CALLER_USER ) ),
-				'caller_host'          => trim( $get( self::HEADER_CALLER_HOST ) ),
-				'chain_depth'          => trim( $get( self::HEADER_CHAIN_DEPTH ) ),
+				'caller_agent_id'       => trim( $get( self::HEADER_CALLER_AGENT ) ),
+				'caller_user_id'        => trim( $get( self::HEADER_CALLER_USER ) ),
+				'caller_host'           => trim( $get( self::HEADER_CALLER_HOST ) ),
+				'chain_depth'           => trim( $get( self::HEADER_CHAIN_DEPTH ) ),
 				'chain_root_request_id' => trim( $get( self::HEADER_CHAIN_ROOT ) ),
 			);
 
@@ -128,7 +130,9 @@ if ( ! class_exists( 'WP_Agent_Caller_Context' ) ) {
 					throw self::invalid( 'chain_depth', 'top-of-chain context cannot include remote caller identity' );
 				}
 
-				return new self( '', 0, self::SELF_HOST, 0, $raw['chain_root_request_id'] ?: self::generate_request_id() );
+				$chain_root_request_id = '' !== $raw['chain_root_request_id'] ? $raw['chain_root_request_id'] : self::generate_request_id();
+
+				return new self( '', 0, self::SELF_HOST, 0, $chain_root_request_id );
 			}
 
 			if ( '' === $raw['caller_agent_id'] ) {
@@ -200,10 +204,10 @@ if ( ! class_exists( 'WP_Agent_Caller_Context' ) ) {
 		 */
 		public function to_array(): array {
 			return array(
-				'caller_agent_id'      => $this->caller_agent_id,
-				'caller_user_id'       => $this->caller_user_id,
-				'caller_host'          => $this->caller_host,
-				'chain_depth'          => $this->chain_depth,
+				'caller_agent_id'       => $this->caller_agent_id,
+				'caller_user_id'        => $this->caller_user_id,
+				'caller_host'           => $this->caller_host,
+				'chain_depth'           => $this->chain_depth,
 				'chain_root_request_id' => $this->chain_root_request_id,
 				'metadata'              => $this->metadata,
 			);
@@ -248,6 +252,7 @@ if ( ! class_exists( 'WP_Agent_Caller_Context' ) ) {
 			}
 
 			if ( ! ctype_digit( $value ) ) {
+				// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Validation exceptions are not rendered output.
 				throw self::invalid( $path, 'must be zero or a positive integer' );
 			}
 
@@ -261,8 +266,8 @@ if ( ! class_exists( 'WP_Agent_Caller_Context' ) ) {
 		 * @return bool
 		 */
 		private static function is_absolute_url( string $value ): bool {
-			$scheme = parse_url( $value, PHP_URL_SCHEME );
-			$host   = parse_url( $value, PHP_URL_HOST );
+			$scheme = wp_parse_url( $value, PHP_URL_SCHEME );
+			$host   = wp_parse_url( $value, PHP_URL_HOST );
 
 			return is_string( $host ) && '' !== $host && in_array( $scheme, array( 'http', 'https' ), true );
 		}

--- a/src/Auth/class-wp-agent-caller-context.php
+++ b/src/Auth/class-wp-agent-caller-context.php
@@ -1,0 +1,309 @@
+<?php
+/**
+ * WP_Agent_Caller_Context value object.
+ *
+ * @package AgentsAPI
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+if ( ! class_exists( 'WP_Agent_Caller_Context' ) ) {
+	/**
+	 * Caller context claimed by an agent-to-agent request.
+	 *
+	 * The substrate parses and carries this shape only. Deciding whether to trust
+	 * the caller host, token, or chain is a host concern.
+	 */
+	final class WP_Agent_Caller_Context {
+
+		public const HEADER_CALLER_AGENT = 'X-Agents-Api-Caller-Agent';
+		public const HEADER_CALLER_USER  = 'X-Agents-Api-Caller-User';
+		public const HEADER_CALLER_HOST  = 'X-Agents-Api-Caller-Host';
+		public const HEADER_CHAIN_DEPTH  = 'X-Agents-Api-Chain-Depth';
+		public const HEADER_CHAIN_ROOT   = 'X-Agents-Api-Chain-Root';
+
+		public const SELF_HOST               = 'self';
+		public const DEFAULT_MAX_CHAIN_DEPTH = 16;
+
+		/**
+		 * @param string $caller_agent_id      Agent ID/slug on the caller host. Empty string means top-of-chain.
+		 * @param int    $caller_user_id       User ID on the caller host. 0 means no user-on-caller-host.
+		 * @param string $caller_host          "self" or an absolute URL for a remote caller host.
+		 * @param int    $chain_depth          0 means top-of-chain.
+		 * @param string $chain_root_request_id Stable identifier for the originating request.
+		 * @param array  $metadata             JSON-serializable host-owned extension payload.
+		 */
+		public function __construct(
+			public readonly string $caller_agent_id = '',
+			public readonly int $caller_user_id = 0,
+			public readonly string $caller_host = self::SELF_HOST,
+			public readonly int $chain_depth = 0,
+			public readonly string $chain_root_request_id = '',
+			public readonly array $metadata = array(),
+		) {
+			if ( $this->caller_user_id < 0 ) {
+				throw self::invalid( 'caller_user_id', 'must be zero or a positive integer' );
+			}
+
+			if ( '' === $this->caller_host ) {
+				throw self::invalid( 'caller_host', 'must be "self" or an absolute URL' );
+			}
+
+			if ( self::SELF_HOST !== $this->caller_host && ! self::is_absolute_url( $this->caller_host ) ) {
+				throw self::invalid( 'caller_host', 'must be "self" or an absolute URL' );
+			}
+
+			if ( $this->chain_depth < 0 ) {
+				throw self::invalid( 'chain_depth', 'must be zero or a positive integer' );
+			}
+
+			if ( '' === $this->chain_root_request_id ) {
+				throw self::invalid( 'chain_root_request_id', 'must be a non-empty string' );
+			}
+
+			if ( 0 === $this->chain_depth && ( '' !== $this->caller_agent_id || 0 !== $this->caller_user_id || self::SELF_HOST !== $this->caller_host ) ) {
+				throw self::invalid( 'chain_depth', 'top-of-chain context cannot include remote caller identity' );
+			}
+
+			if ( false === self::json_encode( $this->metadata ) ) {
+				throw self::invalid( 'metadata', 'must be JSON serializable' );
+			}
+		}
+
+		/**
+		 * Build a top-of-chain caller context.
+		 *
+		 * @param string|null $chain_root_request_id Optional request ID. Generated when omitted.
+		 * @return self
+		 */
+		public static function top_of_chain( ?string $chain_root_request_id = null ): self {
+			return new self( '', 0, self::SELF_HOST, 0, $chain_root_request_id ?: self::generate_request_id() );
+		}
+
+		/**
+		 * Parse caller context headers from a request-like source.
+		 *
+		 * Missing headers produce a top-of-chain context. Malformed caller headers
+		 * throw so request-edge authenticators can fail closed.
+		 *
+		 * @param array|object|null $source Header source. Accepts WP_REST_Request-style get_header() or arrays.
+		 * @param int              $max_chain_depth Maximum accepted chain depth.
+		 * @return self
+		 */
+		public static function from_headers( $source = null, int $max_chain_depth = self::DEFAULT_MAX_CHAIN_DEPTH ): self {
+			if ( $max_chain_depth < 0 ) {
+				throw self::invalid( 'max_chain_depth', 'must be zero or a positive integer' );
+			}
+
+			$get = self::header_accessor( $source );
+			$raw = array(
+				'caller_agent_id'      => trim( $get( self::HEADER_CALLER_AGENT ) ),
+				'caller_user_id'       => trim( $get( self::HEADER_CALLER_USER ) ),
+				'caller_host'          => trim( $get( self::HEADER_CALLER_HOST ) ),
+				'chain_depth'          => trim( $get( self::HEADER_CHAIN_DEPTH ) ),
+				'chain_root_request_id' => trim( $get( self::HEADER_CHAIN_ROOT ) ),
+			);
+
+			$has_headers = false;
+			foreach ( $raw as $value ) {
+				if ( '' !== $value ) {
+					$has_headers = true;
+					break;
+				}
+			}
+
+			if ( ! $has_headers ) {
+				return self::top_of_chain();
+			}
+
+			$caller_user_id = self::parse_non_negative_int( $raw['caller_user_id'], 'caller_user_id' );
+			$chain_depth    = self::parse_non_negative_int( $raw['chain_depth'], 'chain_depth' );
+
+			if ( $chain_depth > $max_chain_depth ) {
+				throw self::invalid( 'chain_depth', 'exceeds maximum chain depth' );
+			}
+
+			if ( 0 === $chain_depth ) {
+				if ( '' !== $raw['caller_agent_id'] || 0 !== $caller_user_id || '' !== $raw['caller_host'] ) {
+					throw self::invalid( 'chain_depth', 'top-of-chain context cannot include remote caller identity' );
+				}
+
+				return new self( '', 0, self::SELF_HOST, 0, $raw['chain_root_request_id'] ?: self::generate_request_id() );
+			}
+
+			if ( '' === $raw['caller_agent_id'] ) {
+				throw self::invalid( 'caller_agent_id', 'must be present when chain_depth is greater than zero' );
+			}
+
+			if ( '' === $raw['caller_host'] ) {
+				throw self::invalid( 'caller_host', 'must be present when chain_depth is greater than zero' );
+			}
+
+			if ( '' === $raw['chain_root_request_id'] ) {
+				throw self::invalid( 'chain_root_request_id', 'must be present when chain_depth is greater than zero' );
+			}
+
+			return new self(
+				$raw['caller_agent_id'],
+				$caller_user_id,
+				$raw['caller_host'],
+				$chain_depth,
+				$raw['chain_root_request_id']
+			);
+		}
+
+		/**
+		 * Export headers for a follow-up agent-to-agent request.
+		 *
+		 * @return array<string,string>
+		 */
+		public function to_headers(): array {
+			return array(
+				self::HEADER_CALLER_AGENT => $this->caller_agent_id,
+				self::HEADER_CALLER_USER  => (string) $this->caller_user_id,
+				self::HEADER_CALLER_HOST  => $this->caller_host,
+				self::HEADER_CHAIN_DEPTH  => (string) $this->chain_depth,
+				self::HEADER_CHAIN_ROOT   => $this->chain_root_request_id,
+			);
+		}
+
+		/**
+		 * Whether this context describes a remote caller host.
+		 *
+		 * @return bool
+		 */
+		public function is_cross_site(): bool {
+			return self::SELF_HOST !== $this->caller_host;
+		}
+
+		/**
+		 * Build from a JSON-friendly array.
+		 *
+		 * @param array<string,mixed> $context Raw context.
+		 * @return self
+		 */
+		public static function from_array( array $context ): self {
+			return new self(
+				isset( $context['caller_agent_id'] ) ? (string) $context['caller_agent_id'] : '',
+				isset( $context['caller_user_id'] ) ? (int) $context['caller_user_id'] : 0,
+				isset( $context['caller_host'] ) ? (string) $context['caller_host'] : self::SELF_HOST,
+				isset( $context['chain_depth'] ) ? (int) $context['chain_depth'] : 0,
+				isset( $context['chain_root_request_id'] ) ? (string) $context['chain_root_request_id'] : '',
+				isset( $context['metadata'] ) && is_array( $context['metadata'] ) ? $context['metadata'] : array()
+			);
+		}
+
+		/**
+		 * Export to a stable, JSON-friendly shape.
+		 *
+		 * @return array<string,mixed>
+		 */
+		public function to_array(): array {
+			return array(
+				'caller_agent_id'      => $this->caller_agent_id,
+				'caller_user_id'       => $this->caller_user_id,
+				'caller_host'          => $this->caller_host,
+				'chain_depth'          => $this->chain_depth,
+				'chain_root_request_id' => $this->chain_root_request_id,
+				'metadata'              => $this->metadata,
+			);
+		}
+
+		/**
+		 * Build a case-insensitive header accessor.
+		 *
+		 * @param array|object|null $source Header source.
+		 * @return callable(string): string
+		 */
+		private static function header_accessor( $source ): callable {
+			if ( is_object( $source ) && method_exists( $source, 'get_header' ) ) {
+				return static function ( string $name ) use ( $source ): string {
+					$value = $source->get_header( $name );
+					return null === $value ? '' : (string) $value;
+				};
+			}
+
+			$normalized = array();
+			if ( is_array( $source ) ) {
+				foreach ( $source as $key => $value ) {
+					$normalized[ strtolower( (string) $key ) ] = is_array( $value ) ? (string) reset( $value ) : (string) $value;
+				}
+			}
+
+			return static function ( string $name ) use ( $normalized ): string {
+				return $normalized[ strtolower( $name ) ] ?? '';
+			};
+		}
+
+		/**
+		 * Parse a non-negative integer header value.
+		 *
+		 * @param string $value Raw value.
+		 * @param string $path Field path for validation errors.
+		 * @return int
+		 */
+		private static function parse_non_negative_int( string $value, string $path ): int {
+			if ( '' === $value ) {
+				return 0;
+			}
+
+			if ( ! ctype_digit( $value ) ) {
+				throw self::invalid( $path, 'must be zero or a positive integer' );
+			}
+
+			return (int) $value;
+		}
+
+		/**
+		 * Whether a string is an absolute HTTP(S) URL.
+		 *
+		 * @param string $value Value to inspect.
+		 * @return bool
+		 */
+		private static function is_absolute_url( string $value ): bool {
+			$scheme = parse_url( $value, PHP_URL_SCHEME );
+			$host   = parse_url( $value, PHP_URL_HOST );
+
+			return is_string( $host ) && '' !== $host && in_array( $scheme, array( 'http', 'https' ), true );
+		}
+
+		/**
+		 * Generate a request/chain identifier.
+		 *
+		 * @return string
+		 */
+		private static function generate_request_id(): string {
+			if ( function_exists( 'wp_generate_uuid4' ) ) {
+				return wp_generate_uuid4();
+			}
+
+			return bin2hex( random_bytes( 16 ) );
+		}
+
+		/**
+		 * Encode JSON without throwing on older PHP configurations.
+		 *
+		 * @param mixed $value Value to encode.
+		 * @return string|false
+		 */
+		private static function json_encode( $value ) {
+			try {
+				// phpcs:ignore WordPress.WP.AlternativeFunctions.json_encode_json_encode -- Pure-PHP value object smoke tests run outside WordPress.
+				return json_encode( $value, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR );
+			} catch ( JsonException $e ) {
+				return false;
+			}
+		}
+
+		/**
+		 * Build a machine-readable validation exception.
+		 *
+		 * @param string $path Field path.
+		 * @param string $reason Failure reason.
+		 * @return InvalidArgumentException Validation exception.
+		 */
+		private static function invalid( string $path, string $reason ): InvalidArgumentException {
+			return new InvalidArgumentException( 'invalid_agent_caller_context: ' . $path . ' ' . $reason );
+		}
+	}
+}

--- a/src/Auth/class-wp-agent-token-authenticator.php
+++ b/src/Auth/class-wp-agent-token-authenticator.php
@@ -29,7 +29,7 @@ if ( ! class_exists( 'WP_Agent_Token_Authenticator' ) ) {
 		 * @param string              $request_context Request context such as rest, cli, cron, or chat.
 		 * @param array<string,mixed> $metadata        Additional request metadata.
 		 */
-		public function authenticate_bearer_token( string $raw_token, string $request_context = AgentsAPI\AI\AgentExecutionPrincipal::REQUEST_CONTEXT_REST, array $metadata = array() ): ?AgentsAPI\AI\AgentExecutionPrincipal {
+		public function authenticate_bearer_token( string $raw_token, string $request_context = AgentsAPI\AI\AgentExecutionPrincipal::REQUEST_CONTEXT_REST, array $metadata = array(), $caller_context_source = null, int $max_chain_depth = WP_Agent_Caller_Context::DEFAULT_MAX_CHAIN_DEPTH ): ?AgentsAPI\AI\AgentExecutionPrincipal {
 			$raw_token = trim( $raw_token );
 			if ( '' === $raw_token ) {
 				return null;
@@ -41,6 +41,12 @@ if ( ! class_exists( 'WP_Agent_Token_Authenticator' ) ) {
 
 			$token = $this->token_store->resolve_token_hash( WP_Agent_Token::hash_token( $raw_token ) );
 			if ( null === $token || $token->is_expired() ) {
+				return null;
+			}
+
+			try {
+				$caller_context = WP_Agent_Caller_Context::from_headers( $caller_context_source, $max_chain_depth );
+			} catch ( InvalidArgumentException $e ) {
 				return null;
 			}
 
@@ -65,7 +71,8 @@ if ( ! class_exists( 'WP_Agent_Token_Authenticator' ) ) {
 				$metadata,
 				$token->workspace_id,
 				$token->client_id,
-				$token->capability_ceiling()
+				$token->capability_ceiling(),
+				$caller_context
 			);
 		}
 	}

--- a/src/Runtime/AgentExecutionPrincipal.php
+++ b/src/Runtime/AgentExecutionPrincipal.php
@@ -39,6 +39,7 @@ final class AgentExecutionPrincipal {
 	 * @param string|null $workspace_id      Optional host workspace/scope identifier.
 	 * @param string|null $client_id         Optional client/login identifier.
 	 * @param \WP_Agent_Capability_Ceiling|null $capability_ceiling Optional capability ceiling for this execution.
+	 * @param \WP_Agent_Caller_Context|null     $caller_context     Optional cross-site caller context claims.
 	 */
 	public function __construct(
 		public readonly int $acting_user_id,
@@ -50,6 +51,7 @@ final class AgentExecutionPrincipal {
 		public readonly ?string $workspace_id = null,
 		public readonly ?string $client_id = null,
 		public readonly ?\WP_Agent_Capability_Ceiling $capability_ceiling = null,
+		public readonly ?\WP_Agent_Caller_Context $caller_context = null,
 	) {
 		if ( $this->acting_user_id < 0 ) {
 			throw self::invalid( 'acting_user_id', 'must be zero or a positive integer' );
@@ -113,8 +115,8 @@ final class AgentExecutionPrincipal {
 	 * @param array  $request_metadata  Request metadata.
 	 * @return self
 	 */
-	public static function user_session( int $acting_user_id, string $effective_agent_id, string $request_context = self::REQUEST_CONTEXT_REST, array $request_metadata = array(), ?string $workspace_id = null, ?string $client_id = null, ?\WP_Agent_Capability_Ceiling $capability_ceiling = null ): self {
-		return new self( $acting_user_id, $effective_agent_id, self::AUTH_SOURCE_USER, $request_context, null, $request_metadata, $workspace_id, $client_id, $capability_ceiling );
+	public static function user_session( int $acting_user_id, string $effective_agent_id, string $request_context = self::REQUEST_CONTEXT_REST, array $request_metadata = array(), ?string $workspace_id = null, ?string $client_id = null, ?\WP_Agent_Capability_Ceiling $capability_ceiling = null, ?\WP_Agent_Caller_Context $caller_context = null ): self {
+		return new self( $acting_user_id, $effective_agent_id, self::AUTH_SOURCE_USER, $request_context, null, $request_metadata, $workspace_id, $client_id, $capability_ceiling, $caller_context );
 	}
 
 	/**
@@ -127,8 +129,8 @@ final class AgentExecutionPrincipal {
 	 * @param array  $request_metadata  Request metadata.
 	 * @return self
 	 */
-	public static function agent_token( int $acting_user_id, string $effective_agent_id, int $token_id, string $request_context = self::REQUEST_CONTEXT_REST, array $request_metadata = array(), ?string $workspace_id = null, ?string $client_id = null, ?\WP_Agent_Capability_Ceiling $capability_ceiling = null ): self {
-		return new self( $acting_user_id, $effective_agent_id, self::AUTH_SOURCE_AGENT_TOKEN, $request_context, $token_id, $request_metadata, $workspace_id, $client_id, $capability_ceiling );
+	public static function agent_token( int $acting_user_id, string $effective_agent_id, int $token_id, string $request_context = self::REQUEST_CONTEXT_REST, array $request_metadata = array(), ?string $workspace_id = null, ?string $client_id = null, ?\WP_Agent_Capability_Ceiling $capability_ceiling = null, ?\WP_Agent_Caller_Context $caller_context = null ): self {
+		return new self( $acting_user_id, $effective_agent_id, self::AUTH_SOURCE_AGENT_TOKEN, $request_context, $token_id, $request_metadata, $workspace_id, $client_id, $capability_ceiling, $caller_context );
 	}
 
 	/**
@@ -147,6 +149,15 @@ final class AgentExecutionPrincipal {
 			}
 		}
 
+		$caller_context = null;
+		if ( isset( $principal['caller_context'] ) ) {
+			if ( $principal['caller_context'] instanceof \WP_Agent_Caller_Context ) {
+				$caller_context = $principal['caller_context'];
+			} elseif ( is_array( $principal['caller_context'] ) && class_exists( '\WP_Agent_Caller_Context' ) ) {
+				$caller_context = \WP_Agent_Caller_Context::from_array( $principal['caller_context'] );
+			}
+		}
+
 		return new self(
 			isset( $principal['acting_user_id'] ) ? (int) $principal['acting_user_id'] : 0,
 			isset( $principal['effective_agent_id'] ) ? (string) $principal['effective_agent_id'] : '',
@@ -156,7 +167,8 @@ final class AgentExecutionPrincipal {
 			isset( $principal['request_metadata'] ) && is_array( $principal['request_metadata'] ) ? $principal['request_metadata'] : array(),
 			array_key_exists( 'workspace_id', $principal ) && null !== $principal['workspace_id'] ? (string) $principal['workspace_id'] : null,
 			array_key_exists( 'client_id', $principal ) && null !== $principal['client_id'] ? (string) $principal['client_id'] : null,
-			$capability_ceiling
+			$capability_ceiling,
+			$caller_context
 		);
 	}
 
@@ -176,6 +188,7 @@ final class AgentExecutionPrincipal {
 			'workspace_id'       => $this->workspace_id,
 			'client_id'          => $this->client_id,
 			'capability_ceiling' => $this->capability_ceiling instanceof \WP_Agent_Capability_Ceiling ? $this->capability_ceiling->to_array() : null,
+			'caller_context'     => $this->caller_context instanceof \WP_Agent_Caller_Context ? $this->caller_context->to_array() : null,
 		);
 	}
 
@@ -195,7 +208,8 @@ final class AgentExecutionPrincipal {
 			$request_metadata,
 			$this->workspace_id,
 			$this->client_id,
-			$this->capability_ceiling
+			$this->capability_ceiling,
+			$this->caller_context
 		);
 	}
 

--- a/tests/agents-api-smoke-helpers.php
+++ b/tests/agents-api-smoke-helpers.php
@@ -96,6 +96,10 @@ function wp_json_encode( $value, int $flags = 0, int $depth = 512 ) {
 	return json_encode( $value, $flags, max( 1, $depth ) );
 }
 
+function wp_parse_url( string $url, int $component = -1 ) {
+	return parse_url( $url, $component );
+}
+
 function _doing_it_wrong( string $function_name, string $message, string $version ): void {
 	$GLOBALS['__agents_api_smoke_wrong'][] = array(
 		'function' => $function_name,

--- a/tests/authorization-smoke.php
+++ b/tests/authorization-smoke.php
@@ -104,8 +104,42 @@ agents_api_smoke_assert_equals( 'editor-agent', $principal->effective_agent_id, 
 agents_api_smoke_assert_equals( 33, $principal->token_id, 'authenticator records token id', $failures, $passes );
 agents_api_smoke_assert_equals( 'site:42', $principal->workspace_id, 'authenticator records workspace id', $failures, $passes );
 agents_api_smoke_assert_equals( 'ci', $principal->client_id, 'authenticator records client id', $failures, $passes );
+agents_api_smoke_assert_equals( 0, $principal->caller_context->chain_depth, 'authenticator records top-of-chain caller context by default', $failures, $passes );
 agents_api_smoke_assert_equals( 1, $token_store->touches, 'authenticator touches successful token', $failures, $passes );
 agents_api_smoke_assert_equals( null, $authenticator->authenticate_bearer_token( 'other_prefix_secret' ), 'authenticator ignores non-owned token prefix', $failures, $passes );
+
+$chain_principal = $authenticator->authenticate_bearer_token(
+	$raw_token,
+	AgentsAPI\AI\AgentExecutionPrincipal::REQUEST_CONTEXT_REST,
+	array(),
+	array(
+		WP_Agent_Caller_Context::HEADER_CALLER_AGENT => 'source-agent',
+		WP_Agent_Caller_Context::HEADER_CALLER_USER  => '42',
+		WP_Agent_Caller_Context::HEADER_CALLER_HOST  => 'https://source.example',
+		WP_Agent_Caller_Context::HEADER_CHAIN_DEPTH  => '2',
+		WP_Agent_Caller_Context::HEADER_CHAIN_ROOT   => 'root-request-123',
+	)
+);
+agents_api_smoke_assert_equals( 'source-agent', $chain_principal->caller_context->caller_agent_id, 'authenticator records caller agent from headers', $failures, $passes );
+agents_api_smoke_assert_equals( 42, $chain_principal->caller_context->caller_user_id, 'authenticator records caller user from headers', $failures, $passes );
+agents_api_smoke_assert_equals( 'https://source.example', $chain_principal->caller_context->caller_host, 'authenticator records caller host from headers', $failures, $passes );
+agents_api_smoke_assert_equals( 2, $chain_principal->caller_context->chain_depth, 'authenticator records caller chain depth from headers', $failures, $passes );
+agents_api_smoke_assert_equals( 'root-request-123', $chain_principal->caller_context->chain_root_request_id, 'authenticator records caller chain root from headers', $failures, $passes );
+
+$touches_before_malformed = $token_store->touches;
+$malformed_principal      = $authenticator->authenticate_bearer_token(
+	$raw_token,
+	AgentsAPI\AI\AgentExecutionPrincipal::REQUEST_CONTEXT_REST,
+	array(),
+	array(
+		WP_Agent_Caller_Context::HEADER_CALLER_AGENT => 'source-agent',
+		WP_Agent_Caller_Context::HEADER_CALLER_HOST  => 'https://source.example',
+		WP_Agent_Caller_Context::HEADER_CHAIN_DEPTH  => 'bogus',
+		WP_Agent_Caller_Context::HEADER_CHAIN_ROOT   => 'root-request-123',
+	)
+);
+agents_api_smoke_assert_equals( null, $malformed_principal, 'authenticator fails closed on malformed caller headers', $failures, $passes );
+agents_api_smoke_assert_equals( $touches_before_malformed, $token_store->touches, 'authenticator does not touch token after malformed caller headers', $failures, $passes );
 
 $policy = new WP_Agent_WordPress_Authorization_Policy(
 	null,

--- a/tests/caller-context-smoke.php
+++ b/tests/caller-context-smoke.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Pure-PHP smoke test for caller context primitives.
+ *
+ * Run with: php tests/caller-context-smoke.php
+ *
+ * @package AgentsAPI\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+$failures = array();
+$passes   = 0;
+
+echo "agents-api-caller-context-smoke\n";
+
+require_once __DIR__ . '/agents-api-smoke-helpers.php';
+agents_api_smoke_require_module();
+
+agents_api_smoke_assert_equals( true, class_exists( 'WP_Agent_Caller_Context' ), 'caller context value object is available', $failures, $passes );
+
+$top = WP_Agent_Caller_Context::from_headers( array() );
+agents_api_smoke_assert_equals( '', $top->caller_agent_id, 'no headers produces no caller agent', $failures, $passes );
+agents_api_smoke_assert_equals( 0, $top->caller_user_id, 'no headers produces no caller user', $failures, $passes );
+agents_api_smoke_assert_equals( WP_Agent_Caller_Context::SELF_HOST, $top->caller_host, 'no headers produces self caller host', $failures, $passes );
+agents_api_smoke_assert_equals( 0, $top->chain_depth, 'no headers produces top-of-chain depth', $failures, $passes );
+agents_api_smoke_assert_equals( false, $top->is_cross_site(), 'no headers is not cross-site', $failures, $passes );
+agents_api_smoke_assert_equals( true, '' !== $top->chain_root_request_id, 'no headers generates a chain root request id', $failures, $passes );
+
+$valid_headers = array(
+	WP_Agent_Caller_Context::HEADER_CALLER_AGENT => 'source-agent',
+	WP_Agent_Caller_Context::HEADER_CALLER_USER  => '42',
+	WP_Agent_Caller_Context::HEADER_CALLER_HOST  => 'https://source.example',
+	WP_Agent_Caller_Context::HEADER_CHAIN_DEPTH  => '2',
+	WP_Agent_Caller_Context::HEADER_CHAIN_ROOT   => 'root-request-123',
+);
+
+$chain = WP_Agent_Caller_Context::from_headers( $valid_headers );
+agents_api_smoke_assert_equals( 'source-agent', $chain->caller_agent_id, 'valid headers record caller agent', $failures, $passes );
+agents_api_smoke_assert_equals( 42, $chain->caller_user_id, 'valid headers record caller user', $failures, $passes );
+agents_api_smoke_assert_equals( 'https://source.example', $chain->caller_host, 'valid headers record caller host', $failures, $passes );
+agents_api_smoke_assert_equals( 2, $chain->chain_depth, 'valid headers record chain depth', $failures, $passes );
+agents_api_smoke_assert_equals( 'root-request-123', $chain->chain_root_request_id, 'valid headers record chain root', $failures, $passes );
+agents_api_smoke_assert_equals( true, $chain->is_cross_site(), 'valid remote host is cross-site', $failures, $passes );
+agents_api_smoke_assert_equals( $chain->to_array(), WP_Agent_Caller_Context::from_array( $chain->to_array() )->to_array(), 'caller context round-trips through array shape', $failures, $passes );
+
+try {
+	WP_Agent_Caller_Context::from_headers(
+		array(
+			WP_Agent_Caller_Context::HEADER_CALLER_AGENT => 'source-agent',
+			WP_Agent_Caller_Context::HEADER_CALLER_HOST  => 'https://source.example',
+			WP_Agent_Caller_Context::HEADER_CHAIN_DEPTH  => 'not-a-number',
+			WP_Agent_Caller_Context::HEADER_CHAIN_ROOT   => 'root-request-123',
+		)
+	);
+	agents_api_smoke_assert_equals( true, false, 'malformed chain depth is rejected', $failures, $passes );
+} catch ( InvalidArgumentException $e ) {
+	agents_api_smoke_assert_equals( true, str_contains( $e->getMessage(), 'chain_depth' ), 'malformed chain depth is rejected', $failures, $passes );
+}
+
+try {
+	WP_Agent_Caller_Context::from_headers( $valid_headers, 1 );
+	agents_api_smoke_assert_equals( true, false, 'chain depth limit is enforced', $failures, $passes );
+} catch ( InvalidArgumentException $e ) {
+	agents_api_smoke_assert_equals( true, str_contains( $e->getMessage(), 'chain_depth' ), 'chain depth limit is enforced', $failures, $passes );
+}
+
+agents_api_smoke_finish( 'Agents API caller context', $failures, $passes );

--- a/tests/execution-principal-smoke.php
+++ b/tests/execution-principal-smoke.php
@@ -66,6 +66,13 @@ $from_array = AgentsAPI\AI\AgentExecutionPrincipal::from_array(
 			'user_id'              => 7,
 			'allowed_capabilities' => array( 'read' ),
 		),
+		'caller_context'       => array(
+			'caller_agent_id'      => 'caller-agent',
+			'caller_user_id'       => 5,
+			'caller_host'          => 'https://caller.example',
+			'chain_depth'          => 1,
+			'chain_root_request_id' => 'root-1',
+		),
 	)
 );
 agents_api_smoke_assert_equals( 7, $from_array->acting_user_id, 'from_array normalizes acting user id', $failures, $passes );
@@ -76,6 +83,8 @@ agents_api_smoke_assert_equals( array( 'ip_hash' => 'abc123' ), $from_array->req
 agents_api_smoke_assert_equals( 'site:99', $from_array->workspace_id, 'from_array normalizes workspace id', $failures, $passes );
 agents_api_smoke_assert_equals( 'browser', $from_array->client_id, 'from_array normalizes client id', $failures, $passes );
 agents_api_smoke_assert_equals( array( 'read' ), $from_array->capability_ceiling->allowed_capabilities, 'from_array normalizes capability ceiling', $failures, $passes );
+agents_api_smoke_assert_equals( 'caller-agent', $from_array->caller_context->caller_agent_id, 'from_array restores caller context', $failures, $passes );
+agents_api_smoke_assert_equals( 'root-1', $from_array->to_array()['caller_context']['chain_root_request_id'], 'principal exports caller context', $failures, $passes );
 
 $user_session = AgentsAPI\AI\AgentExecutionPrincipal::user_session(
 	99,


### PR DESCRIPTION
## Summary
- Adds `WP_Agent_Caller_Context` as the generic cross-site A2A caller-chain value object and parser.
- Carries caller context on `AgentExecutionPrincipal` and resolves it in `WP_Agent_Token_Authenticator` after token lookup, failing closed on malformed headers before touching tokens.
- Documents the canonical `X-Agents-Api-*` header convention, depth ceiling, and host-owned trust boundary.

Fixes #76.

## Tests
- `composer test`
- `homeboy test --path /Users/chubes/Developer/agents-api@issue-76`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the caller context substrate, documentation, and smoke tests; Chris remains responsible for review and merge.