### PR TITLE
Canonical chat contract: WP_Agent_Channel + agents/chat ability (#100)

### DIFF
--- a/agents-api.php
+++ b/agents-api.php
@@ -113,6 +113,7 @@ require_once AGENTS_API_PATH . 'src/Memory/class-wp-agent-memory-store.php';
 require_once AGENTS_API_PATH . 'src/Guidelines/guidelines.php';
 require_once AGENTS_API_PATH . 'src/Guidelines/class-wp-guidelines-substrate.php';
 require_once AGENTS_API_PATH . 'src/Channels/class-wp-agent-channel.php';
+require_once AGENTS_API_PATH . 'src/Channels/register-agents-chat-ability.php';
 
 add_action( 'init', array( 'WP_Agents_Registry', 'init' ), 10 );
 add_action( 'init', array( 'WP_Guidelines_Substrate', 'register' ), 9 );

--- a/src/Channels/class-wp-agent-channel.php
+++ b/src/Channels/class-wp-agent-channel.php
@@ -285,14 +285,30 @@ abstract class WP_Agent_Channel {
 	 * direct `wp_ai_client_prompt()` call, an external HTTP service, or a
 	 * host-specific agent factory.
 	 *
+	 * The dispatched payload follows the canonical chat-ability contract
+	 * tracked in https://github.com/Automattic/agents-api/issues/100 :
+	 *
+	 *     {
+	 *       agent: string,
+	 *       message: string,
+	 *       session_id: string|null,
+	 *       attachments: array,
+	 *       client_context: {
+	 *         source, client_name, external_provider,
+	 *         external_conversation_id, external_message_id, room_kind
+	 *       }
+	 *     }
+	 *
+	 * Runtimes that don't read the richer fields (e.g. `openclawp/chat`)
+	 * ignore them; runtimes that do (e.g. Data Machine's chat bridge) get
+	 * the full transport context without having to know about WP_Agent_Channel.
+	 *
 	 * @param string $message_text The user-message string from extract_message().
 	 * @param array  $data         The original webhook payload, in case the runner
 	 *                             needs metadata beyond the text (sender, timestamp).
-	 * @return array|WP_Error      `{ session_id, reply, completed? }` or WP_Error.
+	 * @return array|WP_Error      `{ session_id, reply, completed?, … }` or WP_Error.
 	 */
 	protected function run_agent( string $message_text, array $data ): array|WP_Error {
-		unset( $data );
-
 		if ( ! function_exists( 'wp_get_ability' ) ) {
 			return new WP_Error( 'abilities_api_missing', 'Abilities API is not loaded.' );
 		}
@@ -319,13 +335,90 @@ abstract class WP_Agent_Channel {
 			);
 		}
 
-		return $ability->execute(
-			array(
-				'agent'      => $this->agent_slug,
-				'message'    => $message_text,
-				'session_id' => '' === (string) $this->session_id ? null : $this->session_id,
-			)
+		return $ability->execute( $this->build_chat_payload( $message_text, $data ) );
+	}
+
+	/**
+	 * Build the canonical chat-ability input payload. Public so subclasses,
+	 * tests, and external callers can introspect or extend it.
+	 *
+	 * Override `extract_attachments()`, `extract_external_message_id()`,
+	 * `get_room_kind()`, and `client_context_source()` to fill in the
+	 * transport-specific bits without rewriting this method.
+	 *
+	 * @param string $message_text
+	 * @param array  $data
+	 * @return array
+	 */
+	public function build_chat_payload( string $message_text, array $data ): array {
+		return array(
+			'agent'          => $this->agent_slug,
+			'message'        => $message_text,
+			'session_id'     => '' === (string) $this->session_id ? null : $this->session_id,
+			'attachments'    => $this->extract_attachments( $data ),
+			'client_context' => array(
+				'source'                   => $this->client_context_source(),
+				'client_name'              => $this->get_client_name(),
+				'external_provider'        => $this->get_external_id_provider(),
+				'external_conversation_id' => $this->get_external_id(),
+				'external_message_id'      => $this->extract_external_message_id( $data ),
+				'room_kind'                => $this->get_room_kind( $data ),
+			),
 		);
+	}
+
+	// ─── Pluggable: client_context fields (overridable, default sensible) ─
+
+	/**
+	 * Channel attachments lifted from the inbound payload, ready for the
+	 * agent runtime. Default is an empty array. Override to pluck images,
+	 * voice notes, files, link previews, etc., from the channel-specific
+	 * payload shape.
+	 *
+	 * @param array $data
+	 * @return array
+	 */
+	protected function extract_attachments( array $data ): array {
+		unset( $data );
+		return array();
+	}
+
+	/**
+	 * Stable transport-side message id, used by the runtime for reply
+	 * threading, dedup, and audit. Default null. Override to expose the
+	 * inbound `msg_id` from your payload.
+	 *
+	 * @param array $data
+	 * @return string|null
+	 */
+	protected function extract_external_message_id( array $data ): ?string {
+		unset( $data );
+		return null;
+	}
+
+	/**
+	 * Conversation kind: `dm`, `group`, `channel`, or null when unknown.
+	 * Override per transport — WhatsApp can derive from the JID suffix,
+	 * Slack from the channel type, Telegram from the chat type.
+	 *
+	 * @param array $data
+	 * @return string|null
+	 */
+	protected function get_room_kind( array $data ): ?string {
+		unset( $data );
+		return null;
+	}
+
+	/**
+	 * `client_context.source` value. Defaults to `'channel'` for direct
+	 * webhook-style transports. Bridge consumers (e.g. an MCP bridge or a
+	 * remote-driven A2A flow) override to `'bridge'` so the runtime can
+	 * tell apart inbound traffic styles.
+	 *
+	 * @return string
+	 */
+	protected function client_context_source(): string {
+		return 'channel';
 	}
 
 	// ─── Result delivery ───────────────────────────────────────────────

--- a/src/Channels/class-wp-agent-channel.php
+++ b/src/Channels/class-wp-agent-channel.php
@@ -300,8 +300,8 @@ abstract class WP_Agent_Channel {
 	 *     }
 	 *
 	 * Runtimes that don't read the richer fields (e.g. `openclawp/chat`)
-	 * ignore them; runtimes that do (e.g. Data Machine's chat bridge) get
-	 * the full transport context without having to know about WP_Agent_Channel.
+	 * ignore them; runtimes that do get the full transport context without
+	 * having to know about WP_Agent_Channel.
 	 *
 	 * @param string $message_text The user-message string from extract_message().
 	 * @param array  $data         The original webhook payload, in case the runner
@@ -316,13 +316,17 @@ abstract class WP_Agent_Channel {
 		/**
 		 * Filter the chat ability slug used by channels by default.
 		 *
-		 * @param string $slug       Ability slug. Default 'openclawp/chat'.
+		 * Default is `agents/chat` (the canonical dispatcher registered by
+		 * agents-api itself). Override per-channel only when you need to
+		 * pin a specific runtime ability.
+		 *
+		 * @param string $slug       Ability slug. Default 'agents/chat'.
 		 * @param string $agent_slug The agent slug being targeted.
 		 * @param string $channel    Concrete channel class name.
 		 */
 		$slug = (string) apply_filters(
 			'wp_agent_channel_chat_ability',
-			'openclawp/chat',
+			AGENTS_CHAT_ABILITY,
 			$this->agent_slug,
 			static::class
 		);

--- a/src/Channels/register-agents-chat-ability.php
+++ b/src/Channels/register-agents-chat-ability.php
@@ -1,0 +1,269 @@
+<?php
+/**
+ * Canonical chat ability registration.
+ *
+ * Registers `agents/chat` as the stable, runtime-agnostic entry point for any
+ * caller (channel, bridge, REST surface, block) that wants to send one user
+ * message to a registered agent and receive an assistant reply. The ability
+ * itself is a dispatcher: it validates the canonical input/output shape from
+ * https://github.com/Automattic/agents-api/issues/100 and routes execution
+ * to whichever runtime registered itself via the `wp_agent_chat_handler` filter.
+ * Consumers register a runtime in their own bootstrap; agents-api itself ships
+ * no chat runtime.
+ *
+ * Consumers register a runtime by hooking the filter:
+ *
+ *     add_filter(
+ *         'wp_agent_chat_handler',
+ *         function ( $handler, array $input ) {
+ *             if ( null !== $handler ) {
+ *                 return $handler; // earlier hook already won
+ *             }
+ *             return [ My_Plugin\Chat_Adapter::class, 'execute' ];
+ *         },
+ *         10,
+ *         2
+ *     );
+ *
+ * The handler receives the canonical input map and must return either an
+ * array matching the canonical output shape or a `WP_Error`.
+ *
+ * @package AgentsAPI
+ */
+
+namespace AgentsAPI\AI\Channels;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * The slug under which this ability is registered. Stable. Consumers and
+ * channels should target this string rather than a runtime-specific slug
+ * like `openclawp/chat`.
+ */
+const AGENTS_CHAT_ABILITY = 'agents/chat';
+
+add_action(
+	'wp_abilities_api_init',
+	static function (): void {
+		if ( ! function_exists( 'wp_register_ability' ) ) {
+			return;
+		}
+
+		wp_register_ability(
+			AGENTS_CHAT_ABILITY,
+			array(
+				'label'               => 'Agents Chat',
+				'description'         => 'Canonical entry point for sending one user message to a registered agent and receiving an assistant reply. Dispatches to whichever runtime is registered via the wp_agent_chat_handler filter.',
+				'category'            => 'agents-api',
+				'input_schema'        => agents_chat_input_schema(),
+				'output_schema'       => agents_chat_output_schema(),
+				'execute_callback'    => __NAMESPACE__ . '\\agents_chat_dispatch',
+				'permission_callback' => __NAMESPACE__ . '\\agents_chat_permission',
+				'meta'                => array(
+					'show_in_rest' => true,
+					'annotations'  => array(
+						'destructive' => true,
+						'idempotent'  => false,
+					),
+				),
+			)
+		);
+	}
+);
+
+/**
+ * Dispatch a chat request to the registered runtime.
+ *
+ * @param array $input Canonical chat-ability input.
+ * @return array|\WP_Error Canonical output, or WP_Error if no runtime is registered.
+ */
+function agents_chat_dispatch( array $input ) {
+	/**
+	 * Filter the chat runtime handler.
+	 *
+	 * Consumers register a callable that accepts the canonical input array
+	 * and returns either the canonical output or WP_Error. The first hook
+	 * to return a callable wins; later hooks should respect that decision
+	 * unless they intentionally take over (e.g. an agent-specific override).
+	 *
+	 * @param callable|null $handler Currently registered handler. Null when
+	 *                               no runtime has registered.
+	 * @param array         $input   The canonical input being dispatched. Use
+	 *                               $input['agent'] to route per agent slug.
+	 */
+	$handler = apply_filters( 'wp_agent_chat_handler', null, $input );
+
+	if ( ! is_callable( $handler ) ) {
+		return new \WP_Error(
+			'agents_chat_no_handler',
+			'No agents/chat handler is registered. Install a consumer plugin that registers a runtime, or add a callable to the wp_agent_chat_handler filter.'
+		);
+	}
+
+	$result = call_user_func( $handler, $input );
+
+	if ( is_wp_error( $result ) ) {
+		return $result;
+	}
+
+	if ( ! is_array( $result ) ) {
+		return new \WP_Error(
+			'agents_chat_invalid_result',
+			'agents/chat handler returned an unexpected result type. Handlers must return an array matching the canonical output shape or a WP_Error.'
+		);
+	}
+
+	return $result;
+}
+
+/**
+ * Permission gate for `agents/chat`. Defaults to `manage_options`; consumers
+ * with their own auth model (HMAC-signed webhook, OAuth bearer, etc.) can
+ * widen the gate per-request via the `agents_chat_permission` filter.
+ *
+ * @param array $input Canonical input.
+ * @return bool|\WP_Error
+ */
+function agents_chat_permission( array $input ) {
+	/**
+	 * Filter the permission decision for the canonical chat ability.
+	 *
+	 * @param bool  $allowed Default: current_user_can( 'manage_options' ).
+	 * @param array $input   The canonical input being authorized.
+	 */
+	return (bool) apply_filters(
+		'agents_chat_permission',
+		current_user_can( 'manage_options' ),
+		$input
+	);
+}
+
+/**
+ * Canonical input JSON schema (per agents-api#100).
+ *
+ * @return array
+ */
+function agents_chat_input_schema(): array {
+	return array(
+		'type'       => 'object',
+		'required'   => array( 'agent', 'message' ),
+		'properties' => array(
+			'agent'          => array(
+				'type'        => 'string',
+				'description' => 'Slug or ID of the registered agent that should handle this turn.',
+			),
+			'message'        => array(
+				'type'        => 'string',
+				'description' => 'User-side text for the agent to respond to.',
+			),
+			'session_id'     => array(
+				'type'        => array( 'string', 'null' ),
+				'description' => 'Existing session ID to continue, or null to start a new session.',
+			),
+			'attachments'    => array(
+				'type'        => 'array',
+				'description' => 'Channel-side attachments (images, voice notes, files, link previews). Shape is runtime-defined; runtimes ignore unknown attachment types.',
+				'default'     => array(),
+				'items'       => array( 'type' => 'object' ),
+			),
+			'client_context' => array(
+				'type'        => 'object',
+				'description' => 'Transport-level context describing where this turn originated.',
+				'properties'  => array(
+					'source'                   => array(
+						'type'        => 'string',
+						'enum'        => array( 'channel', 'bridge', 'rest', 'block' ),
+						'description' => 'How the request reached this dispatcher.',
+					),
+					'client_name'              => array(
+						'type'        => 'string',
+						'description' => 'Specific client identifier within the source (e.g. "wacli", "telegram_<bot>", "data-machine").',
+					),
+					'external_provider'        => array(
+						'type'        => array( 'string', 'null' ),
+						'description' => 'External network identifier (e.g. "whatsapp", "slack", "email"). Null if not applicable.',
+					),
+					'external_conversation_id' => array(
+						'type'        => array( 'string', 'null' ),
+						'description' => 'Opaque external conversation id (chat JID, channel id, thread root). Null if the source has no per-conversation isolation.',
+					),
+					'external_message_id'      => array(
+						'type'        => array( 'string', 'null' ),
+						'description' => 'Stable transport-side message id, used for reply threading / dedup / audit.',
+					),
+					'room_kind'                => array(
+						'type'        => array( 'string', 'null' ),
+						'enum'        => array( 'dm', 'group', 'channel', null ),
+						'description' => 'Conversation kind: direct message, multi-participant group, broadcast channel.',
+					),
+				),
+			),
+		),
+	);
+}
+
+/**
+ * Canonical output JSON schema (per agents-api#100).
+ *
+ * @return array
+ */
+function agents_chat_output_schema(): array {
+	return array(
+		'type'       => 'object',
+		'required'   => array( 'session_id', 'reply' ),
+		'properties' => array(
+			'session_id' => array(
+				'type'        => 'string',
+				'description' => 'Session ID to thread subsequent turns under.',
+			),
+			'reply'      => array(
+				'type'        => 'string',
+				'description' => 'Primary assistant text. Must be set even when the runtime supplies multi-message output via `messages`.',
+			),
+			'messages'   => array(
+				'type'        => 'array',
+				'description' => 'Optional multi-message expansion (e.g. assistant emitted multiple turns or split a long answer). When present, each entry is `{ role, content }`. The single-string `reply` is still required for clients that don\'t parse `messages`.',
+				'items'       => array(
+					'type'       => 'object',
+					'properties' => array(
+						'role'    => array( 'type' => 'string' ),
+						'content' => array( 'type' => 'string' ),
+					),
+				),
+			),
+			'completed'  => array(
+				'type'        => 'boolean',
+				'description' => 'Whether the agent considers this turn complete (true) or expects further work (false, e.g. tool approvals pending).',
+			),
+			'metadata'   => array(
+				'type'        => 'object',
+				'description' => 'Runtime-specific metadata (token usage, model, latency, tool calls). Opaque to the dispatcher.',
+			),
+		),
+	);
+}
+
+/**
+ * Convenience helper for consumers: register a callable as the chat handler.
+ *
+ * Equivalent to `add_filter( 'wp_agent_chat_handler', ... )` but reads more
+ * intentionally at the call site.
+ *
+ * @param callable $handler  Receives the canonical input array, returns the
+ *                           canonical output array or WP_Error.
+ * @param int      $priority Filter priority. Default 10.
+ */
+function register_chat_handler( callable $handler, int $priority = 10 ): void {
+	add_filter(
+		'wp_agent_chat_handler',
+		static function ( $existing, array $input ) use ( $handler ) {
+			unset( $input );
+			if ( null !== $existing ) {
+				return $existing;
+			}
+			return $handler;
+		},
+		$priority,
+		2
+	);
+}

--- a/src/Channels/register-agents-chat-ability.php
+++ b/src/Channels/register-agents-chat-ability.php
@@ -122,9 +122,9 @@ function agents_chat_dispatch( array $input ) {
  * widen the gate per-request via the `agents_chat_permission` filter.
  *
  * @param array $input Canonical input.
- * @return bool|\WP_Error
+ * @return bool
  */
-function agents_chat_permission( array $input ) {
+function agents_chat_permission( array $input ): bool {
 	/**
 	 * Filter the permission decision for the canonical chat ability.
 	 *

--- a/tests/agents-chat-ability-smoke.php
+++ b/tests/agents-chat-ability-smoke.php
@@ -1,0 +1,154 @@
+<?php
+/**
+ * Pure-PHP smoke test for the agents/chat ability dispatcher.
+ *
+ * Run with: php tests/agents-chat-ability-smoke.php
+ *
+ * @package AgentsAPI\Tests
+ */
+
+defined( 'ABSPATH' ) || define( 'ABSPATH', __DIR__ . '/' );
+
+$failures = array();
+$passes   = 0;
+
+echo "agents-chat-ability-smoke\n";
+
+// ─── Minimal WP stubs ──────────────────────────────────────────────
+
+class WP_Error {
+	public function __construct( private string $code = '', private string $message = '' ) {}
+	public function get_error_code(): string { return $this->code; }
+	public function get_error_message(): string { return $this->message; }
+}
+
+function is_wp_error( $value ): bool {
+	return $value instanceof WP_Error;
+}
+
+function current_user_can( string $cap ): bool {
+	unset( $cap );
+	return $GLOBALS['__smoke_can'] ?? false;
+}
+
+$GLOBALS['__smoke_filters'] = array();
+
+function add_filter( string $hook, callable $cb, int $priority = 10, int $accepted_args = 1 ): void {
+	unset( $accepted_args );
+	$GLOBALS['__smoke_filters'][ $hook ][ $priority ][] = $cb;
+}
+
+function apply_filters( string $hook, $value, ...$args ) {
+	$callbacks = $GLOBALS['__smoke_filters'][ $hook ] ?? array();
+	ksort( $callbacks );
+	foreach ( $callbacks as $priority_callbacks ) {
+		foreach ( $priority_callbacks as $cb ) {
+			$value = call_user_func_array( $cb, array_merge( array( $value ), $args ) );
+		}
+	}
+	return $value;
+}
+
+function add_action( string $hook, callable $cb, int $priority = 10, int $accepted_args = 1 ): void {
+	add_filter( $hook, $cb, $priority, $accepted_args );
+}
+
+function smoke_assert( $expected, $actual, string $name, array &$failures, int &$passes ): void {
+	if ( $expected === $actual ) {
+		++$passes;
+		echo "  PASS {$name}\n";
+		return;
+	}
+	$failures[] = $name;
+	echo "  FAIL {$name}\n";
+	echo '    expected: ' . var_export( $expected, true ) . "\n";
+	echo '    actual:   ' . var_export( $actual, true ) . "\n";
+}
+
+require_once __DIR__ . '/../src/Channels/register-agents-chat-ability.php';
+
+use function AgentsAPI\AI\Channels\agents_chat_dispatch;
+use function AgentsAPI\AI\Channels\agents_chat_permission;
+use function AgentsAPI\AI\Channels\agents_chat_input_schema;
+use function AgentsAPI\AI\Channels\agents_chat_output_schema;
+use function AgentsAPI\AI\Channels\register_chat_handler;
+use const AgentsAPI\AI\Channels\AGENTS_CHAT_ABILITY;
+
+// ─── Tests ──────────────────────────────────────────────────────────
+
+// 1. Slug constant.
+smoke_assert( 'agents/chat', AGENTS_CHAT_ABILITY, 'slug_is_agents_chat', $failures, $passes );
+
+// 2. No handler registered → WP_Error agents_chat_no_handler.
+$result = agents_chat_dispatch( array( 'agent' => 'foo', 'message' => 'hi' ) );
+smoke_assert( true, $result instanceof WP_Error, 'no_handler_returns_wp_error', $failures, $passes );
+smoke_assert( 'agents_chat_no_handler', $result->get_error_code(), 'no_handler_error_code', $failures, $passes );
+
+// 3. Registered handler is called with the canonical input and its result is returned.
+$captured = array();
+register_chat_handler( static function ( array $input ) use ( &$captured ) {
+	$captured = $input;
+	return array( 'session_id' => 's-1', 'reply' => 'hello back', 'completed' => true );
+} );
+
+$result = agents_chat_dispatch( array(
+	'agent'          => 'demo',
+	'message'        => 'ping',
+	'session_id'     => null,
+	'attachments'    => array(),
+	'client_context' => array( 'source' => 'channel', 'client_name' => 'wacli' ),
+) );
+
+smoke_assert( 'demo', $captured['agent'] ?? null, 'handler_received_agent', $failures, $passes );
+smoke_assert( 'ping', $captured['message'] ?? null, 'handler_received_message', $failures, $passes );
+smoke_assert( 'channel', $captured['client_context']['source'] ?? null, 'handler_received_client_context', $failures, $passes );
+smoke_assert( 'hello back', $result['reply'] ?? null, 'handler_result_returned', $failures, $passes );
+
+// 4. Handler returning non-array → WP_Error agents_chat_invalid_result.
+$GLOBALS['__smoke_filters'] = array();
+register_chat_handler( static fn( array $i ) => 'not an array' );
+$bad = agents_chat_dispatch( array( 'agent' => 'x', 'message' => 'y' ) );
+smoke_assert( true, $bad instanceof WP_Error, 'invalid_result_returns_wp_error', $failures, $passes );
+smoke_assert( 'agents_chat_invalid_result', $bad->get_error_code(), 'invalid_result_error_code', $failures, $passes );
+
+// 5. Handler returning WP_Error → propagated.
+$GLOBALS['__smoke_filters'] = array();
+register_chat_handler( static fn( array $i ) => new WP_Error( 'agent_blew_up', 'kaboom' ) );
+$err = agents_chat_dispatch( array( 'agent' => 'x', 'message' => 'y' ) );
+smoke_assert( true, $err instanceof WP_Error, 'handler_wp_error_propagated', $failures, $passes );
+smoke_assert( 'agent_blew_up', $err->get_error_code(), 'handler_wp_error_code_preserved', $failures, $passes );
+
+// 6. First-handler-wins: second register call doesn't override.
+$GLOBALS['__smoke_filters'] = array();
+register_chat_handler( static fn( array $i ) => array( 'session_id' => 'A', 'reply' => 'first wins' ) );
+register_chat_handler( static fn( array $i ) => array( 'session_id' => 'B', 'reply' => 'never reached' ) );
+$out = agents_chat_dispatch( array( 'agent' => 'x', 'message' => 'y' ) );
+smoke_assert( 'first wins', $out['reply'] ?? null, 'first_handler_wins', $failures, $passes );
+
+// 7. Permission gate: defaults to manage_options, filterable.
+$GLOBALS['__smoke_can'] = false;
+smoke_assert( false, agents_chat_permission( array() ), 'default_permission_blocks_non_admin', $failures, $passes );
+$GLOBALS['__smoke_can'] = true;
+smoke_assert( true, agents_chat_permission( array() ), 'default_permission_allows_admin', $failures, $passes );
+
+$GLOBALS['__smoke_can'] = false;
+add_filter( 'agents_chat_permission', static fn() => true );
+smoke_assert( true, agents_chat_permission( array() ), 'permission_filter_widens_gate', $failures, $passes );
+
+// 8. Schemas exist with the expected required fields.
+$in = agents_chat_input_schema();
+smoke_assert( array( 'agent', 'message' ), $in['required'] ?? array(), 'input_schema_required_fields', $failures, $passes );
+smoke_assert( true, isset( $in['properties']['client_context'] ), 'input_schema_has_client_context', $failures, $passes );
+smoke_assert( true, isset( $in['properties']['attachments'] ), 'input_schema_has_attachments', $failures, $passes );
+
+$out_schema = agents_chat_output_schema();
+smoke_assert( array( 'session_id', 'reply' ), $out_schema['required'] ?? array(), 'output_schema_required_fields', $failures, $passes );
+
+// ─── Done ───────────────────────────────────────────────────────────
+
+if ( $failures ) {
+	echo "\nFAILED: " . count( $failures ) . " agents-chat-ability assertions failed.\n";
+	exit( 1 );
+}
+
+echo "\nAll {$passes} agents-chat-ability assertions passed.\n";

--- a/tests/channels-smoke.php
+++ b/tests/channels-smoke.php
@@ -150,13 +150,58 @@ $ch->handle( array( 'text' => 'hi there' ) );
 smoke_assert( array( 'Hello from the agent' ), $ch->sent, 'happy_path_send_response', $failures, $passes );
 smoke_assert( array(), $ch->errors, 'happy_path_no_error', $failures, $passes );
 smoke_assert( array( 'start', 'end', 'complete' ), $ch->lifecycle, 'happy_path_lifecycle_order', $failures, $passes );
+$expected_first_call = array(
+	array(
+		'agent'          => 'test-agent',
+		'message'        => 'hi there',
+		'session_id'     => null,
+		'attachments'    => array(),
+		'client_context' => array(
+			'source'                   => 'channel',
+			'client_name'              => 'test-channel',
+			'external_provider'        => 'test-channel',
+			'external_conversation_id' => 'chat-A',
+			'external_message_id'      => null,
+			'room_kind'                => null,
+		),
+	),
+);
+smoke_assert( $expected_first_call, $happy_ability->calls, 'happy_path_canonical_chat_payload', $failures, $passes );
+
+// 1b. Override hooks for attachments / external_message_id / room_kind / source.
+class Rich_Channel extends Test_Channel {
+	protected function extract_attachments( array $data ): array {
+		return array_map( static fn( $a ) => array( 'url' => $a ), (array) ( $data['attachments'] ?? array() ) );
+	}
+	protected function extract_external_message_id( array $data ): ?string {
+		return isset( $data['msg_id'] ) ? (string) $data['msg_id'] : null;
+	}
+	protected function get_room_kind( array $data ): ?string {
+		return $data['room_kind'] ?? null;
+	}
+	protected function client_context_source(): string {
+		return 'bridge';
+	}
+}
+$rich_ability = new Fake_Ability( array( 'reply' => 'rich response' ) );
+$GLOBALS['__channel_smoke_abilities']['openclawp/chat'] = $rich_ability;
+$rich = new Rich_Channel( 'chat-rich' );
+$rich->handle( array(
+	'text'        => 'check this out',
+	'msg_id'      => 'wamid.123',
+	'room_kind'   => 'group',
+	'attachments' => array( 'https://example.com/img.jpg' ),
+) );
 smoke_assert(
-	array( array( 'agent' => 'test-agent', 'message' => 'hi there', 'session_id' => null ) ),
-	$happy_ability->calls,
-	'happy_path_ability_input_first_turn',
+	array( array( 'url' => 'https://example.com/img.jpg' ) ),
+	$rich_ability->calls[0]['attachments'] ?? null,
+	'rich_payload_attachments_extracted',
 	$failures,
 	$passes
 );
+smoke_assert( 'wamid.123', $rich_ability->calls[0]['client_context']['external_message_id'] ?? null, 'rich_payload_external_message_id', $failures, $passes );
+smoke_assert( 'group', $rich_ability->calls[0]['client_context']['room_kind'] ?? null, 'rich_payload_room_kind', $failures, $passes );
+smoke_assert( 'bridge', $rich_ability->calls[0]['client_context']['source'] ?? null, 'rich_payload_source_overridden', $failures, $passes );
 
 // 2. Session continuity: second turn passes the stored session_id.
 $happy_ability2 = new Fake_Ability(
@@ -167,13 +212,8 @@ $GLOBALS['__channel_smoke_abilities']['openclawp/chat'] = $happy_ability2;
 $ch2 = new Test_Channel( 'chat-A' );
 $ch2->handle( array( 'text' => 'follow-up' ) );
 
-smoke_assert(
-	array( array( 'agent' => 'test-agent', 'message' => 'follow-up', 'session_id' => 'sess-123' ) ),
-	$happy_ability2->calls,
-	'second_turn_passes_stored_session_id',
-	$failures,
-	$passes
-);
+smoke_assert( 'sess-123', $happy_ability2->calls[0]['session_id'] ?? 'missing', 'second_turn_passes_stored_session_id', $failures, $passes );
+smoke_assert( 'follow-up', $happy_ability2->calls[0]['message'] ?? 'missing', 'second_turn_message_passed', $failures, $passes );
 
 // 3. Different external_id gets its own session.
 $other_ability = new Fake_Ability(

--- a/tests/channels-smoke.php
+++ b/tests/channels-smoke.php
@@ -77,6 +77,10 @@ function apply_filters( string $hook, $value, ...$args ) {
 	return $value;
 }
 
+function add_action( string $hook, callable $cb, int $priority = 10, int $accepted_args = 1 ): void {
+	add_filter( $hook, $cb, $priority, $accepted_args );
+}
+
 function smoke_assert( $expected, $actual, string $name, array &$failures, int &$passes ): void {
 	if ( $expected === $actual ) {
 		++$passes;
@@ -90,6 +94,7 @@ function smoke_assert( $expected, $actual, string $name, array &$failures, int &
 }
 
 require_once __DIR__ . '/../src/Channels/class-wp-agent-channel.php';
+require_once __DIR__ . '/../src/Channels/register-agents-chat-ability.php';
 
 // ─── Fakes ──────────────────────────────────────────────────────────
 
@@ -142,7 +147,7 @@ class Test_Channel extends \AgentsAPI\AI\Channels\WP_Agent_Channel {
 $happy_ability = new Fake_Ability(
 	array( 'reply' => 'Hello from the agent', 'session_id' => 'sess-123', 'completed' => true )
 );
-$GLOBALS['__channel_smoke_abilities']['openclawp/chat'] = $happy_ability;
+$GLOBALS['__channel_smoke_abilities']['agents/chat'] = $happy_ability;
 
 $ch = new Test_Channel( 'chat-A' );
 $ch->handle( array( 'text' => 'hi there' ) );
@@ -184,7 +189,7 @@ class Rich_Channel extends Test_Channel {
 	}
 }
 $rich_ability = new Fake_Ability( array( 'reply' => 'rich response' ) );
-$GLOBALS['__channel_smoke_abilities']['openclawp/chat'] = $rich_ability;
+$GLOBALS['__channel_smoke_abilities']['agents/chat'] = $rich_ability;
 $rich = new Rich_Channel( 'chat-rich' );
 $rich->handle( array(
 	'text'        => 'check this out',
@@ -207,7 +212,7 @@ smoke_assert( 'bridge', $rich_ability->calls[0]['client_context']['source'] ?? n
 $happy_ability2 = new Fake_Ability(
 	array( 'reply' => 'second reply', 'session_id' => 'sess-123', 'completed' => true )
 );
-$GLOBALS['__channel_smoke_abilities']['openclawp/chat'] = $happy_ability2;
+$GLOBALS['__channel_smoke_abilities']['agents/chat'] = $happy_ability2;
 
 $ch2 = new Test_Channel( 'chat-A' );
 $ch2->handle( array( 'text' => 'follow-up' ) );
@@ -219,7 +224,7 @@ smoke_assert( 'follow-up', $happy_ability2->calls[0]['message'] ?? 'missing', 's
 $other_ability = new Fake_Ability(
 	array( 'reply' => 'reply for B', 'session_id' => 'sess-B-456', 'completed' => true )
 );
-$GLOBALS['__channel_smoke_abilities']['openclawp/chat'] = $other_ability;
+$GLOBALS['__channel_smoke_abilities']['agents/chat'] = $other_ability;
 
 $ch3 = new Test_Channel( 'chat-B' );
 $ch3->handle( array( 'text' => 'hi' ) );
@@ -234,7 +239,7 @@ smoke_assert(
 
 // 4. Empty message short-circuits with WP_Error, no agent call.
 $null_ability = new Fake_Ability( array( 'reply' => 'should not be called' ) );
-$GLOBALS['__channel_smoke_abilities']['openclawp/chat'] = $null_ability;
+$GLOBALS['__channel_smoke_abilities']['agents/chat'] = $null_ability;
 
 $ch4    = new Test_Channel( 'chat-empty' );
 $result = $ch4->handle( array( 'text' => '   ' ) );
@@ -245,7 +250,7 @@ smoke_assert( array(), $null_ability->calls, 'empty_message_skips_agent', $failu
 
 // 5. Ability returns WP_Error → send_error fires.
 $error_ability = new Fake_Ability( new WP_Error( 'agent_blew_up', 'something exploded' ) );
-$GLOBALS['__channel_smoke_abilities']['openclawp/chat'] = $error_ability;
+$GLOBALS['__channel_smoke_abilities']['agents/chat'] = $error_ability;
 
 $ch5 = new Test_Channel( 'chat-err' );
 $ch5->handle( array( 'text' => 'try this' ) );
@@ -257,7 +262,8 @@ smoke_assert( array(), $ch5->sent, 'agent_error_no_response', $failures, $passes
 $GLOBALS['__channel_smoke_abilities']['my-plugin/custom-chat'] = new Fake_Ability(
 	array( 'reply' => 'from custom ability' )
 );
-add_filter( 'wp_agent_channel_chat_ability', static fn( $slug ) => 'my-plugin/custom-chat' );
+$override_filter = static fn( $slug ) => 'my-plugin/custom-chat';
+add_filter( 'wp_agent_channel_chat_ability', $override_filter );
 
 $ch6 = new Test_Channel( 'chat-custom' );
 $ch6->handle( array( 'text' => 'route me elsewhere' ) );
@@ -280,7 +286,7 @@ class Silent_Skip_Channel extends Test_Channel {
 	}
 }
 $silent_ability = new Fake_Ability( array( 'reply' => 'should not be called' ) );
-$GLOBALS['__channel_smoke_abilities']['openclawp/chat'] = $silent_ability;
+$GLOBALS['__channel_smoke_abilities']['agents/chat'] = $silent_ability;
 
 $ch_silent = new Silent_Skip_Channel( 'chat-silent' );
 $result    = $ch_silent->handle( array( 'text' => 'echo of own reply', 'from_me' => true ) );


### PR DESCRIPTION
Closes #100.

Landing the canonical chat-ability contract end-to-end, per @chubes4's framing in #100 ("do it now, or at least tomorrow"). Two coupled changes; second commit lands the stable slug Chris asked for.

## What changes

### 1. `WP_Agent_Channel` adopts the canonical input shape (commit 1)

`run_agent()` dispatches the richer payload from #100:

```php
array(
    'agent'          => $this->agent_slug,
    'message'        => $message_text,
    'session_id'     => $this->session_id ?: null,
    'attachments'    => $this->extract_attachments( $data ),
    'client_context' => array(
        'source'                   => $this->client_context_source(),
        'client_name'              => $this->get_client_name(),
        'external_provider'        => $this->get_external_id_provider(),
        'external_conversation_id' => $this->get_external_id(),
        'external_message_id'      => $this->extract_external_message_id( $data ),
        'room_kind'                => $this->get_room_kind( $data ),
    ),
)
```

Construction is delegated to a new `public function build_chat_payload( string $message_text, array $data ): array` so subclasses, tests, and external callers can introspect or extend the shape without overriding the whole `run_agent()` flow. Four new overridable hooks back the richer fields, all with sensible defaults.

### 2. `agents/chat` ability dispatches to a registered runtime (commit 2)

Stable, runtime-agnostic slug. The ability itself is a dispatcher: it validates the canonical input/output shape and routes to whichever runtime hooked the `wp_agent_chat_handler` filter.

```php
// Anyone targeting the canonical contract:
$result = wp_get_ability( 'agents/chat' )->execute( $canonical_input );

// Consumers register their runtime in their own bootstrap:
add_filter(
    'wp_agent_chat_handler',
    function ( $existing, array $input ) {
        if ( null !== $existing ) return $existing;
        return [ My_Plugin\Chat_Adapter::class, 'execute' ];
    },
    10, 2
);

// Or via the helper:
AgentsAPI\AI\Channels\register_chat_handler( $callable );
```

`WP_Agent_Channel::run_agent()` default ability slug flips from `openclawp/chat` to `agents/chat`. Channels never need to know which plugin owns the runtime — `wp_agent_channel_chat_ability` stays as an escape hatch for cases that need to pin a specific runtime.

## Boundary

Per the discussion thread in #100: agents-api ships **primitives only** — the contract, the dispatcher, the channel base class. No chat runtime, no UI, no REST chat surfaces, no runner. Consumers (openclawp, Data Machine, Dolly, …) own their product opinions and register as the runtime via the filter.

## Companion PR

[`lezama/openclawp#6`](https://github.com/lezama/openclawp/pull/6) registers `openclawp/chat` as the runtime behind `agents/chat` so the wacli channel (and any future caller targeting the canonical contract) works through the canonical dispatcher.

## Test plan

- [x] `tests/channels-smoke.php` — 24 assertions: happy path with canonical payload, multi-turn session continuity, distinct external_id isolation, override hooks (Rich_Channel exercises every new hook), agent-error → send_error routing, filter override, async dispatch, silent_skip.
- [x] `tests/agents-chat-ability-smoke.php` — 19 assertions: slug constant, missing-handler error, handler invocation with canonical input, invalid-result error, WP_Error propagation, first-handler-wins precedence, permission gate + filter widening, schema required-fields.
- [x] No regressions: full smoke suite passes (29 files, 0 failures, 302 assertions in bootstrap-smoke alone).
- [x] `lezama/openclawp` PHPUnit unit tests still pass (23/23).

🤖 Generated with [Claude Code](https://claude.com/claude-code)