### PR TITLE
Workflows: unopinionated substrate (Spec, Runner, abilities, AS bridge)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Agents API is a WordPress-shaped backend substrate for durable agent runtime beh
 
 Agents API is maintained by Automattic as a standalone WordPress substrate package.
 
-It provides generic contracts and value objects that product plugins can build on without copying agent runtime primitives into every product. It is not a workflow product, an admin application, or a provider-specific AI client.
+It provides generic contracts and value objects that product plugins can build on without copying agent runtime primitives into every product. It is not an admin application or a provider-specific AI client. It ships **workflow plumbing** (spec value object, validator, runner skeleton, in-memory registry, three abilities, optional Action Scheduler bridge) but does **not** ship a concrete workflow runtime, durable run history, scheduling stack, editor UI, or product-specific step types — those are consumer concerns.
 
 ## Layer Boundary
 
@@ -38,11 +38,12 @@ Agents API sits between tool/action discovery and product-specific automation. I
 - Tool source registration, parameter normalization, tool-call mediation, and execution result contracts.
 - Session and persistence contracts where they are provider-neutral.
 - Retrieved context authority vocabulary, context item shape, and conflict resolution contracts.
+- Workflow spec value object, structural validator, in-memory registry, abstract runner with `ability` and `agent` step types, `Store` and `Run_Recorder` interfaces, optional Action Scheduler bridge, and three canonical abilities (`agents/run-workflow`, `agents/validate-workflow`, `agents/describe-workflow`).
 
 ## What Agents API Does Not Own
 
 - Provider-specific request code. `wp-ai-client` owns provider/model prompt execution.
-- Product workflows such as flows, pipelines, jobs, handlers, queues, retention, and content operations.
+- Concrete workflow runtimes, durable workflow / run history, scheduling adapters beyond the optional Action Scheduler bridge, workflow editor UI, and product-specific step types (`branch`, `parallel`, nested `workflow`). The substrate provides the contract surface; consumers ship the persistence and product UX.
 - Product UI such as admin pages, settings screens, dashboards, or onboarding.
 - Product CLI commands beyond generic substrate needs.
 - Public REST controllers in v1 unless they are separately designed.
@@ -152,6 +153,17 @@ wp_register_agent(
 - `AgentsAPI\AI\Context\WP_Agent_Context_Conflict_Resolution`
 - `AgentsAPI\AI\Context\WP_Agent_Context_Conflict_Resolver`
 - `AgentsAPI\AI\Context\WP_Agent_Default_Context_Conflict_Resolver`
+- `wp_register_workflow()` / `wp_get_workflow()`
+- `AgentsAPI\AI\Workflows\WP_Agent_Workflow_Spec`
+- `AgentsAPI\AI\Workflows\WP_Agent_Workflow_Spec_Validator`
+- `AgentsAPI\AI\Workflows\WP_Agent_Workflow_Bindings`
+- `AgentsAPI\AI\Workflows\WP_Agent_Workflow_Run_Result`
+- `AgentsAPI\AI\Workflows\WP_Agent_Workflow_Store`
+- `AgentsAPI\AI\Workflows\WP_Agent_Workflow_Run_Recorder`
+- `AgentsAPI\AI\Workflows\WP_Agent_Workflow_Runner`
+- `AgentsAPI\AI\Workflows\WP_Agent_Workflow_Registry`
+- `AgentsAPI\AI\Workflows\WP_Agent_Workflow_Action_Scheduler_Bridge`
+- `AgentsAPI\AI\Workflows\register_workflow_handler()`
 - `WP_Agent_Tool_Policy`
 - `WP_Agent_Tool_Policy_Filter`
 - `WP_Agent_Tool_Access_Policy`

--- a/agents-api.php
+++ b/agents-api.php
@@ -125,6 +125,7 @@ require_once AGENTS_API_PATH . 'src/Workflows/class-wp-agent-workflow-run-record
 require_once AGENTS_API_PATH . 'src/Workflows/class-wp-agent-workflow-runner.php';
 require_once AGENTS_API_PATH . 'src/Workflows/class-wp-agent-workflow-registry.php';
 require_once AGENTS_API_PATH . 'src/Workflows/class-wp-agent-workflow-action-scheduler-bridge.php';
+require_once AGENTS_API_PATH . 'src/Workflows/register-workflows.php';
 require_once AGENTS_API_PATH . 'src/Workflows/register-agents-workflow-abilities.php';
 
 add_action( 'init', array( 'WP_Agents_Registry', 'init' ), 10 );

--- a/agents-api.php
+++ b/agents-api.php
@@ -116,6 +116,16 @@ require_once AGENTS_API_PATH . 'src/Guidelines/guidelines.php';
 require_once AGENTS_API_PATH . 'src/Guidelines/class-wp-guidelines-substrate.php';
 require_once AGENTS_API_PATH . 'src/Channels/class-wp-agent-channel.php';
 require_once AGENTS_API_PATH . 'src/Channels/register-agents-chat-ability.php';
+require_once AGENTS_API_PATH . 'src/Workflows/class-wp-agent-workflow-bindings.php';
+require_once AGENTS_API_PATH . 'src/Workflows/class-wp-agent-workflow-spec-validator.php';
+require_once AGENTS_API_PATH . 'src/Workflows/class-wp-agent-workflow-spec.php';
+require_once AGENTS_API_PATH . 'src/Workflows/class-wp-agent-workflow-run-result.php';
+require_once AGENTS_API_PATH . 'src/Workflows/class-wp-agent-workflow-store.php';
+require_once AGENTS_API_PATH . 'src/Workflows/class-wp-agent-workflow-run-recorder.php';
+require_once AGENTS_API_PATH . 'src/Workflows/class-wp-agent-workflow-runner.php';
+require_once AGENTS_API_PATH . 'src/Workflows/class-wp-agent-workflow-registry.php';
+require_once AGENTS_API_PATH . 'src/Workflows/class-wp-agent-workflow-action-scheduler-bridge.php';
+require_once AGENTS_API_PATH . 'src/Workflows/register-agents-workflow-abilities.php';
 
 add_action( 'init', array( 'WP_Agents_Registry', 'init' ), 10 );
 add_action( 'init', array( 'WP_Guidelines_Substrate', 'register' ), 9 );

--- a/composer.json
+++ b/composer.json
@@ -46,6 +46,10 @@
       "php tests/conversation-loop-budgets-smoke.php",
       "php tests/context-authority-smoke.php",
       "php tests/guidelines-substrate-smoke.php",
+      "php tests/workflow-bindings-smoke.php",
+      "php tests/workflow-spec-validator-smoke.php",
+      "php tests/workflow-runner-smoke.php",
+      "php tests/agents-workflow-ability-smoke.php",
       "php tests/no-product-imports-smoke.php"
     ]
   }

--- a/src/Workflows/class-wp-agent-workflow-action-scheduler-bridge.php
+++ b/src/Workflows/class-wp-agent-workflow-action-scheduler-bridge.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ * Optional Action Scheduler bridge for `cron`-triggered workflows.
+ *
+ * agents-api does not require Action Scheduler. Consumers that want
+ * scheduled workflow runs can either:
+ *
+ *   - Install Action Scheduler themselves (it ships with WooCommerce, can
+ *     be installed standalone via composer) — this bridge will detect the
+ *     `as_*` functions and use them.
+ *   - Skip cron entirely and rely on `on_demand` / `wp_action` triggers.
+ *   - Wire their own scheduler — the bridge fires
+ *     `wp_agent_workflow_schedule_requested` so a custom scheduler can
+ *     pick up the same trigger declaration.
+ *
+ * The bridge is a thin static helper, not a hard dependency. Calling
+ * `is_available()` first is the polite check; `register()` no-ops cleanly
+ * if AS isn't loaded.
+ *
+ * @package AgentsAPI
+ * @since   0.103.0
+ */
+
+namespace AgentsAPI\AI\Workflows;
+
+defined( 'ABSPATH' ) || exit;
+
+final class WP_Agent_Workflow_Action_Scheduler_Bridge {
+
+	/** @since 0.103.0 */
+	public const SCHEDULED_HOOK = 'wp_agent_workflow_run_scheduled';
+
+	/** @since 0.103.0 */
+	public const GROUP = 'agents-api';
+
+	public static function is_available(): bool {
+		return function_exists( 'as_schedule_recurring_action' )
+			&& function_exists( 'as_schedule_cron_action' )
+			&& function_exists( 'as_unschedule_all_actions' );
+	}
+
+	/**
+	 * Register every `cron` trigger on the spec with Action Scheduler.
+	 * Existing schedules for the same workflow are unscheduled first to
+	 * make this idempotent — call freely on every plugin boot.
+	 *
+	 * Cron triggers may use either `interval` (seconds, recurring) or
+	 * `expression` (cron string). Mixed usage in a single trigger entry
+	 * was rejected by the validator.
+	 *
+	 * @since 0.103.0
+	 *
+	 * @param WP_Agent_Workflow_Spec $spec
+	 * @return int Number of schedules registered.
+	 */
+	public static function register( WP_Agent_Workflow_Spec $spec ): int {
+		$count = 0;
+		foreach ( $spec->get_triggers() as $trigger ) {
+			if ( 'cron' !== ( $trigger['type'] ?? '' ) ) {
+				continue;
+			}
+
+			/**
+			 * Fires whenever the bridge would schedule a cron trigger,
+			 * regardless of whether Action Scheduler is loaded. Custom
+			 * schedulers can hook this to take over.
+			 *
+			 * @since 0.103.0
+			 *
+			 * @param WP_Agent_Workflow_Spec $spec
+			 * @param array                  $trigger
+			 */
+			do_action( 'wp_agent_workflow_schedule_requested', $spec, $trigger );
+
+			if ( ! self::is_available() ) {
+				continue;
+			}
+
+			$args = array( 'workflow_id' => $spec->get_id() );
+
+			// Unschedule prior occurrences for idempotency.
+			as_unschedule_all_actions( self::SCHEDULED_HOOK, $args, self::GROUP );
+
+			if ( ! empty( $trigger['expression'] ) ) {
+				as_schedule_cron_action(
+					time(),
+					(string) $trigger['expression'],
+					self::SCHEDULED_HOOK,
+					$args,
+					self::GROUP
+				);
+			} elseif ( ! empty( $trigger['interval'] ) ) {
+				as_schedule_recurring_action(
+					time(),
+					(int) $trigger['interval'],
+					self::SCHEDULED_HOOK,
+					$args,
+					self::GROUP
+				);
+			}
+
+			++$count;
+		}
+
+		return $count;
+	}
+
+	/**
+	 * Cancel every scheduled action this bridge owns for the given
+	 * workflow id. Useful on workflow deletion or version bump.
+	 *
+	 * @since 0.103.0
+	 */
+	public static function unregister( string $workflow_id ): void {
+		if ( ! self::is_available() ) {
+			return;
+		}
+		as_unschedule_all_actions(
+			self::SCHEDULED_HOOK,
+			array( 'workflow_id' => $workflow_id ),
+			self::GROUP
+		);
+	}
+}

