### PR TITLE
Add WP_Agent_Channel base class for messaging transports

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Agents API sits between tool/action discovery and product-specific automation. I
 ## What Agents API Owns
 
 - Agent registration and lookup.
+- Messaging channel base class (`WP_Agent_Channel`) that maps an external transport (Telegram, Slack, WhatsApp, Email, …) onto the Abilities-API chat surface, with shared session continuity and lifecycle hooks.
 - Runtime message, request, result, and completion value objects.
 - Agent execution principal/context value objects.
 - Agent access grant, token, token authenticator, authorization policy, and capability ceiling contracts.

--- a/agents-api.php
+++ b/agents-api.php
@@ -112,6 +112,7 @@ require_once AGENTS_API_PATH . 'src/Memory/class-wp-agent-memory-write-result.ph
 require_once AGENTS_API_PATH . 'src/Memory/class-wp-agent-memory-store.php';
 require_once AGENTS_API_PATH . 'src/Guidelines/guidelines.php';
 require_once AGENTS_API_PATH . 'src/Guidelines/class-wp-guidelines-substrate.php';
+require_once AGENTS_API_PATH . 'src/Channels/class-wp-agent-channel.php';
 
 add_action( 'init', array( 'WP_Agents_Registry', 'init' ), 10 );
 add_action( 'init', array( 'WP_Guidelines_Substrate', 'register' ), 9 );

