### PR TITLE
Add webhook safety primitives

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,10 @@ wp_register_agent(
 - `AgentsAPI\AI\Channels\WP_Agent_Channel_Session_Store`
 - `AgentsAPI\AI\Channels\WP_Agent_Option_Channel_Session_Store`
 - `AgentsAPI\AI\Channels\WP_Agent_Channel_Session_Map`
+- `AgentsAPI\AI\Channels\WP_Agent_Webhook_Signature`
+- `AgentsAPI\AI\Channels\WP_Agent_Message_Idempotency_Store`
+- `AgentsAPI\AI\Channels\WP_Agent_Transient_Message_Idempotency_Store`
+- `AgentsAPI\AI\Channels\WP_Agent_Message_Idempotency`
 - `AgentsAPI\AI\Tools\WP_Agent_Tool_Declaration`
 - `AgentsAPI\AI\Tools\WP_Agent_Tool_Call`
 - `AgentsAPI\AI\Tools\WP_Agent_Tool_Source_Registry`

--- a/agents-api.php
+++ b/agents-api.php
@@ -118,6 +118,10 @@ require_once AGENTS_API_PATH . 'src/Channels/class-wp-agent-external-message.php
 require_once AGENTS_API_PATH . 'src/Channels/class-wp-agent-channel-session-store.php';
 require_once AGENTS_API_PATH . 'src/Channels/class-wp-agent-option-channel-session-store.php';
 require_once AGENTS_API_PATH . 'src/Channels/class-wp-agent-channel-session-map.php';
+require_once AGENTS_API_PATH . 'src/Channels/class-wp-agent-webhook-signature.php';
+require_once AGENTS_API_PATH . 'src/Channels/class-wp-agent-message-idempotency-store.php';
+require_once AGENTS_API_PATH . 'src/Channels/class-wp-agent-transient-message-idempotency-store.php';
+require_once AGENTS_API_PATH . 'src/Channels/class-wp-agent-message-idempotency.php';
 require_once AGENTS_API_PATH . 'src/Channels/class-wp-agent-channel.php';
 require_once AGENTS_API_PATH . 'src/Channels/register-agents-chat-ability.php';
 require_once AGENTS_API_PATH . 'src/Workflows/class-wp-agent-workflow-bindings.php';

--- a/composer.json
+++ b/composer.json
@@ -45,6 +45,7 @@
       "php tests/iteration-budget-smoke.php",
       "php tests/conversation-loop-budgets-smoke.php",
       "php tests/channels-smoke.php",
+      "php tests/webhook-safety-smoke.php",
       "php tests/context-authority-smoke.php",
       "php tests/guidelines-substrate-smoke.php",
       "php tests/workflow-bindings-smoke.php",

--- a/src/Channels/class-wp-agent-message-idempotency-store.php
+++ b/src/Channels/class-wp-agent-message-idempotency-store.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Inbound message idempotency store contract.
+ *
+ * @package AgentsAPI
+ * @since   0.103.0
+ */
+
+namespace AgentsAPI\AI\Channels;
+
+defined( 'ABSPATH' ) || exit;
+
+interface WP_Agent_Message_Idempotency_Store {
+
+	/**
+	 * Whether an inbound external message has already been processed.
+	 *
+	 * @param string $provider   External provider or connector scope.
+	 * @param string $message_id Opaque provider message id.
+	 * @return bool True when the message was already marked seen.
+	 */
+	public function seen( string $provider, string $message_id ): bool;
+
+	/**
+	 * Mark an inbound external message as processed for a bounded time.
+	 *
+	 * @param string $provider   External provider or connector scope.
+	 * @param string $message_id Opaque provider message id.
+	 * @param int    $ttl        Time-to-live in seconds.
+	 */
+	public function mark_seen( string $provider, string $message_id, int $ttl ): void;
+
+	/**
+	 * Remove a processed marker, primarily for tests and manual recovery.
+	 *
+	 * @param string $provider   External provider or connector scope.
+	 * @param string $message_id Opaque provider message id.
+	 */
+	public function forget( string $provider, string $message_id ): void;
+}

--- a/src/Channels/class-wp-agent-message-idempotency.php
+++ b/src/Channels/class-wp-agent-message-idempotency.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Inbound message idempotency facade.
+ *
+ * @package AgentsAPI
+ * @since   0.103.0
+ */
+
+namespace AgentsAPI\AI\Channels;
+
+defined( 'ABSPATH' ) || exit;
+
+final class WP_Agent_Message_Idempotency {
+
+	private static ?WP_Agent_Message_Idempotency_Store $store = null;
+
+	/**
+	 * Replace the backing store. Pass null to restore the transient default.
+	 *
+	 * @param WP_Agent_Message_Idempotency_Store|null $store Store implementation.
+	 */
+	public static function set_store( ?WP_Agent_Message_Idempotency_Store $store ): void {
+		self::$store = $store;
+	}
+
+	/**
+	 * Return the active backing store.
+	 *
+	 * @return WP_Agent_Message_Idempotency_Store
+	 */
+	public static function store(): WP_Agent_Message_Idempotency_Store {
+		if ( null === self::$store ) {
+			self::$store = new WP_Agent_Transient_Message_Idempotency_Store();
+		}
+		return self::$store;
+	}
+
+	/**
+	 * Whether an inbound external message has already been processed.
+	 *
+	 * @param string $provider   External provider or connector scope.
+	 * @param string $message_id Opaque provider message id.
+	 * @return bool True when the message was already marked seen.
+	 */
+	public static function seen( string $provider, string $message_id ): bool {
+		return self::store()->seen( $provider, $message_id );
+	}
+
+	/**
+	 * Mark an inbound external message as processed for a bounded time.
+	 *
+	 * @param string $provider   External provider or connector scope.
+	 * @param string $message_id Opaque provider message id.
+	 * @param int    $ttl        Time-to-live in seconds.
+	 */
+	public static function mark_seen( string $provider, string $message_id, int $ttl ): void {
+		self::store()->mark_seen( $provider, $message_id, $ttl );
+	}
+
+	/**
+	 * Remove a processed marker, primarily for tests and manual recovery.
+	 *
+	 * @param string $provider   External provider or connector scope.
+	 * @param string $message_id Opaque provider message id.
+	 */
+	public static function forget( string $provider, string $message_id ): void {
+		self::store()->forget( $provider, $message_id );
+	}
+}

--- a/src/Channels/class-wp-agent-transient-message-idempotency-store.php
+++ b/src/Channels/class-wp-agent-transient-message-idempotency-store.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Transient-backed inbound message idempotency store.
+ *
+ * @package AgentsAPI
+ * @since   0.103.0
+ */
+
+namespace AgentsAPI\AI\Channels;
+
+defined( 'ABSPATH' ) || exit;
+
+final class WP_Agent_Transient_Message_Idempotency_Store implements WP_Agent_Message_Idempotency_Store {
+
+	public function seen( string $provider, string $message_id ): bool {
+		$key = $this->storage_key( $provider, $message_id );
+		if ( null === $key ) {
+			return false;
+		}
+
+		return false !== get_transient( $key );
+	}
+
+	public function mark_seen( string $provider, string $message_id, int $ttl ): void {
+		$key = $this->storage_key( $provider, $message_id );
+		if ( null === $key || $ttl < 1 ) {
+			return;
+		}
+
+		set_transient( $key, '1', $ttl );
+	}
+
+	public function forget( string $provider, string $message_id ): void {
+		$key = $this->storage_key( $provider, $message_id );
+		if ( null === $key ) {
+			return;
+		}
+
+		delete_transient( $key );
+	}
+
+	/**
+	 * Build a stable transient key for a provider/message tuple.
+	 *
+	 * @param string $provider
+	 * @param string $message_id
+	 * @return string|null
+	 */
+	public function storage_key( string $provider, string $message_id ): ?string {
+		$provider   = $this->normalize_provider( $provider );
+		$message_id = trim( $message_id );
+
+		if ( '' === $provider || '' === $message_id ) {
+			return null;
+		}
+
+		return 'wp_agent_message_seen_' . md5( $provider . ':' . $message_id );
+	}
+
+	private function normalize_provider( string $provider ): string {
+		return trim( strtolower( str_replace( '_', '-', $provider ) ) );
+	}
+}

--- a/src/Channels/class-wp-agent-webhook-signature.php
+++ b/src/Channels/class-wp-agent-webhook-signature.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Webhook signature verification helpers for channel and bridge callbacks.
+ *
+ * @package AgentsAPI
+ * @since   0.103.0
+ */
+
+namespace AgentsAPI\AI\Channels;
+
+defined( 'ABSPATH' ) || exit;
+
+final class WP_Agent_Webhook_Signature {
+
+	/**
+	 * Verify an HMAC SHA-256 signature header against a raw request body.
+	 *
+	 * @param string $body    Raw request body.
+	 * @param string $header  Signature header value.
+	 * @param string $secret  Shared webhook secret. Empty secrets are rejected.
+	 * @param array  $options Optional settings: expected_prefix, allow_raw_hex.
+	 * @return bool True when the signature is valid.
+	 */
+	public static function verify_hmac_sha256( string $body, string $header, string $secret, array $options = array() ): bool {
+		if ( '' === $secret ) {
+			return false;
+		}
+
+		$signature = self::extract_signature(
+			$header,
+			(string) ( $options['expected_prefix'] ?? 'sha256=' ),
+			(bool) ( $options['allow_raw_hex'] ?? false )
+		);
+
+		if ( null === $signature ) {
+			return false;
+		}
+
+		$expected = hash_hmac( 'sha256', $body, $secret );
+		return hash_equals( $expected, $signature );
+	}
+
+	private static function extract_signature( string $header, string $expected_prefix, bool $allow_raw_hex ): ?string {
+		$header = trim( $header );
+		if ( '' === $header ) {
+			return null;
+		}
+
+		if ( '' !== $expected_prefix && str_starts_with( $header, $expected_prefix ) ) {
+			return self::normalize_hex( substr( $header, strlen( $expected_prefix ) ) );
+		}
+
+		if ( $allow_raw_hex ) {
+			return self::normalize_hex( $header );
+		}
+
+		return null;
+	}
+
+	private static function normalize_hex( string $value ): ?string {
+		$value = strtolower( trim( $value ) );
+		if ( 1 !== preg_match( '/^[a-f0-9]{64}$/', $value ) ) {
+			return null;
+		}
+		return $value;
+	}
+}

--- a/src/Runtime/class-wp-agent-effective-agent-resolver.php
+++ b/src/Runtime/class-wp-agent-effective-agent-resolver.php
@@ -83,7 +83,7 @@ final class WP_Agent_Effective_Agent_Resolver {
 		}
 
 		throw new \InvalidArgumentException(
-			'invalid_effective_agent_resolution: owner_user_id is ambiguous; provide an explicit agent_slug or execution principal. Candidates: ' . implode( ', ', $candidates )
+			'invalid_effective_agent_resolution: owner_user_id is ambiguous; provide an explicit agent_slug or execution principal. Candidates: ' . implode( ', ', array_map( 'esc_html', $candidates ) )
 		);
 	}
 