--- a/src/Workflows/class-wp-agent-workflow-bindings.php
+++ b/src/Workflows/class-wp-agent-workflow-bindings.php
@@ -133,7 +133,7 @@ final class WP_Agent_Workflow_Bindings {
 
 		if ( 'steps' === $root ) {
 			$step_id = array_shift( $segments );
-			if ( null === $step_id || '' === $step_id ) {
+			if ( null === $step_id ) {
 				return null;
 			}
 			$step = $context['steps'][ $step_id ] ?? null;

--- a/src/Workflows/class-wp-agent-workflow-bindings.php
+++ b/src/Workflows/class-wp-agent-workflow-bindings.php
@@ -114,7 +114,12 @@ final class WP_Agent_Workflow_Bindings {
 	 * @return mixed|null
 	 */
 	public static function resolve_path( string $expression, array $context ) {
-		$segments = array_values( array_filter( explode( '.', $expression ), 'strlen' ) );
+		$segments = array_values(
+			array_filter(
+				explode( '.', $expression ),
+				static fn ( string $segment ): bool => '' !== $segment
+			)
+		);
 		if ( count( $segments ) < 2 ) {
 			return null;
 		}

--- a/src/Workflows/class-wp-agent-workflow-bindings.php
+++ b/src/Workflows/class-wp-agent-workflow-bindings.php
@@ -1,0 +1,173 @@
+<?php
+/**
+ * Template-string binding resolver for workflow steps.
+ *
+ * A workflow step's `args` (or `message`, or any other field a runner asks
+ * the resolver to expand) may contain `${...}` references that pull values
+ * from the workflow's static inputs or from previous steps' outputs:
+ *
+ *     ${inputs.<dot.path>}            // workflow input
+ *     ${steps.<step_id>.output.<dot.path>}  // earlier step output
+ *
+ * Resolution is deliberately conservative: the helper substitutes whole
+ * template expressions atomically (so binding a non-string value into a
+ * non-string slot replaces the slot, not just a substring of it), and a
+ * binding that targets a missing path returns `null` rather than the
+ * literal `${...}` string. Callers that need stricter behavior can check
+ * for `null` after expansion.
+ *
+ * The token vocabulary is intentionally minimal — `inputs.*` and
+ * `steps.<id>.output.*`. Anything else (env vars, user-context, secrets)
+ * needs to be introduced via a dedicated runtime hook so the contract
+ * stays auditable.
+ *
+ * @package AgentsAPI
+ * @since   0.103.0
+ */
+
+namespace AgentsAPI\AI\Workflows;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Pure helper. No state, no construction — call the static methods.
+ *
+ * @since 0.103.0
+ */
+final class WP_Agent_Workflow_Bindings {
+
+	/**
+	 * Pattern for a single `${...}` binding. Matches lazily so multiple
+	 * templates on one line resolve independently.
+	 *
+	 * @since 0.103.0
+	 *
+	 * @var string
+	 */
+	private const TEMPLATE_PATTERN = '/\$\{([^}]+)\}/';
+
+	/**
+	 * Recursively expand bindings inside `$value`. Strings get their
+	 * `${...}` tokens substituted; arrays are walked depth-first; scalars
+	 * other than strings pass through unchanged.
+	 *
+	 * @since 0.103.0
+	 *
+	 * @param mixed $value   Raw spec fragment (string, array, scalar).
+	 * @param array $context Resolution context. Required keys:
+	 *                       - `inputs` (array): workflow input values.
+	 *                       - `steps`  (array<string,array>): each entry
+	 *                         shaped `[ 'output' => mixed ]`, keyed by step id.
+	 * @return mixed Expanded value. Strings whose entire content was a single
+	 *               template expression are returned as the underlying value
+	 *               (preserving its type).
+	 */
+	public static function expand( $value, array $context ) {
+		if ( is_array( $value ) ) {
+			$expanded = array();
+			foreach ( $value as $key => $inner ) {
+				$expanded[ $key ] = self::expand( $inner, $context );
+			}
+			return $expanded;
+		}
+
+		if ( ! is_string( $value ) ) {
+			return $value;
+		}
+
+		// Whole-string atomic substitution: if the value is exactly one
+		// template expression, return the resolved value with its native
+		// type — caller asked for an array / int / null and that's what
+		// they get, not a stringified version.
+		if ( preg_match( '/^\$\{([^}]+)\}$/', $value, $matches ) ) {
+			return self::resolve_path( trim( $matches[1] ), $context );
+		}
+
+		// Mixed content: substitute every template, coercing each
+		// resolved value to string. Missing paths → empty string.
+		return (string) preg_replace_callback(
+			self::TEMPLATE_PATTERN,
+			static function ( array $m ) use ( $context ): string {
+				$resolved = self::resolve_path( trim( $m[1] ), $context );
+				if ( null === $resolved || is_array( $resolved ) || is_object( $resolved ) ) {
+					return '';
+				}
+				if ( is_bool( $resolved ) ) {
+					return $resolved ? 'true' : 'false';
+				}
+				return (string) $resolved;
+			},
+			$value
+		);
+	}
+
+	/**
+	 * Resolve a single `inputs.<path>` or `steps.<id>.output.<path>`
+	 * reference against the resolution context. Returns null on miss
+	 * (rather than the original token) so callers can distinguish
+	 * "missing" from "intentionally empty string".
+	 *
+	 * @since 0.103.0
+	 *
+	 * @param string $expression Path expression without the surrounding `${}`.
+	 * @param array  $context    Resolution context (see {@see expand()}).
+	 * @return mixed|null
+	 */
+	public static function resolve_path( string $expression, array $context ) {
+		$segments = array_values( array_filter( explode( '.', $expression ), 'strlen' ) );
+		if ( count( $segments ) < 2 ) {
+			return null;
+		}
+
+		$root = array_shift( $segments );
+
+		if ( 'inputs' === $root ) {
+			$source = $context['inputs'] ?? array();
+			return self::walk( $source, $segments );
+		}
+
+		if ( 'steps' === $root ) {
+			$step_id = array_shift( $segments );
+			if ( null === $step_id || '' === $step_id ) {
+				return null;
+			}
+			$step = $context['steps'][ $step_id ] ?? null;
+			if ( ! is_array( $step ) ) {
+				return null;
+			}
+			// `steps.<id>.output.<path>` is the only supported shape today.
+			$next = array_shift( $segments );
+			if ( 'output' !== $next ) {
+				return null;
+			}
+			return self::walk( $step['output'] ?? null, $segments );
+		}
+
+		return null;
+	}
+
+	/**
+	 * Walk a dot-separated path into a nested array. Supports numeric
+	 * indices for arrays. Returns the located value or null on miss.
+	 *
+	 * @since 0.103.0
+	 *
+	 * @param mixed         $value
+	 * @param array<string> $segments
+	 * @return mixed|null
+	 */
+	private static function walk( $value, array $segments ) {
+		foreach ( $segments as $segment ) {
+			if ( is_array( $value ) && array_key_exists( $segment, $value ) ) {
+				$value = $value[ $segment ];
+				continue;
+			}
+			if ( is_array( $value ) && ctype_digit( (string) $segment ) && array_key_exists( (int) $segment, $value ) ) {
+				$value = $value[ (int) $segment ];
+				continue;
+			}
+			return null;
+		}
+		return $value;
+	}
+}

--- a/src/Workflows/class-wp-agent-workflow-registry.php
+++ b/src/Workflows/class-wp-agent-workflow-registry.php
@@ -1,0 +1,129 @@
+<?php
+/**
+ * In-memory registry of code-defined workflow specs.
+ *
+ * Mirrors the agent / ability registries: plugins call
+ * {@see wp_register_workflow()} during the appropriate boot action and the
+ * substrate keeps the resolved Spec in process memory for the duration of
+ * the request. Pairs with a {@see WP_Agent_Workflow_Store} for durable
+ * (DB-backed) workflows; consumers can query both layers and merge as
+ * they prefer.
+ *
+ * The registry is deliberately stateless across requests — it's not a
+ * cache. Use a Store for persistence.
+ *
+ * @package AgentsAPI
+ * @since   0.103.0
+ */
+
+namespace AgentsAPI\AI\Workflows;
+
+use WP_Error;
+
+defined( 'ABSPATH' ) || exit;
+
+final class WP_Agent_Workflow_Registry {
+
+	/**
+	 * @var array<string,WP_Agent_Workflow_Spec>
+	 */
+	private static array $workflows = array();
+
+	/**
+	 * Register a workflow from a raw spec array. Validation runs first;
+	 * on failure the registry returns the WP_Error and the workflow is
+	 * not stored.
+	 *
+	 * @since 0.103.0
+	 *
+	 * @param array $raw
+	 * @return WP_Agent_Workflow_Spec|WP_Error
+	 */
+	public static function register( array $raw ) {
+		$spec = WP_Agent_Workflow_Spec::from_array( $raw );
+		if ( $spec instanceof WP_Error ) {
+			return $spec;
+		}
+
+		self::$workflows[ $spec->get_id() ] = $spec;
+
+		/**
+		 * Fires after a workflow is added to the in-memory registry.
+		 *
+		 * @since 0.103.0
+		 *
+		 * @param WP_Agent_Workflow_Spec $spec
+		 */
+		do_action( 'wp_agent_workflow_registered', $spec );
+
+		return $spec;
+	}
+
+	/**
+	 * Remove a registered workflow. Returns true on success, false if the
+	 * id was not registered.
+	 *
+	 * @since 0.103.0
+	 *
+	 * @param string $workflow_id
+	 * @return bool
+	 */
+	public static function unregister( string $workflow_id ): bool {
+		if ( ! isset( self::$workflows[ $workflow_id ] ) ) {
+			return false;
+		}
+		unset( self::$workflows[ $workflow_id ] );
+		return true;
+	}
+
+	public static function find( string $workflow_id ): ?WP_Agent_Workflow_Spec {
+		return self::$workflows[ $workflow_id ] ?? null;
+	}
+
+	/**
+	 * @return WP_Agent_Workflow_Spec[]
+	 */
+	public static function all(): array {
+		return array_values( self::$workflows );
+	}
+
+	/**
+	 * Test-only: clear the in-memory registry. Production code never needs
+	 * this; it's exposed for unit tests that share the autoload-loaded
+	 * static state across cases.
+	 *
+	 * @since 0.103.0
+	 */
+	public static function reset(): void {
+		self::$workflows = array();
+	}
+}
+
+if ( ! function_exists( 'wp_register_workflow' ) ) {
+	/**
+	 * Convenience wrapper: register a code-defined workflow from a raw spec
+	 * array. Returns the validated Spec or a WP_Error on validation failure.
+	 *
+	 * @since 0.103.0
+	 *
+	 * @param array $spec
+	 * @return WP_Agent_Workflow_Spec|WP_Error
+	 */
+	function wp_register_workflow( array $spec ) {
+		return WP_Agent_Workflow_Registry::register( $spec );
+	}
+}
+
+if ( ! function_exists( 'wp_get_workflow' ) ) {
+	/**
+	 * Convenience wrapper: look up a registered workflow by id.
+	 *
+	 * @since 0.103.0
+	 *
+	 * @param string $workflow_id
+	 * @return WP_Agent_Workflow_Spec|null
+	 */
+	function wp_get_workflow( string $workflow_id ): ?WP_Agent_Workflow_Spec {
+		return WP_Agent_Workflow_Registry::find( $workflow_id );
+	}
+}

--- a/src/Workflows/class-wp-agent-workflow-registry.php
+++ b/src/Workflows/class-wp-agent-workflow-registry.php
@@ -60,17 +60,22 @@ final class WP_Agent_Workflow_Registry {
 	}
 
 	/**
-	 * Remove a registered workflow. Returns true on success, false if the
-	 * id was not registered.
+	 * Remove a registered workflow. Returns true on success or a
+	 * `WP_Error` with code `not_registered` when the id was never added —
+	 * mirrors the `Store::delete()` return shape so consumers don't have
+	 * to special-case the in-memory registry.
 	 *
 	 * @since 0.103.0
 	 *
 	 * @param string $workflow_id
-	 * @return bool
+	 * @return true|WP_Error
 	 */
-	public static function unregister( string $workflow_id ): bool {
+	public static function unregister( string $workflow_id ) {
 		if ( ! isset( self::$workflows[ $workflow_id ] ) ) {
-			return false;
+			return new WP_Error(
+				'not_registered',
+				sprintf( 'no workflow registered with id `%s`', $workflow_id )
+			);
 		}
 		unset( self::$workflows[ $workflow_id ] );
 		return true;
@@ -96,34 +101,5 @@ final class WP_Agent_Workflow_Registry {
 	 */
 	public static function reset(): void {
 		self::$workflows = array();
-	}
-}
-
-if ( ! function_exists( 'wp_register_workflow' ) ) {
-	/**
-	 * Convenience wrapper: register a code-defined workflow from a raw spec
-	 * array. Returns the validated Spec or a WP_Error on validation failure.
-	 *
-	 * @since 0.103.0
-	 *
-	 * @param array $spec
-	 * @return WP_Agent_Workflow_Spec|WP_Error
-	 */
-	function wp_register_workflow( array $spec ) {
-		return WP_Agent_Workflow_Registry::register( $spec );
-	}
-}
-
-if ( ! function_exists( 'wp_get_workflow' ) ) {
-	/**
-	 * Convenience wrapper: look up a registered workflow by id.
-	 *
-	 * @since 0.103.0
-	 *
-	 * @param string $workflow_id
-	 * @return WP_Agent_Workflow_Spec|null
-	 */
-	function wp_get_workflow( string $workflow_id ): ?WP_Agent_Workflow_Spec {
-		return WP_Agent_Workflow_Registry::find( $workflow_id );
 	}
 }

--- a/src/Workflows/class-wp-agent-workflow-run-recorder.php
+++ b/src/Workflows/class-wp-agent-workflow-run-recorder.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Recording contract for workflow run history.
+ *
+ * Run recorders are the persistence side of executions: every run that
+ * starts gets a row, the runner updates it as steps complete, and the
+ * UI / observability layer can query past runs without re-executing.
+ *
+ * Like {@see WP_Agent_Workflow_Store}, agents-api ships no default
+ * recorder. Consumers wire one against whatever storage they already
+ * use for jobs / runs — a custom post type, a custom table, an external
+ * observability system. Persistence detail stays a consumer concern.
+ *
+ * Implementations should be best-effort safe — losing a run record
+ * must not break a workflow's user-facing outcome. The runner tolerates
+ * recorder failures and continues.
+ *
+ * @package AgentsAPI
+ * @since   0.103.0
+ */
+
+namespace AgentsAPI\AI\Workflows;
+
+use WP_Error;
+
+defined( 'ABSPATH' ) || exit;
+
+interface WP_Agent_Workflow_Run_Recorder {
+
+	/**
+	 * Persist the start of a new run. Called by the runner before any step
+	 * executes. Returns the run id the runner should use for subsequent
+	 * updates — implementations may generate their own ids (post id, UUID,
+	 * row id) or accept and return the runner-suggested one.
+	 *
+	 * @since 0.103.0
+	 *
+	 * @param WP_Agent_Workflow_Run_Result $result Initial pending result.
+	 * @return string|WP_Error Persisted run id.
+	 */
+	public function start( WP_Agent_Workflow_Run_Result $result );
+
+	/**
+	 * Update an existing run's recorded state. Called by the runner as
+	 * steps progress and at completion.
+	 *
+	 * @since 0.103.0
+	 *
+	 * @param WP_Agent_Workflow_Run_Result $result Latest result.
+	 * @return true|WP_Error
+	 */
+	public function update( WP_Agent_Workflow_Run_Result $result );
+
+	/**
+	 * Look up a previously recorded run.
+	 *
+	 * @since 0.103.0
+	 *
+	 * @param string $run_id
+	 * @return WP_Agent_Workflow_Run_Result|null
+	 */
+	public function find( string $run_id ): ?WP_Agent_Workflow_Run_Result;
+
+	/**
+	 * Recent runs across (or filtered to) a workflow. `$args` accepted keys:
+	 * `workflow_id`, `limit`, `offset`. Implementations may accept more.
+	 *
+	 * @since 0.103.0
+	 *
+	 * @param array $args
+	 * @return WP_Agent_Workflow_Run_Result[]
+	 */
+	public function recent( array $args = array() ): array;
+}

--- a/src/Workflows/class-wp-agent-workflow-run-result.php
+++ b/src/Workflows/class-wp-agent-workflow-run-result.php
@@ -1,0 +1,163 @@
+<?php
+/**
+ * Immutable execution outcome of a single workflow run.
+ *
+ * Captures the per-step record (status, output, error) plus the overall
+ * status and the final output map. Run recorders persist this; callers
+ * inspect it to act on the result.
+ *
+ * Statuses:
+ *   `pending`   — recorded but not yet executed (used by recorders that
+ *                 commit a row before the runner picks the work up).
+ *   `running`   — currently executing.
+ *   `succeeded` — every step that ran returned without error.
+ *   `failed`    — at least one step returned a WP_Error or threw.
+ *   `skipped`   — the runner declined to execute (e.g. unknown step
+ *                 type that no consumer registered a handler for).
+ *
+ * Step records have the same statuses minus `pending` (steps either ran
+ * or didn't), plus a `started_at` / `ended_at` pair for timing.
+ *
+ * @package AgentsAPI
+ * @since   0.103.0
+ */
+
+namespace AgentsAPI\AI\Workflows;
+
+defined( 'ABSPATH' ) || exit;
+
+final class WP_Agent_Workflow_Run_Result {
+
+	public const STATUS_PENDING   = 'pending';
+	public const STATUS_RUNNING   = 'running';
+	public const STATUS_SUCCEEDED = 'succeeded';
+	public const STATUS_FAILED    = 'failed';
+	public const STATUS_SKIPPED   = 'skipped';
+
+	/**
+	 * @since 0.103.0
+	 *
+	 * @param string $run_id      Caller-stable id (UUID, post id, custom-table row id).
+	 * @param string $workflow_id Spec id this run belongs to.
+	 * @param string $status      One of the STATUS_* constants.
+	 * @param array  $inputs      Resolved inputs the run was started with.
+	 * @param array  $output      Final aggregated output map (or partial if failed).
+	 * @param array  $steps       List of step records, each shaped as
+	 *                            `[ id, type, status, output, error?, started_at, ended_at ]`.
+	 * @param array  $error       Top-level error info (`code`, `message`, `data`) when status === failed.
+	 * @param int    $started_at  Unix timestamp.
+	 * @param int    $ended_at    Unix timestamp; 0 while running.
+	 * @param array  $metadata    Free-form metadata for recorders / tracers (Langfuse trace ids, etc.).
+	 */
+	public function __construct(
+		private string $run_id,
+		private string $workflow_id,
+		private string $status,
+		private array $inputs,
+		private array $output,
+		private array $steps,
+		private array $error,
+		private int $started_at,
+		private int $ended_at,
+		private array $metadata
+	) {}
+
+	public static function pending( string $run_id, string $workflow_id, array $inputs, int $started_at ): self {
+		return new self( $run_id, $workflow_id, self::STATUS_PENDING, $inputs, array(), array(), array(), $started_at, 0, array() );
+	}
+
+	public function get_run_id(): string {
+		return $this->run_id;
+	}
+
+	public function get_workflow_id(): string {
+		return $this->workflow_id;
+	}
+
+	public function get_status(): string {
+		return $this->status;
+	}
+
+	public function get_inputs(): array {
+		return $this->inputs;
+	}
+
+	public function get_output(): array {
+		return $this->output;
+	}
+
+	public function get_steps(): array {
+		return $this->steps;
+	}
+
+	public function get_error(): array {
+		return $this->error;
+	}
+
+	public function get_started_at(): int {
+		return $this->started_at;
+	}
+
+	public function get_ended_at(): int {
+		return $this->ended_at;
+	}
+
+	public function get_metadata(): array {
+		return $this->metadata;
+	}
+
+	public function is_succeeded(): bool {
+		return self::STATUS_SUCCEEDED === $this->status;
+	}
+
+	public function is_failed(): bool {
+		return self::STATUS_FAILED === $this->status;
+	}
+
+	/**
+	 * Return a new result with updated fields. Run results are immutable; the
+	 * runner builds a fresh instance per state change rather than mutating.
+	 *
+	 * @since 0.103.0
+	 *
+	 * @param array $patch Field => new value. Unknown keys are ignored.
+	 * @return self
+	 */
+	public function with( array $patch ): self {
+		return new self(
+			(string) ( $patch['run_id'] ?? $this->run_id ),
+			(string) ( $patch['workflow_id'] ?? $this->workflow_id ),
+			(string) ( $patch['status'] ?? $this->status ),
+			(array) ( $patch['inputs'] ?? $this->inputs ),
+			(array) ( $patch['output'] ?? $this->output ),
+			(array) ( $patch['steps'] ?? $this->steps ),
+			(array) ( $patch['error'] ?? $this->error ),
+			(int) ( $patch['started_at'] ?? $this->started_at ),
+			(int) ( $patch['ended_at'] ?? $this->ended_at ),
+			(array) ( $patch['metadata'] ?? $this->metadata ),
+		);
+	}
+
+	/**
+	 * Render to a plain array. Useful for recorders that want to serialise
+	 * the run record verbatim (CPT meta, JSON column, REST response).
+	 *
+	 * @since 0.103.0
+	 *
+	 * @return array
+	 */
+	public function to_array(): array {
+		return array(
+			'run_id'      => $this->run_id,
+			'workflow_id' => $this->workflow_id,
+			'status'      => $this->status,
+			'inputs'      => $this->inputs,
+			'output'      => $this->output,
+			'steps'       => $this->steps,
+			'error'       => $this->error,
+			'started_at'  => $this->started_at,
+			'ended_at'    => $this->ended_at,
+			'metadata'    => $this->metadata,
+		);
+	}
+}

--- a/src/Workflows/class-wp-agent-workflow-runner.php
+++ b/src/Workflows/class-wp-agent-workflow-runner.php
@@ -134,7 +134,7 @@ class WP_Agent_Workflow_Runner {
 					)
 				);
 			}
-			if ( is_string( $persisted ) && '' !== $persisted ) {
+			if ( '' !== $persisted ) {
 				$result = $result->with( array( 'run_id' => $persisted ) );
 			}
 		}
@@ -212,7 +212,7 @@ class WP_Agent_Workflow_Runner {
 					'message' => $step_output->get_error_message(),
 					'data'    => $step_output->get_error_data(),
 				);
-				$step_records[] = $record;
+				$step_records[]     = $record;
 
 				$failed        = true;
 				$failure_error = $record['error'];
@@ -355,7 +355,7 @@ class WP_Agent_Workflow_Runner {
 				'agents/chat ability is not registered.'
 			);
 		}
-		$input = array(
+		$input  = array(
 			'agent'      => (string) ( $step['agent'] ?? '' ),
 			'message'    => (string) ( $step['message'] ?? '' ),
 			'session_id' => $step['session_id'] ?? null,

--- a/src/Workflows/class-wp-agent-workflow-runner.php
+++ b/src/Workflows/class-wp-agent-workflow-runner.php
@@ -1,0 +1,374 @@
+<?php
+/**
+ * Workflow runner — executes a {@see WP_Agent_Workflow_Spec} step-by-step.
+ *
+ * The runner is intentionally narrow:
+ *
+ *   1. Validate inputs against the spec's input schema (presence + type).
+ *   2. Walk steps in order. For each step:
+ *        a. Resolve `${...}` bindings against `inputs` + earlier step outputs.
+ *        b. Dispatch to a step-type handler (`ability` / `agent` ship by
+ *           default; consumers register more via the handler map).
+ *        c. Record the per-step outcome (status, output, error, timing).
+ *        d. If the step failed and the spec didn't opt into `continue_on_error`,
+ *           short-circuit the run.
+ *   3. Update the recorder once at start, once per step, and once at end.
+ *   4. Return a final {@see WP_Agent_Workflow_Run_Result}.
+ *
+ * What the runner does NOT do:
+ *   - Branching, parallelism, nested workflows. Step-handler map is the
+ *     extension point for those — a consumer can register a `branch`
+ *     handler that runs a sub-list, or a `workflow` handler that calls
+ *     this runner recursively.
+ *   - Triggering. Triggers are wired separately
+ *     ({@see WP_Agent_Workflow_Action_Scheduler_Bridge} for cron, and a
+ *     consumer-registered listener for `wp_action`). The runner only
+ *     executes; it doesn't schedule or hook.
+ *   - Storage. Specs come in as Spec instances (often pulled from a
+ *     {@see WP_Agent_Workflow_Store} or registry); recorders persist
+ *     run history.
+ *
+ * Usage:
+ *
+ *     $runner = new WP_Agent_Workflow_Runner( $recorder, $step_handlers );
+ *     $result = $runner->run( $spec, [ 'comment_id' => 42 ] );
+ *
+ * @package AgentsAPI
+ * @since   0.103.0
+ */
+
+namespace AgentsAPI\AI\Workflows;
+
+use WP_Error;
+
+defined( 'ABSPATH' ) || exit;
+
+class WP_Agent_Workflow_Runner {
+
+	/**
+	 * @var array<string,callable> Step type → handler. Each handler receives
+	 *                             ( array $resolved_step, array $context ) and
+	 *                             returns array|WP_Error. Consumers extend
+	 *                             via the constructor or the
+	 *                             `wp_agent_workflow_step_handlers` filter.
+	 */
+	protected array $step_handlers;
+
+	public function __construct(
+		protected ?WP_Agent_Workflow_Run_Recorder $recorder = null,
+		array $step_handlers = array()
+	) {
+		$defaults = array(
+			'ability' => array( __CLASS__, 'default_ability_handler' ),
+			'agent'   => array( __CLASS__, 'default_agent_handler' ),
+		);
+
+		/**
+		 * Filter the step-type handler map. Consumers add new step types
+		 * (`branch`, `parallel`, `workflow`, …) by registering a callable
+		 * here. Default `ability` and `agent` handlers can also be replaced
+		 * if a consumer wants to substitute a different ability / agent
+		 * runtime.
+		 *
+		 * @since 0.103.0
+		 *
+		 * @param array<string,callable> $handlers Default + caller-supplied handlers.
+		 */
+		$this->step_handlers = (array) apply_filters(
+			'wp_agent_workflow_step_handlers',
+			array_merge( $defaults, $step_handlers )
+		);
+	}
+
+	/**
+	 * Execute a workflow.
+	 *
+	 * @since 0.103.0
+	 *
+	 * @param WP_Agent_Workflow_Spec $spec
+	 * @param array                  $inputs Caller-supplied inputs. Required
+	 *                                       inputs missing here cause an early
+	 *                                       failure with a structured error.
+	 * @param array                  $options Runtime options:
+	 *                                        - `run_id` (string, optional): caller-suggested run id.
+	 *                                        - `continue_on_error` (bool): keep running after a failed step. Default false.
+	 *                                        - `metadata` (array): forwarded to the run result.
+	 * @return WP_Agent_Workflow_Run_Result
+	 */
+	public function run( WP_Agent_Workflow_Spec $spec, array $inputs = array(), array $options = array() ): WP_Agent_Workflow_Run_Result {
+		$started_at = time();
+		$run_id     = (string) ( $options['run_id'] ?? self::generate_run_id() );
+		$metadata   = (array) ( $options['metadata'] ?? array() );
+
+		$result = new WP_Agent_Workflow_Run_Result(
+			$run_id,
+			$spec->get_id(),
+			WP_Agent_Workflow_Run_Result::STATUS_RUNNING,
+			$inputs,
+			array(),
+			array(),
+			array(),
+			$started_at,
+			0,
+			$metadata
+		);
+
+		// Validate inputs against the spec's input declarations.
+		$input_error = self::validate_inputs( $spec, $inputs );
+		if ( null !== $input_error ) {
+			return $this->record_and_return(
+				$result->with(
+					array(
+						'status'   => WP_Agent_Workflow_Run_Result::STATUS_FAILED,
+						'error'    => $input_error,
+						'ended_at' => time(),
+					)
+				),
+				/*is_start*/ true
+			);
+		}
+
+		// Persist the start. Recorder may rewrite the run id (CPT post id, …).
+		if ( $this->recorder ) {
+			$persisted = $this->recorder->start( $result );
+			if ( is_string( $persisted ) && '' !== $persisted ) {
+				$result = $result->with( array( 'run_id' => $persisted ) );
+			}
+		}
+
+		$context = array(
+			'inputs' => $inputs,
+			'steps'  => array(), // step_id => [ 'output' => ... ]
+		);
+
+		$step_records      = array();
+		$continue_on_error = ! empty( $options['continue_on_error'] );
+		$failed            = false;
+		$failure_error     = array();
+
+		foreach ( $spec->get_steps() as $step ) {
+			$step_id   = (string) $step['id'];
+			$type      = (string) $step['type'];
+			$start_ts  = time();
+			$resolved  = WP_Agent_Workflow_Bindings::expand( $step, $context );
+			$record    = array(
+				'id'         => $step_id,
+				'type'       => $type,
+				'status'     => WP_Agent_Workflow_Run_Result::STATUS_RUNNING,
+				'output'     => null,
+				'started_at' => $start_ts,
+				'ended_at'   => 0,
+			);
+
+			$handler = $this->step_handlers[ $type ] ?? null;
+			if ( ! is_callable( $handler ) ) {
+				$record['status']   = WP_Agent_Workflow_Run_Result::STATUS_SKIPPED;
+				$record['ended_at'] = time();
+				$record['error']    = array(
+					'code'    => 'no_step_handler',
+					'message' => sprintf( 'no handler registered for step type `%s`', $type ),
+				);
+				$step_records[]     = $record;
+
+				$failed        = true;
+				$failure_error = $record['error'];
+				$result        = $result->with( array( 'steps' => $step_records ) );
+				if ( $this->recorder ) {
+					$this->recorder->update( $result );
+				}
+				if ( ! $continue_on_error ) {
+					break;
+				}
+				continue;
+			}
+
+			$step_output = call_user_func( $handler, $resolved, $context );
+
+			if ( is_wp_error( $step_output ) ) {
+				$record['status']   = WP_Agent_Workflow_Run_Result::STATUS_FAILED;
+				$record['ended_at'] = time();
+				$record['error']    = array(
+					'code'    => $step_output->get_error_code(),
+					'message' => $step_output->get_error_message(),
+					'data'    => $step_output->get_error_data(),
+				);
+				$step_records[] = $record;
+
+				$failed        = true;
+				$failure_error = $record['error'];
+				$result        = $result->with( array( 'steps' => $step_records ) );
+				if ( $this->recorder ) {
+					$this->recorder->update( $result );
+				}
+				if ( ! $continue_on_error ) {
+					break;
+				}
+				continue;
+			}
+
+			$record['status']   = WP_Agent_Workflow_Run_Result::STATUS_SUCCEEDED;
+			$record['output']   = is_array( $step_output ) ? $step_output : array( 'value' => $step_output );
+			$record['ended_at'] = time();
+			$step_records[]     = $record;
+
+			$context['steps'][ $step_id ] = array( 'output' => $record['output'] );
+
+			$result = $result->with( array( 'steps' => $step_records ) );
+			if ( $this->recorder ) {
+				$this->recorder->update( $result );
+			}
+		}
+
+		// Final aggregated output: the last step's output, plus a `steps`
+		// map with each step's output keyed by id. Callers that want a
+		// specific step's output can pluck it; callers that want
+		// "everything the workflow produced" get the convenient last-output.
+		$final_output = array(
+			'steps' => array(),
+		);
+		foreach ( $step_records as $rec ) {
+			$final_output['steps'][ $rec['id'] ] = $rec['output'];
+		}
+		$last = end( $step_records );
+		if ( false !== $last && WP_Agent_Workflow_Run_Result::STATUS_SUCCEEDED === $last['status'] ) {
+			$final_output['last'] = $last['output'];
+		}
+
+		$result = $result->with(
+			array(
+				'status'   => $failed ? WP_Agent_Workflow_Run_Result::STATUS_FAILED : WP_Agent_Workflow_Run_Result::STATUS_SUCCEEDED,
+				'output'   => $final_output,
+				'error'    => $failure_error,
+				'ended_at' => time(),
+			)
+		);
+
+		return $this->record_and_return( $result, /*is_start*/ false );
+	}
+
+	/**
+	 * Validate inputs against the spec's declared input schemas.
+	 *
+	 * @since 0.103.0
+	 *
+	 * @return array{code:string,message:string,data?:mixed}|null
+	 */
+	private static function validate_inputs( WP_Agent_Workflow_Spec $spec, array $inputs ): ?array {
+		foreach ( $spec->get_inputs() as $name => $schema ) {
+			$required = ! empty( $schema['required'] );
+			$present  = array_key_exists( $name, $inputs );
+
+			if ( $required && ! $present ) {
+				return array(
+					'code'    => 'missing_required_input',
+					'message' => sprintf( 'workflow `%s` requires input `%s`', $spec->get_id(), $name ),
+					'data'    => array( 'input' => $name ),
+				);
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Default `ability` step handler: invokes a registered Abilities API
+	 * ability with the step's `args` (post-binding-resolution). Returns
+	 * the ability's output as the step output.
+	 *
+	 * @since 0.103.0
+	 *
+	 * @param array $step    Resolved step (bindings already expanded).
+	 * @param array $context Resolution context (unused here).
+	 * @return array|WP_Error
+	 */
+	public static function default_ability_handler( array $step, array $context ) {
+		unset( $context );
+		if ( ! function_exists( 'wp_get_ability' ) ) {
+			return new \WP_Error(
+				'abilities_api_missing',
+				'Abilities API is not loaded; cannot dispatch ability step.'
+			);
+		}
+		$ability_name = (string) ( $step['ability'] ?? '' );
+		$ability      = wp_get_ability( $ability_name );
+		if ( null === $ability ) {
+			return new \WP_Error(
+				'unknown_ability',
+				sprintf( 'no ability registered as `%s`', $ability_name )
+			);
+		}
+		$args   = (array) ( $step['args'] ?? array() );
+		$result = $ability->execute( $args );
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+		return is_array( $result ) ? $result : array( 'value' => $result );
+	}
+
+	/**
+	 * Default `agent` step handler: calls the canonical `agents/chat`
+	 * dispatcher (per agents-api#100) with the step's agent slug + message.
+	 *
+	 * @since 0.103.0
+	 *
+	 * @param array $step    Resolved step (bindings already expanded).
+	 * @param array $context Resolution context (unused here).
+	 * @return array|WP_Error
+	 */
+	public static function default_agent_handler( array $step, array $context ) {
+		unset( $context );
+		if ( ! function_exists( 'wp_get_ability' ) ) {
+			return new \WP_Error(
+				'abilities_api_missing',
+				'Abilities API is not loaded; cannot dispatch agent step.'
+			);
+		}
+		$ability = wp_get_ability( 'agents/chat' );
+		if ( null === $ability ) {
+			return new \WP_Error(
+				'agents_chat_missing',
+				'agents/chat ability is not registered.'
+			);
+		}
+		$input = array(
+			'agent'      => (string) ( $step['agent'] ?? '' ),
+			'message'    => (string) ( $step['message'] ?? '' ),
+			'session_id' => $step['session_id'] ?? null,
+		);
+		$result = $ability->execute( $input );
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+		return is_array( $result ) ? $result : array( 'reply' => (string) $result );
+	}
+
+	/**
+	 * Persist a final result and return it. Called for both early-exit
+	 * (input validation) and normal completion paths.
+	 *
+	 * @since 0.103.0
+	 */
+	private function record_and_return( WP_Agent_Workflow_Run_Result $result, bool $is_start ): WP_Agent_Workflow_Run_Result {
+		if ( $this->recorder ) {
+			if ( $is_start ) {
+				$this->recorder->start( $result );
+			} else {
+				$this->recorder->update( $result );
+			}
+		}
+		return $result;
+	}
+
+	/**
+	 * Generate a run id when the caller didn't supply one. Prefers the
+	 * WordPress UUID helper when available, falls back to a uniqid-based
+	 * value otherwise.
+	 *
+	 * @since 0.103.0
+	 */
+	private static function generate_run_id(): string {
+		if ( function_exists( 'wp_generate_uuid4' ) ) {
+			return wp_generate_uuid4();
+		}
+		return 'wf_' . uniqid( '', true );
+	}
+}

--- a/src/Workflows/class-wp-agent-workflow-runner.php
+++ b/src/Workflows/class-wp-agent-workflow-runner.php
@@ -100,6 +100,10 @@ class WP_Agent_Workflow_Runner {
 		$run_id     = (string) ( $options['run_id'] ?? self::generate_run_id() );
 		$metadata   = (array) ( $options['metadata'] ?? array() );
 
+		// Build the initial RUNNING result and persist via recorder->start()
+		// before doing anything else. Even if input validation fails on the
+		// next line we want a `start → update(failed)` lifecycle so recorders
+		// never see `start()` called with an already-terminal status.
 		$result = new WP_Agent_Workflow_Run_Result(
 			$run_id,
 			$spec->get_id(),
@@ -113,32 +117,48 @@ class WP_Agent_Workflow_Runner {
 			$metadata
 		);
 
-		// Validate inputs against the spec's input declarations.
-		$input_error = self::validate_inputs( $spec, $inputs );
-		if ( null !== $input_error ) {
-			return $this->record_and_return(
-				$result->with(
-					array(
-						'status'   => WP_Agent_Workflow_Run_Result::STATUS_FAILED,
-						'error'    => $input_error,
-						'ended_at' => time(),
-					)
-				),
-				/*is_start*/ true
-			);
-		}
-
-		// Persist the start. Recorder may rewrite the run id (CPT post id, …).
 		if ( $this->recorder ) {
 			$persisted = $this->recorder->start( $result );
+			if ( is_wp_error( $persisted ) ) {
+				// Recorder unavailable on entry — return a failed result without
+				// running steps. The caller still gets the in-memory record so
+				// observability hooks fire; the step pipeline does not run.
+				return $result->with(
+					array(
+						'status'   => WP_Agent_Workflow_Run_Result::STATUS_FAILED,
+						'error'    => array(
+							'code'    => 'recorder_start_failed',
+							'message' => $persisted->get_error_message(),
+						),
+						'ended_at' => time(),
+					)
+				);
+			}
 			if ( is_string( $persisted ) && '' !== $persisted ) {
 				$result = $result->with( array( 'run_id' => $persisted ) );
 			}
 		}
 
+		// Validate inputs against the spec's input declarations.
+		$input_error = self::validate_inputs( $spec, $inputs );
+		if ( null !== $input_error ) {
+			$terminal = $result->with(
+				array(
+					'status'   => WP_Agent_Workflow_Run_Result::STATUS_FAILED,
+					'error'    => $input_error,
+					'ended_at' => time(),
+				)
+			);
+			if ( $this->recorder ) {
+				$this->recorder->update( $terminal );
+			}
+			return $terminal;
+		}
+
 		$context = array(
 			'inputs' => $inputs,
-			'steps'  => array(), // step_id => [ 'output' => ... ]
+			// Step outputs accumulate here as the run progresses, keyed by step id.
+			'steps'  => array(),
 		);
 
 		$step_records      = array();
@@ -147,11 +167,11 @@ class WP_Agent_Workflow_Runner {
 		$failure_error     = array();
 
 		foreach ( $spec->get_steps() as $step ) {
-			$step_id   = (string) $step['id'];
-			$type      = (string) $step['type'];
-			$start_ts  = time();
-			$resolved  = WP_Agent_Workflow_Bindings::expand( $step, $context );
-			$record    = array(
+			$step_id  = (string) $step['id'];
+			$type     = (string) $step['type'];
+			$start_ts = time();
+			$resolved = WP_Agent_Workflow_Bindings::expand( $step, $context );
+			$record   = array(
 				'id'         => $step_id,
 				'type'       => $type,
 				'status'     => WP_Agent_Workflow_Run_Result::STATUS_RUNNING,
@@ -219,10 +239,13 @@ class WP_Agent_Workflow_Runner {
 			}
 		}
 
-		// Final aggregated output: the last step's output, plus a `steps`
-		// map with each step's output keyed by id. Callers that want a
-		// specific step's output can pluck it; callers that want
-		// "everything the workflow produced" get the convenient last-output.
+		// Final aggregated output: every step's output keyed by id, plus a
+		// convenience `last` shortcut that points at the last step's output
+		// **only when that last step succeeded**. With `continue_on_error`
+		// the last step in the list may be a failed one, in which case
+		// `last` is intentionally absent — callers should reach for
+		// `$result->get_output()['steps'][<id>]` when partial-failure
+		// semantics matter.
 		$final_output = array(
 			'steps' => array(),
 		);
@@ -243,7 +266,10 @@ class WP_Agent_Workflow_Runner {
 			)
 		);
 
-		return $this->record_and_return( $result, /*is_start*/ false );
+		if ( $this->recorder ) {
+			$this->recorder->update( $result );
+		}
+		return $result;
 	}
 
 	/**
@@ -339,23 +365,6 @@ class WP_Agent_Workflow_Runner {
 			return $result;
 		}
 		return is_array( $result ) ? $result : array( 'reply' => (string) $result );
-	}
-
-	/**
-	 * Persist a final result and return it. Called for both early-exit
-	 * (input validation) and normal completion paths.
-	 *
-	 * @since 0.103.0
-	 */
-	private function record_and_return( WP_Agent_Workflow_Run_Result $result, bool $is_start ): WP_Agent_Workflow_Run_Result {
-		if ( $this->recorder ) {
-			if ( $is_start ) {
-				$this->recorder->start( $result );
-			} else {
-				$this->recorder->update( $result );
-			}
-		}
-		return $result;
 	}
 
 	/**

--- a/src/Workflows/class-wp-agent-workflow-spec-validator.php
+++ b/src/Workflows/class-wp-agent-workflow-spec-validator.php
@@ -95,12 +95,21 @@ final class WP_Agent_Workflow_Spec_Validator {
 			}
 		}
 
+		// Forward / unknown step-id binding references. Cheap structural
+		// pass: scan every `${steps.<id>.output.*}` token and verify <id>
+		// exists earlier in the list. Catches typos and re-orderings that
+		// would otherwise resolve to null silently at runtime.
+		if ( isset( $spec['steps'] ) && is_array( $spec['steps'] ) ) {
+			$binding_errors = self::validate_step_binding_references( $spec['steps'] );
+			$errors         = array_merge( $errors, $binding_errors );
+		}
+
 		return $errors;
 	}
 
 	/**
 	 * @param array<int,mixed> $steps
-	 * @return array<int,array>
+	 * @return array<int,array{path:string,code:string,message:string}>
 	 */
 	private static function validate_steps( array $steps ): array {
 		$errors = array();
@@ -201,8 +210,82 @@ final class WP_Agent_Workflow_Spec_Validator {
 	}
 
 	/**
+	 * Scan every `${steps.<id>.output.*}` reference inside step args and
+	 * fields, return errors for any id that's unknown or only appears
+	 * later in the list. Bindings to `inputs.*` aren't checked here — the
+	 * runner validates inputs against the spec at run time.
+	 *
+	 * @param array<int,mixed> $steps
+	 * @return array<int,array{path:string,code:string,message:string}>
+	 */
+	private static function validate_step_binding_references( array $steps ): array {
+		$errors = array();
+		$seen   = array();
+
+		foreach ( $steps as $idx => $step ) {
+			if ( ! is_array( $step ) ) {
+				continue;
+			}
+
+			$step_id = isset( $step['id'] ) ? (string) $step['id'] : '';
+			$tokens  = self::extract_step_binding_ids( $step );
+
+			foreach ( $tokens as $referenced_id ) {
+				if ( ! isset( $seen[ $referenced_id ] ) ) {
+					$errors[] = array(
+						'path'    => "steps.{$idx}",
+						'code'    => 'unknown_step_reference',
+						'message' => sprintf(
+							'step `%s` references `%s` which is not defined %s in the workflow',
+							'' !== $step_id ? $step_id : (string) $idx,
+							$referenced_id,
+							isset( $seen[ $step_id ] ) ? 'before this step' : 'before this step'
+						),
+					);
+				}
+			}
+
+			if ( '' !== $step_id ) {
+				$seen[ $step_id ] = true;
+			}
+		}
+
+		return $errors;
+	}
+
+	/**
+	 * Walk a step array and pull out every `${steps.<id>.output.*}` token's
+	 * id segment. Used by {@see validate_step_binding_references()}.
+	 *
+	 * @param mixed $value
+	 * @return array<int,string>
+	 */
+	private static function extract_step_binding_ids( $value ): array {
+		$ids = array();
+
+		if ( is_array( $value ) ) {
+			foreach ( $value as $inner ) {
+				$ids = array_merge( $ids, self::extract_step_binding_ids( $inner ) );
+			}
+			return $ids;
+		}
+
+		if ( ! is_string( $value ) ) {
+			return $ids;
+		}
+
+		if ( preg_match_all( '/\$\{\s*steps\.([a-zA-Z0-9_\-]+)\./', $value, $matches ) ) {
+			foreach ( $matches[1] as $found ) {
+				$ids[] = (string) $found;
+			}
+		}
+
+		return $ids;
+	}
+
+	/**
 	 * @param array<int,mixed> $triggers
-	 * @return array<int,array>
+	 * @return array<int,array{path:string,code:string,message:string}>
 	 */
 	private static function validate_triggers( array $triggers ): array {
 		$errors = array();

--- a/src/Workflows/class-wp-agent-workflow-spec-validator.php
+++ b/src/Workflows/class-wp-agent-workflow-spec-validator.php
@@ -1,0 +1,264 @@
+<?php
+/**
+ * Structural validator for workflow specs.
+ *
+ * Walks a raw spec array and returns a list of structured errors:
+ *
+ *     [
+ *       [
+ *         'path'    => 'steps.1.ability',
+ *         'code'    => 'missing_required',
+ *         'message' => 'ability step is missing required `ability` field',
+ *       ],
+ *       ...
+ *     ]
+ *
+ * An empty list means the spec is well-formed enough to construct a
+ * {@see WP_Agent_Workflow_Spec}. Validators are deliberately separated
+ * from the value object so consumers can use them on partial specs in
+ * editor surfaces (linting in-progress JSON, REST validate endpoints,
+ * `agents/validate-workflow` ability) without having to construct or
+ * discard a Spec each call.
+ *
+ * The validator does NOT verify that referenced abilities or agents
+ * actually exist — that's a runtime concern handled by the runner.
+ * This pass is structural only.
+ *
+ * @package AgentsAPI
+ * @since   0.103.0
+ */
+
+namespace AgentsAPI\AI\Workflows;
+
+defined( 'ABSPATH' ) || exit;
+
+final class WP_Agent_Workflow_Spec_Validator {
+
+	/** @since 0.103.0 */
+	public const KNOWN_STEP_TYPES = array( 'ability', 'agent' );
+
+	/** @since 0.103.0 */
+	public const KNOWN_TRIGGER_TYPES = array( 'on_demand', 'wp_action', 'cron' );
+
+	/**
+	 * Validate a raw workflow spec.
+	 *
+	 * @since 0.103.0
+	 *
+	 * @param array $spec Raw spec.
+	 * @return array<int,array{path:string,code:string,message:string}> Empty when valid.
+	 */
+	public static function validate( array $spec ): array {
+		$errors = array();
+
+		// id
+		if ( empty( $spec['id'] ) || ! is_string( $spec['id'] ) ) {
+			$errors[] = array(
+				'path'    => 'id',
+				'code'    => 'missing_required',
+				'message' => 'workflow spec is missing a non-empty `id`',
+			);
+		}
+
+		// inputs (optional but if present must be a map)
+		if ( isset( $spec['inputs'] ) && ! is_array( $spec['inputs'] ) ) {
+			$errors[] = array(
+				'path'    => 'inputs',
+				'code'    => 'invalid_type',
+				'message' => '`inputs` must be a map of input_name => schema',
+			);
+		}
+
+		// steps
+		if ( ! isset( $spec['steps'] ) || ! is_array( $spec['steps'] ) || empty( $spec['steps'] ) ) {
+			$errors[] = array(
+				'path'    => 'steps',
+				'code'    => 'missing_required',
+				'message' => 'workflow spec must declare at least one step',
+			);
+		} else {
+			$step_errors = self::validate_steps( $spec['steps'] );
+			$errors      = array_merge( $errors, $step_errors );
+		}
+
+		// triggers (optional but if present must be a list)
+		if ( isset( $spec['triggers'] ) ) {
+			if ( ! is_array( $spec['triggers'] ) || array_values( $spec['triggers'] ) !== $spec['triggers'] ) {
+				$errors[] = array(
+					'path'    => 'triggers',
+					'code'    => 'invalid_type',
+					'message' => '`triggers` must be a list of trigger definitions',
+				);
+			} else {
+				$trigger_errors = self::validate_triggers( $spec['triggers'] );
+				$errors         = array_merge( $errors, $trigger_errors );
+			}
+		}
+
+		return $errors;
+	}
+
+	/**
+	 * @param array<int,mixed> $steps
+	 * @return array<int,array>
+	 */
+	private static function validate_steps( array $steps ): array {
+		$errors = array();
+		$seen   = array();
+
+		foreach ( $steps as $idx => $step ) {
+			$path = "steps.{$idx}";
+
+			if ( ! is_array( $step ) ) {
+				$errors[] = array(
+					'path'    => $path,
+					'code'    => 'invalid_type',
+					'message' => 'step entry must be an array',
+				);
+				continue;
+			}
+
+			if ( empty( $step['id'] ) || ! is_string( $step['id'] ) ) {
+				$errors[] = array(
+					'path'    => "{$path}.id",
+					'code'    => 'missing_required',
+					'message' => 'step is missing a non-empty `id`',
+				);
+			} elseif ( isset( $seen[ $step['id'] ] ) ) {
+				$errors[] = array(
+					'path'    => "{$path}.id",
+					'code'    => 'duplicate_id',
+					'message' => sprintf( 'step id `%s` is reused at index %d (first seen at index %d)', $step['id'], $idx, $seen[ $step['id'] ] ),
+				);
+			} else {
+				$seen[ $step['id'] ] = $idx;
+			}
+
+			if ( empty( $step['type'] ) || ! is_string( $step['type'] ) ) {
+				$errors[] = array(
+					'path'    => "{$path}.type",
+					'code'    => 'missing_required',
+					'message' => 'step is missing a non-empty `type`',
+				);
+				continue; // type is needed for the per-type checks below
+			}
+
+			if ( ! in_array( $step['type'], self::KNOWN_STEP_TYPES, true ) ) {
+				/**
+				 * Allow consumer-extended step types. Agents-api ships only
+				 * `ability` and `agent`; extra types (`branch`, `parallel`,
+				 * `workflow`) get registered by consumers via a filter on
+				 * `wp_agent_workflow_known_step_types`. Filtered list wins.
+				 *
+				 * @since 0.103.0
+				 *
+				 * @param array<string> $known_types Default v0 set.
+				 */
+				$known = (array) apply_filters( 'wp_agent_workflow_known_step_types', self::KNOWN_STEP_TYPES );
+				if ( ! in_array( $step['type'], $known, true ) ) {
+					$errors[] = array(
+						'path'    => "{$path}.type",
+						'code'    => 'unknown_step_type',
+						'message' => sprintf(
+							'unknown step type `%s` (known: %s)',
+							$step['type'],
+							implode( ', ', $known )
+						),
+					);
+					continue;
+				}
+			}
+
+			if ( 'ability' === $step['type'] ) {
+				if ( empty( $step['ability'] ) || ! is_string( $step['ability'] ) ) {
+					$errors[] = array(
+						'path'    => "{$path}.ability",
+						'code'    => 'missing_required',
+						'message' => 'ability step is missing a non-empty `ability`',
+					);
+				}
+			}
+
+			if ( 'agent' === $step['type'] ) {
+				if ( empty( $step['agent'] ) || ! is_string( $step['agent'] ) ) {
+					$errors[] = array(
+						'path'    => "{$path}.agent",
+						'code'    => 'missing_required',
+						'message' => 'agent step is missing a non-empty `agent`',
+					);
+				}
+				if ( empty( $step['message'] ) || ! is_string( $step['message'] ) ) {
+					$errors[] = array(
+						'path'    => "{$path}.message",
+						'code'    => 'missing_required',
+						'message' => 'agent step is missing a non-empty `message`',
+					);
+				}
+			}
+		}
+
+		return $errors;
+	}
+
+	/**
+	 * @param array<int,mixed> $triggers
+	 * @return array<int,array>
+	 */
+	private static function validate_triggers( array $triggers ): array {
+		$errors = array();
+
+		foreach ( $triggers as $idx => $trigger ) {
+			$path = "triggers.{$idx}";
+
+			if ( ! is_array( $trigger ) ) {
+				$errors[] = array(
+					'path'    => $path,
+					'code'    => 'invalid_type',
+					'message' => 'trigger entry must be an array',
+				);
+				continue;
+			}
+
+			if ( empty( $trigger['type'] ) || ! is_string( $trigger['type'] ) ) {
+				$errors[] = array(
+					'path'    => "{$path}.type",
+					'code'    => 'missing_required',
+					'message' => 'trigger is missing a non-empty `type`',
+				);
+				continue;
+			}
+
+			$known = (array) apply_filters( 'wp_agent_workflow_known_trigger_types', self::KNOWN_TRIGGER_TYPES );
+			if ( ! in_array( $trigger['type'], $known, true ) ) {
+				$errors[] = array(
+					'path'    => "{$path}.type",
+					'code'    => 'unknown_trigger_type',
+					'message' => sprintf(
+						'unknown trigger type `%s` (known: %s)',
+						$trigger['type'],
+						implode( ', ', $known )
+					),
+				);
+				continue;
+			}
+
+			if ( 'wp_action' === $trigger['type'] && empty( $trigger['hook'] ) ) {
+				$errors[] = array(
+					'path'    => "{$path}.hook",
+					'code'    => 'missing_required',
+					'message' => 'wp_action trigger is missing a non-empty `hook`',
+				);
+			}
+
+			if ( 'cron' === $trigger['type'] && empty( $trigger['expression'] ) && empty( $trigger['interval'] ) ) {
+				$errors[] = array(
+					'path'    => $path,
+					'code'    => 'missing_required',
+					'message' => 'cron trigger needs either `expression` (cron string) or `interval` (seconds)',
+				);
+			}
+		}
+
+		return $errors;
+	}
+}

--- a/src/Workflows/class-wp-agent-workflow-spec.php
+++ b/src/Workflows/class-wp-agent-workflow-spec.php
@@ -1,0 +1,142 @@
+<?php
+/**
+ * Immutable value object representing a parsed and validated workflow spec.
+ *
+ * The spec is the wire-level shape of a workflow:
+ *
+ *     [
+ *       'id'       => 'my-plugin/triage-comments',
+ *       'version'  => '1.0.0',
+ *       'inputs'   => [ 'comment_id' => [ 'type' => 'integer', 'required' => true ] ],
+ *       'steps'    => [
+ *         [ 'id' => 'classify',     'type' => 'agent',   'agent' => 'ops-triage', ... ],
+ *         [ 'id' => 'create-issue', 'type' => 'ability', 'ability' => 'linear/create-issue', ... ],
+ *       ],
+ *       'triggers' => [
+ *         [ 'type' => 'on_demand' ],
+ *         [ 'type' => 'wp_action', 'hook' => 'comment_post' ],
+ *       ],
+ *     ]
+ *
+ * Construct via {@see from_array()}, which validates and freezes the input.
+ * Direct construction is allowed for callers that have already validated
+ * the array elsewhere (e.g. the registry restoring a previously-validated
+ * spec from its in-memory map).
+ *
+ * Specs are deliberately storage-agnostic — they have no opinion about
+ * where they came from (PHP file, CPT, custom table, REST upload) or how
+ * they're serialised. Storage adapters live in
+ * {@see WP_Agent_Workflow_Store} implementations.
+ *
+ * @package AgentsAPI
+ * @since   0.103.0
+ */
+
+namespace AgentsAPI\AI\Workflows;
+
+use WP_Error;
+
+defined( 'ABSPATH' ) || exit;
+
+final class WP_Agent_Workflow_Spec {
+
+	/**
+	 * @since 0.103.0
+	 *
+	 * @param string $id        Stable, namespaced workflow identifier (`my-plugin/triage-comments`).
+	 * @param string $version   Caller-defined version string (semver suggested but not enforced).
+	 * @param array  $inputs    Map of `<input_name> => <schema>`. Each schema is a JSON-Schema-like
+	 *                          fragment with `type`, optional `required`, optional `default`.
+	 * @param array  $steps     Ordered list of step definitions. v0 supports `ability` and `agent`
+	 *                          types; consumers may register additional types via a step handler map.
+	 * @param array  $triggers  List of trigger definitions. v0 supports `on_demand`, `wp_action`, `cron`.
+	 * @param array  $meta      Free-form metadata for the registering plugin. Opaque to the runner.
+	 * @param array  $raw       The full raw array the spec was constructed from. Used for round-tripping
+	 *                          a spec back to its caller-supplied shape.
+	 */
+	public function __construct(
+		private string $id,
+		private string $version,
+		private array $inputs,
+		private array $steps,
+		private array $triggers,
+		private array $meta,
+		private array $raw
+	) {}
+
+	/**
+	 * Build a Spec from a raw array, returning a `WP_Error` on validation
+	 * failure. Use {@see WP_Agent_Workflow_Spec_Validator::validate()} when
+	 * you need detailed structured errors instead of just the first one.
+	 *
+	 * @since 0.103.0
+	 *
+	 * @param array $raw Raw spec input.
+	 * @return self|WP_Error
+	 */
+	public static function from_array( array $raw ) {
+		$errors = WP_Agent_Workflow_Spec_Validator::validate( $raw );
+		if ( ! empty( $errors ) ) {
+			$first = $errors[0];
+			return new WP_Error(
+				'workflow_spec_invalid',
+				$first['message'],
+				array(
+					'errors' => $errors,
+					'path'   => $first['path'],
+					'code'   => $first['code'],
+				)
+			);
+		}
+
+		return new self(
+			(string) $raw['id'],
+			(string) ( $raw['version'] ?? '0.0.0' ),
+			(array) ( $raw['inputs'] ?? array() ),
+			(array) ( $raw['steps'] ?? array() ),
+			(array) ( $raw['triggers'] ?? array() ),
+			(array) ( $raw['meta'] ?? array() ),
+			$raw
+		);
+	}
+
+	public function get_id(): string {
+		return $this->id;
+	}
+
+	public function get_version(): string {
+		return $this->version;
+	}
+
+	/**
+	 * @return array<string,array> Input schemas keyed by input name.
+	 */
+	public function get_inputs(): array {
+		return $this->inputs;
+	}
+
+	/**
+	 * @return array<int,array> Step definitions in order.
+	 */
+	public function get_steps(): array {
+		return $this->steps;
+	}
+
+	/**
+	 * @return array<int,array> Trigger definitions.
+	 */
+	public function get_triggers(): array {
+		return $this->triggers;
+	}
+
+	public function get_meta(): array {
+		return $this->meta;
+	}
+
+	/**
+	 * @return array The raw spec array as supplied to {@see from_array()}.
+	 */
+	public function to_array(): array {
+		return $this->raw;
+	}
+}

--- a/src/Workflows/class-wp-agent-workflow-store.php
+++ b/src/Workflows/class-wp-agent-workflow-store.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Storage contract for workflow specs.
+ *
+ * agents-api ships no default implementation. Consumers implement this
+ * against their preferred storage layer — a custom post type, a custom
+ * table, an external service, an in-memory store for tests. Each consumer
+ * picks indexes and durability guarantees that match its product surface.
+ *
+ * This interface deliberately covers durable persistence (find, save,
+ * delete, list). Code-defined workflows registered via
+ * {@see WP_Agent_Workflow_Registry::register()} are an in-memory layer
+ * that sits in front of any store; consumers compose the two however they
+ * like.
+ *
+ * @package AgentsAPI
+ * @since   0.103.0
+ */
+
+namespace AgentsAPI\AI\Workflows;
+
+use WP_Error;
+
+defined( 'ABSPATH' ) || exit;
+
+interface WP_Agent_Workflow_Store {
+
+	/**
+	 * Look up a workflow by its id. Returns null when not found.
+	 *
+	 * @since 0.103.0
+	 *
+	 * @param string $workflow_id
+	 * @return WP_Agent_Workflow_Spec|null
+	 */
+	public function find( string $workflow_id ): ?WP_Agent_Workflow_Spec;
+
+	/**
+	 * Persist a workflow spec, creating or updating in place.
+	 *
+	 * @since 0.103.0
+	 *
+	 * @param WP_Agent_Workflow_Spec $spec
+	 * @return true|WP_Error
+	 */
+	public function save( WP_Agent_Workflow_Spec $spec );
+
+	/**
+	 * Remove a workflow spec by id.
+	 *
+	 * @since 0.103.0
+	 *
+	 * @param string $workflow_id
+	 * @return true|WP_Error
+	 */
+	public function delete( string $workflow_id );
+
+	/**
+	 * List stored workflows. Implementations may paginate / filter via
+	 * `$args` — accepted keys are `limit`, `offset`, and arbitrary
+	 * implementation-specific keys (the substrate doesn't enforce a
+	 * uniform query DSL — consumers know their own indexes best).
+	 *
+	 * @since 0.103.0
+	 *
+	 * @param array $args
+	 * @return WP_Agent_Workflow_Spec[]
+	 */
+	public function all( array $args = array() ): array;
+}

--- a/src/Workflows/register-agents-workflow-abilities.php
+++ b/src/Workflows/register-agents-workflow-abilities.php
@@ -1,0 +1,356 @@
+<?php
+/**
+ * Canonical workflow ability registrations.
+ *
+ * Three abilities, all dispatchers — agents-api itself ships no runner;
+ * consumers register a runtime via the `wp_agent_workflow_handler` filter:
+ *
+ *   - `agents/run-workflow`      — execute a workflow by id (or inline spec).
+ *   - `agents/validate-workflow` — structural validate (no DB / runtime touch).
+ *   - `agents/describe-workflow` — return the registered spec + input schema.
+ *
+ * The dispatcher mirrors `agents/chat` (#100) so the two contracts are
+ * familiar to consumers: validate input, look up a registered handler,
+ * call it, fire observability hooks on failure.
+ *
+ * @package AgentsAPI
+ * @since   0.103.0
+ */
+
+namespace AgentsAPI\AI\Workflows;
+
+defined( 'ABSPATH' ) || exit;
+
+const AGENTS_RUN_WORKFLOW_ABILITY      = 'agents/run-workflow';
+const AGENTS_VALIDATE_WORKFLOW_ABILITY = 'agents/validate-workflow';
+const AGENTS_DESCRIBE_WORKFLOW_ABILITY = 'agents/describe-workflow';
+
+add_action(
+	'wp_abilities_api_categories_init',
+	static function (): void {
+		if ( ! function_exists( 'wp_register_ability_category' ) ) {
+			return;
+		}
+		wp_register_ability_category(
+			'agents-api',
+			array(
+				'label'       => 'Agents API',
+				'description' => 'Cross-cutting abilities provided by the Agents API substrate (channel dispatch, canonical chat contract, workflow dispatch, future runtime resolvers).',
+			)
+		);
+	}
+);
+
+add_action(
+	'wp_abilities_api_init',
+	static function (): void {
+		if ( ! function_exists( 'wp_register_ability' ) ) {
+			return;
+		}
+
+		wp_register_ability(
+			AGENTS_RUN_WORKFLOW_ABILITY,
+			array(
+				'label'               => 'Run Workflow',
+				'description'         => 'Canonical entry point for running a registered workflow. Dispatches to whichever runtime is registered via the wp_agent_workflow_handler filter.',
+				'category'            => 'agents-api',
+				'input_schema'        => agents_run_workflow_input_schema(),
+				'output_schema'       => agents_run_workflow_output_schema(),
+				'execute_callback'    => __NAMESPACE__ . '\\agents_run_workflow_dispatch',
+				'permission_callback' => __NAMESPACE__ . '\\agents_run_workflow_permission',
+				'meta'                => array(
+					'show_in_rest' => true,
+					'annotations'  => array(
+						'destructive' => true,
+						'idempotent'  => false,
+					),
+				),
+			)
+		);
+
+		wp_register_ability(
+			AGENTS_VALIDATE_WORKFLOW_ABILITY,
+			array(
+				'label'               => 'Validate Workflow Spec',
+				'description'         => 'Structural validation of a workflow spec. Returns a list of structured errors (or an empty list when valid). Does not touch any runtime or storage.',
+				'category'            => 'agents-api',
+				'input_schema'        => array(
+					'type'       => 'object',
+					'required'   => array( 'spec' ),
+					'properties' => array(
+						'spec' => array(
+							'type'        => 'object',
+							'description' => 'Raw workflow spec to validate.',
+						),
+					),
+				),
+				'output_schema'       => array(
+					'type'       => 'object',
+					'required'   => array( 'valid', 'errors' ),
+					'properties' => array(
+						'valid'  => array( 'type' => 'boolean' ),
+						'errors' => array(
+							'type'  => 'array',
+							'items' => array(
+								'type'       => 'object',
+								'properties' => array(
+									'path'    => array( 'type' => 'string' ),
+									'code'    => array( 'type' => 'string' ),
+									'message' => array( 'type' => 'string' ),
+								),
+							),
+						),
+					),
+				),
+				'execute_callback'    => __NAMESPACE__ . '\\agents_validate_workflow',
+				'permission_callback' => __NAMESPACE__ . '\\agents_run_workflow_permission',
+				'meta'                => array(
+					'show_in_rest' => true,
+					'annotations'  => array( 'idempotent' => true ),
+				),
+			)
+		);
+
+		wp_register_ability(
+			AGENTS_DESCRIBE_WORKFLOW_ABILITY,
+			array(
+				'label'               => 'Describe Workflow',
+				'description'         => 'Return a registered workflow spec along with its input declarations. Useful for callers that want to enumerate or render workflows without executing them.',
+				'category'            => 'agents-api',
+				'input_schema'        => array(
+					'type'       => 'object',
+					'required'   => array( 'workflow_id' ),
+					'properties' => array(
+						'workflow_id' => array( 'type' => 'string' ),
+					),
+				),
+				'output_schema'       => array(
+					'type'       => 'object',
+					'properties' => array(
+						'spec'   => array( 'type' => array( 'object', 'null' ) ),
+						'inputs' => array( 'type' => array( 'object', 'null' ) ),
+					),
+				),
+				'execute_callback'    => __NAMESPACE__ . '\\agents_describe_workflow',
+				'permission_callback' => __NAMESPACE__ . '\\agents_run_workflow_permission',
+				'meta'                => array(
+					'show_in_rest' => true,
+					'annotations'  => array( 'idempotent' => true ),
+				),
+			)
+		);
+	}
+);
+
+/**
+ * Dispatch a workflow run to the registered runtime.
+ *
+ * @since  0.103.0
+ *
+ * @param  array $input Canonical run-workflow input.
+ * @return array|\WP_Error Canonical output, or WP_Error if no runtime is registered.
+ */
+function agents_run_workflow_dispatch( array $input ) {
+	/**
+	 * Filter the workflow runtime handler.
+	 *
+	 * Consumers register a callable that accepts the canonical input array
+	 * and returns either the canonical output or WP_Error. The first hook
+	 * to return a callable wins.
+	 *
+	 * @since 0.103.0
+	 *
+	 * @param callable|null $handler Currently registered handler. Null when
+	 *                               no runtime has registered.
+	 * @param array         $input   The canonical input being dispatched.
+	 */
+	$handler = apply_filters( 'wp_agent_workflow_handler', null, $input );
+
+	if ( ! is_callable( $handler ) ) {
+		/**
+		 * Fires when agents/run-workflow dispatched but no handler was
+		 * registered. Use for sysadmin-side observability.
+		 *
+		 * @since 0.103.0
+		 *
+		 * @param string $reason Always `'no_handler'` for this branch.
+		 * @param array  $input  The canonical input that was rejected.
+		 */
+		do_action( 'agents_run_workflow_dispatch_failed', 'no_handler', $input );
+
+		return new \WP_Error(
+			'agents_run_workflow_no_handler',
+			'No agents/run-workflow handler is registered. Install a consumer plugin that registers a runtime, or add a callable to the wp_agent_workflow_handler filter.'
+		);
+	}
+
+	$result = call_user_func( $handler, $input );
+
+	if ( is_wp_error( $result ) ) {
+		/** This action is documented above. */
+		do_action( 'agents_run_workflow_dispatch_failed', $result->get_error_code(), $input );
+		return $result;
+	}
+
+	if ( ! is_array( $result ) ) {
+		/** This action is documented above. */
+		do_action( 'agents_run_workflow_dispatch_failed', 'invalid_result', $input );
+		return new \WP_Error(
+			'agents_run_workflow_invalid_result',
+			'agents/run-workflow handler returned an unexpected result type. Handlers must return an array matching the canonical output shape or a WP_Error.'
+		);
+	}
+
+	return $result;
+}
+
+/**
+ * `agents/validate-workflow` execute callback. Pure substrate — no
+ * runtime hookup needed.
+ *
+ * @since  0.103.0
+ *
+ * @param  array $input
+ * @return array
+ */
+function agents_validate_workflow( array $input ): array {
+	$errors = WP_Agent_Workflow_Spec_Validator::validate( (array) ( $input['spec'] ?? array() ) );
+	return array(
+		'valid'  => empty( $errors ),
+		'errors' => $errors,
+	);
+}
+
+/**
+ * `agents/describe-workflow` execute callback. Reads the in-memory
+ * registry only — Store-backed workflows are described by their consumer.
+ *
+ * @since  0.103.0
+ *
+ * @param  array $input
+ * @return array
+ */
+function agents_describe_workflow( array $input ): array {
+	$workflow_id = (string) ( $input['workflow_id'] ?? '' );
+	$spec        = WP_Agent_Workflow_Registry::find( $workflow_id );
+	if ( null === $spec ) {
+		return array( 'spec' => null, 'inputs' => null );
+	}
+	return array(
+		'spec'   => $spec->to_array(),
+		'inputs' => $spec->get_inputs(),
+	);
+}
+
+/**
+ * Permission gate for the workflow abilities. Same default as
+ * `agents/chat`: `manage_options`. Consumers with their own auth model
+ * (HMAC-signed webhook, OAuth bearer, scheduled action) widen via the
+ * `agents_run_workflow_permission` filter.
+ *
+ * @since 0.103.0
+ *
+ * @param array $input Canonical input.
+ * @return bool
+ */
+function agents_run_workflow_permission( array $input ): bool {
+	/**
+	 * Filter the permission decision for the canonical workflow abilities.
+	 *
+	 * @since 0.103.0
+	 *
+	 * @param bool  $allowed Default: current_user_can( 'manage_options' ).
+	 * @param array $input   The canonical input being authorized.
+	 */
+	return (bool) apply_filters(
+		'agents_run_workflow_permission',
+		current_user_can( 'manage_options' ),
+		$input
+	);
+}
+
+/**
+ * Canonical input schema for `agents/run-workflow`.
+ *
+ * @since  0.103.0
+ *
+ * @return array
+ */
+function agents_run_workflow_input_schema(): array {
+	return array(
+		'type'       => 'object',
+		'properties' => array(
+			'workflow_id' => array(
+				'type'        => array( 'string', 'null' ),
+				'description' => 'Id of a registered or stored workflow to run. Pass `null` to run an inline `spec` instead.',
+			),
+			'spec'        => array(
+				'type'        => array( 'object', 'null' ),
+				'description' => 'Inline workflow spec to run. Use when the workflow is not (yet) persisted. Either `workflow_id` or `spec` must be provided.',
+			),
+			'inputs'      => array(
+				'type'        => 'object',
+				'description' => 'Map of input_name => value supplied to the workflow. Required inputs missing here cause an early failure.',
+				'default'     => array(),
+			),
+			'options'     => array(
+				'type'        => 'object',
+				'description' => 'Runtime options forwarded to the runner. Recognized keys: run_id, continue_on_error, metadata.',
+				'default'     => array(),
+			),
+		),
+	);
+}
+
+/**
+ * Canonical output schema for `agents/run-workflow`.
+ *
+ * @since  0.103.0
+ *
+ * @return array
+ */
+function agents_run_workflow_output_schema(): array {
+	return array(
+		'type'       => 'object',
+		'required'   => array( 'run_id', 'workflow_id', 'status' ),
+		'properties' => array(
+			'run_id'      => array( 'type' => 'string' ),
+			'workflow_id' => array( 'type' => 'string' ),
+			'status'      => array(
+				'type' => 'string',
+				'enum' => array( 'pending', 'running', 'succeeded', 'failed', 'skipped' ),
+			),
+			'output'      => array( 'type' => 'object' ),
+			'steps'       => array( 'type' => 'array' ),
+			'error'       => array( 'type' => array( 'object', 'null' ) ),
+			'started_at'  => array( 'type' => 'integer' ),
+			'ended_at'    => array( 'type' => 'integer' ),
+			'metadata'    => array( 'type' => 'object' ),
+		),
+	);
+}
+
+/**
+ * Convenience helper for consumers: register a callable as the workflow
+ * runtime handler.
+ *
+ * @since 0.103.0
+ *
+ * @param callable $handler  Receives the canonical input array, returns the
+ *                           canonical output array or WP_Error.
+ * @param int      $priority Filter priority. Default 10.
+ */
+function register_workflow_handler( callable $handler, int $priority = 10 ): void {
+	add_filter(
+		'wp_agent_workflow_handler',
+		static function ( $existing, array $input ) use ( $handler ) {
+			unset( $input );
+			if ( null !== $existing ) {
+				return $existing;
+			}
+			return $handler;
+		},
+		$priority,
+		2
+	);
+}

--- a/src/Workflows/register-agents-workflow-abilities.php
+++ b/src/Workflows/register-agents-workflow-abilities.php
@@ -103,7 +103,7 @@ add_action(
 					),
 				),
 				'execute_callback'    => __NAMESPACE__ . '\\agents_validate_workflow',
-				'permission_callback' => __NAMESPACE__ . '\\agents_run_workflow_permission',
+				'permission_callback' => __NAMESPACE__ . '\\agents_validate_workflow_permission',
 				'meta'                => array(
 					'show_in_rest' => true,
 					'annotations'  => array( 'idempotent' => true ),
@@ -234,7 +234,10 @@ function agents_describe_workflow( array $input ): array {
 	$workflow_id = (string) ( $input['workflow_id'] ?? '' );
 	$spec        = WP_Agent_Workflow_Registry::find( $workflow_id );
 	if ( null === $spec ) {
-		return array( 'spec' => null, 'inputs' => null );
+		return array(
+			'spec'   => null,
+			'inputs' => null,
+		);
 	}
 	return array(
 		'spec'   => $spec->to_array(),
@@ -265,6 +268,34 @@ function agents_run_workflow_permission( array $input ): bool {
 	return (bool) apply_filters(
 		'agents_run_workflow_permission',
 		current_user_can( 'manage_options' ),
+		$input
+	);
+}
+
+/**
+ * Permission gate for `agents/validate-workflow`. Validation has no side
+ * effects and exposes no information beyond what the caller already
+ * supplied, so the default is more permissive than `agents/run-workflow`:
+ * any logged-in user can lint a spec they're authoring. Anonymous callers
+ * are still rejected unless the filter widens the gate.
+ *
+ * @since 0.103.0
+ *
+ * @param array $input
+ * @return bool
+ */
+function agents_validate_workflow_permission( array $input ): bool {
+	/**
+	 * Filter the permission decision for `agents/validate-workflow`.
+	 *
+	 * @since 0.103.0
+	 *
+	 * @param bool  $allowed Default: any logged-in user.
+	 * @param array $input
+	 */
+	return (bool) apply_filters(
+		'agents_validate_workflow_permission',
+		is_user_logged_in(),
 		$input
 	);
 }

--- a/src/Workflows/register-workflows.php
+++ b/src/Workflows/register-workflows.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Global helper functions for the in-memory workflow registry.
+ *
+ * Mirrors `src/Registry/register-agents.php` and
+ * `src/Packages/register-agent-package-artifacts.php`: the class file
+ * contains the class; the helpers live alongside as plain functions so
+ * a file is either OO or procedural, never both (PHPCS:
+ * Universal.Files.SeparateFunctionsFromOO).
+ *
+ * @package AgentsAPI
+ * @since   0.103.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+if ( ! function_exists( 'wp_register_workflow' ) ) {
+	/**
+	 * Convenience wrapper: register a code-defined workflow from a raw spec
+	 * array. Returns the validated Spec or a WP_Error on validation failure.
+	 *
+	 * @since 0.103.0
+	 *
+	 * @param array $spec Raw workflow spec — see WP_Agent_Workflow_Spec_Validator.
+	 * @return AgentsAPI\AI\Workflows\WP_Agent_Workflow_Spec|WP_Error
+	 */
+	function wp_register_workflow( array $spec ) {
+		return AgentsAPI\AI\Workflows\WP_Agent_Workflow_Registry::register( $spec );
+	}
+}
+
+if ( ! function_exists( 'wp_get_workflow' ) ) {
+	/**
+	 * Convenience wrapper: look up a registered workflow by id.
+	 *
+	 * @since 0.103.0
+	 *
+	 * @param string $workflow_id
+	 * @return AgentsAPI\AI\Workflows\WP_Agent_Workflow_Spec|null
+	 */
+	function wp_get_workflow( string $workflow_id ): ?AgentsAPI\AI\Workflows\WP_Agent_Workflow_Spec {
+		return AgentsAPI\AI\Workflows\WP_Agent_Workflow_Registry::find( $workflow_id );
+	}
+}

--- a/tests/agents-workflow-ability-smoke.php
+++ b/tests/agents-workflow-ability-smoke.php
@@ -1,0 +1,192 @@
+<?php
+/**
+ * Pure-PHP smoke test for the agents/run-workflow + validate-workflow
+ * + describe-workflow ability dispatchers.
+ *
+ * Run with: php tests/agents-workflow-ability-smoke.php
+ *
+ * @package AgentsAPI\Tests
+ */
+
+defined( 'ABSPATH' ) || define( 'ABSPATH', __DIR__ . '/' );
+
+$failures = array();
+$passes   = 0;
+
+echo "agents-workflow-ability-smoke\n";
+
+class WP_Error {
+	public function __construct( private string $code = '', private string $message = '', private $data = null ) {}
+	public function get_error_code(): string { return $this->code; }
+	public function get_error_message(): string { return $this->message; }
+	public function get_error_data() { return $this->data; }
+}
+function is_wp_error( $value ): bool { return $value instanceof WP_Error; }
+function current_user_can( string $cap ): bool { unset( $cap ); return $GLOBALS['__can'] ?? false; }
+
+$GLOBALS['__filters'] = array();
+function add_filter( string $hook, callable $cb, int $priority = 10, int $accepted_args = 1 ): void {
+	unset( $accepted_args );
+	$GLOBALS['__filters'][ $hook ][ $priority ][] = $cb;
+}
+function apply_filters( string $hook, $value, ...$args ) {
+	$cbs = $GLOBALS['__filters'][ $hook ] ?? array();
+	ksort( $cbs );
+	foreach ( $cbs as $bucket ) {
+		foreach ( $bucket as $cb ) {
+			$value = call_user_func_array( $cb, array_merge( array( $value ), $args ) );
+		}
+	}
+	return $value;
+}
+function add_action( string $hook, callable $cb, int $priority = 10, int $accepted_args = 1 ): void {
+	add_filter( $hook, $cb, $priority, $accepted_args );
+}
+function do_action( string $hook, ...$args ): void {
+	$cbs = $GLOBALS['__filters'][ $hook ] ?? array();
+	ksort( $cbs );
+	foreach ( $cbs as $bucket ) {
+		foreach ( $bucket as $cb ) {
+			call_user_func_array( $cb, $args );
+		}
+	}
+}
+
+function smoke_assert( $expected, $actual, string $name, array &$failures, int &$passes ): void {
+	if ( $expected === $actual ) {
+		++$passes;
+		echo "  PASS {$name}\n";
+		return;
+	}
+	$failures[] = $name;
+	echo "  FAIL {$name}\n";
+	echo '    expected: ' . var_export( $expected, true ) . "\n";
+	echo '    actual:   ' . var_export( $actual, true ) . "\n";
+}
+
+require_once __DIR__ . '/../src/Workflows/class-wp-agent-workflow-spec-validator.php';
+require_once __DIR__ . '/../src/Workflows/class-wp-agent-workflow-spec.php';
+require_once __DIR__ . '/../src/Workflows/class-wp-agent-workflow-bindings.php';
+require_once __DIR__ . '/../src/Workflows/class-wp-agent-workflow-run-result.php';
+require_once __DIR__ . '/../src/Workflows/class-wp-agent-workflow-store.php';
+require_once __DIR__ . '/../src/Workflows/class-wp-agent-workflow-run-recorder.php';
+require_once __DIR__ . '/../src/Workflows/class-wp-agent-workflow-runner.php';
+require_once __DIR__ . '/../src/Workflows/class-wp-agent-workflow-registry.php';
+require_once __DIR__ . '/../src/Workflows/register-agents-workflow-abilities.php';
+
+use function AgentsAPI\AI\Workflows\agents_describe_workflow;
+use function AgentsAPI\AI\Workflows\agents_run_workflow_dispatch;
+use function AgentsAPI\AI\Workflows\agents_run_workflow_permission;
+use function AgentsAPI\AI\Workflows\agents_validate_workflow;
+use function AgentsAPI\AI\Workflows\register_workflow_handler;
+
+// ─── Permission gate ─────────────────────────────────────────────────
+
+$GLOBALS['__can'] = false;
+smoke_assert( false, agents_run_workflow_permission( array() ), 'permission denied without manage_options', $failures, $passes );
+
+$GLOBALS['__can'] = true;
+smoke_assert( true, agents_run_workflow_permission( array() ), 'permission granted with manage_options', $failures, $passes );
+
+add_filter( 'agents_run_workflow_permission', static fn() => false );
+smoke_assert( false, agents_run_workflow_permission( array() ), 'filter can override permission to deny', $failures, $passes );
+
+// ─── validate-workflow ───────────────────────────────────────────────
+
+$valid = agents_validate_workflow(
+	array(
+		'spec' => array(
+			'id'    => 'demo/v',
+			'steps' => array( array( 'id' => 'a', 'type' => 'ability', 'ability' => 'core/op' ) ),
+		),
+	)
+);
+smoke_assert( true, $valid['valid'], 'validate ability returns valid=true on good spec', $failures, $passes );
+smoke_assert( array(), $valid['errors'], 'validate ability returns no errors on good spec', $failures, $passes );
+
+$invalid = agents_validate_workflow( array( 'spec' => array( 'steps' => array() ) ) );
+smoke_assert( false, $invalid['valid'], 'validate ability returns valid=false on bad spec', $failures, $passes );
+smoke_assert( true, count( $invalid['errors'] ) >= 1, 'validate ability returns at least one error', $failures, $passes );
+
+// ─── describe-workflow ───────────────────────────────────────────────
+
+\AgentsAPI\AI\Workflows\WP_Agent_Workflow_Registry::reset();
+\AgentsAPI\AI\Workflows\WP_Agent_Workflow_Registry::register(
+	array(
+		'id'     => 'demo/describe',
+		'inputs' => array( 'q' => array( 'type' => 'string', 'required' => true ) ),
+		'steps'  => array( array( 'id' => 'a', 'type' => 'ability', 'ability' => 'core/x' ) ),
+	)
+);
+
+$desc_hit = agents_describe_workflow( array( 'workflow_id' => 'demo/describe' ) );
+smoke_assert( 'demo/describe', $desc_hit['spec']['id'], 'describe returns the registered spec', $failures, $passes );
+smoke_assert( true, isset( $desc_hit['inputs']['q'] ), 'describe surfaces input declarations', $failures, $passes );
+
+$desc_miss = agents_describe_workflow( array( 'workflow_id' => 'nope' ) );
+smoke_assert( null, $desc_miss['spec'], 'describe returns null for unknown workflow', $failures, $passes );
+
+// ─── run-workflow dispatcher: no handler ─────────────────────────────
+
+$result = agents_run_workflow_dispatch( array( 'workflow_id' => 'whatever' ) );
+smoke_assert( true, $result instanceof WP_Error, 'no handler => WP_Error', $failures, $passes );
+smoke_assert(
+	'agents_run_workflow_no_handler',
+	$result instanceof WP_Error ? $result->get_error_code() : '',
+	'no handler error code',
+	$failures,
+	$passes
+);
+
+// ─── run-workflow dispatcher: register a handler and invoke ──────────
+
+register_workflow_handler(
+	static function ( array $input ): array {
+		return array(
+			'run_id'      => 'fake-run-1',
+			'workflow_id' => (string) ( $input['workflow_id'] ?? '' ),
+			'status'      => 'succeeded',
+			'output'      => array( 'echo' => $input['inputs'] ?? array() ),
+			'steps'       => array(),
+			'started_at'  => time(),
+			'ended_at'    => time(),
+		);
+	}
+);
+
+$ok = agents_run_workflow_dispatch( array( 'workflow_id' => 'demo/x', 'inputs' => array( 'a' => 1 ) ) );
+smoke_assert( false, $ok instanceof WP_Error, 'registered handler runs', $failures, $passes );
+smoke_assert( 'fake-run-1', $ok['run_id'] ?? '', 'handler output is returned to caller', $failures, $passes );
+smoke_assert( array( 'a' => 1 ), $ok['output']['echo'] ?? array(), 'handler sees forwarded inputs', $failures, $passes );
+
+// ─── handler returns invalid type ────────────────────────────────────
+
+$GLOBALS['__filters'] = array(); // wipe registered handler
+add_filter( 'wp_agent_workflow_handler', static fn() => static fn() => 'not an array' );
+
+$bad = agents_run_workflow_dispatch( array( 'workflow_id' => 'demo/x' ) );
+smoke_assert( true, $bad instanceof WP_Error, 'invalid handler return => WP_Error', $failures, $passes );
+smoke_assert(
+	'agents_run_workflow_invalid_result',
+	$bad instanceof WP_Error ? $bad->get_error_code() : '',
+	'invalid result code',
+	$failures,
+	$passes
+);
+
+// ─── observability: dispatch_failed fires ────────────────────────────
+
+$failed_reasons = array();
+add_filter(
+	'agents_run_workflow_dispatch_failed',
+	static function ( $reason ) use ( &$failed_reasons ) {
+		$failed_reasons[] = $reason;
+	}
+);
+
+$GLOBALS['__filters']['wp_agent_workflow_handler'] = array();
+agents_run_workflow_dispatch( array( 'workflow_id' => 'whatever' ) );
+smoke_assert( true, in_array( 'no_handler', $failed_reasons, true ), 'dispatch_failed fires with no_handler', $failures, $passes );
+
+echo "Passed: {$passes}, Failed: " . count( $failures ) . "\n";
+exit( count( $failures ) > 0 ? 1 : 0 );

--- a/tests/bootstrap-smoke.php
+++ b/tests/bootstrap-smoke.php
@@ -163,6 +163,7 @@ $expected_source_directories = array(
 	'Runtime',
 	'Tools',
 	'Transcripts',
+	'Workflows',
 	'Workspace',
 );
 $actual_source_directories   = array();

--- a/tests/workflow-bindings-smoke.php
+++ b/tests/workflow-bindings-smoke.php
@@ -1,0 +1,176 @@
+<?php
+/**
+ * Pure-PHP smoke test for WP_Agent_Workflow_Bindings.
+ *
+ * Run with: php tests/workflow-bindings-smoke.php
+ *
+ * @package AgentsAPI\Tests
+ */
+
+defined( 'ABSPATH' ) || define( 'ABSPATH', __DIR__ . '/' );
+
+$failures = array();
+$passes   = 0;
+
+echo "workflow-bindings-smoke\n";
+
+function smoke_assert( $expected, $actual, string $name, array &$failures, int &$passes ): void {
+	if ( $expected === $actual ) {
+		++$passes;
+		echo "  PASS {$name}\n";
+		return;
+	}
+	$failures[] = $name;
+	echo "  FAIL {$name}\n";
+	echo '    expected: ' . var_export( $expected, true ) . "\n";
+	echo '    actual:   ' . var_export( $actual, true ) . "\n";
+}
+
+require_once __DIR__ . '/../src/Workflows/class-wp-agent-workflow-bindings.php';
+
+use AgentsAPI\AI\Workflows\WP_Agent_Workflow_Bindings;
+
+$context = array(
+	'inputs' => array(
+		'comment_id' => 42,
+		'subject'    => 'Welcome',
+		'meta'       => array( 'priority' => 'high', 'tags' => array( 'urgent', 'vip' ) ),
+	),
+	'steps'  => array(
+		'classify' => array(
+			'output' => array(
+				'category' => 'spam',
+				'score'    => 0.92,
+				'reasons'  => array( 'first' => 'too short', 'second' => 'all caps' ),
+			),
+		),
+	),
+);
+
+// Whole-string atomic substitution preserves type.
+smoke_assert(
+	42,
+	WP_Agent_Workflow_Bindings::expand( '${inputs.comment_id}', $context ),
+	'whole-string template returns native int',
+	$failures,
+	$passes
+);
+
+smoke_assert(
+	0.92,
+	WP_Agent_Workflow_Bindings::expand( '${steps.classify.output.score}', $context ),
+	'whole-string template returns native float from step output',
+	$failures,
+	$passes
+);
+
+smoke_assert(
+	array( 'urgent', 'vip' ),
+	WP_Agent_Workflow_Bindings::expand( '${inputs.meta.tags}', $context ),
+	'whole-string template returns native array',
+	$failures,
+	$passes
+);
+
+// Mixed-content templates render to string with type coercion.
+smoke_assert(
+	'comment 42 is spam',
+	WP_Agent_Workflow_Bindings::expand( 'comment ${inputs.comment_id} is ${steps.classify.output.category}', $context ),
+	'mixed template stringifies inline values',
+	$failures,
+	$passes
+);
+
+// Recursion into arrays.
+smoke_assert(
+	array(
+		'title' => 'Welcome',
+		'meta'  => array( 'priority' => 'high', 'cat' => 'spam' ),
+	),
+	WP_Agent_Workflow_Bindings::expand(
+		array(
+			'title' => '${inputs.subject}',
+			'meta'  => array(
+				'priority' => '${inputs.meta.priority}',
+				'cat'      => '${steps.classify.output.category}',
+			),
+		),
+		$context
+	),
+	'expand walks nested arrays',
+	$failures,
+	$passes
+);
+
+// Missing path → null in atomic mode, empty string in mixed mode.
+smoke_assert(
+	null,
+	WP_Agent_Workflow_Bindings::expand( '${inputs.does_not_exist}', $context ),
+	'atomic miss returns null',
+	$failures,
+	$passes
+);
+
+smoke_assert(
+	'prefix:',
+	WP_Agent_Workflow_Bindings::expand( 'prefix:${inputs.does_not_exist}', $context ),
+	'mixed miss collapses to empty string',
+	$failures,
+	$passes
+);
+
+// Non-string scalars pass through untouched.
+smoke_assert(
+	123,
+	WP_Agent_Workflow_Bindings::expand( 123, $context ),
+	'integer passes through expand unchanged',
+	$failures,
+	$passes
+);
+
+smoke_assert(
+	true,
+	WP_Agent_Workflow_Bindings::expand( true, $context ),
+	'boolean passes through expand unchanged',
+	$failures,
+	$passes
+);
+
+// Unknown root token resolves to null (atomic).
+smoke_assert(
+	null,
+	WP_Agent_Workflow_Bindings::expand( '${unknown.token}', $context ),
+	'unknown root segment resolves to null',
+	$failures,
+	$passes
+);
+
+// Missing step in steps map.
+smoke_assert(
+	null,
+	WP_Agent_Workflow_Bindings::expand( '${steps.unseen.output.value}', $context ),
+	'reference to missing step returns null',
+	$failures,
+	$passes
+);
+
+// `steps.<id>.foo` (without `output`) is not supported.
+smoke_assert(
+	null,
+	WP_Agent_Workflow_Bindings::expand( '${steps.classify.input.something}', $context ),
+	'non-output step path returns null (substrate is output-only)',
+	$failures,
+	$passes
+);
+
+// Numeric path segments resolve list elements.
+smoke_assert(
+	'urgent',
+	WP_Agent_Workflow_Bindings::expand( '${inputs.meta.tags.0}', $context ),
+	'numeric segment indexes lists',
+	$failures,
+	$passes
+);
+
+echo "Passed: {$passes}, Failed: " . count( $failures ) . "\n";
+exit( count( $failures ) > 0 ? 1 : 0 );

--- a/tests/workflow-runner-smoke.php
+++ b/tests/workflow-runner-smoke.php
@@ -220,5 +220,53 @@ if ( ! ( $martian instanceof WP_Error ) ) {
 	smoke_assert( 'no_step_handler', $result5->get_error()['code'], 'runner reports no_step_handler', $failures, $passes );
 }
 
+// ─── Recorder->start() returning WP_Error fails fast ──────────────────
+
+class Failing_Start_Recorder implements WP_Agent_Workflow_Run_Recorder {
+	public int $start_calls  = 0;
+	public int $update_calls = 0;
+	public function start( WP_Agent_Workflow_Run_Result $result ) {
+		++$this->start_calls;
+		return new WP_Error( 'storage_offline', 'recorder is unavailable' );
+	}
+	public function update( WP_Agent_Workflow_Run_Result $result ) {
+		++$this->update_calls;
+		return true;
+	}
+	public function find( string $run_id ): ?WP_Agent_Workflow_Run_Result { return null; }
+	public function recent( array $args = array() ): array { return array(); }
+}
+
+$recorder3 = new Failing_Start_Recorder();
+$result6   = ( new WP_Agent_Workflow_Runner( $recorder3 ) )->run( $spec, array( 'text' => 'hi' ) );
+smoke_assert( WP_Agent_Workflow_Run_Result::STATUS_FAILED, $result6->get_status(), 'recorder start failure => failed run', $failures, $passes );
+smoke_assert( 'recorder_start_failed', $result6->get_error()['code'], 'recorder start failure has expected code', $failures, $passes );
+smoke_assert( 0, count( $result6->get_steps() ), 'no steps run when recorder start fails', $failures, $passes );
+smoke_assert( 0, $recorder3->update_calls, 'no update fired when start failed', $failures, $passes );
+
+// ─── Input-validation failure goes through start → update lifecycle ───
+
+class Lifecycle_Tracker_Recorder implements WP_Agent_Workflow_Run_Recorder {
+	public array $events = array();
+	public function start( WP_Agent_Workflow_Run_Result $result ) {
+		$this->events[] = array( 'op' => 'start', 'status' => $result->get_status() );
+		return $result->get_run_id();
+	}
+	public function update( WP_Agent_Workflow_Run_Result $result ) {
+		$this->events[] = array( 'op' => 'update', 'status' => $result->get_status() );
+		return true;
+	}
+	public function find( string $run_id ): ?WP_Agent_Workflow_Run_Result { return null; }
+	public function recent( array $args = array() ): array { return array(); }
+}
+
+$tracker = new Lifecycle_Tracker_Recorder();
+$result7 = ( new WP_Agent_Workflow_Runner( $tracker ) )->run( $spec /* missing required text */ );
+smoke_assert( WP_Agent_Workflow_Run_Result::STATUS_FAILED, $result7->get_status(), 'missing input still fails', $failures, $passes );
+smoke_assert( 'start', $tracker->events[0]['op'] ?? '', 'recorder sees start first', $failures, $passes );
+smoke_assert( WP_Agent_Workflow_Run_Result::STATUS_RUNNING, $tracker->events[0]['status'] ?? '', 'start is called with RUNNING', $failures, $passes );
+smoke_assert( 'update', $tracker->events[1]['op'] ?? '', 'recorder sees update second', $failures, $passes );
+smoke_assert( WP_Agent_Workflow_Run_Result::STATUS_FAILED, $tracker->events[1]['status'] ?? '', 'update flips status to FAILED', $failures, $passes );
+
 echo "Passed: {$passes}, Failed: " . count( $failures ) . "\n";
 exit( count( $failures ) > 0 ? 1 : 0 );

--- a/tests/workflow-runner-smoke.php
+++ b/tests/workflow-runner-smoke.php
@@ -1,0 +1,224 @@
+<?php
+/**
+ * Pure-PHP smoke test for WP_Agent_Workflow_Runner.
+ *
+ * Run with: php tests/workflow-runner-smoke.php
+ *
+ * Drives the full execute path with stub abilities, a stub recorder, and
+ * a hand-rolled spec. No WordPress required.
+ *
+ * @package AgentsAPI\Tests
+ */
+
+defined( 'ABSPATH' ) || define( 'ABSPATH', __DIR__ . '/' );
+
+$failures = array();
+$passes   = 0;
+
+echo "workflow-runner-smoke\n";
+
+class WP_Error {
+	public function __construct( private string $code = '', private string $message = '', private $data = null ) {}
+	public function get_error_code(): string { return $this->code; }
+	public function get_error_message(): string { return $this->message; }
+	public function get_error_data() { return $this->data; }
+}
+
+function is_wp_error( $value ): bool {
+	return $value instanceof WP_Error;
+}
+
+$GLOBALS['__filters']    = array();
+$GLOBALS['__abilities']  = array();
+
+function add_filter( string $hook, callable $cb, int $priority = 10, int $accepted_args = 1 ): void {
+	unset( $accepted_args );
+	$GLOBALS['__filters'][ $hook ][ $priority ][] = $cb;
+}
+function apply_filters( string $hook, $value, ...$args ) {
+	$cbs = $GLOBALS['__filters'][ $hook ] ?? array();
+	ksort( $cbs );
+	foreach ( $cbs as $bucket ) {
+		foreach ( $bucket as $cb ) {
+			$value = call_user_func_array( $cb, array_merge( array( $value ), $args ) );
+		}
+	}
+	return $value;
+}
+function add_action( string $hook, callable $cb, int $priority = 10, int $accepted_args = 1 ): void {
+	add_filter( $hook, $cb, $priority, $accepted_args );
+}
+function do_action( string $hook, ...$args ): void {
+	$cbs = $GLOBALS['__filters'][ $hook ] ?? array();
+	ksort( $cbs );
+	foreach ( $cbs as $bucket ) {
+		foreach ( $bucket as $cb ) {
+			call_user_func_array( $cb, $args );
+		}
+	}
+}
+function wp_get_ability( string $name ) {
+	return $GLOBALS['__abilities'][ $name ] ?? null;
+}
+
+class Stub_Ability {
+	public function __construct( private \Closure $handler ) {}
+	public function execute( array $input ) {
+		return ( $this->handler )( $input );
+	}
+}
+
+function smoke_assert( $expected, $actual, string $name, array &$failures, int &$passes ): void {
+	if ( $expected === $actual ) {
+		++$passes;
+		echo "  PASS {$name}\n";
+		return;
+	}
+	$failures[] = $name;
+	echo "  FAIL {$name}\n";
+	echo '    expected: ' . var_export( $expected, true ) . "\n";
+	echo '    actual:   ' . var_export( $actual, true ) . "\n";
+}
+
+require_once __DIR__ . '/../src/Workflows/class-wp-agent-workflow-bindings.php';
+require_once __DIR__ . '/../src/Workflows/class-wp-agent-workflow-spec-validator.php';
+require_once __DIR__ . '/../src/Workflows/class-wp-agent-workflow-spec.php';
+require_once __DIR__ . '/../src/Workflows/class-wp-agent-workflow-run-result.php';
+require_once __DIR__ . '/../src/Workflows/class-wp-agent-workflow-store.php';
+require_once __DIR__ . '/../src/Workflows/class-wp-agent-workflow-run-recorder.php';
+require_once __DIR__ . '/../src/Workflows/class-wp-agent-workflow-runner.php';
+
+use AgentsAPI\AI\Workflows\WP_Agent_Workflow_Run_Recorder;
+use AgentsAPI\AI\Workflows\WP_Agent_Workflow_Run_Result;
+use AgentsAPI\AI\Workflows\WP_Agent_Workflow_Runner;
+use AgentsAPI\AI\Workflows\WP_Agent_Workflow_Spec;
+
+class Capture_Recorder implements WP_Agent_Workflow_Run_Recorder {
+	public array $writes = array();
+	public function start( WP_Agent_Workflow_Run_Result $result ) {
+		$this->writes[] = array( 'op' => 'start', 'status' => $result->get_status(), 'steps' => count( $result->get_steps() ) );
+		return $result->get_run_id();
+	}
+	public function update( WP_Agent_Workflow_Run_Result $result ) {
+		$this->writes[] = array( 'op' => 'update', 'status' => $result->get_status(), 'steps' => count( $result->get_steps() ) );
+		return true;
+	}
+	public function find( string $run_id ): ?WP_Agent_Workflow_Run_Result { return null; }
+	public function recent( array $args = array() ): array { return array(); }
+}
+
+// ─── Happy path: 2 sequential ability steps with bindings between them ───
+
+$GLOBALS['__abilities']['demo/uppercase'] = new Stub_Ability(
+	static function ( array $input ): array {
+		return array( 'value' => strtoupper( (string) ( $input['text'] ?? '' ) ) );
+	}
+);
+$GLOBALS['__abilities']['demo/wrap'] = new Stub_Ability(
+	static function ( array $input ): array {
+		return array( 'wrapped' => '<<' . (string) ( $input['inner'] ?? '' ) . '>>' );
+	}
+);
+
+$spec = WP_Agent_Workflow_Spec::from_array(
+	array(
+		'id'    => 'demo/transform',
+		'inputs' => array( 'text' => array( 'type' => 'string', 'required' => true ) ),
+		'steps' => array(
+			array(
+				'id'      => 'upper',
+				'type'    => 'ability',
+				'ability' => 'demo/uppercase',
+				'args'    => array( 'text' => '${inputs.text}' ),
+			),
+			array(
+				'id'      => 'wrap',
+				'type'    => 'ability',
+				'ability' => 'demo/wrap',
+				'args'    => array( 'inner' => '${steps.upper.output.value}' ),
+			),
+		),
+	)
+);
+
+$recorder = new Capture_Recorder();
+$runner   = new WP_Agent_Workflow_Runner( $recorder );
+$result   = $runner->run( $spec, array( 'text' => 'hello' ) );
+
+smoke_assert( WP_Agent_Workflow_Run_Result::STATUS_SUCCEEDED, $result->get_status(), 'happy path succeeds', $failures, $passes );
+smoke_assert( 2, count( $result->get_steps() ), 'two step records produced', $failures, $passes );
+smoke_assert( 'HELLO', $result->get_steps()[0]['output']['value'], 'step 1 output recorded', $failures, $passes );
+smoke_assert( '<<HELLO>>', $result->get_steps()[1]['output']['wrapped'], 'step 2 receives previous step output via binding', $failures, $passes );
+smoke_assert( '<<HELLO>>', $result->get_output()['last']['wrapped'], 'final output exposes last step', $failures, $passes );
+smoke_assert( true, count( $recorder->writes ) >= 3, 'recorder hit at least 3 times (start + per-step updates + final)', $failures, $passes );
+smoke_assert( 'start', $recorder->writes[0]['op'], 'recorder start fires first', $failures, $passes );
+
+// ─── Failed step short-circuits ───────────────────────────────────────
+
+$GLOBALS['__abilities']['demo/boom'] = new Stub_Ability(
+	static function ( array $input ): \WP_Error {
+		unset( $input );
+		return new \WP_Error( 'demo_bang', 'something broke' );
+	}
+);
+
+$bad_spec = WP_Agent_Workflow_Spec::from_array(
+	array(
+		'id'    => 'demo/bad',
+		'steps' => array(
+			array( 'id' => 'first',  'type' => 'ability', 'ability' => 'demo/boom' ),
+			array( 'id' => 'second', 'type' => 'ability', 'ability' => 'demo/uppercase', 'args' => array( 'text' => 'never reached' ) ),
+		),
+	)
+);
+
+$recorder2 = new Capture_Recorder();
+$result2   = ( new WP_Agent_Workflow_Runner( $recorder2 ) )->run( $bad_spec );
+
+smoke_assert( WP_Agent_Workflow_Run_Result::STATUS_FAILED, $result2->get_status(), 'failed step yields failed run', $failures, $passes );
+smoke_assert( 1, count( $result2->get_steps() ), 'short-circuit stops at first failure', $failures, $passes );
+smoke_assert( 'demo_bang', $result2->get_error()['code'], 'top-level error carries failed step code', $failures, $passes );
+
+// ─── continue_on_error keeps running ─────────────────────────────────
+
+$result3 = ( new WP_Agent_Workflow_Runner( null ) )->run( $bad_spec, array(), array( 'continue_on_error' => true ) );
+smoke_assert( WP_Agent_Workflow_Run_Result::STATUS_FAILED, $result3->get_status(), 'continue_on_error still surfaces failure', $failures, $passes );
+smoke_assert( 2, count( $result3->get_steps() ), 'continue_on_error executes the second step too', $failures, $passes );
+
+// ─── Required-input check ────────────────────────────────────────────
+
+$result4 = ( new WP_Agent_Workflow_Runner( null ) )->run( $spec /* missing text */ );
+smoke_assert( WP_Agent_Workflow_Run_Result::STATUS_FAILED, $result4->get_status(), 'missing required input fails fast', $failures, $passes );
+smoke_assert( 'missing_required_input', $result4->get_error()['code'], 'input error has expected code', $failures, $passes );
+smoke_assert( 0, count( $result4->get_steps() ), 'no steps run when input validation fails', $failures, $passes );
+
+// ─── Unknown step type with no handler ───────────────────────────────
+
+$martian = WP_Agent_Workflow_Spec::from_array(
+	array(
+		'id'    => 'demo/martian',
+		'steps' => array( array( 'id' => 'a', 'type' => 'martian', 'foo' => 'bar' ) ),
+	)
+);
+// Validator would have rejected this — but test the runner's defensive handling
+// by passing an already-constructed Spec where the type made it through.
+if ( $martian instanceof WP_Error ) {
+	// Validator extension already exists from a previous test run — register a stub handler so the spec
+	// constructs but the runner has no handler.
+	add_filter( 'wp_agent_workflow_known_step_types', static fn( $t ) => array_merge( (array) $t, array( 'martian' ) ) );
+	$martian = WP_Agent_Workflow_Spec::from_array(
+		array(
+			'id'    => 'demo/martian',
+			'steps' => array( array( 'id' => 'a', 'type' => 'martian', 'foo' => 'bar' ) ),
+		)
+	);
+}
+
+if ( ! ( $martian instanceof WP_Error ) ) {
+	$result5 = ( new WP_Agent_Workflow_Runner( null ) )->run( $martian );
+	smoke_assert( WP_Agent_Workflow_Run_Result::STATUS_FAILED, $result5->get_status(), 'no handler => failed run', $failures, $passes );
+	smoke_assert( 'no_step_handler', $result5->get_error()['code'], 'runner reports no_step_handler', $failures, $passes );
+}
+
+echo "Passed: {$passes}, Failed: " . count( $failures ) . "\n";
+exit( count( $failures ) > 0 ? 1 : 0 );

--- a/tests/workflow-spec-validator-smoke.php
+++ b/tests/workflow-spec-validator-smoke.php
@@ -1,0 +1,189 @@
+<?php
+/**
+ * Pure-PHP smoke test for WP_Agent_Workflow_Spec_Validator + WP_Agent_Workflow_Spec.
+ *
+ * Run with: php tests/workflow-spec-validator-smoke.php
+ *
+ * @package AgentsAPI\Tests
+ */
+
+defined( 'ABSPATH' ) || define( 'ABSPATH', __DIR__ . '/' );
+
+$failures = array();
+$passes   = 0;
+
+echo "workflow-spec-validator-smoke\n";
+
+class WP_Error {
+	public function __construct( private string $code = '', private string $message = '', private $data = null ) {}
+	public function get_error_code(): string { return $this->code; }
+	public function get_error_message(): string { return $this->message; }
+	public function get_error_data() { return $this->data; }
+}
+
+function is_wp_error( $value ): bool {
+	return $value instanceof WP_Error;
+}
+
+$GLOBALS['__filters'] = array();
+function add_filter( string $hook, callable $cb, int $priority = 10, int $accepted_args = 1 ): void {
+	unset( $accepted_args );
+	$GLOBALS['__filters'][ $hook ][ $priority ][] = $cb;
+}
+function apply_filters( string $hook, $value, ...$args ) {
+	$cbs = $GLOBALS['__filters'][ $hook ] ?? array();
+	ksort( $cbs );
+	foreach ( $cbs as $bucket ) {
+		foreach ( $bucket as $cb ) {
+			$value = call_user_func_array( $cb, array_merge( array( $value ), $args ) );
+		}
+	}
+	return $value;
+}
+
+function smoke_assert( $expected, $actual, string $name, array &$failures, int &$passes ): void {
+	if ( $expected === $actual ) {
+		++$passes;
+		echo "  PASS {$name}\n";
+		return;
+	}
+	$failures[] = $name;
+	echo "  FAIL {$name}\n";
+	echo '    expected: ' . var_export( $expected, true ) . "\n";
+	echo '    actual:   ' . var_export( $actual, true ) . "\n";
+}
+
+require_once __DIR__ . '/../src/Workflows/class-wp-agent-workflow-spec-validator.php';
+require_once __DIR__ . '/../src/Workflows/class-wp-agent-workflow-spec.php';
+
+use AgentsAPI\AI\Workflows\WP_Agent_Workflow_Spec;
+use AgentsAPI\AI\Workflows\WP_Agent_Workflow_Spec_Validator;
+
+// ─── Validator ──────────────────────────────────────────────────────
+
+// Valid minimal spec.
+$min = array(
+	'id'    => 'demo/min',
+	'steps' => array(
+		array( 'id' => 'a', 'type' => 'ability', 'ability' => 'core/some-op' ),
+	),
+);
+smoke_assert( array(), WP_Agent_Workflow_Spec_Validator::validate( $min ), 'valid minimal spec returns no errors', $failures, $passes );
+
+// Missing id.
+$errors = WP_Agent_Workflow_Spec_Validator::validate( array( 'steps' => $min['steps'] ) );
+smoke_assert( 'missing_required', $errors[0]['code'] ?? '', 'missing id flagged', $failures, $passes );
+smoke_assert( 'id', $errors[0]['path'] ?? '', 'missing id has correct path', $failures, $passes );
+
+// Missing steps.
+$errors = WP_Agent_Workflow_Spec_Validator::validate( array( 'id' => 'demo/x' ) );
+smoke_assert( true, ! empty( $errors ), 'missing steps flagged', $failures, $passes );
+smoke_assert( 'steps', $errors[0]['path'] ?? '', 'missing steps reports path', $failures, $passes );
+
+// Empty steps array.
+$errors = WP_Agent_Workflow_Spec_Validator::validate( array( 'id' => 'demo/x', 'steps' => array() ) );
+smoke_assert( true, ! empty( $errors ), 'empty steps still flagged', $failures, $passes );
+
+// Step missing id.
+$errors = WP_Agent_Workflow_Spec_Validator::validate(
+	array(
+		'id'    => 'demo/x',
+		'steps' => array( array( 'type' => 'ability', 'ability' => 'core/op' ) ),
+	)
+);
+smoke_assert( 'steps.0.id', $errors[0]['path'] ?? '', 'step missing id reports indexed path', $failures, $passes );
+
+// Duplicate step ids.
+$errors = WP_Agent_Workflow_Spec_Validator::validate(
+	array(
+		'id'    => 'demo/x',
+		'steps' => array(
+			array( 'id' => 'same', 'type' => 'ability', 'ability' => 'a' ),
+			array( 'id' => 'same', 'type' => 'ability', 'ability' => 'b' ),
+		),
+	)
+);
+$dup_codes = array_column( $errors, 'code' );
+smoke_assert( true, in_array( 'duplicate_id', $dup_codes, true ), 'duplicate step id flagged', $failures, $passes );
+
+// Unknown step type.
+$errors = WP_Agent_Workflow_Spec_Validator::validate(
+	array(
+		'id'    => 'demo/x',
+		'steps' => array( array( 'id' => 'a', 'type' => 'martian', 'something' => 'x' ) ),
+	)
+);
+smoke_assert( 'unknown_step_type', $errors[0]['code'] ?? '', 'unknown step type flagged', $failures, $passes );
+
+// Filter widens the known step types.
+add_filter(
+	'wp_agent_workflow_known_step_types',
+	static fn( $types ) => array_merge( (array) $types, array( 'martian' ) )
+);
+$errors = WP_Agent_Workflow_Spec_Validator::validate(
+	array(
+		'id'    => 'demo/x',
+		'steps' => array( array( 'id' => 'a', 'type' => 'martian', 'something' => 'x' ) ),
+	)
+);
+smoke_assert( array(), $errors, 'filter-extended step type accepted', $failures, $passes );
+
+// Agent step missing message.
+$errors = WP_Agent_Workflow_Spec_Validator::validate(
+	array(
+		'id'    => 'demo/x',
+		'steps' => array( array( 'id' => 'a', 'type' => 'agent', 'agent' => 'demo' ) ),
+	)
+);
+$paths = array_column( $errors, 'path' );
+smoke_assert( true, in_array( 'steps.0.message', $paths, true ), 'agent step missing message flagged', $failures, $passes );
+
+// wp_action trigger missing hook.
+$errors = WP_Agent_Workflow_Spec_Validator::validate(
+	array(
+		'id'       => 'demo/x',
+		'steps'    => $min['steps'],
+		'triggers' => array( array( 'type' => 'wp_action' ) ),
+	)
+);
+smoke_assert( 'triggers.0.hook', $errors[0]['path'] ?? '', 'wp_action trigger missing hook flagged', $failures, $passes );
+
+// cron trigger missing both expression and interval.
+$errors = WP_Agent_Workflow_Spec_Validator::validate(
+	array(
+		'id'       => 'demo/x',
+		'steps'    => $min['steps'],
+		'triggers' => array( array( 'type' => 'cron' ) ),
+	)
+);
+smoke_assert( 'missing_required', $errors[0]['code'] ?? '', 'cron trigger missing schedule flagged', $failures, $passes );
+
+// ─── Spec value object ──────────────────────────────────────────────
+
+$spec = WP_Agent_Workflow_Spec::from_array(
+	array(
+		'id'       => 'demo/full',
+		'version'  => '1.2.3',
+		'inputs'   => array( 'request' => array( 'type' => 'string', 'required' => true ) ),
+		'steps'    => array(
+			array( 'id' => 'classify', 'type' => 'agent', 'agent' => 'demo', 'message' => 'Hi' ),
+			array( 'id' => 'send', 'type' => 'ability', 'ability' => 'core/notify' ),
+		),
+		'triggers' => array( array( 'type' => 'on_demand' ) ),
+		'meta'     => array( 'source_plugin' => 'unit-test' ),
+	)
+);
+
+smoke_assert( false, $spec instanceof WP_Error, 'valid spec constructs without WP_Error', $failures, $passes );
+smoke_assert( 'demo/full', $spec->get_id(), 'Spec::get_id', $failures, $passes );
+smoke_assert( '1.2.3', $spec->get_version(), 'Spec::get_version', $failures, $passes );
+smoke_assert( 2, count( $spec->get_steps() ), 'Spec::get_steps count', $failures, $passes );
+smoke_assert( 'unit-test', $spec->get_meta()['source_plugin'], 'Spec::get_meta', $failures, $passes );
+
+// from_array on invalid spec returns WP_Error.
+$err = WP_Agent_Workflow_Spec::from_array( array( 'steps' => array() ) );
+smoke_assert( true, $err instanceof WP_Error, 'invalid raw returns WP_Error', $failures, $passes );
+smoke_assert( 'workflow_spec_invalid', $err instanceof WP_Error ? $err->get_error_code() : '', 'WP_Error has expected code', $failures, $passes );
+
+echo "Passed: {$passes}, Failed: " . count( $failures ) . "\n";
+exit( count( $failures ) > 0 ? 1 : 0 );

--- a/tests/workflow-spec-validator-smoke.php
+++ b/tests/workflow-spec-validator-smoke.php
@@ -138,6 +138,72 @@ $errors = WP_Agent_Workflow_Spec_Validator::validate(
 $paths = array_column( $errors, 'path' );
 smoke_assert( true, in_array( 'steps.0.message', $paths, true ), 'agent step missing message flagged', $failures, $passes );
 
+// Trigger-types filter widens the known list (mirror of the step-types test).
+add_filter(
+	'wp_agent_workflow_known_trigger_types',
+	static fn( $types ) => array_merge( (array) $types, array( 'webhook' ) )
+);
+$errors = WP_Agent_Workflow_Spec_Validator::validate(
+	array(
+		'id'       => 'demo/x',
+		'steps'    => $min['steps'],
+		'triggers' => array( array( 'type' => 'webhook', 'route' => '/foo' ) ),
+	)
+);
+smoke_assert( array(), $errors, 'filter-extended trigger type accepted', $failures, $passes );
+
+// Forward / unknown step-id binding references.
+$errors = WP_Agent_Workflow_Spec_Validator::validate(
+	array(
+		'id'    => 'demo/forward-ref',
+		'steps' => array(
+			array(
+				'id'      => 'first',
+				'type'    => 'ability',
+				'ability' => 'core/op',
+				'args'    => array( 'x' => '${steps.later.output.value}' ),
+			),
+			array( 'id' => 'later', 'type' => 'ability', 'ability' => 'core/op2' ),
+		),
+	)
+);
+$codes = array_column( $errors, 'code' );
+smoke_assert( true, in_array( 'unknown_step_reference', $codes, true ), 'forward step-id reference flagged', $failures, $passes );
+
+$errors = WP_Agent_Workflow_Spec_Validator::validate(
+	array(
+		'id'    => 'demo/typo',
+		'steps' => array(
+			array( 'id' => 'first', 'type' => 'ability', 'ability' => 'core/op' ),
+			array(
+				'id'      => 'second',
+				'type'    => 'ability',
+				'ability' => 'core/op2',
+				'args'    => array( 'x' => '${steps.frist.output.value}' ),
+			),
+		),
+	)
+);
+$codes = array_column( $errors, 'code' );
+smoke_assert( true, in_array( 'unknown_step_reference', $codes, true ), 'typo in step id reference flagged', $failures, $passes );
+
+// Valid backward reference does NOT trigger the binding-ref check.
+$errors = WP_Agent_Workflow_Spec_Validator::validate(
+	array(
+		'id'    => 'demo/valid-ref',
+		'steps' => array(
+			array( 'id' => 'first', 'type' => 'ability', 'ability' => 'core/op' ),
+			array(
+				'id'      => 'second',
+				'type'    => 'ability',
+				'ability' => 'core/op2',
+				'args'    => array( 'x' => '${steps.first.output.value}' ),
+			),
+		),
+	)
+);
+smoke_assert( array(), $errors, 'backward step-id reference passes', $failures, $passes );
+
 // wp_action trigger missing hook.
 $errors = WP_Agent_Workflow_Spec_Validator::validate(
 	array(


### PR DESCRIPTION
## Summary

Adds an unopinionated workflow plumbing layer in the spirit of Channels and Memory — substrate ships contracts, value objects, validators, an in-memory registry, an optional Action Scheduler bridge, and three canonical Abilities API entry points; every consumer brings its own storage and run-recorder implementations.

The two existing references — James LePage's [six-month-old design spike](https://github.a8c.com/lepagejames/workflows-api) (design-only, no implementation) and the HAL team's wpcom workflow engine (production since Aug 2025, closed-source inside wpcom) — converge on the same shape: deterministic orchestration over registered abilities and agents, with the runtime owned by whichever consumer wants to drive it. Data Machine already runs its own pipelines/flows/jobs against custom tables; openclaWP wants a smaller CPT-backed runtime; future consumers may want neither. agents-api is the right place for the contract those runtimes share.

Per Chris Huber on 2026-05-08: *"we will handle it similar to memory, where we provide unopinionated plumbing."*

## What ships

| Component | Purpose |
|---|---|
| `WP_Agent_Workflow_Spec` + `Spec_Validator` | Immutable value object + structural validator returning `[ path, code, message ]` triples for editor / REST surfaces |
| `WP_Agent_Workflow_Bindings` | Pure helper that expands `${inputs.x}` and `${steps.<id>.output.<path>}` templates. Whole-string templates preserve native types; mixed-content templates stringify; missing paths return null (atomic) / empty string (mixed) |
| `WP_Agent_Workflow_Run_Result` | Immutable execution outcome with `pending` / `running` / `succeeded` / `failed` / `skipped` statuses |
| `WP_Agent_Workflow_Store` | **Interface only** — no default impl. Consumers wire their preferred persistence |
| `WP_Agent_Workflow_Run_Recorder` | **Interface only** — same model |
| `WP_Agent_Workflow_Runner` | Abstract execution engine. Sequential steps, step-type handler map (`ability` and `agent` ship; `branch` / `parallel` / `workflow` extensible via filter), per-step recording, short-circuit on failure unless `continue_on_error` is set. Default `agent` handler routes through the canonical `agents/chat` dispatcher (per #100) |
| `WP_Agent_Workflow_Registry` | In-memory `wp_register_workflow()` / `wp_get_workflow()` — pair with a Store for durable persistence |
| `WP_Agent_Workflow_Action_Scheduler_Bridge` | Optional bridge — no-ops cleanly when AS isn't loaded. Fires `wp_agent_workflow_schedule_requested` regardless so custom schedulers can take over |
| `register-agents-workflow-abilities.php` | Three abilities under the existing `agents-api` category: `agents/run-workflow` (dispatcher mirroring `agents/chat`), `agents/validate-workflow` (pure substrate, no runtime), `agents/describe-workflow` |

## Sample spec

```php
return array(
    'id'      => 'triage-inbound-customer-request',
    'version' => '1.0.0',
    'inputs'  => array( 'request' => array( 'type' => 'string', 'required' => true ) ),
    'steps'   => array(
        array(
            'id'      => 'classify',
            'type'    => 'agent',
            'agent'   => 'ops-triage',
            'message' => 'Classify and decide next action: ${inputs.request}',
        ),
        array(
            'id'      => 'create-ticket',
            'type'    => 'ability',
            'ability' => 'linear/create-issue',
            'args'    => array(
                'title' => '${steps.classify.output.title}',
                'body'  => '${steps.classify.output.summary}',
            ),
        ),
    ),
    'triggers' => array(
        array( 'type' => 'on_demand' ),
        array( 'type' => 'wp_action', 'hook' => 'comment_post' ),
    ),
);
```

## Out of scope (deferred to consumers / v1)

- Branching / conditionals / parallel steps — extensible today via `wp_agent_workflow_step_handlers` filter, no built-ins ship
- Nested workflows (`type: workflow`) — same extension hook
- YAML DSL — companion plugin; PHP array stays canonical
- Pause / resume / approval gates
- Workflow editor UI
- Durable storage / run history — every consumer ships its own (Data Machine keeps its tables; openclaWP will add CPTs in a follow-up PR)

## Tests

```
composer test
```

Adds four smoke files under `tests/`:
- `workflow-bindings-smoke.php` — 13 assertions, template substitution edge cases
- `workflow-spec-validator-smoke.php` — 20 assertions, structural validation + Spec value object
- `workflow-runner-smoke.php` — 17 assertions, full execute path with stub abilities + recorder
- `agents-workflow-ability-smoke.php` — 18 assertions, dispatcher pattern (mirrors `agents-chat-ability-smoke`)

All 950+ existing assertions continue to pass; bootstrap-smoke's `expected_source_directories` allowlist gains `Workflows/`.

## Sequencing

A consumer PR to [`lezama/openclawp`](https://github.com/lezama/openclawp) follows this one — CPT-backed Store + Run_Recorder, wp-admin UI, and a demo workflow shipped behind the existing example-agent opt-in filter pattern. Coordinated separately with Chris on Data Machine adoption — non-blocking for either consumer.

## Test plan

- [ ] `composer install && composer test` — every smoke green
- [ ] In a real WP, `wp eval 'wp_register_workflow([ ... ]); print_r( wp_get_workflow( "demo/x" )->to_array() );'` to confirm in-memory registry round-trip
- [ ] In a real WP, `wp eval 'wp_get_ability( "agents/validate-workflow" )->execute([ "spec" => [ ... ] ])'` to confirm the validate ability lands