--- a/src/Channels/class-wp-agent-channel.php
+++ b/src/Channels/class-wp-agent-channel.php
@@ -186,6 +186,7 @@ abstract class WP_Agent_Channel {
 	 * @return WP_Error|null
 	 */
 	protected function validate( array $data ): ?WP_Error {
+		unset( $data );
 		return null;
 	}
 
@@ -290,6 +291,8 @@ abstract class WP_Agent_Channel {
 	 * @return array|WP_Error      `{ session_id, reply, completed? }` or WP_Error.
 	 */
 	protected function run_agent( string $message_text, array $data ): array|WP_Error {
+		unset( $data );
+
 		if ( ! function_exists( 'wp_get_ability' ) ) {
 			return new WP_Error( 'abilities_api_missing', 'Abilities API is not loaded.' );
 		}
@@ -320,7 +323,7 @@ abstract class WP_Agent_Channel {
 			array(
 				'agent'      => $this->agent_slug,
 				'message'    => $message_text,
-				'session_id' => $this->session_id ?: null,
+				'session_id' => '' === (string) $this->session_id ? null : $this->session_id,
 			)
 		);
 	}
@@ -338,13 +341,8 @@ abstract class WP_Agent_Channel {
 	protected function deliver_result( $result ): void {
 		if ( is_wp_error( $result ) ) {
 			$this->response_status = 'failed';
-			$this->send_error( $result->get_error_message() ?: 'Sorry, I could not process your message right now.' );
-			return;
-		}
-
-		if ( ! is_array( $result ) ) {
-			$this->response_status = 'failed';
-			$this->send_error( 'Agent returned an unexpected result.' );
+			$message               = $result->get_error_message();
+			$this->send_error( '' !== $message ? $message : 'Sorry, I could not process your message right now.' );
 			return;
 		}
 

--- a/src/Channels/class-wp-agent-channel.php
+++ b/src/Channels/class-wp-agent-channel.php
@@ -1,0 +1,445 @@
+<?php
+/**
+ * Abstract base class for agent messaging channels.
+ *
+ * A "channel" is a transport that connects an external messaging surface
+ * (Telegram, Slack, WhatsApp, Email, …) to a chat ability registered through
+ * the WordPress Abilities API. The channel handles transport-specific I/O
+ * (how to extract a user message from a webhook payload, how to send a reply
+ * back) while delegating the actual agent run to the configured chat ability.
+ *
+ * Two entry points:
+ * - {@see receive()}: webhook side. Default schedules an async job; override
+ *   for concurrency control (per-conversation lock, debounced drain).
+ * - {@see handle()}: job side. Runs the full pipeline:
+ *     validate → extract message → look up session → run agent →
+ *     persist session → deliver responses → lifecycle hooks.
+ *
+ * This base class is intentionally agnostic about the agent runtime. The
+ * default `run_agent()` calls the chat ability registered under the slug
+ * returned by the `wp_agent_channel_chat_ability` filter (default
+ * `openclawp/chat`); override `run_agent()` to plug in a different runtime.
+ *
+ * Mirrors a similar pattern used internally at WordPress.com to drive
+ * Telegram, Slack, and other agent surfaces. The host-specific orchestration
+ * (multi-tenant user resolution, blog switching, internal agent runtime) is
+ * intentionally not part of this contract — implementations that need those
+ * concerns should add their own subclass layer between this base class and
+ * the concrete channel.
+ *
+ * @package AgentsAPI
+ */
+
+namespace AgentsAPI\AI\Channels;
+
+use WP_Error;
+
+defined( 'ABSPATH' ) || exit;
+
+abstract class WP_Agent_Channel {
+
+	/**
+	 * Sentinel error code that {@see validate()} can return to drop a
+	 * message silently — no send_error(), no agent invocation. Use for
+	 * loop-prevention (own-bot messages bouncing back), allowlist misses,
+	 * and well-formed-but-uninteresting webhook events. Anything else
+	 * returning a WP_Error from validate() will be reported via send_error.
+	 */
+	public const SILENT_SKIP_CODE = 'silent_skip';
+
+	/**
+	 * The agent slug this channel forwards messages to. Resolved against
+	 * the agent registry (`wp_register_agent`) by the chat ability.
+	 *
+	 * @var string
+	 */
+	protected string $agent_slug;
+
+	/**
+	 * Session ID for conversation continuity, resolved during handle().
+	 *
+	 * @var string|null
+	 */
+	protected ?string $session_id = null;
+
+	/**
+	 * Delivery outcome: null = no response attempted, 'sent' = delivered,
+	 * 'failed' = at least one send_response()/send_error() call failed.
+	 * Set by deliver_result(); checked in on_complete() for stats.
+	 *
+	 * @var string|null
+	 */
+	protected ?string $response_status = null;
+
+	/**
+	 * @param string $agent_slug Slug of the registered agent. Empty string is allowed
+	 *                           when the chat ability resolves the target agent itself.
+	 */
+	public function __construct( string $agent_slug = '' ) {
+		$this->agent_slug = $agent_slug;
+	}
+
+	// ─── Channel identity (abstract) ───────────────────────────────────
+
+	/**
+	 * Stable identifier for the channel type and instance. Used together with
+	 * the per-conversation `external_id` to scope sessions across redeploys.
+	 *
+	 * Convention: `<channel-type>` for single-instance channels (`slack`,
+	 * `whatsapp`); `<channel-type>_<bot-or-account>` when one site runs
+	 * multiple instances of the same channel (`telegram_<bot-name>`).
+	 *
+	 * @return string
+	 */
+	abstract public function get_external_id_provider(): string;
+
+	/**
+	 * The channel-side ID of the conversation. Telegram chat ID, Slack
+	 * channel ID, WhatsApp JID — whatever the channel uses to address a
+	 * single thread. Returning null disables per-conversation isolation.
+	 *
+	 * @return string|null
+	 */
+	abstract public function get_external_id(): ?string;
+
+	/**
+	 * Human-readable client name used for tracing, attribution, and any
+	 * agent-side behavior that varies per channel. Lowercase, hyphenated.
+	 *
+	 * @return string
+	 */
+	abstract public function get_client_name(): string;
+
+	// ─── I/O (abstract) ────────────────────────────────────────────────
+
+	/**
+	 * Convert the channel-specific webhook payload into the user message
+	 * string that gets handed to the agent. Override to extract text from
+	 * non-text messages (download images, transcribe voice, follow links).
+	 *
+	 * @param array $data The same map passed to receive() / handle().
+	 * @return string The user message to send to the agent.
+	 */
+	abstract protected function extract_message( array $data ): string;
+
+	/**
+	 * Send one assistant response back through the channel. Called once per
+	 * assistant message in the agent result (most chat abilities return a
+	 * single `reply`, but the contract supports multiple).
+	 *
+	 * Implementations should throw or log on send failure; the channel will
+	 * mark `response_status = 'failed'` if you set it explicitly.
+	 *
+	 * @param string $text The assistant's response text.
+	 */
+	abstract protected function send_response( string $text ): void;
+
+	/**
+	 * Send an error message back through the channel. Called by the pipeline
+	 * when validation, agent execution, or response generation fails.
+	 *
+	 * @param string $text Error message text.
+	 */
+	abstract protected function send_error( string $text ): void;
+
+	/**
+	 * Send a one-shot notification through the channel. Used for completion
+	 * pings from long-running tasks (deep research, scheduled jobs) that
+	 * already finished outside this channel's normal request/response loop
+	 * and need to deliver a result back to the user.
+	 *
+	 * Distinct from {@see send_response()} / {@see send_error()} because
+	 * those are protected lifecycle hooks bound to handle(); this is a
+	 * public, standalone entry point that does not require an active
+	 * agent run.
+	 *
+	 * Default body is a no-op so existing concrete subclasses don't fatal
+	 * on "contains 1 abstract method" during a deploy. Subclasses SHOULD
+	 * override.
+	 *
+	 * @param string $title Short title (one line).
+	 * @param string $body  Body text. May be multi-line plain text.
+	 * @param string $url   Optional URL to include / linkify. Empty for none.
+	 */
+	public function send_notification( string $title, string $body, string $url = '' ): void {}
+
+	// ─── Async dispatch (abstract) ─────────────────────────────────────
+
+	/**
+	 * The action hook fired by `receive()` to schedule the job side. The
+	 * subclass must register a handler for this hook that calls `handle()`
+	 * with the same payload, e.g.:
+	 *
+	 *     add_action( 'wp_agent_channel_my_channel', [ $this, 'handle' ] );
+	 *
+	 * @return string
+	 */
+	abstract protected function get_job_action(): string;
+
+	// ─── Lifecycle hooks (overridable, default no-ops) ─────────────────
+
+	/**
+	 * Validate the channel-specific webhook payload before processing.
+	 * Return a WP_Error to short-circuit; null to continue.
+	 *
+	 * @param array $data Per-message data from receive() / handle().
+	 * @return WP_Error|null
+	 */
+	protected function validate( array $data ): ?WP_Error {
+		return null;
+	}
+
+	/** Called before agent execution. Use for typing indicators, reactions. */
+	protected function on_processing_start(): void {}
+
+	/** Called after agent execution (success or failure). Use to clean up indicators. */
+	protected function on_processing_end(): void {}
+
+	/** Called after responses are delivered. Use for stats, lock release, post-run side effects. */
+	protected function on_complete(): void {}
+
+	// ─── Webhook side ──────────────────────────────────────────────────
+
+	/**
+	 * Receive an incoming message from the external platform. Default
+	 * schedules a single async job via `wp_schedule_single_event`; override
+	 * for concurrency control (per-conversation lock + pending queue,
+	 * debounced drain, durable persistence).
+	 *
+	 * @param array $data Channel-specific message data passed to the job.
+	 */
+	public function receive( array $data ): void {
+		$action = $this->get_job_action();
+		if ( '' === $action ) {
+			// No async dispatch configured — run synchronously.
+			$this->handle( $data );
+			return;
+		}
+		wp_schedule_single_event( time(), $action, array( $data ) );
+	}
+
+	// ─── Job side: full pipeline ───────────────────────────────────────
+
+	/**
+	 * Process an incoming message through the full pipeline.
+	 *
+	 *   validate
+	 *     → extract user message
+	 *     → look up session_id (if any) for this external_id
+	 *     → on_processing_start
+	 *     → run_agent (calls the chat ability)
+	 *     → on_processing_end
+	 *     → persist any new session_id
+	 *     → deliver_result (send_response / send_error)
+	 *     → on_complete
+	 *
+	 * @param array $data Channel-specific per-message data.
+	 * @return array|WP_Error Agent result or error.
+	 */
+	public function handle( array $data ): array|WP_Error {
+		$error = $this->validate( $data );
+		if ( null !== $error ) {
+			// 'silent_skip' code = the message is one we deliberately don't
+			// react to (loop-prevention drops, allowlist misses, malformed
+			// non-chat events). Skip send_error so the user isn't pinged
+			// with diagnostic noise.
+			if ( self::SILENT_SKIP_CODE !== $error->get_error_code() ) {
+				$this->send_error( $error->get_error_message() );
+			}
+			return $error;
+		}
+
+		$message_text = trim( $this->extract_message( $data ) );
+		if ( '' === $message_text ) {
+			return new WP_Error( 'empty_message', 'No message text to process.' );
+		}
+
+		$this->session_id = $this->lookup_session_id();
+
+		$this->on_processing_start();
+
+		try {
+			$result = $this->run_agent( $message_text, $data );
+		} finally {
+			$this->on_processing_end();
+		}
+
+		try {
+			$this->deliver_result( $result );
+		} finally {
+			$this->on_complete();
+		}
+
+		return $result;
+	}
+
+	// ─── Pluggable: agent runner ───────────────────────────────────────
+
+	/**
+	 * Run the agent for one user message and return its result.
+	 *
+	 * Default implementation calls the chat ability registered under the slug
+	 * returned by the `wp_agent_channel_chat_ability` filter (default
+	 * `openclawp/chat`). Override to plug in a different runtime — a
+	 * direct `wp_ai_client_prompt()` call, an external HTTP service, or a
+	 * host-specific agent factory.
+	 *
+	 * @param string $message_text The user-message string from extract_message().
+	 * @param array  $data         The original webhook payload, in case the runner
+	 *                             needs metadata beyond the text (sender, timestamp).
+	 * @return array|WP_Error      `{ session_id, reply, completed? }` or WP_Error.
+	 */
+	protected function run_agent( string $message_text, array $data ): array|WP_Error {
+		if ( ! function_exists( 'wp_get_ability' ) ) {
+			return new WP_Error( 'abilities_api_missing', 'Abilities API is not loaded.' );
+		}
+
+		/**
+		 * Filter the chat ability slug used by channels by default.
+		 *
+		 * @param string $slug       Ability slug. Default 'openclawp/chat'.
+		 * @param string $agent_slug The agent slug being targeted.
+		 * @param string $channel    Concrete channel class name.
+		 */
+		$slug = (string) apply_filters(
+			'wp_agent_channel_chat_ability',
+			'openclawp/chat',
+			$this->agent_slug,
+			static::class
+		);
+
+		$ability = wp_get_ability( $slug );
+		if ( ! $ability ) {
+			return new WP_Error(
+				'chat_ability_unavailable',
+				sprintf( 'Chat ability "%s" is not registered.', $slug )
+			);
+		}
+
+		return $ability->execute(
+			array(
+				'agent'      => $this->agent_slug,
+				'message'    => $message_text,
+				'session_id' => $this->session_id ?: null,
+			)
+		);
+	}
+
+	// ─── Result delivery ───────────────────────────────────────────────
+
+	/**
+	 * Extract assistant text from the agent result and dispatch it through
+	 * the channel via send_response() / send_error(). Persists any new
+	 * session_id returned in the result so the next inbound message
+	 * continues the same conversation.
+	 *
+	 * @param array|WP_Error $result Agent run result.
+	 */
+	protected function deliver_result( $result ): void {
+		if ( is_wp_error( $result ) ) {
+			$this->response_status = 'failed';
+			$this->send_error( $result->get_error_message() ?: 'Sorry, I could not process your message right now.' );
+			return;
+		}
+
+		if ( ! is_array( $result ) ) {
+			$this->response_status = 'failed';
+			$this->send_error( 'Agent returned an unexpected result.' );
+			return;
+		}
+
+		// Persist session continuity before delivering the reply, so a slow
+		// send_response() doesn't lose the new session if it errors.
+		if ( ! empty( $result['session_id'] ) && (string) $result['session_id'] !== $this->session_id ) {
+			$this->store_session_id( (string) $result['session_id'] );
+		}
+
+		$replies = $this->extract_replies( $result );
+		if ( empty( $replies ) ) {
+			$this->response_status = 'failed';
+			$this->send_error( 'Sorry, I could not generate a response.' );
+			return;
+		}
+
+		foreach ( $replies as $text ) {
+			$this->send_response( $text );
+		}
+		$this->response_status = 'sent';
+	}
+
+	/**
+	 * Pull assistant text out of the agent result. Default supports two
+	 * shapes: `{ reply: string }` (openclawp/chat single-turn) and
+	 * `{ messages: [ { role, content } ] }` (multi-message). Override for
+	 * exotic result shapes.
+	 *
+	 * @param array $result
+	 * @return string[]
+	 */
+	protected function extract_replies( array $result ): array {
+		if ( ! empty( $result['reply'] ) ) {
+			return array( (string) $result['reply'] );
+		}
+
+		if ( ! empty( $result['messages'] ) && is_array( $result['messages'] ) ) {
+			$texts = array();
+			foreach ( $result['messages'] as $message ) {
+				if ( ! is_array( $message ) ) {
+					continue;
+				}
+				$role = $message['role'] ?? '';
+				if ( 'assistant' !== $role ) {
+					continue;
+				}
+				$content = (string) ( $message['content'] ?? '' );
+				if ( '' !== $content ) {
+					$texts[] = $content;
+				}
+			}
+			return $texts;
+		}
+
+		return array();
+	}
+
+	// ─── Session persistence (option-based default) ────────────────────
+
+	/**
+	 * Storage key for the external_id ↔ session_id mapping. Subclasses can
+	 * override to change scope (per-user, per-blog, custom table). Default
+	 * is a single site option keyed by hashed `provider:external_id`.
+	 *
+	 * @return string
+	 */
+	protected function session_storage_key(): string {
+		$external_id = $this->get_external_id() ?? '';
+		return 'wp_agent_channel_session_' . md5(
+			$this->get_external_id_provider() . ':' . $external_id
+		);
+	}
+
+	/**
+	 * Read the persisted session_id for this channel + external_id.
+	 *
+	 * @return string|null
+	 */
+	protected function lookup_session_id(): ?string {
+		if ( null === $this->get_external_id() ) {
+			return null;
+		}
+		$value = get_option( $this->session_storage_key(), '' );
+		return '' === $value ? null : (string) $value;
+	}
+
+	/**
+	 * Persist the session_id for this channel + external_id.
+	 *
+	 * @param string $session_id
+	 */
+	protected function store_session_id( string $session_id ): void {
+		if ( null === $this->get_external_id() ) {
+			return;
+		}
+		update_option( $this->session_storage_key(), $session_id, false );
+	}
+}

--- a/tests/bootstrap-smoke.php
+++ b/tests/bootstrap-smoke.php
@@ -152,6 +152,7 @@ echo "\n[3] Module source tree uses Agents API vocabulary:\n";
 $expected_source_directories = array(
 	'Approvals',
 	'Auth',
+	'Channels',
 	'Consent',
 	'Context',
 	'Guidelines',

--- a/tests/channels-smoke.php
+++ b/tests/channels-smoke.php
@@ -1,0 +1,269 @@
+<?php
+/**
+ * Pure-PHP smoke test for WP_Agent_Channel.
+ *
+ * Run with: php tests/channels-smoke.php
+ *
+ * Covers the full pipeline (validate → extract → run_agent → deliver →
+ * lifecycle hooks → session persistence) using a fake chat ability and
+ * an in-memory option store. No WordPress required.
+ *
+ * @package AgentsAPI\Tests
+ */
+
+defined( 'ABSPATH' ) || define( 'ABSPATH', __DIR__ . '/' );
+
+$failures = array();
+$passes   = 0;
+
+echo "agents-api-channels-smoke\n";
+
+// ─── Minimal WP stubs (this test does not load the full bootstrap) ──
+
+class WP_Error {
+	public function __construct(
+		private string $code = '',
+		private string $message = ''
+	) {}
+	public function get_error_code(): string { return $this->code; }
+	public function get_error_message(): string { return $this->message; }
+}
+
+function is_wp_error( $value ): bool {
+	return $value instanceof WP_Error;
+}
+
+$GLOBALS['__channel_smoke_options']   = array();
+$GLOBALS['__channel_smoke_scheduled'] = array();
+$GLOBALS['__channel_smoke_abilities'] = array();
+$GLOBALS['__channel_smoke_filters']   = array();
+
+function get_option( string $key, $default = '' ) {
+	return $GLOBALS['__channel_smoke_options'][ $key ] ?? $default;
+}
+
+function update_option( string $key, $value, $autoload = null ): bool {
+	unset( $autoload );
+	$GLOBALS['__channel_smoke_options'][ $key ] = $value;
+	return true;
+}
+
+function wp_schedule_single_event( int $timestamp, string $hook, array $args = array() ): bool {
+	$GLOBALS['__channel_smoke_scheduled'][] = array(
+		'timestamp' => $timestamp,
+		'hook'      => $hook,
+		'args'      => $args,
+	);
+	return true;
+}
+
+function wp_get_ability( string $name ) {
+	return $GLOBALS['__channel_smoke_abilities'][ $name ] ?? null;
+}
+
+function add_filter( string $hook, callable $cb, int $priority = 10, int $accepted_args = 1 ): void {
+	unset( $accepted_args );
+	$GLOBALS['__channel_smoke_filters'][ $hook ][ $priority ][] = $cb;
+}
+
+function apply_filters( string $hook, $value, ...$args ) {
+	$callbacks = $GLOBALS['__channel_smoke_filters'][ $hook ] ?? array();
+	ksort( $callbacks );
+	foreach ( $callbacks as $priority_callbacks ) {
+		foreach ( $priority_callbacks as $cb ) {
+			$value = call_user_func_array( $cb, array_merge( array( $value ), $args ) );
+		}
+	}
+	return $value;
+}
+
+function smoke_assert( $expected, $actual, string $name, array &$failures, int &$passes ): void {
+	if ( $expected === $actual ) {
+		++$passes;
+		echo "  PASS {$name}\n";
+		return;
+	}
+	$failures[] = $name;
+	echo "  FAIL {$name}\n";
+	echo '    expected: ' . var_export( $expected, true ) . "\n";
+	echo '    actual:   ' . var_export( $actual, true ) . "\n";
+}
+
+require_once __DIR__ . '/../src/Channels/class-wp-agent-channel.php';
+
+// ─── Fakes ──────────────────────────────────────────────────────────
+
+class Fake_Ability {
+	public array $calls = array();
+	public function __construct( private mixed $next_result ) {}
+	public function execute( array $input ) {
+		$this->calls[] = $input;
+		return $this->next_result;
+	}
+}
+
+class Test_Channel extends \AgentsAPI\AI\Channels\WP_Agent_Channel {
+
+	public string $external_id;
+	public array $sent      = array();
+	public array $errors    = array();
+	public array $lifecycle = array();
+
+	public function __construct( string $external_id, string $agent_slug = 'test-agent' ) {
+		parent::__construct( $agent_slug );
+		$this->external_id = $external_id;
+	}
+
+	public function get_external_id_provider(): string { return 'test-channel'; }
+	public function get_external_id(): ?string { return $this->external_id; }
+	public function get_client_name(): string { return 'test-channel'; }
+	protected function get_job_action(): string { return 'test_channel_handle'; }
+
+	protected function extract_message( array $data ): string {
+		return (string) ( $data['text'] ?? '' );
+	}
+
+	protected function send_response( string $text ): void {
+		$this->sent[] = $text;
+	}
+
+	protected function send_error( string $text ): void {
+		$this->errors[] = $text;
+	}
+
+	protected function on_processing_start(): void { $this->lifecycle[] = 'start'; }
+	protected function on_processing_end(): void { $this->lifecycle[] = 'end'; }
+	protected function on_complete(): void { $this->lifecycle[] = 'complete'; }
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────
+
+// 1. Happy path: chat ability returns reply + session_id.
+$happy_ability = new Fake_Ability(
+	array( 'reply' => 'Hello from the agent', 'session_id' => 'sess-123', 'completed' => true )
+);
+$GLOBALS['__channel_smoke_abilities']['openclawp/chat'] = $happy_ability;
+
+$ch = new Test_Channel( 'chat-A' );
+$ch->handle( array( 'text' => 'hi there' ) );
+
+smoke_assert( array( 'Hello from the agent' ), $ch->sent, 'happy_path_send_response', $failures, $passes );
+smoke_assert( array(), $ch->errors, 'happy_path_no_error', $failures, $passes );
+smoke_assert( array( 'start', 'end', 'complete' ), $ch->lifecycle, 'happy_path_lifecycle_order', $failures, $passes );
+smoke_assert(
+	array( array( 'agent' => 'test-agent', 'message' => 'hi there', 'session_id' => null ) ),
+	$happy_ability->calls,
+	'happy_path_ability_input_first_turn',
+	$failures,
+	$passes
+);
+
+// 2. Session continuity: second turn passes the stored session_id.
+$happy_ability2 = new Fake_Ability(
+	array( 'reply' => 'second reply', 'session_id' => 'sess-123', 'completed' => true )
+);
+$GLOBALS['__channel_smoke_abilities']['openclawp/chat'] = $happy_ability2;
+
+$ch2 = new Test_Channel( 'chat-A' );
+$ch2->handle( array( 'text' => 'follow-up' ) );
+
+smoke_assert(
+	array( array( 'agent' => 'test-agent', 'message' => 'follow-up', 'session_id' => 'sess-123' ) ),
+	$happy_ability2->calls,
+	'second_turn_passes_stored_session_id',
+	$failures,
+	$passes
+);
+
+// 3. Different external_id gets its own session.
+$other_ability = new Fake_Ability(
+	array( 'reply' => 'reply for B', 'session_id' => 'sess-B-456', 'completed' => true )
+);
+$GLOBALS['__channel_smoke_abilities']['openclawp/chat'] = $other_ability;
+
+$ch3 = new Test_Channel( 'chat-B' );
+$ch3->handle( array( 'text' => 'hi' ) );
+
+smoke_assert(
+	true,
+	array_key_exists( 'session_id', $other_ability->calls[0] ) && null === $other_ability->calls[0]['session_id'],
+	'different_external_id_starts_fresh_session',
+	$failures,
+	$passes
+);
+
+// 4. Empty message short-circuits with WP_Error, no agent call.
+$null_ability = new Fake_Ability( array( 'reply' => 'should not be called' ) );
+$GLOBALS['__channel_smoke_abilities']['openclawp/chat'] = $null_ability;
+
+$ch4    = new Test_Channel( 'chat-empty' );
+$result = $ch4->handle( array( 'text' => '   ' ) );
+
+smoke_assert( true, $result instanceof WP_Error, 'empty_message_returns_wp_error', $failures, $passes );
+smoke_assert( 'empty_message', $result->get_error_code(), 'empty_message_error_code', $failures, $passes );
+smoke_assert( array(), $null_ability->calls, 'empty_message_skips_agent', $failures, $passes );
+
+// 5. Ability returns WP_Error → send_error fires.
+$error_ability = new Fake_Ability( new WP_Error( 'agent_blew_up', 'something exploded' ) );
+$GLOBALS['__channel_smoke_abilities']['openclawp/chat'] = $error_ability;
+
+$ch5 = new Test_Channel( 'chat-err' );
+$ch5->handle( array( 'text' => 'try this' ) );
+
+smoke_assert( array( 'something exploded' ), $ch5->errors, 'agent_error_routed_to_send_error', $failures, $passes );
+smoke_assert( array(), $ch5->sent, 'agent_error_no_response', $failures, $passes );
+
+// 6. Filter overrides the chat ability slug.
+$GLOBALS['__channel_smoke_abilities']['my-plugin/custom-chat'] = new Fake_Ability(
+	array( 'reply' => 'from custom ability' )
+);
+add_filter( 'wp_agent_channel_chat_ability', static fn( $slug ) => 'my-plugin/custom-chat' );
+
+$ch6 = new Test_Channel( 'chat-custom' );
+$ch6->handle( array( 'text' => 'route me elsewhere' ) );
+
+smoke_assert(
+	array( 'from custom ability' ),
+	$ch6->sent,
+	'filter_overrides_chat_ability_slug',
+	$failures,
+	$passes
+);
+
+// 7. validate() returning 'silent_skip' WP_Error drops the message — no send_error, no agent call.
+class Silent_Skip_Channel extends Test_Channel {
+	protected function validate( array $data ): ?WP_Error {
+		if ( ! empty( $data['from_me'] ) ) {
+			return new WP_Error( \AgentsAPI\AI\Channels\WP_Agent_Channel::SILENT_SKIP_CODE, 'self_message' );
+		}
+		return null;
+	}
+}
+$silent_ability = new Fake_Ability( array( 'reply' => 'should not be called' ) );
+$GLOBALS['__channel_smoke_abilities']['openclawp/chat'] = $silent_ability;
+
+$ch_silent = new Silent_Skip_Channel( 'chat-silent' );
+$result    = $ch_silent->handle( array( 'text' => 'echo of own reply', 'from_me' => true ) );
+
+smoke_assert( true, $result instanceof WP_Error, 'silent_skip_returns_wp_error', $failures, $passes );
+smoke_assert( array(), $ch_silent->errors, 'silent_skip_no_send_error', $failures, $passes );
+smoke_assert( array(), $ch_silent->sent, 'silent_skip_no_send_response', $failures, $passes );
+smoke_assert( array(), $silent_ability->calls, 'silent_skip_no_agent_call', $failures, $passes );
+
+// 8. receive() schedules an async event by default.
+$GLOBALS['__channel_smoke_scheduled'] = array();
+$ch7 = new Test_Channel( 'chat-async' );
+$ch7->receive( array( 'text' => 'queue me' ) );
+
+smoke_assert( 1, count( $GLOBALS['__channel_smoke_scheduled'] ), 'receive_schedules_one_event', $failures, $passes );
+smoke_assert( 'test_channel_handle', $GLOBALS['__channel_smoke_scheduled'][0]['hook'], 'receive_uses_job_action', $failures, $passes );
+smoke_assert( array( array( 'text' => 'queue me' ) ), $GLOBALS['__channel_smoke_scheduled'][0]['args'], 'receive_passes_payload', $failures, $passes );
+
+// ─── Done ───────────────────────────────────────────────────────────
+
+if ( $failures ) {
+	echo "\nFAILED: " . count( $failures ) . " channel assertions failed.\n";
+	exit( 1 );
+}
+
+echo "\nAll {$passes} channel assertions passed.\n";


### PR DESCRIPTION
## Summary

Introduces `AgentsAPI\AI\Channels\WP_Agent_Channel`, a reusable abstract base for transports that connect external messaging surfaces (Telegram, Slack, WhatsApp, Email, …) to a chat ability registered through the WordPress Abilities API.

The base class owns the agent loop end-to-end:

```
validate → extract_message → run_agent → deliver_result → lifecycle hooks → session persistence
```

Concrete channels only fill in the transport-specific I/O — extract a user message from the webhook payload, send a reply, lifecycle hooks for typing indicators / reactions / stats. The default `run_agent()` calls the chat ability under the slug returned by the `wp_agent_channel_chat_ability` filter (default `openclawp/chat`); override to plug in a different runtime.

## Why this matters

Mirrors a pattern that's been validated in production at WordPress.com for Telegram and Slack agents. Lifting the portable surface into agents-api means consumers (openclaWP, Data Machine, Intelligence, future plugins) can ship new channels by extending one class instead of reinventing the agent dispatch + session continuity + loop-prevention plumbing each time.

The first public consumer is `OpenclaWP_Wacli_Channel` (WhatsApp via openclaw/wacli) in [lezama/openclawp](https://github.com/lezama/openclawp); see the companion PR there.

## Surface

- **Channel identity**: `get_external_id_provider()`, `get_external_id()`, `get_client_name()` — used to scope sessions across redeploys and for tracing.
- **I/O**: `extract_message()`, `send_response()`, `send_error()`, optional `send_notification()`.
- **Async dispatch**: `get_job_action()` — returning a hook name makes `receive()` schedule a single async event; returning `''` runs synchronously inside the receive call.
- **Lifecycle hooks**: `validate()`, `on_processing_start()`, `on_processing_end()`, `on_complete()`.
- **Loop-prevention seam**: `validate()` returning a `WP_Error` with code `WP_Agent_Channel::SILENT_SKIP_CODE` drops the message silently — no `send_error()`, no agent invocation. Use for own-bot echoes, allowlist misses, and well-formed-but-uninteresting webhook events.
- **Session persistence**: option-based by default, keyed on `md5(provider:external_id)`. Subclasses can override `session_storage_key()` to scope per-user, per-blog, or to a custom store.

## Filter

```php
add_filter( 'wp_agent_channel_chat_ability', function ( $slug, $agent_slug, $channel_class ) {
    // Route specific agents to a custom chat ability.
    return 'my-plugin/chat';
}, 10, 3 );
```

## Test plan

- [x] `tests/channels-smoke.php` — 19 pure-PHP assertions covering happy path, multi-turn session continuity, distinct `external_id` isolation, empty-message short-circuit, agent-error routed to `send_error`, filter override, async dispatch via `wp_schedule_single_event`, and `silent_skip`.
- [x] `tests/bootstrap-smoke.php` updated to include `Channels` in the agent-native source-directory list (300 / 300 assertions pass).
- [x] No regressions: full smoke suite passes (28 files, 0 failures).

## Implementer notes

- The default `run_agent()` calls `wp_get_ability($slug)->execute(['agent' => …, 'message' => …, 'session_id' => …])`. Subclasses can override for a different runtime — direct `wp_ai_client_prompt()`, an external HTTP service, or a host-specific factory.
- `deliver_result()` understands two result shapes: `{ reply: string, session_id?: string }` (single-turn) and `{ messages: [ { role, content } ] }` (multi-message). Override `extract_replies()` for exotic shapes.
- Permission gating for unauthenticated webhook callers is left to consumers — typical pattern is a short-lived `add_filter` on the chat ability's permission callback, scoped to the request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)