@@ -161,16 +161,12 @@ final class WP_Agent_Effective_Agent_Resolver {
 
 		$matches = array();
 		foreach ( $registry->get_all_registered() as $agent ) {
-			if ( ! $agent instanceof \WP_Agent ) {
-				continue;
-			}
-
 			$owner_resolver = $agent->get_owner_resolver();
 			if ( ! is_callable( $owner_resolver ) ) {
 				continue;
 			}
 
-			if ( $owner_user_id === (int) call_user_func( $owner_resolver ) ) {
+			if ( (int) call_user_func( $owner_resolver ) === $owner_user_id ) {
 				$matches[] = $agent->get_slug();
 			}
 		}

--- a/tests/bootstrap-smoke.php
+++ b/tests/bootstrap-smoke.php
@@ -109,6 +109,10 @@ agents_api_smoke_assert_equals( true, class_exists( 'AgentsAPI\AI\Channels\WP_Ag
 agents_api_smoke_assert_equals( true, interface_exists( 'AgentsAPI\AI\Channels\WP_Agent_Channel_Session_Store' ), 'WP_Agent_Channel_Session_Store contract is available', $failures, $passes );
 agents_api_smoke_assert_equals( true, class_exists( 'AgentsAPI\AI\Channels\WP_Agent_Option_Channel_Session_Store' ), 'WP_Agent_Option_Channel_Session_Store implementation is available', $failures, $passes );
 agents_api_smoke_assert_equals( true, class_exists( 'AgentsAPI\AI\Channels\WP_Agent_Channel_Session_Map' ), 'WP_Agent_Channel_Session_Map facade is available', $failures, $passes );
+agents_api_smoke_assert_equals( true, class_exists( 'AgentsAPI\AI\Channels\WP_Agent_Webhook_Signature' ), 'WP_Agent_Webhook_Signature helper is available', $failures, $passes );
+agents_api_smoke_assert_equals( true, interface_exists( 'AgentsAPI\AI\Channels\WP_Agent_Message_Idempotency_Store' ), 'WP_Agent_Message_Idempotency_Store contract is available', $failures, $passes );
+agents_api_smoke_assert_equals( true, class_exists( 'AgentsAPI\AI\Channels\WP_Agent_Transient_Message_Idempotency_Store' ), 'WP_Agent_Transient_Message_Idempotency_Store implementation is available', $failures, $passes );
+agents_api_smoke_assert_equals( true, class_exists( 'AgentsAPI\AI\Channels\WP_Agent_Message_Idempotency' ), 'WP_Agent_Message_Idempotency facade is available', $failures, $passes );
 foreach ( $namespace_map as $legacy_class => $target_class ) {
 	agents_api_smoke_assert_equals( true, class_exists( $target_class ) || interface_exists( $target_class ), $target_class . ' contract is available', $failures, $passes );
 	agents_api_smoke_assert_equals( false, class_exists( $legacy_class, false ) || interface_exists( $legacy_class, false ), $legacy_class . ' compatibility alias is not loaded', $failures, $passes );

--- a/tests/webhook-safety-smoke.php
+++ b/tests/webhook-safety-smoke.php
@@ -1,0 +1,128 @@
+<?php
+/**
+ * Pure-PHP smoke test for webhook verification and inbound idempotency helpers.
+ *
+ * Run with: php tests/webhook-safety-smoke.php
+ *
+ * @package AgentsAPI\Tests
+ */
+
+defined( 'ABSPATH' ) || define( 'ABSPATH', __DIR__ . '/' );
+
+$failures = array();
+$passes   = 0;
+
+echo "agents-api-webhook-safety-smoke\n";
+
+$GLOBALS['__webhook_safety_transients'] = array();
+$GLOBALS['__webhook_safety_now']        = 1000;
+
+function get_transient( string $key ) {
+	$entry = $GLOBALS['__webhook_safety_transients'][ $key ] ?? null;
+	if ( null === $entry ) {
+		return false;
+	}
+
+	if ( 0 !== $entry['expires'] && $entry['expires'] <= $GLOBALS['__webhook_safety_now'] ) {
+		unset( $GLOBALS['__webhook_safety_transients'][ $key ] );
+		return false;
+	}
+
+	return $entry['value'];
+}
+
+function set_transient( string $key, $value, int $expiration = 0 ): bool {
+	$GLOBALS['__webhook_safety_transients'][ $key ] = array(
+		'value'   => $value,
+		'expires' => 0 < $expiration ? $GLOBALS['__webhook_safety_now'] + $expiration : 0,
+	);
+	return true;
+}
+
+function delete_transient( string $key ): bool {
+	unset( $GLOBALS['__webhook_safety_transients'][ $key ] );
+	return true;
+}
+
+function webhook_safety_assert( $expected, $actual, string $name, array &$failures, int &$passes ): void {
+	if ( $expected === $actual ) {
+		++$passes;
+		echo "  PASS {$name}\n";
+		return;
+	}
+
+	$failures[] = $name;
+	echo "  FAIL {$name}\n";
+	echo '    expected: ' . var_export( $expected, true ) . "\n";
+	echo '    actual:   ' . var_export( $actual, true ) . "\n";
+}
+
+require_once __DIR__ . '/../src/Channels/class-wp-agent-webhook-signature.php';
+require_once __DIR__ . '/../src/Channels/class-wp-agent-message-idempotency-store.php';
+require_once __DIR__ . '/../src/Channels/class-wp-agent-transient-message-idempotency-store.php';
+require_once __DIR__ . '/../src/Channels/class-wp-agent-message-idempotency.php';
+
+use AgentsAPI\AI\Channels\WP_Agent_Message_Idempotency;
+use AgentsAPI\AI\Channels\WP_Agent_Message_Idempotency_Store;
+use AgentsAPI\AI\Channels\WP_Agent_Webhook_Signature;
+
+$body      = '{"event":"message","text":"hello"}';
+$secret    = 'super-secret';
+$signature = hash_hmac( 'sha256', $body, $secret );
+
+webhook_safety_assert( true, WP_Agent_Webhook_Signature::verify_hmac_sha256( $body, 'sha256=' . $signature, $secret ), 'hmac_prefixed_signature_valid', $failures, $passes );
+webhook_safety_assert( true, WP_Agent_Webhook_Signature::verify_hmac_sha256( $body, 'SHA256=' . strtoupper( $signature ), $secret, array( 'expected_prefix' => 'SHA256=' ) ), 'hmac_uppercase_hex_valid', $failures, $passes );
+webhook_safety_assert( false, WP_Agent_Webhook_Signature::verify_hmac_sha256( $body, $signature, $secret ), 'hmac_raw_hex_rejected_by_default', $failures, $passes );
+webhook_safety_assert( true, WP_Agent_Webhook_Signature::verify_hmac_sha256( $body, $signature, $secret, array( 'allow_raw_hex' => true ) ), 'hmac_raw_hex_allowed_when_requested', $failures, $passes );
+webhook_safety_assert( false, WP_Agent_Webhook_Signature::verify_hmac_sha256( $body, 'sha256=' . str_repeat( '0', 64 ), $secret ), 'hmac_wrong_signature_rejected', $failures, $passes );
+webhook_safety_assert( false, WP_Agent_Webhook_Signature::verify_hmac_sha256( $body, 'sha1=' . $signature, $secret ), 'hmac_wrong_prefix_rejected', $failures, $passes );
+webhook_safety_assert( false, WP_Agent_Webhook_Signature::verify_hmac_sha256( $body, 'sha256=' . $signature, '' ), 'hmac_empty_secret_rejected', $failures, $passes );
+webhook_safety_assert( false, WP_Agent_Webhook_Signature::verify_hmac_sha256( $body, 'sha256=not-hex', $secret ), 'hmac_malformed_signature_rejected', $failures, $passes );
+
+webhook_safety_assert( false, WP_Agent_Message_Idempotency::seen( 'whatsapp', 'wamid.1' ), 'idempotency_unseen_by_default', $failures, $passes );
+WP_Agent_Message_Idempotency::mark_seen( 'whatsapp', 'wamid.1', 604800 );
+webhook_safety_assert( true, WP_Agent_Message_Idempotency::seen( 'whatsapp', 'wamid.1' ), 'idempotency_seen_after_mark', $failures, $passes );
+webhook_safety_assert( false, WP_Agent_Message_Idempotency::seen( 'slack', 'wamid.1' ), 'idempotency_scoped_by_provider', $failures, $passes );
+WP_Agent_Message_Idempotency::forget( 'whatsapp', 'wamid.1' );
+webhook_safety_assert( false, WP_Agent_Message_Idempotency::seen( 'whatsapp', 'wamid.1' ), 'idempotency_forget_removes_marker', $failures, $passes );
+
+WP_Agent_Message_Idempotency::mark_seen( 'whatsapp', 'wamid.2', 10 );
+$GLOBALS['__webhook_safety_now'] += 11;
+webhook_safety_assert( false, WP_Agent_Message_Idempotency::seen( 'whatsapp', 'wamid.2' ), 'idempotency_marker_expires_after_ttl', $failures, $passes );
+
+WP_Agent_Message_Idempotency::mark_seen( 'whatsapp', 'wamid.3', 0 );
+webhook_safety_assert( false, WP_Agent_Message_Idempotency::seen( 'whatsapp', 'wamid.3' ), 'idempotency_zero_ttl_is_not_stored', $failures, $passes );
+
+WP_Agent_Message_Idempotency::mark_seen( '', 'wamid.4', 60 );
+webhook_safety_assert( false, WP_Agent_Message_Idempotency::seen( '', 'wamid.4' ), 'idempotency_empty_provider_is_ignored', $failures, $passes );
+
+class Webhook_Safety_Fake_Store implements WP_Agent_Message_Idempotency_Store {
+	public array $seen = array();
+
+	public function seen( string $provider, string $message_id ): bool {
+		return isset( $this->seen[ $provider . ':' . $message_id ] );
+	}
+
+	public function mark_seen( string $provider, string $message_id, int $ttl ): void {
+		unset( $ttl );
+		$this->seen[ $provider . ':' . $message_id ] = true;
+	}
+
+	public function forget( string $provider, string $message_id ): void {
+		unset( $this->seen[ $provider . ':' . $message_id ] );
+	}
+}
+
+$fake_store = new Webhook_Safety_Fake_Store();
+WP_Agent_Message_Idempotency::set_store( $fake_store );
+WP_Agent_Message_Idempotency::mark_seen( 'bridge', 'queue-1', 30 );
+webhook_safety_assert( true, WP_Agent_Message_Idempotency::seen( 'bridge', 'queue-1' ), 'idempotency_store_can_be_replaced', $failures, $passes );
+WP_Agent_Message_Idempotency::set_store( null );
+webhook_safety_assert( false, WP_Agent_Message_Idempotency::seen( 'bridge', 'queue-1' ), 'idempotency_store_can_be_reset', $failures, $passes );
+
+if ( ! empty( $failures ) ) {
+	echo "\nFailures: " . implode( ', ', $failures ) . "\n";
+	exit( 1 );
+}
+
+echo "\nAll {$passes} webhook safety assertions passed.\n";


### PR DESCRIPTION
## Summary
- Add a generic HMAC SHA-256 webhook signature verifier with empty-secret rejection, safe `hash_equals()` comparison, prefixed signatures, and optional raw-hex support.
- Add a replaceable inbound message idempotency contract with a transient-backed default and facade for duplicate suppression.
- Add focused smoke coverage and export checks for webhook safety helpers.
- Clean up existing effective-agent resolver lint findings so full repo lint stays green.

Closes #103.

## Testing
- `php tests/webhook-safety-smoke.php`
- `php tests/effective-agent-resolver-smoke.php`
- `composer test`
- `homeboy lint --force-hot`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the implementation, smoke coverage, lint cleanup, and PR description; Chris remains responsible for review and merge.