### PR TITLE
Loop: default should_continue to continue-always when tool mediation is enabled

### DIFF
--- a/src/Runtime/class-wp-agent-conversation-loop.php
+++ b/src/Runtime/class-wp-agent-conversation-loop.php
@@ -43,6 +43,13 @@ class WP_Agent_Conversation_Loop {
 	 * - `budgets` (WP_Agent_Iteration_Budget[]): Named iteration budgets for bounded execution.
 	 * - `context` (array): Caller-owned context passed to adapters.
 	 * - `should_continue` (callable|null): Caller-owned continuation policy.
+	 *   Defaults to `null` in the legacy path (which causes the loop to break
+	 *   after one turn unless the caller supplies a callback). When tool
+	 *   mediation is enabled (`tool_executor` + `tool_declarations` provided),
+	 *   defaults to a `__return_true` callable so the loop continues until
+	 *   `tool_calls` is empty (natural completion), `completion_policy` fires,
+	 *   `max_turns` is reached, or a budget is exceeded — i.e. the caller no
+	 *   longer needs to supply this option just to get multi-turn mediation.
 	 * - `compaction_policy` (array|null): Optional compaction policy.
 	 * - `summarizer` (callable|null): Optional compaction summarizer.
 	 * - `tool_executor` (WP_Agent_Tool_Executor|null): Tool execution adapter.
@@ -62,9 +69,9 @@ class WP_Agent_Conversation_Loop {
 	public static function run( array $messages, callable $turn_runner, array $options = array() ): array {
 		$max_turns             = self::max_turns( $options['max_turns'] ?? 1 );
 		$context               = isset( $options['context'] ) && is_array( $options['context'] ) ? $options['context'] : array();
-		$should_continue       = $options['should_continue'] ?? null;
 		$tool_executor         = self::resolve_tool_executor( $options );
 		$tool_declarations     = self::resolve_tool_declarations( $options );
+		$should_continue       = self::resolve_should_continue( $options, $tool_executor, $tool_declarations );
 		$completion_policy     = self::resolve_completion_policy( $options );
 		$transcript_persister  = self::resolve_transcript_persister( $options );
 		$transcript_lock       = self::resolve_transcript_lock( $options );
@@ -505,6 +512,47 @@ class WP_Agent_Conversation_Loop {
 	private static function resolve_tool_executor( array $options ): ?WP_Agent_Tool_Executor {
 		$executor = $options['tool_executor'] ?? null;
 		return $executor instanceof WP_Agent_Tool_Executor ? $executor : null;
+	}
+
+	/**
+	 * Resolve the should_continue callable for this run.
+	 *
+	 * When tool mediation is enabled, defaults to a continue-always callable so
+	 * `max_turns`, `completion_policy`, budgets, and natural completion (empty
+	 * `tool_calls`) become the only stop conditions. In the legacy path (no
+	 * mediation), preserves the historical break-after-1 behavior unless the
+	 * caller supplies their own continuation policy.
+	 *
+	 * @param array                       $options           Loop options.
+	 * @param WP_Agent_Tool_Executor|null $tool_executor     Resolved tool executor.
+	 * @param array                       $tool_declarations Resolved tool declarations.
+	 * @return callable|null
+	 */
+	private static function resolve_should_continue(
+		array $options,
+		?WP_Agent_Tool_Executor $tool_executor,
+		array $tool_declarations
+	) {
+		if ( array_key_exists( 'should_continue', $options ) ) {
+			$caller_supplied = $options['should_continue'];
+			if ( is_callable( $caller_supplied ) ) {
+				return $caller_supplied;
+			}
+			// Caller passed a non-callable value (e.g. null) — preserve the
+			// legacy break-after-1 behavior they explicitly opted into.
+			return null;
+		}
+
+		// No caller-supplied policy. When mediation is enabled, default to
+		// "keep going" so the loop's other stop conditions can do their job.
+		$mediation_enabled = null !== $tool_executor && ! empty( $tool_declarations );
+		if ( $mediation_enabled ) {
+			return static function (): bool {
+				return true;
+			};
+		}
+
+		return null;
 	}
 
 	/**

--- a/tests/conversation-loop-tool-execution-smoke.php
+++ b/tests/conversation-loop-tool-execution-smoke.php
@@ -184,4 +184,73 @@ agents_api_smoke_assert_equals( 0, count( $executor->executed ), 'executor was n
 agents_api_smoke_assert_equals( 1, count( $validation_result['tool_execution_results'] ), 'validation error is recorded as tool result', $failures, $passes );
 agents_api_smoke_assert_equals( false, $validation_result['tool_execution_results'][0]['result']['success'], 'validation error marks result as failed', $failures, $passes );
 
+echo "\n[5] Multi-turn mediation runs without an explicit should_continue option:\n";
+$executor->executed   = array();
+$default_turn_count   = 0;
+
+$default_result = AgentsAPI\AI\WP_Agent_Conversation_Loop::run(
+	array( array( 'role' => 'user', 'content' => 'start' ) ),
+	static function ( array $messages, array $context ) use ( &$default_turn_count ): array {
+		++$default_turn_count;
+
+		if ( 1 === $context['turn'] ) {
+			return array(
+				'messages'   => $messages,
+				'tool_calls' => array(
+					array(
+						'name'       => 'client/summarize',
+						'parameters' => array( 'text' => 'turn ' . $context['turn'] ),
+					),
+				),
+			);
+		}
+
+		return array(
+			'messages'   => $messages,
+			'content'    => 'All done.',
+			'tool_calls' => array(),
+		);
+	},
+	array(
+		'max_turns'         => 5,
+		'tool_executor'     => $executor,
+		'tool_declarations' => $tools,
+		// NOTE: no should_continue option here — the loop should default to a
+		// continue-always policy when mediation is enabled, so this test fails
+		// before #96's fix and passes after.
+	)
+);
+
+agents_api_smoke_assert_equals( 1, count( $executor->executed ), 'mediation executor ran once with no explicit should_continue', $failures, $passes );
+agents_api_smoke_assert_equals( 2, $default_turn_count, 'mediation loop ran two turns with no explicit should_continue', $failures, $passes );
+agents_api_smoke_assert_equals( 1, count( $default_result['tool_execution_results'] ), 'mediation default returned the tool result', $failures, $passes );
+
+echo "\n[6] Legacy path (no mediation) preserves break-after-1 default:\n";
+$legacy_default_count = 0;
+
+$legacy_default_result = AgentsAPI\AI\WP_Agent_Conversation_Loop::run(
+	array( array( 'role' => 'user', 'content' => 'go' ) ),
+	static function ( array $messages, array $context ) use ( &$legacy_default_count ): array {
+		++$legacy_default_count;
+
+		$messages[] = array(
+			'role'    => 'assistant',
+			'content' => 'turn ' . $context['turn'],
+		);
+
+		return array(
+			'messages'               => $messages,
+			'tool_execution_results' => array(),
+			'events'                 => array(),
+		);
+	},
+	array(
+		'max_turns' => 3,
+		// No mediation, no should_continue → loop should still break after 1.
+	)
+);
+
+agents_api_smoke_assert_equals( 1, $legacy_default_count, 'legacy path still breaks after one turn without should_continue', $failures, $passes );
+agents_api_smoke_assert_equals( 2, count( $legacy_default_result['messages'] ), 'legacy transcript has user + one assistant message', $failures, $passes );
+
 agents_api_smoke_finish( 'Agents API conversation loop tool execution', $failures, $passes );


### PR DESCRIPTION
Fixes #96.

## Problem

`WP_Agent_Conversation_Loop::run()` breaks after one turn unless the caller passes `should_continue` returning truthy. When tool mediation is enabled, this defeats the whole point of mediation: the loop runs turn 1, dispatches the tool, appends `tool_call` + `tool_result` to the transcript… and stops, never giving the model a chance to read the result and produce a final reply.

Every multi-turn-with-mediation caller ends up writing the same boilerplate:

```php
'should_continue' => static function (): bool { return true; },
```

The existing test at `tests/conversation-loop-tool-execution-smoke.php#118-153` literally has that closure inline — proof that the contract's default is the wrong shape for the most common case.

## Fix

Centralize `should_continue` resolution in a new `resolve_should_continue()` helper. When the caller doesn't supply one and tool mediation is enabled (`tool_executor` + `tool_declarations` both provided), default to a continue-always closure. Then `max_turns`, `completion_policy`, budgets, and natural completion (empty `tool_calls`) become the only stop conditions — which is what mediation users actually want.

Legacy path is untouched: when mediation is **not** enabled, the default stays `null` and the loop still breaks after turn 1 unless the caller supplies a callback. Anything that was working continues to work.

## Tests

Two new assertions in `conversation-loop-tool-execution-smoke.php`:

- **[5]** Multi-turn mediation runs without an explicit `should_continue` option — exercises the new default. Fails before this PR, passes after.
- **[6]** Legacy path (no mediation) preserves the break-after-1 default — pins the no-regression on the historical legacy contract.

The existing test [3] still passes too: explicitly providing `should_continue` continues to win over the new default.

## Quality gate results

- `composer test` — full smoke suite green, including the two new assertions and all 17 prior `conversation-loop-tool-execution` assertions.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Code (Opus 4.7)
- **Used for:** Identifying the gap while building a sibling consumer plugin, drafting the resolver, writing the new smoke assertions.