### PR TITLE
Add effective agent resolver

### DIFF
--- a/agents-api.php
+++ b/agents-api.php
@@ -69,6 +69,7 @@ require_once AGENTS_API_PATH . 'src/Consent/class-wp-agent-consent-policy.php';
 require_once AGENTS_API_PATH . 'src/Consent/class-wp-agent-default-consent-policy.php';
 require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-message.php';
 require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-execution-principal.php';
+require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-effective-agent-resolver.php';
 require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-compaction-item.php';
 require_once AGENTS_API_PATH . 'src/Tools/class-wp-agent-tool-declaration.php';
 require_once AGENTS_API_PATH . 'src/Tools/class-wp-agent-action-policy.php';

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
       "php tests/message-envelope-smoke.php",
       "php tests/registry-smoke.php",
       "php tests/execution-principal-smoke.php",
+      "php tests/effective-agent-resolver-smoke.php",
       "php tests/caller-context-smoke.php",
       "php tests/authorization-smoke.php",
       "php tests/action-policy-values-smoke.php",

--- a/src/Runtime/class-wp-agent-effective-agent-resolver.php
+++ b/src/Runtime/class-wp-agent-effective-agent-resolver.php
@@ -1,0 +1,180 @@
+<?php
+/**
+ * Effective agent resolver.
+ *
+ * @package AgentsAPI
+ */
+
+namespace AgentsAPI\AI;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Resolves the per-invocation effective agent for scoped operations.
+ *
+ * This deliberately models request/job/session identity, not global mutable
+ * "active agent" state. Consumers should pass explicit operation input when
+ * available, then principal or persisted context from the current invocation.
+ */
+final class WP_Agent_Effective_Agent_Resolver {
+
+	/**
+	 * Resolve the effective agent slug from the best available context.
+	 *
+	 * Resolution order:
+	 * 1) Explicit operation input: `agent_slug` / `effective_agent_id`.
+	 * 2) Execution principal: `principal->effective_agent_id`.
+	 * 3) Persisted invocation context: `persisted_agent_slug` / `persisted_effective_agent_id`.
+	 * 4) Owner fallback only when exactly one registered/candidate agent matches.
+	 *
+	 * @param array<string,mixed> $context Resolution context.
+	 * @return string Effective agent slug, or an empty string when no candidate exists.
+	 * @throws \InvalidArgumentException When owner fallback is ambiguous.
+	 */
+	public static function resolve( array $context = array() ): string {
+		$explicit = self::first_slug(
+			array(
+				$context['agent_slug'] ?? null,
+				$context['effective_agent_id'] ?? null,
+			)
+		);
+		if ( '' !== $explicit ) {
+			return $explicit;
+		}
+
+		$principal = $context['principal'] ?? null;
+		if ( ! $principal instanceof WP_Agent_Execution_Principal && ! empty( $context['resolve_principal'] ) ) {
+			$principal_context = isset( $context['principal_context'] ) && is_array( $context['principal_context'] ) ? $context['principal_context'] : array();
+			$principal         = WP_Agent_Execution_Principal::resolve( $principal_context );
+		}
+
+		if ( $principal instanceof WP_Agent_Execution_Principal ) {
+			$principal_slug = self::normalize_slug( $principal->effective_agent_id );
+			if ( '' !== $principal_slug ) {
+				return $principal_slug;
+			}
+		}
+
+		$persisted = self::first_slug(
+			array(
+				$context['persisted_agent_slug'] ?? null,
+				$context['persisted_effective_agent_id'] ?? null,
+			)
+		);
+		if ( '' !== $persisted ) {
+			return $persisted;
+		}
+
+		$owner_user_id = (int) ( $context['owner_user_id'] ?? 0 );
+		if ( $owner_user_id <= 0 ) {
+			return '';
+		}
+
+		$candidates = isset( $context['owner_agent_slugs'] ) && is_array( $context['owner_agent_slugs'] )
+			? self::normalize_slug_list( $context['owner_agent_slugs'] )
+			: self::registered_agent_slugs_for_owner( $owner_user_id );
+
+		if ( 0 === count( $candidates ) ) {
+			return '';
+		}
+
+		if ( 1 === count( $candidates ) ) {
+			return $candidates[0];
+		}
+
+		throw new \InvalidArgumentException(
+			'invalid_effective_agent_resolution: owner_user_id is ambiguous; provide an explicit agent_slug or execution principal. Candidates: ' . implode( ', ', $candidates )
+		);
+	}
+
+	/**
+	 * Return the first non-empty normalized slug.
+	 *
+	 * @param array<int,mixed> $values Candidate values.
+	 * @return string Normalized slug.
+	 */
+	private static function first_slug( array $values ): string {
+		foreach ( $values as $value ) {
+			$slug = is_scalar( $value ) ? self::normalize_slug( (string) $value ) : '';
+			if ( '' !== $slug ) {
+				return $slug;
+			}
+		}
+
+		return '';
+	}
+
+	/**
+	 * Normalize an agent slug.
+	 *
+	 * @param string $slug Raw slug.
+	 * @return string Normalized slug.
+	 */
+	private static function normalize_slug( string $slug ): string {
+		if ( function_exists( 'sanitize_title' ) ) {
+			return sanitize_title( $slug );
+		}
+
+		$slug = strtolower( $slug );
+		$slug = preg_replace( '/[^a-z0-9]+/', '-', $slug );
+
+		return trim( (string) $slug, '-' );
+	}
+
+	/**
+	 * Normalize and dedupe candidate slug list.
+	 *
+	 * @param array<int,mixed> $slugs Raw slugs.
+	 * @return string[] Normalized slugs.
+	 */
+	private static function normalize_slug_list( array $slugs ): array {
+		$normalized = array();
+		foreach ( $slugs as $slug ) {
+			if ( ! is_scalar( $slug ) ) {
+				continue;
+			}
+
+			$slug = self::normalize_slug( (string) $slug );
+			if ( '' !== $slug ) {
+				$normalized[ $slug ] = true;
+			}
+		}
+
+		return array_keys( $normalized );
+	}
+
+	/**
+	 * Resolve registered agent slugs whose owner resolver matches the user.
+	 *
+	 * @param int $owner_user_id Owner WordPress user ID.
+	 * @return string[] Matching registered agent slugs.
+	 */
+	private static function registered_agent_slugs_for_owner( int $owner_user_id ): array {
+		if ( ! class_exists( '\WP_Agents_Registry' ) ) {
+			return array();
+		}
+
+		$registry = \WP_Agents_Registry::get_instance();
+		if ( null === $registry ) {
+			return array();
+		}
+
+		$matches = array();
+		foreach ( $registry->get_all_registered() as $agent ) {
+			if ( ! $agent instanceof \WP_Agent ) {
+				continue;
+			}
+
+			$owner_resolver = $agent->get_owner_resolver();
+			if ( ! is_callable( $owner_resolver ) ) {
+				continue;
+			}
+
+			if ( $owner_user_id === (int) call_user_func( $owner_resolver ) ) {
+				$matches[] = $agent->get_slug();
+			}
+		}
+
+		return self::normalize_slug_list( $matches );
+	}
+}

