### PR TITLE
Fix: register the agents-api ability category

### DIFF
--- a/src/Channels/register-agents-chat-ability.php
+++ b/src/Channels/register-agents-chat-ability.php
@@ -43,6 +43,22 @@ defined( 'ABSPATH' ) || exit;
 const AGENTS_CHAT_ABILITY = 'agents/chat';
 
 add_action(
+	'wp_abilities_api_categories_init',
+	static function (): void {
+		if ( ! function_exists( 'wp_register_ability_category' ) ) {
+			return;
+		}
+		wp_register_ability_category(
+			'agents-api',
+			array(
+				'label'       => 'Agents API',
+				'description' => 'Cross-cutting abilities provided by the Agents API substrate (channel dispatch, canonical chat contract, future runtime resolvers).',
+			)
+		);
+	}
+);
+
+add_action(
 	'wp_abilities_api_init',
 	static function (): void {
 		if ( ! function_exists( 'wp_register_ability' ) ) {


### PR DESCRIPTION
## Bug

PR #105 introduced \`agents/chat\` with \`'category' => 'agents-api'\` but didn't register the matching category. \`wp_register_ability\` silently returns \`null\` when the declared category isn't pre-registered, so on a real WP boot \`agents/chat\` never lands in the registry. The hand-rolled smoke test passed because it doesn't exercise the WP abilities-api category gate.

Found while running a live E2E in a Studio site (WP 7.0-RC2). \`wp_get_abilities()\` showed every other ability (\`openclawp/chat\`, \`ai/get-post-details\`, etc.) but \`agents/chat\` was absent. Tracing showed the registered closure ran on \`wp_abilities_api_init\`, but \`wp_register_ability\` returned \`null\` because \`'agents-api'\` wasn't a known category.

## Fix

Add a \`wp_abilities_api_categories_init\` listener that registers the \`agents-api\` category, mirroring the pattern existing consumers already use (e.g. dollypack registers a \`dollypack\` category at the same hook).

## Verified

Live in Studio after the fix:

\`\`\`
✓ agents/chat registered: WP_Ability
  category: agents-api
  input.required: agent,message
  output.required: session_id,reply
\`\`\`

Full dispatch chain works end-to-end: \`WP_Agent_Channel\` → \`agents/chat\` dispatcher → \`wp_agent_chat_handler\` filter → openclawp's handler → \`openclawp/chat\` runner → reply with session continuity (multi-turn confirmed: second turn correctly recalls "hi from agents/chat" from turn 1).

Webhook E2E with HMAC also verified across 5 paths:

| Case | Result |
|---|---|
| Valid HMAC + agent reply | \`200 {ok:true, note:"replied"}\` |
| Bad HMAC | \`401 {error:"bad_signature"}\` |
| \`from_me: true\` (loop prevention) | \`200 {ok:true, note:"self_message"}\` |
| Chat outside allowlist | \`200 {ok:true, note:"chat_not_allowed"}\` |
| Session continuity across two webhook hits | session_id persisted in option keyed by chat-jid hash |

🤖 Generated with [Claude Code](https://claude.com/claude-code)