### PR TITLE
Conversation store: document agent_slug metadata convention + add constant

### DIFF
--- a/src/Transcripts/class-wp-agent-conversation-store.php
+++ b/src/Transcripts/class-wp-agent-conversation-store.php
@@ -20,13 +20,37 @@ defined( 'ABSPATH' ) || exit;
 interface WP_Agent_Conversation_Store {
 
 	/**
+	 * Convention key for storing the agent's registered slug inside session
+	 * `metadata`.
+	 *
+	 * Agents are slug-keyed in this substrate (`wp_register_agent`,
+	 * `wp_get_agent`, `wp_has_agent` all take strings) but the conversation
+	 * store contract carries `int $agent_id`. Until the contract is widened
+	 * to a string identifier, callers that registered an agent via
+	 * `wp_register_agent` should mirror its slug into the session metadata
+	 * under this key so that downstream consumers can resolve the agent the
+	 * same way the registry does. The value is a `WP_Agent::get_slug()`
+	 * string; recommended reading path is
+	 * `$session['metadata'][ WP_Agent_Conversation_Store::META_KEY_AGENT_SLUG ]`.
+	 *
+	 * Tracking issue: https://github.com/Automattic/agents-api/issues/95
+	 */
+	public const META_KEY_AGENT_SLUG = 'agent_slug';
+
+	/**
 	 * Create a new conversation transcript session and return its ID.
 	 *
+	 * `$agent_id` is an opaque integer; consumers without an integer agent
+	 * identifier should pass `0` and mirror the slug into `$metadata` under
+	 * {@see self::META_KEY_AGENT_SLUG}. See #95 for context on the slug-vs-int gap.
+	 *
 	 * @param WP_Agent_Workspace_Scope $workspace Workspace owning the session.
-	 * @param int                 $user_id   WordPress user ID owning the session.
-	 * @param int                 $agent_id  Agent ID (0 = agent-less session).
-	 * @param array               $metadata  Arbitrary session metadata (JSON-serializable).
-	 * @param string              $context   Execution mode ('chat', 'pipeline', 'system').
+	 * @param int                      $user_id   WordPress user ID owning the session.
+	 * @param int                      $agent_id  Agent ID (0 = agent-less or slug-only session).
+	 * @param array                    $metadata  Arbitrary session metadata (JSON-serializable). When the
+	 *                                            session belongs to a slug-registered agent, callers should
+	 *                                            include `[ self::META_KEY_AGENT_SLUG => $slug ]`.
+	 * @param string                   $context   Execution mode ('chat', 'pipeline', 'system').
 	 * @return string Session ID (UUIDv4), or empty string on failure.
 	 */
 	public function create_session( WP_Agent_Workspace_Scope $workspace, int $user_id, int $agent_id = 0, array $metadata = array(), string $context = 'chat' ): string;
@@ -39,6 +63,9 @@ interface WP_Agent_Conversation_Store {
 	 * metadata (decoded array), provider, model, provider_response_id, context/mode, created_at,
 	 * updated_at, last_read_at, expires_at.
 	 *
+	 * The agent slug, when present, lives at
+	 * `$session['metadata'][ self::META_KEY_AGENT_SLUG ]`.
+	 *
 	 * @param string $session_id Session UUID.
 	 * @return array|null Session data or null if not found.
 	 */
@@ -47,11 +74,12 @@ interface WP_Agent_Conversation_Store {
 	/**
 	 * Replace a session's messages + metadata.
 	 *
-	 * @param string $session_id Session UUID.
-	 * @param array  $messages   Complete messages array (not a delta).
-	 * @param array  $metadata   Updated metadata.
-	 * @param string $provider   Optional AI provider identifier.
-	 * @param string $model      Optional AI model identifier.
+	 * @param string      $session_id           Session UUID.
+	 * @param array       $messages             Complete messages array (not a delta).
+	 * @param array       $metadata             Updated metadata. Slug-registered agents should keep
+	 *                                          the {@see self::META_KEY_AGENT_SLUG} entry in sync.
+	 * @param string      $provider             Optional AI provider identifier.
+	 * @param string      $model                Optional AI model identifier.
 	 * @param string|null $provider_response_id Opaque provider-side response/state ID, or null when none.
 	 * @return bool True on success.
 	 */


### PR DESCRIPTION
Refs #95.

## Why this PR is small

#95 lays out three options: (1) re-type `int $agent_id` → `string $agent_slug` in the contract, (2) add a sibling `string $agent_slug` parameter, or (3) document a metadata convention. The first two are interface-signature changes, which are breaking for every existing implementer. **This PR ships option 3 only**, leaving room for the maintainer to decide whether option 1 or 2 should follow as a separate breaking change.

If the preferred direction is (1) or (2), this PR's constant + docs survive that change unchanged — they document a convention that applies regardless of how the eventual contract is widened.

## Changes

- New interface constant `WP_Agent_Conversation_Store::META_KEY_AGENT_SLUG = 'agent_slug'`. Stable reference for both writers and readers; no parameter signature change.
- `create_session()` docblock: clarifies that `$agent_id = 0` is acceptable for slug-only registrations and recommends mirroring the slug into `$metadata` under the new constant.
- `get_session()` docblock: notes the slug, when present, lives at `$session['metadata'][ self::META_KEY_AGENT_SLUG ]`.
- `update_session()` docblock: nudges callers to keep the metadata entry in sync.

## Why a constant on the interface

Both implementers (Data Machine, [`lezama/openclawp`](https://github.com/lezama/openclawp/blob/main/includes/class-openclawp-runner.php)) currently encode the slug in metadata under different ad-hoc keys. Pinning a constant makes the convention discoverable and stops the divergence from spreading. Interface constants don't break PHP impls (any class implementing the interface can read the constant; no signature change required).

## Quality gate results

- `composer test` — full smoke suite green; no behavior changes, only docblocks + a new constant.

## Not changed in this PR

- `int $agent_id` parameter signature — left for the maintainer's call on options (1) vs (2). Either is mechanically a follow-up: a search-and-replace once the canonical direction is settled.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Code (Opus 4.7)
- **Used for:** Identifying the gap while building [`lezama/openclawp`](https://github.com/lezama/openclawp), drafting the docblock + constant.