### PR TITLE
Support WordPress 6.9 plugin activation

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Products can require Agents API because they build on the substrate. Agents API 
 
 ## Requirements
 
-Agents API requires **WordPress 7.0 or higher**. The substrate itself is provider-agnostic and loads on earlier versions, but every realistic consumer needs an AI provider. The only WordPress-native provider story is `wp-ai-client`, which ships in WordPress 7.0 core. Sites running 6.8–6.9 can install Agents API without errors but won't have a working AI provider unless they manually install the deprecated `wp-ai-client` plugin.
+Agents API requires **WordPress 6.9 or higher**. The substrate itself is provider-agnostic; every realistic consumer still needs an AI provider. The first WordPress-native provider story is `wp-ai-client`, which ships in WordPress 7.0 core. Sites running 6.9 can install Agents API and use it with a provider plugin.
 
 ## Consumer Integration
 

--- a/agents-api.php
+++ b/agents-api.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Agents API
  * Description: WordPress-shaped agent runtime substrate.
- * Requires at least: 7.0
+ * Requires at least: 6.9
  * Requires PHP: 8.1
  * Author: Automattic
  * License: GPL-2.0-or-later

--- a/tests/bootstrap-smoke.php
+++ b/tests/bootstrap-smoke.php
@@ -92,6 +92,7 @@ agents_api_smoke_assert_equals( true, class_exists( 'WP_Agent_Context_Section_Re
 agents_api_smoke_assert_equals( true, class_exists( 'WP_Agent_Context_Injection_Policy' ), 'WP_Agent_Context_Injection_Policy vocabulary is available', $failures, $passes );
 agents_api_smoke_assert_equals( true, class_exists( 'WP_Agent_Composable_Context' ), 'WP_Agent_Composable_Context value object is available', $failures, $passes );
 agents_api_smoke_assert_equals( true, defined( 'AGENTS_API_PLUGIN_FILE' ), 'plugin file constant is available', $failures, $passes );
+agents_api_smoke_assert_equals( true, str_contains( file_get_contents( AGENTS_API_PLUGIN_FILE ), 'Requires at least: 6.9' ), 'plugin header supports WordPress 6.9 consumers', $failures, $passes );
 agents_api_smoke_assert_equals( true, class_exists( 'AgentsAPI\\AI\\WP_Agent_Markdown_Section_Compaction_Adapter' ), 'AgentsAPI\\AI\\WP_Agent_Markdown_Section_Compaction_Adapter contract is available', $failures, $passes );
 agents_api_smoke_assert_equals( true, class_exists( 'AgentsAPI\\AI\\WP_Agent_Conversation_Loop' ), 'WP_Agent_Conversation_Loop facade is available', $failures, $passes );
 agents_api_smoke_assert_equals( true, interface_exists( 'AgentsAPI\\AI\\Approvals\\WP_Agent_Pending_Action_Store' ), 'AgentsAPI\\AI\\Approvals\\WP_Agent_Pending_Action_Store contract is available', $failures, $passes );


### PR DESCRIPTION
## Summary
- Lower the plugin header requirement from WordPress 7.0 to 6.9 so consumer plugins can declare Agents API as a required plugin dependency in 6.9 test/runtime environments.
- Clarify that WordPress 7.0 is the first native `wp-ai-client` provider story, while 6.9 consumers can use provider plugins.
- Add bootstrap smoke coverage for the plugin header requirement.

## Testing
- `php tests/bootstrap-smoke.php`
- `php -l agents-api.php && php -l tests/bootstrap-smoke.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the downstream Data Machine CI activation failure, drafted the header/docs/test change, and ran local smoke validation. Chris remains responsible for review and merge.