### PR TITLE
Add plugin version header

### DIFF
--- a/agents-api.php
+++ b/agents-api.php
@@ -2,6 +2,7 @@
 /**
  * Plugin Name: Agents API
  * Description: WordPress-shaped agent runtime substrate.
+ * Version: 0.1.0
  * Requires at least: 7.0
  * Requires PHP: 8.1
  * Author: Automattic


### PR DESCRIPTION
## Summary
- Add a `Version` header to `agents-api.php` so WordPress/Homeboy packaging can extract plugin metadata.

## Validation
- `php -l agents-api.php`
- `homeboy deploy intelligence-chubes4 agents-api --head --force` from this branch built and deployed successfully after the header was added.
- `studio wp plugin list --format=json` now reports `agents-api` active at `0.1.0` on `intelligence-chubes4`.

## Context
Data Machine now consumes Agents API as a runtime plugin dependency. Deploying Data Machine `0.106.1` exposed that the Agents API plugin package lacked a version header, which blocked Homeboy's WordPress build metadata extraction.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the deploy failure, added the minimal plugin metadata, and validated the site boot/deploy path; Chris directed the Data Machine release and deploy.