### PR TITLE
Add external channel message session mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,10 @@ wp_register_agent(
 - `WP_Agent_Default_Consent_Policy`
 - `AgentsAPI\AI\Consent\WP_Agent_Consent_Operation`
 - `AgentsAPI\AI\Consent\WP_Agent_Consent_Decision`
+- `AgentsAPI\AI\Channels\WP_Agent_External_Message`
+- `AgentsAPI\AI\Channels\WP_Agent_Channel_Session_Store`
+- `AgentsAPI\AI\Channels\WP_Agent_Option_Channel_Session_Store`
+- `AgentsAPI\AI\Channels\WP_Agent_Channel_Session_Map`
 - `AgentsAPI\AI\Tools\WP_Agent_Tool_Declaration`
 - `AgentsAPI\AI\Tools\WP_Agent_Tool_Call`
 - `AgentsAPI\AI\Tools\WP_Agent_Tool_Source_Registry`

--- a/agents-api.php
+++ b/agents-api.php
@@ -112,6 +112,10 @@ require_once AGENTS_API_PATH . 'src/Memory/class-wp-agent-memory-write-result.ph
 require_once AGENTS_API_PATH . 'src/Memory/class-wp-agent-memory-store.php';
 require_once AGENTS_API_PATH . 'src/Guidelines/guidelines.php';
 require_once AGENTS_API_PATH . 'src/Guidelines/class-wp-guidelines-substrate.php';
+require_once AGENTS_API_PATH . 'src/Channels/class-wp-agent-external-message.php';
+require_once AGENTS_API_PATH . 'src/Channels/class-wp-agent-channel-session-store.php';
+require_once AGENTS_API_PATH . 'src/Channels/class-wp-agent-option-channel-session-store.php';
+require_once AGENTS_API_PATH . 'src/Channels/class-wp-agent-channel-session-map.php';
 require_once AGENTS_API_PATH . 'src/Channels/class-wp-agent-channel.php';
 require_once AGENTS_API_PATH . 'src/Channels/register-agents-chat-ability.php';
 

--- a/composer.json
+++ b/composer.json
@@ -43,6 +43,7 @@
       "php tests/conversation-loop-events-smoke.php",
       "php tests/iteration-budget-smoke.php",
       "php tests/conversation-loop-budgets-smoke.php",
+      "php tests/channels-smoke.php",
       "php tests/context-authority-smoke.php",
       "php tests/guidelines-substrate-smoke.php",
       "php tests/no-product-imports-smoke.php"

--- a/src/Channels/class-wp-agent-channel-session-map.php
+++ b/src/Channels/class-wp-agent-channel-session-map.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Channel session mapping facade.
+ *
+ * @package AgentsAPI
+ * @since   0.103.0
+ */
+
+namespace AgentsAPI\AI\Channels;
+
+defined( 'ABSPATH' ) || exit;
+
+final class WP_Agent_Channel_Session_Map {
+
+	private static ?WP_Agent_Channel_Session_Store $store = null;
+
+	/**
+	 * Replace the backing store. Pass null to restore the option-backed default.
+	 *
+	 * @param WP_Agent_Channel_Session_Store|null $store Store implementation.
+	 */
+	public static function set_store( ?WP_Agent_Channel_Session_Store $store ): void {
+		self::$store = $store;
+	}
+
+	/**
+	 * Return the active backing store.
+	 *
+	 * @return WP_Agent_Channel_Session_Store
+	 */
+	public static function store(): WP_Agent_Channel_Session_Store {
+		if ( null === self::$store ) {
+			self::$store = new WP_Agent_Option_Channel_Session_Store();
+		}
+		return self::$store;
+	}
+
+	/**
+	 * Read the mapped agent session id for an external conversation.
+	 *
+	 * @param string $connector_id             Connector or channel instance id.
+	 * @param string $external_conversation_id Opaque external conversation id.
+	 * @param string $agent_slug               Agent slug or empty string for runtime-resolved agents.
+	 * @return string|null Session id, or null when no mapping exists.
+	 */
+	public static function get( string $connector_id, string $external_conversation_id, string $agent_slug = '' ): ?string {
+		return self::store()->get( $connector_id, $external_conversation_id, $agent_slug );
+	}
+
+	/**
+	 * Store the mapped agent session id for an external conversation.
+	 *
+	 * @param string $connector_id             Connector or channel instance id.
+	 * @param string $external_conversation_id Opaque external conversation id.
+	 * @param string $session_id               Agent session id.
+	 * @param string $agent_slug               Agent slug or empty string for runtime-resolved agents.
+	 */
+	public static function set( string $connector_id, string $external_conversation_id, string $session_id, string $agent_slug = '' ): void {
+		self::store()->set( $connector_id, $external_conversation_id, $session_id, $agent_slug );
+	}
+
+	/**
+	 * Delete the mapped session id for an external conversation.
+	 *
+	 * @param string $connector_id             Connector or channel instance id.
+	 * @param string $external_conversation_id Opaque external conversation id.
+	 * @param string $agent_slug               Agent slug or empty string for runtime-resolved agents.
+	 */
+	public static function delete( string $connector_id, string $external_conversation_id, string $agent_slug = '' ): void {
+		self::store()->delete( $connector_id, $external_conversation_id, $agent_slug );
+	}
+}

--- a/src/Channels/class-wp-agent-channel-session-store.php
+++ b/src/Channels/class-wp-agent-channel-session-store.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Channel session mapping store contract.
+ *
+ * @package AgentsAPI
+ * @since   0.103.0
+ */
+
+namespace AgentsAPI\AI\Channels;
+
+defined( 'ABSPATH' ) || exit;
+
+interface WP_Agent_Channel_Session_Store {
+
+	/**
+	 * Read the mapped agent session id for an external conversation.
+	 *
+	 * @param string $connector_id             Connector or channel instance id.
+	 * @param string $external_conversation_id Opaque external conversation id.
+	 * @param string $agent_slug               Agent slug or empty string for runtime-resolved agents.
+	 * @return string|null Session id, or null when no mapping exists.
+	 */
+	public function get( string $connector_id, string $external_conversation_id, string $agent_slug = '' ): ?string;
+
+	/**
+	 * Store the mapped agent session id for an external conversation.
+	 *
+	 * @param string $connector_id             Connector or channel instance id.
+	 * @param string $external_conversation_id Opaque external conversation id.
+	 * @param string $session_id               Agent session id.
+	 * @param string $agent_slug               Agent slug or empty string for runtime-resolved agents.
+	 */
+	public function set( string $connector_id, string $external_conversation_id, string $session_id, string $agent_slug = '' ): void;
+
+	/**
+	 * Delete the mapped session id for an external conversation.
+	 *
+	 * @param string $connector_id             Connector or channel instance id.
+	 * @param string $external_conversation_id Opaque external conversation id.
+	 * @param string $agent_slug               Agent slug or empty string for runtime-resolved agents.
+	 */
+	public function delete( string $connector_id, string $external_conversation_id, string $agent_slug = '' ): void;
+}

--- a/src/Channels/class-wp-agent-channel.php
+++ b/src/Channels/class-wp-agent-channel.php
@@ -18,7 +18,7 @@
  * This base class is intentionally agnostic about the agent runtime. The
  * default `run_agent()` calls the chat ability registered under the slug
  * returned by the `wp_agent_channel_chat_ability` filter (default
- * `openclawp/chat`); override `run_agent()` to plug in a different runtime.
+ * `agents/chat`); override `run_agent()` to plug in a different runtime.
  *
  * Mirrors a similar pattern used internally at WordPress.com to drive
  * Telegram, Slack, and other agent surfaces. The host-specific orchestration
