### PR TITLE
Add generic markdown compaction primitives

### DIFF
--- a/agents-api.php
+++ b/agents-api.php
@@ -72,6 +72,7 @@ require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-message.php';
 require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-execution-principal.php';
 require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-effective-agent-resolver.php';
 require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-compaction-item.php';
+require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-compaction-conservation.php';
 require_once AGENTS_API_PATH . 'src/Tools/class-wp-agent-tool-declaration.php';
 require_once AGENTS_API_PATH . 'src/Tools/class-wp-agent-action-policy.php';
 require_once AGENTS_API_PATH . 'src/Tools/class-wp-agent-tool-access-policy.php';

--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,7 @@
       "php tests/approval-action-value-shape-smoke.php",
       "php tests/workspace-scope-smoke.php",
       "php tests/compaction-item-smoke.php",
+      "php tests/compaction-conservation-smoke.php",
       "php tests/conversation-runner-contracts-smoke.php",
       "php tests/conversation-transcript-lock-smoke.php",
       "php tests/conversation-compaction-smoke.php",

--- a/src/Runtime/class-wp-agent-compaction-conservation.php
+++ b/src/Runtime/class-wp-agent-compaction-conservation.php
@@ -1,0 +1,160 @@
+<?php
+/**
+ * Generic compaction conservation metadata.
+ *
+ * @package AgentsAPI
+ */
+
+namespace AgentsAPI\AI;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Evaluates whether compacted, retained, and archived items conserve source bytes.
+ */
+class WP_Agent_Compaction_Conservation {
+
+	/**
+	 * Normalize conservation policy fields while preserving caller-owned keys.
+	 *
+	 * @param array<string, mixed> $policy Raw policy.
+	 * @return array<string, mixed>
+	 */
+	public static function normalize_policy( array $policy ): array {
+		$policy['conservation_enabled']         = (bool) ( $policy['conservation_enabled'] ?? false );
+		$policy['minimum_conserved_byte_ratio'] = max( 0.0, (float) ( $policy['minimum_conserved_byte_ratio'] ?? 1.0 ) );
+		$policy['fail_on_conservation_failure'] = (bool) ( $policy['fail_on_conservation_failure'] ?? true );
+
+		return $policy;
+	}
+
+	/**
+	 * Build provenance and conservation metadata for generic compaction items.
+	 *
+	 * @param array<string, mixed>    $policy          Compaction policy.
+	 * @param array<int, mixed>       $original_items  Original items.
+	 * @param array<int, mixed>       $compacted_items Compacted items.
+	 * @param array<int, mixed>       $retained_items  Retained items.
+	 * @param array<int, mixed>       $archived_items  Archived items.
+	 * @param array<string, mixed>    $extra           Extra metadata.
+	 * @param array<string, int>|null $original_stats  Optional precomputed original stats.
+	 * @param array<string, int>|null $compacted_stats Optional precomputed compacted stats.
+	 * @param array<string, int>|null $retained_stats  Optional precomputed retained stats.
+	 * @param array<string, int>|null $archived_stats  Optional precomputed archived stats.
+	 * @return array<string, mixed>
+	 */
+	public static function metadata( array $policy, array $original_items = array(), array $compacted_items = array(), array $retained_items = array(), array $archived_items = array(), array $extra = array(), ?array $original_stats = null, ?array $compacted_stats = null, ?array $retained_stats = null, ?array $archived_stats = null ): array {
+		$policy          = self::normalize_policy( $policy );
+		$original_stats  = self::normalize_stats( $original_stats ?? self::item_stats( $original_items ) );
+		$compacted_stats = self::normalize_stats( $compacted_stats ?? self::item_stats( $compacted_items ) );
+		$retained_stats  = self::normalize_stats( $retained_stats ?? self::item_stats( $retained_items ) );
+		$archived_stats  = self::normalize_stats( $archived_stats ?? self::item_stats( $archived_items ) );
+
+		$conserved_bytes = $compacted_stats['byte_count'] + $retained_stats['byte_count'] + $archived_stats['byte_count'];
+		$required_bytes  = (int) ceil( $original_stats['byte_count'] * $policy['minimum_conserved_byte_ratio'] );
+		$passed          = ! $policy['conservation_enabled'] || $conserved_bytes >= $required_bytes;
+
+		return array_merge(
+			$extra,
+			array(
+				'policy'       => $policy,
+				'provenance'   => array(
+					'original'  => $original_stats,
+					'compacted' => $compacted_stats,
+					'retained'  => $retained_stats,
+					'archived'  => $archived_stats,
+				),
+				'summarizer'   => array(
+					'provider' => is_string( $policy['summary_provider'] ?? null ) ? $policy['summary_provider'] : '',
+					'model'    => is_string( $policy['summary_model'] ?? null ) ? $policy['summary_model'] : '',
+				),
+				'conservation' => array(
+					'enabled'                      => $policy['conservation_enabled'],
+					'minimum_conserved_byte_ratio' => $policy['minimum_conserved_byte_ratio'],
+					'required_byte_count'          => $required_bytes,
+					'conserved_byte_count'         => $conserved_bytes,
+					'conserved_byte_ratio'         => 0 === $original_stats['byte_count'] ? 1.0 : $conserved_bytes / $original_stats['byte_count'],
+					'passed'                       => $passed,
+					'failed_closed'                => $policy['conservation_enabled'] && $policy['fail_on_conservation_failure'] && ! $passed,
+				),
+			)
+		);
+	}
+
+	/**
+	 * Determine whether metadata represents a fail-closed conservation failure.
+	 *
+	 * @param array<string, mixed> $metadata Compaction metadata.
+	 * @return bool
+	 */
+	public static function failed_closed( array $metadata ): bool {
+		$conservation = $metadata['conservation'] ?? array();
+		return true === ( $conservation['failed_closed'] ?? false );
+	}
+
+	/**
+	 * Count items and content bytes for generic provenance metadata.
+	 *
+	 * @param array<int, mixed> $items Items.
+	 * @return array{item_count: int, byte_count: int}
+	 */
+	public static function item_stats( array $items ): array {
+		$bytes = 0;
+
+		foreach ( $items as $item ) {
+			$bytes += self::item_bytes( $item );
+		}
+
+		return array(
+			'item_count' => count( $items ),
+			'byte_count' => $bytes,
+		);
+	}
+
+	/**
+	 * Normalize precomputed stats.
+	 *
+	 * @param array<string, int> $stats Stats.
+	 * @return array{item_count: int, byte_count: int}
+	 */
+	private static function normalize_stats( array $stats ): array {
+		return array(
+			'item_count' => max( 0, (int) ( $stats['item_count'] ?? 0 ) ),
+			'byte_count' => max( 0, (int) ( $stats['byte_count'] ?? 0 ) ),
+		);
+	}
+
+	/**
+	 * Count bytes for an item's durable content.
+	 *
+	 * @param mixed $item Item.
+	 * @return int
+	 */
+	private static function item_bytes( $item ): int {
+		$content = is_array( $item ) && array_key_exists( 'content', $item ) ? $item['content'] : $item;
+
+		if ( is_string( $content ) ) {
+			return strlen( $content );
+		}
+
+		$encoded = self::json_encode( $content );
+		return false === $encoded ? 0 : strlen( $encoded );
+	}
+
+	/**
+	 * Encode data with a pure-PHP fallback for smoke tests.
+	 *
+	 * @param mixed $data Data.
+	 * @return string|false
+	 */
+	private static function json_encode( $data ) {
+		if ( function_exists( 'wp_json_encode' ) ) {
+			return wp_json_encode( $data );
+		}
+
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.json_encode_json_encode -- Pure-PHP smoke tests run without WordPress loaded.
+		return json_encode( $data );
+	}
+}