--- a/tests/effective-agent-resolver-smoke.php
+++ b/tests/effective-agent-resolver-smoke.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * Pure-PHP smoke test for effective agent resolution.
+ *
+ * Run with: php tests/effective-agent-resolver-smoke.php
+ *
+ * @package AgentsAPI\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+$failures = array();
+$passes   = 0;
+
+echo "agents-api-effective-agent-resolver-smoke\n";
+
+require_once __DIR__ . '/agents-api-smoke-helpers.php';
+agents_api_smoke_require_module();
+
+$principal = AgentsAPI\AI\WP_Agent_Execution_Principal::user_session(
+	7,
+	'Principal Agent',
+	AgentsAPI\AI\WP_Agent_Execution_Principal::REQUEST_CONTEXT_CLI
+);
+
+$resolved = AgentsAPI\AI\WP_Agent_Effective_Agent_Resolver::resolve(
+	array(
+		'agent_slug' => 'Explicit Agent',
+		'principal'  => $principal,
+	)
+);
+agents_api_smoke_assert_equals( 'explicit-agent', $resolved, 'explicit agent wins over principal', $failures, $passes );
+
+$resolved = AgentsAPI\AI\WP_Agent_Effective_Agent_Resolver::resolve(
+	array(
+		'principal'              => $principal,
+		'persisted_agent_slug'   => 'persisted-agent',
+		'owner_user_id'          => 7,
+		'owner_agent_slugs'      => array( 'owned-agent' ),
+	)
+);
+agents_api_smoke_assert_equals( 'principal-agent', $resolved, 'principal wins over persisted and owner fallback', $failures, $passes );
+
+$resolved = AgentsAPI\AI\WP_Agent_Effective_Agent_Resolver::resolve(
+	array(
+		'persisted_effective_agent_id' => 'Persisted Agent',
+		'owner_user_id'                => 7,
+		'owner_agent_slugs'            => array( 'owned-agent' ),
+	)
+);
+agents_api_smoke_assert_equals( 'persisted-agent', $resolved, 'persisted context wins over owner fallback', $failures, $passes );
+
+$resolved = AgentsAPI\AI\WP_Agent_Effective_Agent_Resolver::resolve(
+	array(
+		'owner_user_id'     => 7,
+		'owner_agent_slugs' => array( 'Only Agent' ),
+	)
+);
+agents_api_smoke_assert_equals( 'only-agent', $resolved, 'single owner candidate is accepted', $failures, $passes );
+
+try {
+	AgentsAPI\AI\WP_Agent_Effective_Agent_Resolver::resolve(
+		array(
+			'owner_user_id'     => 7,
+			'owner_agent_slugs' => array( 'admin', 'intelligence-chubes4' ),
+		)
+	);
+	agents_api_smoke_assert_equals( true, false, 'ambiguous owner fallback is rejected', $failures, $passes );
+} catch ( InvalidArgumentException $e ) {
+	agents_api_smoke_assert_equals( true, str_contains( $e->getMessage(), 'ambiguous' ), 'ambiguous owner fallback is rejected', $failures, $passes );
+}
+
+add_action(
+	'wp_agents_api_init',
+	static function (): void {
+		wp_register_agent(
+			'registered-owner-agent',
+			array(
+				'owner_resolver' => static fn() => 42,
+			)
+		);
+		wp_register_agent(
+			'other-owner-agent',
+			array(
+				'owner_resolver' => static fn() => 99,
+			)
+		);
+	},
+	10,
+	0
+);
+do_action( 'init' );
+
+$resolved = AgentsAPI\AI\WP_Agent_Effective_Agent_Resolver::resolve(
+	array(
+		'owner_user_id' => 42,
+	)
+);
+agents_api_smoke_assert_equals( 'registered-owner-agent', $resolved, 'registered owner fallback uses owner resolvers when unambiguous', $failures, $passes );
+
+$resolved = AgentsAPI\AI\WP_Agent_Effective_Agent_Resolver::resolve();
+agents_api_smoke_assert_equals( '', $resolved, 'empty context resolves to no agent', $failures, $passes );
+
+agents_api_smoke_finish( 'Agents API effective agent resolver', $failures, $passes );


### PR DESCRIPTION
## Summary
- Adds `WP_Agent_Effective_Agent_Resolver` for per-invocation effective agent resolution without restoring global active-agent state.
- Applies the resolution order from #110: explicit input, execution principal, persisted context, then unambiguous owner fallback.
- Rejects ambiguous owner fallback instead of silently selecting the first owned agent.

## Testing
- `php tests/effective-agent-resolver-smoke.php`
- `composer test`

Closes #110.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafting the resolver implementation, smoke coverage, issue, and PR description. Chris directed the architecture and requested the issue/PR.