@@ -295,7 +295,7 @@ abstract class WP_Agent_Channel {
 	 *       session_id: string|null,
 	 *       attachments: array,
 	 *       client_context: {
-	 *         source, client_name, external_provider,
+	 *         source, connector_id, client_name, external_provider,
 	 *         external_conversation_id, external_message_id, room_kind
 	 *       }
 	 *     }
@@ -356,19 +356,38 @@ abstract class WP_Agent_Channel {
 	 * @return array
 	 */
 	public function build_chat_payload( string $message_text, array $data ): array {
+		$external_message              = $this->build_external_message( $message_text, $data );
+		$client_context                = $external_message->client_context( $this->client_context_source() );
+		$client_context['client_name'] = $this->get_client_name();
+
 		return array(
 			'agent'          => $this->agent_slug,
-			'message'        => $message_text,
+			'message'        => $external_message->text,
 			'session_id'     => '' === (string) $this->session_id ? null : $this->session_id,
-			'attachments'    => $this->extract_attachments( $data ),
-			'client_context' => array(
-				'source'                   => $this->client_context_source(),
-				'client_name'              => $this->get_client_name(),
-				'external_provider'        => $this->get_external_id_provider(),
-				'external_conversation_id' => $this->get_external_id(),
-				'external_message_id'      => $this->extract_external_message_id( $data ),
-				'room_kind'                => $this->get_room_kind( $data ),
-			),
+			'attachments'    => $external_message->attachments,
+			'client_context' => $client_context,
+		);
+	}
+
+	/**
+	 * Build the normalized external message value for this inbound payload.
+	 *
+	 * @param string $message_text
+	 * @param array  $data
+	 * @return WP_Agent_External_Message
+	 */
+	public function build_external_message( string $message_text, array $data ): WP_Agent_External_Message {
+		return new WP_Agent_External_Message(
+			$message_text,
+			$this->get_connector_id(),
+			$this->get_external_id_provider(),
+			$this->get_external_id(),
+			$this->extract_external_message_id( $data ),
+			null,
+			false,
+			$this->get_room_kind( $data ),
+			$this->extract_attachments( $data ),
+			$data
 		);
 	}
 
@@ -386,6 +405,17 @@ abstract class WP_Agent_Channel {
 	protected function extract_attachments( array $data ): array {
 		unset( $data );
 		return array();
+	}
+
+	/**
+	 * Connector or channel instance id used for client context and session maps.
+	 * Defaults to `get_client_name()`; override when a channel needs a stable
+	 * connector id that differs from the human-readable client label.
+	 *
+	 * @return string
+	 */
+	protected function get_connector_id(): string {
+		return $this->get_client_name();
 	}
 
 	/**
@@ -498,19 +528,18 @@ abstract class WP_Agent_Channel {
 		return array();
 	}
 
-	// ─── Session persistence (option-based default) ────────────────────
+	// ─── Session persistence (shared map-backed default) ────────────────
 
 	/**
-	 * Storage key for the external_id ↔ session_id mapping. Subclasses can
-	 * override to change scope (per-user, per-blog, custom table). Default
-	 * is a single site option keyed by hashed `provider:external_id`.
+	 * Storage key for the external_id ↔ session_id mapping. Kept as an
+	 * override point for subclasses that predate the shared session map.
 	 *
 	 * @return string
 	 */
 	protected function session_storage_key(): string {
 		$external_id = $this->get_external_id() ?? '';
 		return 'wp_agent_channel_session_' . md5(
-			$this->get_external_id_provider() . ':' . $external_id
+			implode( ':', array( $this->get_connector_id(), $external_id, $this->agent_slug ) )
 		);
 	}
 
@@ -520,9 +549,15 @@ abstract class WP_Agent_Channel {
 	 * @return string|null
 	 */
 	protected function lookup_session_id(): ?string {
-		if ( null === $this->get_external_id() ) {
+		$external_id = $this->get_external_id();
+		if ( null === $external_id ) {
 			return null;
 		}
+
+		if ( ! $this->uses_custom_session_storage_key() ) {
+			return WP_Agent_Channel_Session_Map::get( $this->get_connector_id(), $external_id, $this->agent_slug );
+		}
+
 		$value = get_option( $this->session_storage_key(), '' );
 		return '' === $value ? null : (string) $value;
 	}
@@ -533,9 +568,21 @@ abstract class WP_Agent_Channel {
 	 * @param string $session_id
 	 */
 	protected function store_session_id( string $session_id ): void {
-		if ( null === $this->get_external_id() ) {
+		$external_id = $this->get_external_id();
+		if ( null === $external_id ) {
 			return;
 		}
+
+		if ( ! $this->uses_custom_session_storage_key() ) {
+			WP_Agent_Channel_Session_Map::set( $this->get_connector_id(), $external_id, $session_id, $this->agent_slug );
+			return;
+		}
+
 		update_option( $this->session_storage_key(), $session_id, false );
+	}
+
+	private function uses_custom_session_storage_key(): bool {
+		$method = new \ReflectionMethod( $this, 'session_storage_key' );
+		return self::class !== $method->getDeclaringClass()->getName();
 	}
 }

--- a/src/Channels/class-wp-agent-external-message.php
+++ b/src/Channels/class-wp-agent-external-message.php
@@ -1,0 +1,185 @@
+<?php
+/**
+ * Normalized external channel message value object.
+ *
+ * @package AgentsAPI
+ * @since   0.103.0
+ */
+
+namespace AgentsAPI\AI\Channels;
+
+use InvalidArgumentException;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Immutable normalized message shape shared by direct channels and bridges.
+ */
+final class WP_Agent_External_Message {
+
+	private const ROOM_KINDS = array( 'dm', 'group', 'channel' );
+
+	public readonly string $text;
+	public readonly string $connector_id;
+	public readonly string $external_provider;
+	public readonly ?string $external_conversation_id;
+	public readonly ?string $external_message_id;
+	public readonly ?string $sender_id;
+	public readonly bool $from_self;
+	public readonly ?string $room_kind;
+	/** @var array<int, mixed> */
+	public readonly array $attachments;
+	/** @var array<string, mixed> */
+	public readonly array $raw;
+
+	/**
+	 * @param string              $text                     User-visible message text.
+	 * @param string              $connector_id             Connector or channel instance id.
+	 * @param string              $external_provider        External network/provider id.
+	 * @param string|null         $external_conversation_id Opaque external conversation id.
+	 * @param string|null         $external_message_id      Opaque external message id.
+	 * @param string|null         $sender_id                Opaque sender id.
+	 * @param bool                $from_self                Whether this message came from the bot/client itself.
+	 * @param string|null         $room_kind                dm, group, channel, or null.
+	 * @param array<int, mixed>   $attachments              Runtime-defined attachment payloads.
+	 * @param array<string,mixed> $raw                      Original payload or safe subset for diagnostics.
+	 */
+	public function __construct(
+		string $text,
+		string $connector_id,
+		string $external_provider,
+		?string $external_conversation_id = null,
+		?string $external_message_id = null,
+		?string $sender_id = null,
+		bool $from_self = false,
+		?string $room_kind = null,
+		array $attachments = array(),
+		array $raw = array()
+	) {
+		$this->text                     = trim( $text );
+		$this->connector_id             = self::normalize_required_slug( $connector_id, 'connector_id' );
+		$this->external_provider        = self::normalize_required_slug( $external_provider, 'external_provider' );
+		$this->external_conversation_id = self::normalize_optional_string( $external_conversation_id );
+		$this->external_message_id      = self::normalize_optional_string( $external_message_id );
+		$this->sender_id                = self::normalize_optional_string( $sender_id );
+		$this->from_self                = $from_self;
+		$this->room_kind                = self::normalize_room_kind( $room_kind );
+		$this->attachments              = array_values( $attachments );
+		$this->raw                      = $raw;
+	}
+
+	/**
+	 * Build a normalized message from an array payload.
+	 *
+	 * @param array<string,mixed> $data Input data.
+	 * @return self
+	 */
+	public static function from_array( array $data ): self {
+		return new self(
+			(string) ( $data['text'] ?? '' ),
+			(string) ( $data['connector_id'] ?? '' ),
+			(string) ( $data['external_provider'] ?? '' ),
+			isset( $data['external_conversation_id'] ) ? (string) $data['external_conversation_id'] : null,
+			isset( $data['external_message_id'] ) ? (string) $data['external_message_id'] : null,
+			isset( $data['sender_id'] ) ? (string) $data['sender_id'] : null,
+			(bool) ( $data['from_self'] ?? false ),
+			isset( $data['room_kind'] ) ? (string) $data['room_kind'] : null,
+			isset( $data['attachments'] ) && is_array( $data['attachments'] ) ? $data['attachments'] : array(),
+			isset( $data['raw'] ) && is_array( $data['raw'] ) ? $data['raw'] : array()
+		);
+	}
+
+	/**
+	 * Build a message object from a channel instance and webhook payload.
+	 *
+	 * @param WP_Agent_Channel $channel      Channel instance.
+	 * @param string           $message_text User message text.
+	 * @param array            $data         Channel payload.
+	 * @return self
+	 */
+	public static function from_channel( WP_Agent_Channel $channel, string $message_text, array $data ): self {
+		$payload = $channel->build_chat_payload( $message_text, $data );
+		$context = is_array( $payload['client_context'] ?? null ) ? $payload['client_context'] : array();
+
+		return new self(
+			$message_text,
+			(string) ( $context['connector_id'] ?? $context['client_name'] ?? $channel->get_client_name() ),
+			(string) ( $context['external_provider'] ?? $channel->get_external_id_provider() ),
+			isset( $context['external_conversation_id'] ) ? (string) $context['external_conversation_id'] : $channel->get_external_id(),
+			isset( $context['external_message_id'] ) ? (string) $context['external_message_id'] : null,
+			null,
+			false,
+			isset( $context['room_kind'] ) ? (string) $context['room_kind'] : null,
+			isset( $payload['attachments'] ) && is_array( $payload['attachments'] ) ? $payload['attachments'] : array(),
+			$data
+		);
+	}
+
+	/**
+	 * Return the canonical array shape.
+	 *
+	 * @return array<string,mixed>
+	 */
+	public function to_array(): array {
+		return array(
+			'text'                     => $this->text,
+			'connector_id'             => $this->connector_id,
+			'external_provider'        => $this->external_provider,
+			'external_conversation_id' => $this->external_conversation_id,
+			'external_message_id'      => $this->external_message_id,
+			'sender_id'                => $this->sender_id,
+			'from_self'                => $this->from_self,
+			'room_kind'                => $this->room_kind,
+			'attachments'              => $this->attachments,
+			'raw'                      => $this->raw,
+		);
+	}
+
+	/**
+	 * Return the chat ability client_context subset.
+	 *
+	 * @param string $source channel, bridge, rest, or block.
+	 * @return array<string,mixed>
+	 */
+	public function client_context( string $source = 'channel' ): array {
+		return array(
+			'source'                   => $source,
+			'connector_id'             => $this->connector_id,
+			'client_name'              => $this->connector_id,
+			'external_provider'        => $this->external_provider,
+			'external_conversation_id' => $this->external_conversation_id,
+			'external_message_id'      => $this->external_message_id,
+			'room_kind'                => $this->room_kind,
+		);
+	}
+
+	private static function normalize_required_slug( string $value, string $field ): string {
+		$value = trim( strtolower( str_replace( '_', '-', $value ) ) );
+		if ( '' === $value || ! preg_match( '/^[a-z0-9][a-z0-9-]*$/', $value ) ) {
+			if ( 'connector_id' === $field ) {
+				throw new InvalidArgumentException( 'connector_id must be a non-empty slug.' );
+			}
+			throw new InvalidArgumentException( 'external_provider must be a non-empty slug.' );
+		}
+		return $value;
+	}
+
+	private static function normalize_optional_string( ?string $value ): ?string {
+		if ( null === $value ) {
+			return null;
+		}
+		$value = trim( $value );
+		return '' === $value ? null : $value;
+	}
+
+	private static function normalize_room_kind( ?string $room_kind ): ?string {
+		$room_kind = self::normalize_optional_string( $room_kind );
+		if ( null === $room_kind ) {
+			return null;
+		}
+		if ( ! in_array( $room_kind, self::ROOM_KINDS, true ) ) {
+			throw new InvalidArgumentException( 'room_kind must be dm, group, channel, or null.' );
+		}
+		return $room_kind;
+	}
+}

--- a/src/Channels/class-wp-agent-external-message.php
+++ b/src/Channels/class-wp-agent-external-message.php
@@ -90,32 +90,6 @@ final class WP_Agent_External_Message {
 	}
 
 	/**
-	 * Build a message object from a channel instance and webhook payload.
-	 *
-	 * @param WP_Agent_Channel $channel      Channel instance.
-	 * @param string           $message_text User message text.
-	 * @param array            $data         Channel payload.
-	 * @return self
-	 */
-	public static function from_channel( WP_Agent_Channel $channel, string $message_text, array $data ): self {
-		$payload = $channel->build_chat_payload( $message_text, $data );
-		$context = is_array( $payload['client_context'] ?? null ) ? $payload['client_context'] : array();
-
-		return new self(
-			$message_text,
-			(string) ( $context['connector_id'] ?? $context['client_name'] ?? $channel->get_client_name() ),
-			(string) ( $context['external_provider'] ?? $channel->get_external_id_provider() ),
-			isset( $context['external_conversation_id'] ) ? (string) $context['external_conversation_id'] : $channel->get_external_id(),
-			isset( $context['external_message_id'] ) ? (string) $context['external_message_id'] : null,
-			null,
-			false,
-			isset( $context['room_kind'] ) ? (string) $context['room_kind'] : null,
-			isset( $payload['attachments'] ) && is_array( $payload['attachments'] ) ? $payload['attachments'] : array(),
-			$data
-		);
-	}
-
-	/**
 	 * Return the canonical array shape.
 	 *
 	 * @return array<string,mixed>

--- a/src/Channels/class-wp-agent-option-channel-session-store.php
+++ b/src/Channels/class-wp-agent-option-channel-session-store.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Option-backed channel session mapping store.
+ *
+ * @package AgentsAPI
+ * @since   0.103.0
+ */
+
+namespace AgentsAPI\AI\Channels;
+
+defined( 'ABSPATH' ) || exit;
+
+final class WP_Agent_Option_Channel_Session_Store implements WP_Agent_Channel_Session_Store {
+
+	public function get( string $connector_id, string $external_conversation_id, string $agent_slug = '' ): ?string {
+		$value = get_option( $this->storage_key( $connector_id, $external_conversation_id, $agent_slug ), '' );
+		return '' === $value ? null : (string) $value;
+	}
+
+	public function set( string $connector_id, string $external_conversation_id, string $session_id, string $agent_slug = '' ): void {
+		update_option( $this->storage_key( $connector_id, $external_conversation_id, $agent_slug ), $session_id, false );
+	}
+
+	public function delete( string $connector_id, string $external_conversation_id, string $agent_slug = '' ): void {
+		delete_option( $this->storage_key( $connector_id, $external_conversation_id, $agent_slug ) );
+	}
+
+	/**
+	 * Build the option key for a connector/conversation/agent tuple.
+	 *
+	 * @param string $connector_id
+	 * @param string $external_conversation_id
+	 * @param string $agent_slug
+	 * @return string
+	 */
+	public function storage_key( string $connector_id, string $external_conversation_id, string $agent_slug = '' ): string {
+		return 'wp_agent_channel_session_' . md5(
+			implode(
+				':',
+				array(
+					$this->normalize_part( $connector_id ),
+					$external_conversation_id,
+					$this->normalize_part( $agent_slug ),
+				)
+			)
+		);
+	}
+
+	private function normalize_part( string $value ): string {
+		return trim( strtolower( str_replace( '_', '-', $value ) ) );
+	}
+}

--- a/src/Channels/register-agents-chat-ability.php
+++ b/src/Channels/register-agents-chat-ability.php
@@ -226,6 +226,10 @@ function agents_chat_input_schema(): array {
 						'type'        => 'string',
 						'description' => 'Specific client identifier within the source (e.g. "wacli", "telegram_<bot>", "data-machine").',
 					),
+					'connector_id'             => array(
+						'type'        => 'string',
+						'description' => 'Stable connector or channel instance id used for settings, attribution, and external conversation session mapping.',
+					),
 					'external_provider'        => array(
 						'type'        => array( 'string', 'null' ),
 						'description' => 'External network identifier (e.g. "whatsapp", "slack", "email"). Null if not applicable.',

--- a/tests/bootstrap-smoke.php
+++ b/tests/bootstrap-smoke.php
@@ -105,6 +105,10 @@ agents_api_smoke_assert_equals( true, class_exists( 'WP_Agent_Tool_Policy_Filter
 agents_api_smoke_assert_equals( true, interface_exists( 'WP_Agent_Tool_Access_Policy' ), 'WP_Agent_Tool_Access_Policy contract is available', $failures, $passes );
 agents_api_smoke_assert_equals( true, class_exists( 'WP_Agent_Action_Policy_Resolver' ), 'WP_Agent_Action_Policy_Resolver contract is available', $failures, $passes );
 agents_api_smoke_assert_equals( true, interface_exists( 'WP_Agent_Action_Policy_Provider' ), 'WP_Agent_Action_Policy_Provider contract is available', $failures, $passes );
+agents_api_smoke_assert_equals( true, class_exists( 'AgentsAPI\AI\Channels\WP_Agent_External_Message' ), 'WP_Agent_External_Message value object is available', $failures, $passes );
+agents_api_smoke_assert_equals( true, interface_exists( 'AgentsAPI\AI\Channels\WP_Agent_Channel_Session_Store' ), 'WP_Agent_Channel_Session_Store contract is available', $failures, $passes );
+agents_api_smoke_assert_equals( true, class_exists( 'AgentsAPI\AI\Channels\WP_Agent_Option_Channel_Session_Store' ), 'WP_Agent_Option_Channel_Session_Store implementation is available', $failures, $passes );
+agents_api_smoke_assert_equals( true, class_exists( 'AgentsAPI\AI\Channels\WP_Agent_Channel_Session_Map' ), 'WP_Agent_Channel_Session_Map facade is available', $failures, $passes );
 foreach ( $namespace_map as $legacy_class => $target_class ) {
 	agents_api_smoke_assert_equals( true, class_exists( $target_class ) || interface_exists( $target_class ), $target_class . ' contract is available', $failures, $passes );
 	agents_api_smoke_assert_equals( false, class_exists( $legacy_class, false ) || interface_exists( $legacy_class, false ), $legacy_class . ' compatibility alias is not loaded', $failures, $passes );

--- a/tests/channels-smoke.php
+++ b/tests/channels-smoke.php
@@ -48,6 +48,11 @@ function update_option( string $key, $value, $autoload = null ): bool {
 	return true;
 }
 
+function delete_option( string $key ): bool {
+	unset( $GLOBALS['__channel_smoke_options'][ $key ] );
+	return true;
+}
+
 function wp_schedule_single_event( int $timestamp, string $hook, array $args = array() ): bool {
 	$GLOBALS['__channel_smoke_scheduled'][] = array(
 		'timestamp' => $timestamp,
@@ -93,8 +98,12 @@ function smoke_assert( $expected, $actual, string $name, array &$failures, int &
 	echo '    actual:   ' . var_export( $actual, true ) . "\n";
 }
 
-require_once __DIR__ . '/../src/Channels/class-wp-agent-channel.php';
 require_once __DIR__ . '/../src/Channels/register-agents-chat-ability.php';
+require_once __DIR__ . '/../src/Channels/class-wp-agent-external-message.php';
+require_once __DIR__ . '/../src/Channels/class-wp-agent-channel-session-store.php';
+require_once __DIR__ . '/../src/Channels/class-wp-agent-option-channel-session-store.php';
+require_once __DIR__ . '/../src/Channels/class-wp-agent-channel-session-map.php';
+require_once __DIR__ . '/../src/Channels/class-wp-agent-channel.php';
 
 // ─── Fakes ──────────────────────────────────────────────────────────
 
@@ -163,6 +172,7 @@ $expected_first_call = array(
 		'attachments'    => array(),
 		'client_context' => array(
 			'source'                   => 'channel',
+			'connector_id'             => 'test-channel',
 			'client_name'              => 'test-channel',
 			'external_provider'        => 'test-channel',
 			'external_conversation_id' => 'chat-A',
@@ -172,6 +182,51 @@ $expected_first_call = array(
 	),
 );
 smoke_assert( $expected_first_call, $happy_ability->calls, 'happy_path_canonical_chat_payload', $failures, $passes );
+
+$external_message = $ch->build_external_message( 'hi there', array( 'text' => 'hi there' ) );
+smoke_assert( true, $external_message instanceof \AgentsAPI\AI\Channels\WP_Agent_External_Message, 'external_message_value_object_created', $failures, $passes );
+smoke_assert(
+	array(
+		'text'                     => 'hi there',
+		'connector_id'             => 'test-channel',
+		'external_provider'        => 'test-channel',
+		'external_conversation_id' => 'chat-A',
+		'external_message_id'      => null,
+		'sender_id'                => null,
+		'from_self'                => false,
+		'room_kind'                => null,
+		'attachments'              => array(),
+		'raw'                      => array( 'text' => 'hi there' ),
+	),
+	$external_message->to_array(),
+	'external_message_array_shape',
+	$failures,
+	$passes
+);
+
+\AgentsAPI\AI\Channels\WP_Agent_Channel_Session_Map::set( 'test-channel', 'manual-chat', 'sess-manual', 'test-agent' );
+smoke_assert(
+	'sess-manual',
+	\AgentsAPI\AI\Channels\WP_Agent_Channel_Session_Map::get( 'test-channel', 'manual-chat', 'test-agent' ),
+	'session_map_static_get_set',
+	$failures,
+	$passes
+);
+smoke_assert(
+	null,
+	\AgentsAPI\AI\Channels\WP_Agent_Channel_Session_Map::get( 'test-channel', 'manual-chat', 'other-agent' ),
+	'session_map_scopes_by_agent',
+	$failures,
+	$passes
+);
+\AgentsAPI\AI\Channels\WP_Agent_Channel_Session_Map::delete( 'test-channel', 'manual-chat', 'test-agent' );
+smoke_assert(
+	null,
+	\AgentsAPI\AI\Channels\WP_Agent_Channel_Session_Map::get( 'test-channel', 'manual-chat', 'test-agent' ),
+	'session_map_static_delete',
+	$failures,
+	$passes
+);
 
 // 1b. Override hooks for attachments / external_message_id / room_kind / source.
 class Rich_Channel extends Test_Channel {
@@ -207,6 +262,19 @@ smoke_assert(
 smoke_assert( 'wamid.123', $rich_ability->calls[0]['client_context']['external_message_id'] ?? null, 'rich_payload_external_message_id', $failures, $passes );
 smoke_assert( 'group', $rich_ability->calls[0]['client_context']['room_kind'] ?? null, 'rich_payload_room_kind', $failures, $passes );
 smoke_assert( 'bridge', $rich_ability->calls[0]['client_context']['source'] ?? null, 'rich_payload_source_overridden', $failures, $passes );
+smoke_assert( 'test-channel', $rich_ability->calls[0]['client_context']['connector_id'] ?? null, 'rich_payload_connector_id', $failures, $passes );
+
+// 1c. Channels with legacy/custom session keys keep that override path.
+class Custom_Key_Channel extends Test_Channel {
+	protected function session_storage_key(): string {
+		return 'legacy_custom_session_key_' . $this->external_id;
+	}
+}
+$custom_key_ability = new Fake_Ability( array( 'reply' => 'legacy key', 'session_id' => 'sess-legacy' ) );
+$GLOBALS['__channel_smoke_abilities']['agents/chat'] = $custom_key_ability;
+$custom_key = new Custom_Key_Channel( 'chat-legacy' );
+$custom_key->handle( array( 'text' => 'use custom key' ) );
+smoke_assert( 'sess-legacy', get_option( 'legacy_custom_session_key_chat-legacy' ), 'custom_session_key_override_is_preserved', $failures, $passes );
 
 // 2. Session continuity: second turn passes the stored session_id.
 $happy_ability2 = new Fake_Ability(


### PR DESCRIPTION
## Summary
- Add a normalized `WP_Agent_External_Message` value object for channel and bridge payload metadata.
- Add a pluggable channel session map/store abstraction with an option-backed default scoped by connector, external conversation, and agent.
- Wire `WP_Agent_Channel` payload construction through the normalized message shape while preserving custom `session_storage_key()` overrides.

Closes #102.

## Testing
- `composer test`
- `php tests/channels-smoke.php`
- `homeboy lint --force-hot`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the implementation, smoke coverage, lint cleanup, and PR description; Chris remains responsible for review and merge.