--- a/src/Runtime/class-wp-agent-conversation-compaction.php
+++ b/src/Runtime/class-wp-agent-conversation-compaction.php
@@ -383,46 +383,7 @@ class WP_Agent_Conversation_Compaction {
 	 * @return array<string, mixed>
 	 */
 	private static function metadata( array $policy, array $original_stats, array $compacted_stats = array(), array $retained_stats = array(), array $archived_stats = array(), array $extra = array() ): array {
-		$empty_stats = array(
-			'item_count' => 0,
-			'byte_count' => 0,
-		);
-
-		$compacted_stats = array_merge( $empty_stats, $compacted_stats );
-		$retained_stats  = array_merge( $empty_stats, $retained_stats );
-		$archived_stats  = array_merge( $empty_stats, $archived_stats );
-
-		$conserved_bytes = $compacted_stats['byte_count'] + $retained_stats['byte_count'] + $archived_stats['byte_count'];
-		$required_bytes  = (int) ceil( $original_stats['byte_count'] * $policy['minimum_conserved_byte_ratio'] );
-		$passed          = ! $policy['conservation_enabled'] || $conserved_bytes >= $required_bytes;
-
-		$metadata = array_merge(
-			$extra,
-			array(
-				'policy'       => $policy,
-				'provenance'   => array(
-					'original'  => $original_stats,
-					'compacted' => $compacted_stats,
-					'retained'  => $retained_stats,
-					'archived'  => $archived_stats,
-				),
-				'summarizer'   => array(
-					'provider' => $policy['summary_provider'],
-					'model'    => $policy['summary_model'],
-				),
-				'conservation' => array(
-					'enabled'                      => $policy['conservation_enabled'],
-					'minimum_conserved_byte_ratio' => $policy['minimum_conserved_byte_ratio'],
-					'required_byte_count'          => $required_bytes,
-					'conserved_byte_count'         => $conserved_bytes,
-					'conserved_byte_ratio'         => 0 === $original_stats['byte_count'] ? 1.0 : $conserved_bytes / $original_stats['byte_count'],
-					'passed'                       => $passed,
-					'failed_closed'                => $policy['conservation_enabled'] && $policy['fail_on_conservation_failure'] && ! $passed,
-				),
-			)
-		);
-
-		return $metadata;
+		return WP_Agent_Compaction_Conservation::metadata( $policy, array(), array(), array(), array(), $extra, $original_stats, $compacted_stats, $retained_stats, $archived_stats );
 	}
 
 	/**
@@ -432,8 +393,7 @@ class WP_Agent_Conversation_Compaction {
 	 * @return bool
 	 */
 	private static function conservation_failed( array $metadata ): bool {
-		$conservation = $metadata['conservation'] ?? array();
-		return true === ( $conservation['failed_closed'] ?? false );
+		return WP_Agent_Compaction_Conservation::failed_closed( $metadata );
 	}
 
 	/**
@@ -471,48 +431,7 @@ class WP_Agent_Conversation_Compaction {
 	 * @return array{item_count: int, byte_count: int}
 	 */
 	private static function item_stats( array $items ): array {
-		$bytes = 0;
-
-		foreach ( $items as $item ) {
-			$bytes += self::item_bytes( $item );
-		}
-
-		return array(
-			'item_count' => count( $items ),
-			'byte_count' => $bytes,
-		);
-	}
-
-	/**
-	 * Count bytes for an item's durable content.
-	 *
-	 * @param mixed $item Item.
-	 * @return int
-	 */
-	private static function item_bytes( $item ): int {
-		$content = is_array( $item ) && array_key_exists( 'content', $item ) ? $item['content'] : $item;
-
-		if ( is_string( $content ) ) {
-			return strlen( $content );
-		}
-
-		$encoded = self::json_encode( $content );
-		return false === $encoded ? 0 : strlen( $encoded );
-	}
-
-	/**
-	 * Encode data with a pure-PHP fallback for smoke tests.
-	 *
-	 * @param mixed $data Data.
-	 * @return string|false
-	 */
-	private static function json_encode( $data ) {
-		if ( function_exists( 'wp_json_encode' ) ) {
-			return wp_json_encode( $data );
-		}
-
-		// phpcs:ignore WordPress.WP.AlternativeFunctions.json_encode_json_encode -- Pure-PHP smoke tests run without WordPress loaded.
-		return json_encode( $data );
+		return WP_Agent_Compaction_Conservation::item_stats( $items );
 	}
 
 	/**

--- a/src/Runtime/class-wp-agent-markdown-section-compaction-adapter.php
+++ b/src/Runtime/class-wp-agent-markdown-section-compaction-adapter.php
@@ -24,6 +24,9 @@ class WP_Agent_Markdown_Section_Compaction_Adapter {
 	public const TYPE_SECTION_SUMMARY = 'markdown_section_summary';
 	public const TYPE_SECTION_POINTER = 'markdown_section_pointer';
 
+	public const STATUS_SKIPPED  = 'skipped';
+	public const STATUS_ARCHIVED = 'archived';
+
 	/**
 	 * Parse markdown into ordered compaction items keyed by heading path.
 	 *
@@ -157,6 +160,231 @@ class WP_Agent_Markdown_Section_Compaction_Adapter {
 		}
 
 		return $groups;
+	}
+
+	/**
+	 * Deterministically split ordered markdown section items for overflow archival.
+	 *
+	 * @param array<int, array<string, mixed>> $items  Ordered markdown section items.
+	 * @param array<string, mixed>            $policy Overflow policy.
+	 * @return array{status: string, retained_items: array<int, array<string, mixed>>, archive_items: array<int, array<string, mixed>>, metadata: array<string, mixed>, events: array<int, array<string, mixed>>}
+	 */
+	public static function split_for_overflow( array $items, array $policy ): array {
+		$policy         = self::normalize_overflow_policy( $policy );
+		$items          = WP_Agent_Compaction_Item::normalize_many( $items );
+		$original_bytes = strlen( self::reconstruct( $items ) );
+
+		if ( $policy['target_bytes'] <= 0 || $original_bytes <= $policy['target_bytes'] ) {
+			return self::overflow_result( self::STATUS_SKIPPED, $items, $items, array(), $policy, array( 'reason' => 'overflow_input_below_target' ) );
+		}
+
+		$sections = array_values(
+			array_filter(
+				$items,
+				static function ( array $item ): bool {
+					return self::TYPE_SECTION === ( $item['type'] ?? '' );
+				}
+			)
+		);
+
+		if ( count( $sections ) < 2 ) {
+			return self::overflow_result( self::STATUS_SKIPPED, $items, $items, array(), $policy, array( 'reason' => 'overflow_input_unsplittable' ) );
+		}
+
+		$retained      = array();
+		$archive_items = array();
+		$pointer       = self::archive_pointer_item( $policy['pointer_heading'], $policy['pointer_destination'], $policy['pointer_level'], $policy['pointer_content'] );
+		$section_seen  = 0;
+
+		foreach ( $items as $item ) {
+			$is_section = self::TYPE_SECTION === ( $item['type'] ?? '' );
+			if ( ! $is_section ) {
+				$retained[] = $item;
+				continue;
+			}
+
+			++$section_seen;
+			$candidate = array_merge( $retained, array( $item, $pointer ) );
+			if ( 1 === $section_seen || strlen( self::reconstruct( $candidate ) ) <= $policy['target_bytes'] ) {
+				$retained[] = $item;
+				continue;
+			}
+
+			$archive_items[] = $item;
+		}
+
+		if ( empty( $archive_items ) ) {
+			return self::overflow_result( self::STATUS_SKIPPED, $items, $items, array(), $policy, array( 'reason' => 'overflow_no_archive_boundary' ) );
+		}
+
+		$retained[] = $pointer;
+
+		return self::overflow_result(
+			self::STATUS_ARCHIVED,
+			$items,
+			$retained,
+			$archive_items,
+			$policy,
+			array(
+				'strategy' => 'deterministic_markdown_section_overflow_archive',
+				'boundary' => array(
+					'retained_count' => count( $retained ),
+					'archive_count'  => count( $archive_items ),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Build an archive pointer section item.
+	 *
+	 * @param string $heading     Pointer heading text.
+	 * @param string $destination Consumer-owned destination string.
+	 * @param int    $level       Markdown heading level.
+	 * @param string $content     Optional pointer content.
+	 * @return array<string, mixed>
+	 */
+	public static function archive_pointer_item( string $heading, string $destination, int $level = 2, string $content = '' ): array {
+		$heading     = trim( $heading );
+		$destination = trim( $destination );
+		$level       = max( 1, min( 6, $level ) );
+
+		if ( '' === $heading ) {
+			throw new \InvalidArgumentException( 'invalid_markdown_section_pointer: heading must be non-empty' );
+		}
+
+		if ( '' === $destination ) {
+			throw new \InvalidArgumentException( 'invalid_markdown_section_pointer: destination must be non-empty' );
+		}
+
+		if ( '' === $content ) {
+			$content = '[Archived section: ' . $destination . ']' . "\n";
+		}
+
+		$heading_line = str_repeat( '#', $level ) . ' ' . $heading . "\n";
+		$heading_path = array( $heading );
+		$heading_key  = self::heading_key( $heading_path );
+
+		return array(
+			'schema'   => self::ITEM_SCHEMA,
+			'version'  => self::ITEM_VERSION,
+			'id'       => 'section:' . $heading_key . ':pointer',
+			'type'     => self::TYPE_SECTION_POINTER,
+			'content'  => $content,
+			'metadata' => array(
+				'heading_path'         => $heading_path,
+				'heading_key'          => $heading_key,
+				'heading_level'        => $level,
+				'heading_text'         => $heading,
+				'heading_line'         => $heading_line,
+				'boundary_heading_key' => $heading_key,
+				'pointer_destination'  => $destination,
+			),
+		);
+	}
+
+	/**
+	 * Normalize markdown overflow policy fields.
+	 *
+	 * @param array<string, mixed> $policy Raw policy.
+	 * @return array<string, mixed>
+	 */
+	private static function normalize_overflow_policy( array $policy ): array {
+		$policy = WP_Agent_Compaction_Conservation::normalize_policy( $policy );
+
+		$policy['target_bytes']        = max( 0, (int) ( $policy['target_bytes'] ?? $policy['overflow_retained_bytes'] ?? 0 ) );
+		$policy['pointer_destination'] = self::normalize_string( $policy['pointer_destination'] ?? $policy['archive_pointer']['destination'] ?? '' );
+		$policy['pointer_heading']     = self::normalize_string( $policy['pointer_heading'] ?? 'Archived Sections' );
+		$policy['pointer_level']       = max( 1, min( 6, (int) ( $policy['pointer_level'] ?? 2 ) ) );
+		$policy['pointer_content']     = is_string( $policy['pointer_content'] ?? null ) ? $policy['pointer_content'] : '';
+
+		return $policy;
+	}
+
+	/**
+	 * Build a normalized overflow result.
+	 *
+	 * @param string                    $status        Status.
+	 * @param array<int, array<string, mixed>> $source_items   Source items.
+	 * @param array<int, array<string, mixed>> $retained_items Retained items.
+	 * @param array<int, array<string, mixed>> $archive_items  Archive items.
+	 * @param array<string, mixed>      $policy        Policy.
+	 * @param array<string, mixed>      $extra         Extra metadata.
+	 * @return array{status: string, retained_items: array<int, array<string, mixed>>, archive_items: array<int, array<string, mixed>>, metadata: array<string, mixed>, events: array<int, array<string, mixed>>}
+	 */
+	private static function overflow_result( string $status, array $source_items, array $retained_items, array $archive_items, array $policy, array $extra ): array {
+		$archive_id = '';
+		if ( ! empty( $archive_items ) ) {
+			$archive_id = 'agents-api-markdown-overflow-' . substr( hash( 'sha256', self::encoded_json( $archive_items ) ), 0, 16 );
+		}
+
+		$metadata = WP_Agent_Compaction_Conservation::metadata(
+			$policy,
+			$source_items,
+			array(),
+			$retained_items,
+			$archive_items,
+			array_merge(
+				$extra,
+				array(
+					'status'               => $status,
+					'archive_id'           => $archive_id,
+					'archive_pointer'      => array( 'destination' => $policy['pointer_destination'] ),
+					'total_markdown_bytes' => strlen( self::reconstruct( $source_items ) ),
+				)
+			)
+		);
+
+		$events = self::STATUS_ARCHIVED === $status ? array( self::event( 'compaction_overflow_archived', $metadata ) ) : array();
+
+		return array(
+			'status'         => $status,
+			'retained_items' => $retained_items,
+			'archive_items'  => $archive_items,
+			'metadata'       => $metadata,
+			'events'         => $events,
+		);
+	}
+
+	/**
+	 * Normalize a string policy field.
+	 *
+	 * @param mixed $value Raw value.
+	 * @return string
+	 */
+	private static function normalize_string( $value ): string {
+		return is_string( $value ) ? trim( $value ) : '';
+	}
+
+	/**
+	 * Encode data consistently for deterministic archive IDs.
+	 *
+	 * @param mixed $data Data to encode.
+	 * @return string Encoded JSON.
+	 */
+	private static function encoded_json( $data ): string {
+		if ( function_exists( 'wp_json_encode' ) ) {
+			$encoded = wp_json_encode( $data );
+		} else {
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.json_encode_json_encode -- Pure-PHP smoke tests run without WordPress loaded.
+			$encoded = json_encode( $data );
+		}
+
+		return is_string( $encoded ) ? $encoded : '';
+	}
+
+	/**
+	 * Build a lifecycle event payload.
+	 *
+	 * @param string               $type Event type.
+	 * @param array<string, mixed> $data Event data.
+	 * @return array<string, mixed>
+	 */
+	private static function event( string $type, array $data ): array {
+		return array(
+			'type'     => $type,
+			'metadata' => $data,
+		);
 	}
 
 	/**

--- a/tests/bootstrap-smoke.php
+++ b/tests/bootstrap-smoke.php
@@ -92,6 +92,7 @@ agents_api_smoke_assert_equals( true, class_exists( 'WP_Agent_Context_Section_Re
 agents_api_smoke_assert_equals( true, class_exists( 'WP_Agent_Context_Injection_Policy' ), 'WP_Agent_Context_Injection_Policy vocabulary is available', $failures, $passes );
 agents_api_smoke_assert_equals( true, class_exists( 'WP_Agent_Composable_Context' ), 'WP_Agent_Composable_Context value object is available', $failures, $passes );
 agents_api_smoke_assert_equals( true, defined( 'AGENTS_API_PLUGIN_FILE' ), 'plugin file constant is available', $failures, $passes );
+agents_api_smoke_assert_equals( true, class_exists( 'AgentsAPI\\AI\\WP_Agent_Compaction_Conservation' ), 'AgentsAPI\\AI\\WP_Agent_Compaction_Conservation contract is available', $failures, $passes );
 agents_api_smoke_assert_equals( true, class_exists( 'AgentsAPI\\AI\\WP_Agent_Markdown_Section_Compaction_Adapter' ), 'AgentsAPI\\AI\\WP_Agent_Markdown_Section_Compaction_Adapter contract is available', $failures, $passes );
 agents_api_smoke_assert_equals( true, class_exists( 'AgentsAPI\\AI\\WP_Agent_Conversation_Loop' ), 'WP_Agent_Conversation_Loop facade is available', $failures, $passes );
 agents_api_smoke_assert_equals( true, interface_exists( 'AgentsAPI\\AI\\Approvals\\WP_Agent_Pending_Action_Store' ), 'AgentsAPI\\AI\\Approvals\\WP_Agent_Pending_Action_Store contract is available', $failures, $passes );

--- a/tests/compaction-conservation-smoke.php
+++ b/tests/compaction-conservation-smoke.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * Pure-PHP smoke test for generic compaction conservation metadata.
+ *
+ * Run with: php tests/compaction-conservation-smoke.php
+ *
+ * @package AgentsAPI\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+$failures = array();
+$passes   = 0;
+
+echo "agents-api-compaction-conservation-smoke\n";
+
+require_once __DIR__ . '/agents-api-smoke-helpers.php';
+agents_api_smoke_require_module();
+
+$original_items = array(
+	array( 'type' => 'memory', 'content' => str_repeat( 'alpha ', 20 ) ),
+	array( 'type' => 'memory', 'content' => str_repeat( 'bravo ', 20 ) ),
+);
+$compacted_items = array(
+	array( 'type' => 'summary', 'content' => str_repeat( 'alpha bravo ', 10 ) ),
+);
+$archived_items = array(
+	array( 'type' => 'archive', 'content' => str_repeat( 'full archive ', 18 ) ),
+);
+
+echo "\n[1] Healthy compaction exposes provenance and passes conservation:\n";
+$metadata = AgentsAPI\AI\WP_Agent_Compaction_Conservation::metadata(
+	array(
+		'conservation_enabled'         => true,
+		'minimum_conserved_byte_ratio' => 0.85,
+	),
+	$original_items,
+	$compacted_items,
+	array(),
+	$archived_items
+);
+agents_api_smoke_assert_equals( 2, $metadata['provenance']['original']['item_count'], 'original item count is recorded', $failures, $passes );
+agents_api_smoke_assert_equals( 1, $metadata['provenance']['compacted']['item_count'], 'compacted item count is recorded', $failures, $passes );
+agents_api_smoke_assert_equals( 1, $metadata['provenance']['archived']['item_count'], 'archived item count is recorded', $failures, $passes );
+agents_api_smoke_assert_equals( true, $metadata['conservation']['passed'], 'healthy compaction passes conservation', $failures, $passes );
+agents_api_smoke_assert_equals( false, AgentsAPI\AI\WP_Agent_Compaction_Conservation::failed_closed( $metadata ), 'healthy compaction is not failed closed', $failures, $passes );
+
+echo "\n[2] Lossy compaction fails closed without conversation compaction:\n";
+$lossy = AgentsAPI\AI\WP_Agent_Compaction_Conservation::metadata(
+	array(
+		'conservation_enabled'         => true,
+		'minimum_conserved_byte_ratio' => 0.95,
+	),
+	$original_items,
+	array( array( 'type' => 'summary', 'content' => 'tiny' ) ),
+	array(),
+	array()
+);
+agents_api_smoke_assert_equals( false, $lossy['conservation']['passed'], 'lossy compaction records failed conservation', $failures, $passes );
+agents_api_smoke_assert_equals( true, $lossy['conservation']['failed_closed'], 'lossy compaction records failed-closed state', $failures, $passes );
+agents_api_smoke_assert_equals( true, AgentsAPI\AI\WP_Agent_Compaction_Conservation::failed_closed( $lossy ), 'failed_closed helper detects failure', $failures, $passes );
+
+echo "\n[3] Disabled conservation records opt-out while preserving metadata:\n";
+$disabled = AgentsAPI\AI\WP_Agent_Compaction_Conservation::metadata(
+	array(
+		'conservation_enabled'         => false,
+		'minimum_conserved_byte_ratio' => 1.0,
+	),
+	$original_items,
+	array( array( 'type' => 'summary', 'content' => 'tiny' ) )
+);
+agents_api_smoke_assert_equals( false, $disabled['conservation']['enabled'], 'disabled conservation records opt-out', $failures, $passes );
+agents_api_smoke_assert_equals( true, $disabled['conservation']['passed'], 'disabled conservation does not fail compacted output', $failures, $passes );
+
+agents_api_smoke_finish( 'Agents API compaction conservation', $failures, $passes );

--- a/tests/markdown-section-compaction-smoke.php
+++ b/tests/markdown-section-compaction-smoke.php
@@ -54,4 +54,51 @@ agents_api_smoke_assert_equals( 4, count( $groups['memory'] ), 'top-level bounda
 $nested_groups = AgentsAPI\AI\WP_Agent_Markdown_Section_Compaction_Adapter::group_by_heading_boundary( $items, 2 );
 agents_api_smoke_assert_equals( array( '__preamble', 'memory', 'memory/project-alpha', 'memory/empty-section', 'later' ), array_keys( $nested_groups ), 'items can group by nested heading boundary', $failures, $passes );
 
+echo "\n[5] Markdown overflow archives tail sections and inserts a pointer:\n";
+$overflow_markdown = "# Agent Memory\n\nIntro stays.\n\n";
+for ( $i = 1; $i <= 6; ++$i ) {
+	$overflow_markdown .= "## Section {$i}\n\n" . str_repeat( "Line {$i} durable memory.\n", 8 ) . "\n";
+}
+$overflow_items = AgentsAPI\AI\WP_Agent_Markdown_Section_Compaction_Adapter::parse( $overflow_markdown );
+$overflow       = AgentsAPI\AI\WP_Agent_Markdown_Section_Compaction_Adapter::split_for_overflow(
+	$overflow_items,
+	array(
+		'target_bytes'        => 900,
+		'pointer_destination' => 'daily/2026/05/01.md',
+		'pointer_heading'     => 'Archived Memory Overflow',
+		'pointer_content'     => "On 2026-05-01, sections were archived verbatim to `daily/2026/05/01.md`.\n",
+	)
+);
+$retained_markdown = AgentsAPI\AI\WP_Agent_Markdown_Section_Compaction_Adapter::reconstruct( $overflow['retained_items'] );
+$archive_markdown  = AgentsAPI\AI\WP_Agent_Markdown_Section_Compaction_Adapter::reconstruct( $overflow['archive_items'] );
+agents_api_smoke_assert_equals( AgentsAPI\AI\WP_Agent_Markdown_Section_Compaction_Adapter::STATUS_ARCHIVED, $overflow['status'], 'overflow produces archived status', $failures, $passes );
+agents_api_smoke_assert_equals( true, str_contains( $retained_markdown, '## Archived Memory Overflow' ), 'retained markdown includes archive pointer heading', $failures, $passes );
+agents_api_smoke_assert_equals( true, str_contains( $retained_markdown, 'daily/2026/05/01.md' ), 'retained markdown includes consumer archive destination', $failures, $passes );
+agents_api_smoke_assert_equals( true, str_contains( $archive_markdown, '## Section 6' ), 'archive markdown includes tail section', $failures, $passes );
+agents_api_smoke_assert_equals( false, str_contains( $retained_markdown, '## Section 6' ), 'archived tail section is removed from retained markdown', $failures, $passes );
+agents_api_smoke_assert_equals( true, 0 < $overflow['metadata']['provenance']['archived']['byte_count'], 'overflow metadata includes archived bytes', $failures, $passes );
+agents_api_smoke_assert_equals( 'compaction_overflow_archived', $overflow['events'][0]['type'], 'overflow emits archive lifecycle event', $failures, $passes );
+
+echo "\n[6] Small markdown and unsplittable markdown remain unchanged:\n";
+$small = AgentsAPI\AI\WP_Agent_Markdown_Section_Compaction_Adapter::split_for_overflow(
+	AgentsAPI\AI\WP_Agent_Markdown_Section_Compaction_Adapter::parse( "# Only\n\nSmall file.\n" ),
+	array(
+		'target_bytes'        => 10000,
+		'pointer_destination' => 'daily/2026/05/01.md',
+	)
+);
+agents_api_smoke_assert_equals( AgentsAPI\AI\WP_Agent_Markdown_Section_Compaction_Adapter::STATUS_SKIPPED, $small['status'], 'small markdown skips overflow', $failures, $passes );
+agents_api_smoke_assert_equals( 'overflow_input_below_target', $small['metadata']['reason'], 'small markdown records below-target reason', $failures, $passes );
+agents_api_smoke_assert_equals( array(), $small['archive_items'], 'small markdown has no archive items', $failures, $passes );
+
+$unsplittable = AgentsAPI\AI\WP_Agent_Markdown_Section_Compaction_Adapter::split_for_overflow(
+	AgentsAPI\AI\WP_Agent_Markdown_Section_Compaction_Adapter::parse( "# Only\n\n" . str_repeat( 'single section ', 100 ) . "\n" ),
+	array(
+		'target_bytes'        => 40,
+		'pointer_destination' => 'daily/2026/05/01.md',
+	)
+);
+agents_api_smoke_assert_equals( AgentsAPI\AI\WP_Agent_Markdown_Section_Compaction_Adapter::STATUS_SKIPPED, $unsplittable['status'], 'single-section oversized markdown skips overflow', $failures, $passes );
+agents_api_smoke_assert_equals( 'overflow_input_unsplittable', $unsplittable['metadata']['reason'], 'single-section oversized markdown records unsplittable reason', $failures, $passes );
+
 agents_api_smoke_finish( 'Agents API markdown section compaction', $failures, $passes );


### PR DESCRIPTION
## Summary

- Add `AgentCompactionConservation` so generic compaction items can reuse provenance and fail-closed byte conservation metadata outside conversation transcripts.
- Update `AgentConversationCompaction` to reuse the generic conservation primitive while preserving existing behavior.
- Add markdown-section overflow planning to `AgentMarkdownSectionCompactionAdapter`, including deterministic pointer insertion, verbatim archive items, skipped/unsplittable handling, and lifecycle metadata.

Fixes #83.
Fixes #84.

## Testing

- `php tests/compaction-conservation-smoke.php`
- `php tests/markdown-section-compaction-smoke.php`
- `php tests/conversation-compaction-smoke.php`
- `php tests/bootstrap-smoke.php`
- `for test in tests/*smoke.php; do php "$test" || exit 1; done`
- `composer test`
- `php -l src/Runtime/AgentCompactionConservation.php && php -l src/Runtime/AgentConversationCompaction.php && php -l src/Runtime/AgentMarkdownSectionCompactionAdapter.php && php -l tests/compaction-conservation-smoke.php && php -l tests/markdown-section-compaction-smoke.php`

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Inspecting the Data Machine downstream migration blocker, implementing the generic conservation and markdown overflow primitives, adding smoke tests, and running verification. Chris remains responsible for review and final merge decisions.