### PR TITLE
Add transcript provider response ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,6 +344,8 @@ $scope = new AgentsAPI\Core\FilesRepository\AgentMemoryScope(
 
 Transcript sessions are also workspace-stamped. `ConversationTranscriptStoreInterface::create_session()` and `::get_recent_pending_session()` both receive an `AgentWorkspaceScope`, and `AgentConversationRequest` can carry a workspace so runtime persisters can stamp the session they materialize.
 
+Transcript stores preserve provider continuity metadata as part of the complete session state. `ConversationTranscriptStoreInterface::update_session()` accepts an optional opaque `provider_response_id`, and `::get_session()` returns the same key alongside `provider` and `model`. Consumers using provider-side state, such as the OpenAI Responses API `previous_response_id` flow, can pass the provider's response ID through this field without encoding per-consumer metadata keys. A `null` value means no provider-side response ID is associated with the current transcript state.
+
 ## Retrieved Context Authority
 
 Retrieved context is not only ordered text. Consumers may retrieve memory, identity, conversation, workspace, platform, or support-mode context that conflicts. Agents API provides generic vocabulary and value objects so products can preserve source authority without encoding product-specific policy into this substrate.

--- a/docs/default-stores-companion.md
+++ b/docs/default-stores-companion.md
@@ -68,7 +68,7 @@ The class names above are placeholders for the companion repository. They are no
 
 - Implements `AgentsAPI\Core\Database\Chat\ConversationTranscriptStoreInterface`.
 - Stores transcript sessions in a companion-owned CPT or table chosen by the companion.
-- Preserves `AgentWorkspaceScope`, `user_id`, `agent_id`, title, metadata, provider, model, timestamps, and pending-session dedup fields from the contract.
+- Preserves `AgentWorkspaceScope`, `user_id`, `agent_id`, title, metadata, provider, model, `provider_response_id`, timestamps, and pending-session dedup fields from the contract.
 - Leaves chat UI listing, read state, retention scheduling, and analytics outside the generic store unless a future contract promotes them.
 
 ## Interop Tests

--- a/src/Transcripts/ConversationTranscriptStoreInterface.php
+++ b/src/Transcripts/ConversationTranscriptStoreInterface.php
@@ -36,7 +36,7 @@ interface ConversationTranscriptStoreInterface {
 	 *
 	 * Returns the session as an associative array with keys:
 	 * session_id, workspace_type, workspace_id, user_id, agent_id, title, messages (decoded array),
-	 * metadata (decoded array), provider, model, context/mode, created_at,
+	 * metadata (decoded array), provider, model, provider_response_id, context/mode, created_at,
 	 * updated_at, last_read_at, expires_at.
 	 *
 	 * @param string $session_id Session UUID.
@@ -52,9 +52,10 @@ interface ConversationTranscriptStoreInterface {
 	 * @param array  $metadata   Updated metadata.
 	 * @param string $provider   Optional AI provider identifier.
 	 * @param string $model      Optional AI model identifier.
+	 * @param string|null $provider_response_id Opaque provider-side response/state ID, or null when none.
 	 * @return bool True on success.
 	 */
-	public function update_session( string $session_id, array $messages, array $metadata = array(), string $provider = '', string $model = '' ): bool;
+	public function update_session( string $session_id, array $messages, array $metadata = array(), string $provider = '', string $model = '', ?string $provider_response_id = null ): bool;
 
 	/**
 	 * Delete a session by ID. Idempotent.

--- a/tests/workspace-scope-smoke.php
+++ b/tests/workspace-scope-smoke.php
@@ -79,12 +79,15 @@ agents_api_smoke_assert_equals( $workspace->to_array(), $request->to_array()['wo
 echo "\n[4] Transcript store contract requires workspace scope on session creation and pending dedup:\n";
 
 $reflection       = new ReflectionClass( AgentsAPI\Core\Database\Chat\ConversationTranscriptStoreInterface::class );
-$create_params    = $reflection->getMethod( 'create_session' )->getParameters();
-$pending_params   = $reflection->getMethod( 'get_recent_pending_session' )->getParameters();
-$workspace_class  = AgentsAPI\Core\Workspace\AgentWorkspaceScope::class;
+$create_params   = $reflection->getMethod( 'create_session' )->getParameters();
+$update_params   = $reflection->getMethod( 'update_session' )->getParameters();
+$pending_params  = $reflection->getMethod( 'get_recent_pending_session' )->getParameters();
+$workspace_class = AgentsAPI\Core\Workspace\AgentWorkspaceScope::class;
 
 agents_api_smoke_assert_equals( 'workspace', $create_params[0]->getName(), 'create_session first parameter is workspace', $failures, $passes );
 agents_api_smoke_assert_equals( $workspace_class, $create_params[0]->getType()->getName(), 'create_session workspace parameter is typed', $failures, $passes );
+agents_api_smoke_assert_equals( 'provider_response_id', $update_params[5]->getName(), 'update_session accepts provider response ID', $failures, $passes );
+agents_api_smoke_assert_equals( true, $update_params[5]->allowsNull(), 'provider response ID can be null when no provider state exists', $failures, $passes );
 agents_api_smoke_assert_equals( 'workspace', $pending_params[0]->getName(), 'get_recent_pending_session first parameter is workspace', $failures, $passes );
 agents_api_smoke_assert_equals( $workspace_class, $pending_params[0]->getType()->getName(), 'get_recent_pending_session workspace parameter is typed', $failures, $passes );
 


### PR DESCRIPTION
## Summary
- Add `provider_response_id` to `ConversationTranscriptStoreInterface::update_session()` and `get_session()` contract docs.
- Document provider-side continuity metadata for stateful APIs such as OpenAI Responses.
- Update default-stores guidance and smoke coverage for the expanded transcript contract.

## Testing
- `php tests/workspace-scope-smoke.php`
- `composer test`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafting the contract/docs/test update and running local smoke verification; Chris reviewed direction and requested the PR.