### PR TITLE
Add remote bridge primitives

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,11 @@ wp_register_agent(
 - `AgentsAPI\AI\Channels\WP_Agent_Message_Idempotency_Store`
 - `AgentsAPI\AI\Channels\WP_Agent_Transient_Message_Idempotency_Store`
 - `AgentsAPI\AI\Channels\WP_Agent_Message_Idempotency`
+- `AgentsAPI\AI\Channels\WP_Agent_Bridge_Client`
+- `AgentsAPI\AI\Channels\WP_Agent_Bridge_Queue_Item`
+- `AgentsAPI\AI\Channels\WP_Agent_Bridge_Store`
+- `AgentsAPI\AI\Channels\WP_Agent_Option_Bridge_Store`
+- `AgentsAPI\AI\Channels\WP_Agent_Bridge`
 - `AgentsAPI\AI\Tools\WP_Agent_Tool_Declaration`
 - `AgentsAPI\AI\Tools\WP_Agent_Tool_Call`
 - `AgentsAPI\AI\Tools\WP_Agent_Tool_Source_Registry`

--- a/agents-api.php
+++ b/agents-api.php
@@ -122,6 +122,11 @@ require_once AGENTS_API_PATH . 'src/Channels/class-wp-agent-webhook-signature.ph
 require_once AGENTS_API_PATH . 'src/Channels/class-wp-agent-message-idempotency-store.php';
 require_once AGENTS_API_PATH . 'src/Channels/class-wp-agent-transient-message-idempotency-store.php';
 require_once AGENTS_API_PATH . 'src/Channels/class-wp-agent-message-idempotency.php';
+require_once AGENTS_API_PATH . 'src/Channels/class-wp-agent-bridge-client.php';
+require_once AGENTS_API_PATH . 'src/Channels/class-wp-agent-bridge-queue-item.php';
+require_once AGENTS_API_PATH . 'src/Channels/class-wp-agent-bridge-store.php';
+require_once AGENTS_API_PATH . 'src/Channels/class-wp-agent-option-bridge-store.php';
+require_once AGENTS_API_PATH . 'src/Channels/class-wp-agent-bridge.php';
 require_once AGENTS_API_PATH . 'src/Channels/class-wp-agent-channel.php';
 require_once AGENTS_API_PATH . 'src/Channels/register-agents-chat-ability.php';
 require_once AGENTS_API_PATH . 'src/Workflows/class-wp-agent-workflow-bindings.php';

--- a/composer.json
+++ b/composer.json
@@ -46,6 +46,7 @@
       "php tests/conversation-loop-budgets-smoke.php",
       "php tests/channels-smoke.php",
       "php tests/webhook-safety-smoke.php",
+      "php tests/remote-bridge-smoke.php",
       "php tests/context-authority-smoke.php",
       "php tests/guidelines-substrate-smoke.php",
       "php tests/workflow-bindings-smoke.php",

--- a/docs/remote-bridge-protocol.md
+++ b/docs/remote-bridge-protocol.md
@@ -1,0 +1,25 @@
+# Remote Bridge Protocol
+
+Remote bridge clients are out-of-process processes that relay messages between an external surface and a WordPress agent runtime. They differ from direct `WP_Agent_Channel` subclasses because the client may be offline, webhook delivery may fail, and replies need a queue-first recovery path.
+
+Agents API provides the generic PHP primitives for that protocol. It does not ship platform-specific clients, REST routes, authentication policy, or a chat runtime.
+
+## Relationship To Core Connectors
+
+Bridge clients may include a `connector_id`. When the Core Connectors API is available, `WP_Agent_Bridge_Client::connector()` resolves that id through `wp_get_connector()`.
+
+Connectors own product/service identity and settings metadata. Agents API stores only bridge runtime state that Connectors does not model: callback URL, opaque bridge context, pending queue items, and acknowledgements.
+
+## Flow
+
+1. A consumer registers a remote bridge client with `WP_Agent_Bridge::register_client()`.
+2. The consumer executes inbound chat turns through the canonical `agents/chat` ability.
+3. The consumer queues outbound bridge replies with `WP_Agent_Bridge::enqueue()`.
+4. A remote bridge polls `WP_Agent_Bridge::pending()` when webhook delivery is unavailable or failed.
+5. The remote bridge acknowledges accepted items with `WP_Agent_Bridge::ack()`.
+
+Queued items remain pending until acknowledged. Best-effort webhook delivery must not delete an item; `ack()` is the removal boundary.
+
+## Storage
+
+The default store is option-backed and intentionally small. Hosts that need custom tables, external queues, leases, or retention policies can replace it with `WP_Agent_Bridge::set_store()`.

--- a/src/Channels/class-wp-agent-bridge-client.php
+++ b/src/Channels/class-wp-agent-bridge-client.php
@@ -1,0 +1,126 @@
+<?php
+/**
+ * Remote bridge client registration value object.
+ *
+ * @package AgentsAPI
+ * @since   0.103.0
+ */
+
+namespace AgentsAPI\AI\Channels;
+
+use InvalidArgumentException;
+
+defined( 'ABSPATH' ) || exit;
+
+final class WP_Agent_Bridge_Client {
+
+	public readonly string $client_id;
+	public readonly ?string $connector_id;
+	public readonly ?string $callback_url;
+	/** @var array<string,mixed> */
+	public readonly array $context;
+	public readonly string $registered_at;
+
+	/**
+	 * @param string              $client_id     Stable remote bridge client id.
+	 * @param string|null         $connector_id  Optional Core Connectors API connector id.
+	 * @param string|null         $callback_url  Optional callback URL for best-effort delivery.
+	 * @param array<string,mixed> $context       Opaque client metadata.
+	 * @param string|null         $registered_at Registration timestamp.
+	 */
+	public function __construct( string $client_id, ?string $connector_id = null, ?string $callback_url = null, array $context = array(), ?string $registered_at = null ) {
+		$this->client_id     = self::normalize_required_id( $client_id, 'client_id' );
+		$this->connector_id  = self::normalize_optional_id( $connector_id );
+		$this->callback_url  = self::normalize_callback_url( $callback_url );
+		$this->context       = $context;
+		$this->registered_at = $registered_at ?? gmdate( 'c' );
+	}
+
+	/**
+	 * Build from an array payload.
+	 *
+	 * @param array<string,mixed> $data Client data.
+	 * @return self
+	 */
+	public static function from_array( array $data ): self {
+		return new self(
+			(string) ( $data['client_id'] ?? '' ),
+			isset( $data['connector_id'] ) ? (string) $data['connector_id'] : null,
+			isset( $data['callback_url'] ) ? (string) $data['callback_url'] : null,
+			isset( $data['context'] ) && is_array( $data['context'] ) ? $data['context'] : array(),
+			isset( $data['registered_at'] ) ? (string) $data['registered_at'] : null
+		);
+	}
+
+	/**
+	 * Export to a JSON-friendly array.
+	 *
+	 * @return array<string,mixed>
+	 */
+	public function to_array(): array {
+		return array(
+			'client_id'     => $this->client_id,
+			'connector_id'  => $this->connector_id,
+			'callback_url'  => $this->callback_url,
+			'context'       => $this->context,
+			'registered_at' => $this->registered_at,
+		);
+	}
+
+	/**
+	 * Resolve Core Connectors metadata for this client when available.
+	 *
+	 * @return array<string,mixed>|null Connector metadata, or null when unavailable.
+	 */
+	public function connector(): ?array {
+		if ( null === $this->connector_id || ! function_exists( 'wp_get_connector' ) ) {
+			return null;
+		}
+
+		$connector = wp_get_connector( $this->connector_id );
+		return is_array( $connector ) ? $connector : null;
+	}
+
+	private static function normalize_required_id( string $value, string $field ): string {
+		$value = self::normalize_id( $value );
+		if ( '' === $value ) {
+			if ( 'client_id' === $field ) {
+				throw new InvalidArgumentException( 'client_id must be a non-empty slug.' );
+			}
+			throw new InvalidArgumentException( 'id must be a non-empty slug.' );
+		}
+		return $value;
+	}
+
+	private static function normalize_optional_id( ?string $value ): ?string {
+		if ( null === $value ) {
+			return null;
+		}
+
+		$value = self::normalize_id( $value );
+		return '' === $value ? null : $value;
+	}
+
+	private static function normalize_id( string $value ): string {
+		$value = trim( strtolower( str_replace( '_', '-', $value ) ) );
+		$value = preg_replace( '/[^a-z0-9-]+/', '-', $value );
+		return trim( (string) $value, '-' );
+	}
+
+	private static function normalize_callback_url( ?string $callback_url ): ?string {
+		if ( null === $callback_url ) {
+			return null;
+		}
+
+		$callback_url = trim( $callback_url );
+		if ( '' === $callback_url ) {
+			return null;
+		}
+
+		if ( false === filter_var( $callback_url, FILTER_VALIDATE_URL ) ) {
+			throw new InvalidArgumentException( 'callback_url must be a valid URL.' );
+		}
+
+		return $callback_url;
+	}
+}

--- a/src/Channels/class-wp-agent-bridge-queue-item.php
+++ b/src/Channels/class-wp-agent-bridge-queue-item.php
@@ -1,0 +1,147 @@
+<?php
+/**
+ * Remote bridge queue item value object.
+ *
+ * @package AgentsAPI
+ * @since   0.103.0
+ */
+
+namespace AgentsAPI\AI\Channels;
+
+use InvalidArgumentException;
+
+defined( 'ABSPATH' ) || exit;
+
+final class WP_Agent_Bridge_Queue_Item {
+
+	public readonly string $queue_id;
+	public readonly string $client_id;
+	public readonly ?string $connector_id;
+	public readonly string $agent;
+	public readonly ?string $session_id;
+	public readonly string $role;
+	public readonly string $content;
+	public readonly bool $completed;
+	public readonly string $created_at;
+	public readonly string $delivery_status;
+	/** @var array<string,mixed> */
+	public readonly array $metadata;
+
+	/**
+	 * @param array<string,mixed> $args Queue item fields.
+	 */
+	public function __construct( array $args ) {
+		$this->queue_id        = self::normalize_required_string( (string) ( $args['queue_id'] ?? self::new_queue_id() ), 'queue_id' );
+		$this->client_id       = self::normalize_required_slug( (string) ( $args['client_id'] ?? '' ), 'client_id' );
+		$this->connector_id    = isset( $args['connector_id'] ) ? self::normalize_optional_slug( (string) $args['connector_id'] ) : null;
+		$this->agent           = self::normalize_required_slug( (string) ( $args['agent'] ?? '' ), 'agent' );
+		$this->session_id      = isset( $args['session_id'] ) ? self::normalize_optional_string( (string) $args['session_id'] ) : null;
+		$this->role            = self::normalize_role( (string) ( $args['role'] ?? 'assistant' ) );
+		$this->content         = self::normalize_required_string( (string) ( $args['content'] ?? '' ), 'content' );
+		$this->completed       = (bool) ( $args['completed'] ?? true );
+		$this->created_at      = isset( $args['created_at'] ) ? (string) $args['created_at'] : gmdate( 'c' );
+		$this->delivery_status = self::normalize_delivery_status( (string) ( $args['delivery_status'] ?? 'pending' ) );
+		$this->metadata        = isset( $args['metadata'] ) && is_array( $args['metadata'] ) ? $args['metadata'] : array();
+	}
+
+	/**
+	 * Build a queue item from a stored array.
+	 *
+	 * @param array<string,mixed> $data Stored data.
+	 * @return self
+	 */
+	public static function from_array( array $data ): self {
+		return new self( $data );
+	}
+
+	/**
+	 * Export to a JSON-friendly array.
+	 *
+	 * @return array<string,mixed>
+	 */
+	public function to_array(): array {
+		return array(
+			'queue_id'        => $this->queue_id,
+			'client_id'       => $this->client_id,
+			'connector_id'    => $this->connector_id,
+			'agent'           => $this->agent,
+			'session_id'      => $this->session_id,
+			'role'            => $this->role,
+			'content'         => $this->content,
+			'completed'       => $this->completed,
+			'created_at'      => $this->created_at,
+			'delivery_status' => $this->delivery_status,
+			'metadata'        => $this->metadata,
+		);
+	}
+
+	/**
+	 * Return a copy with an updated delivery status.
+	 *
+	 * @param string $delivery_status Delivery status.
+	 * @return self
+	 */
+	public function with_delivery_status( string $delivery_status ): self {
+		$data                    = $this->to_array();
+		$data['delivery_status'] = $delivery_status;
+		return new self( $data );
+	}
+
+	private static function new_queue_id(): string {
+		return 'bridge_' . bin2hex( random_bytes( 16 ) );
+	}
+
+	private static function normalize_required_slug( string $value, string $field ): string {
+		$value = self::normalize_slug( $value );
+		if ( '' === $value ) {
+			if ( 'client_id' === $field ) {
+				throw new InvalidArgumentException( 'client_id must be a non-empty slug.' );
+			}
+			throw new InvalidArgumentException( 'agent must be a non-empty slug.' );
+		}
+		return $value;
+	}
+
+	private static function normalize_optional_slug( string $value ): ?string {
+		$value = self::normalize_slug( $value );
+		return '' === $value ? null : $value;
+	}
+
+	private static function normalize_slug( string $value ): string {
+		$value = trim( strtolower( str_replace( '_', '-', $value ) ) );
+		$value = preg_replace( '/[^a-z0-9-]+/', '-', $value );
+		return trim( (string) $value, '-' );
+	}
+
+	private static function normalize_required_string( string $value, string $field ): string {
+		$value = trim( $value );
+		if ( '' === $value ) {
+			if ( 'queue_id' === $field ) {
+				throw new InvalidArgumentException( 'queue_id must be non-empty.' );
+			}
+			throw new InvalidArgumentException( 'content must be non-empty.' );
+		}
+		return $value;
+	}
+
+	private static function normalize_optional_string( string $value ): ?string {
+		$value = trim( $value );
+		return '' === $value ? null : $value;
+	}
+
+	private static function normalize_role( string $role ): string {
+		$role = self::normalize_slug( $role );
+		if ( ! in_array( $role, array( 'assistant', 'system', 'tool' ), true ) ) {
+			throw new InvalidArgumentException( 'role must be assistant, system, or tool.' );
+		}
+		return $role;
+	}
+
+	private static function normalize_delivery_status( string $delivery_status ): string {
+		$delivery_status = self::normalize_slug( $delivery_status );
+		if ( ! in_array( $delivery_status, array( 'pending', 'delivered', 'failed' ), true ) ) {
+			throw new InvalidArgumentException( 'delivery_status must be pending, delivered, or failed.' );
+		}
+		return $delivery_status;
+	}
+}

--- a/src/Channels/class-wp-agent-bridge-store.php
+++ b/src/Channels/class-wp-agent-bridge-store.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Remote bridge store contract.
+ *
+ * @package AgentsAPI
+ * @since   0.103.0
+ */
+
+namespace AgentsAPI\AI\Channels;
+
+defined( 'ABSPATH' ) || exit;
+
+interface WP_Agent_Bridge_Store {
+
+	public function register_client( WP_Agent_Bridge_Client $client ): void;
+
+	public function get_client( string $client_id ): ?WP_Agent_Bridge_Client;
+
+	public function enqueue( WP_Agent_Bridge_Queue_Item $item ): WP_Agent_Bridge_Queue_Item;
+
+	/**
+	 * Return pending queue items for a bridge client.
+	 *
+	 * @param string   $client_id   Bridge client id.
+	 * @param int      $limit       Maximum items to return.
+	 * @param string[] $session_ids Optional session id filter.
+	 * @return WP_Agent_Bridge_Queue_Item[] Pending items.
+	 */
+	public function pending( string $client_id, int $limit = 25, array $session_ids = array() ): array;
+
+	/**
+	 * Acknowledge accepted queue items and remove them from pending delivery.
+	 *
+	 * @param string   $client_id Bridge client id.
+	 * @param string[] $queue_ids Queue ids to acknowledge.
+	 * @return int Number of acknowledged items.
+	 */
+	public function ack( string $client_id, array $queue_ids ): int;
+}

--- a/src/Channels/class-wp-agent-bridge.php
+++ b/src/Channels/class-wp-agent-bridge.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Remote bridge facade for out-of-process chat clients.
+ *
+ * @package AgentsAPI
+ * @since   0.103.0
+ */
+
+namespace AgentsAPI\AI\Channels;
+
+defined( 'ABSPATH' ) || exit;
+
+final class WP_Agent_Bridge {
+
+	private static ?WP_Agent_Bridge_Store $store = null;
+
+	public static function set_store( ?WP_Agent_Bridge_Store $store ): void {
+		self::$store = $store;
+	}
+
+	public static function store(): WP_Agent_Bridge_Store {
+		if ( null === self::$store ) {
+			self::$store = new WP_Agent_Option_Bridge_Store();
+		}
+		return self::$store;
+	}
+
+	/**
+	 * Register or update a remote bridge client.
+	 *
+	 * @param string              $client_id    Stable remote bridge client id.
+	 * @param string|null         $callback_url Optional callback URL for best-effort delivery.
+	 * @param array<string,mixed> $context      Opaque client metadata.
+	 * @param string|null         $connector_id Optional Core Connectors API connector id.
+	 * @return WP_Agent_Bridge_Client Registered client.
+	 */
+	public static function register_client( string $client_id, ?string $callback_url = null, array $context = array(), ?string $connector_id = null ): WP_Agent_Bridge_Client {
+		$client = new WP_Agent_Bridge_Client( $client_id, $connector_id, $callback_url, $context );
+		self::store()->register_client( $client );
+		return $client;
+	}
+
+	public static function get_client( string $client_id ): ?WP_Agent_Bridge_Client {
+		return self::store()->get_client( $client_id );
+	}
+
+	/**
+	 * Queue an outbound bridge message. Items remain pending until acknowledged.
+	 *
+	 * @param array<string,mixed> $args Queue item fields.
+	 * @return WP_Agent_Bridge_Queue_Item Queued item.
+	 */
+	public static function enqueue( array $args ): WP_Agent_Bridge_Queue_Item {
+		$item = new WP_Agent_Bridge_Queue_Item( $args );
+		return self::store()->enqueue( $item );
+	}
+
+	/**
+	 * Return pending queue items for a bridge client.
+	 *
+	 * @param string   $client_id   Bridge client id.
+	 * @param int      $limit       Maximum items to return.
+	 * @param string[] $session_ids Optional session id filter.
+	 * @return WP_Agent_Bridge_Queue_Item[] Pending items.
+	 */
+	public static function pending( string $client_id, int $limit = 25, array $session_ids = array() ): array {
+		return self::store()->pending( $client_id, $limit, $session_ids );
+	}
+
+	/**
+	 * Acknowledge accepted queue items.
+	 *
+	 * @param string   $client_id Bridge client id.
+	 * @param string[] $queue_ids Queue ids to acknowledge.
+	 * @return int Number of acknowledged items.
+	 */
+	public static function ack( string $client_id, array $queue_ids ): int {
+		return self::store()->ack( $client_id, $queue_ids );
+	}
+}

--- a/src/Channels/class-wp-agent-option-bridge-store.php
+++ b/src/Channels/class-wp-agent-option-bridge-store.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * Option-backed remote bridge store.
+ *
+ * @package AgentsAPI
+ * @since   0.103.0
+ */
+
+namespace AgentsAPI\AI\Channels;
+
+defined( 'ABSPATH' ) || exit;
+
+final class WP_Agent_Option_Bridge_Store implements WP_Agent_Bridge_Store {
+
+	private const CLIENTS_OPTION = 'wp_agent_bridge_clients';
+	private const QUEUE_OPTION   = 'wp_agent_bridge_queue';
+
+	public function register_client( WP_Agent_Bridge_Client $client ): void {
+		$clients                       = $this->read_clients();
+		$clients[ $client->client_id ] = $client->to_array();
+		update_option( self::CLIENTS_OPTION, $clients, false );
+	}
+
+	public function get_client( string $client_id ): ?WP_Agent_Bridge_Client {
+		$client_id = $this->normalize_id( $client_id );
+		$clients   = $this->read_clients();
+		if ( ! isset( $clients[ $client_id ] ) || ! is_array( $clients[ $client_id ] ) ) {
+			return null;
+		}
+
+		return WP_Agent_Bridge_Client::from_array( $clients[ $client_id ] );
+	}
+
+	public function enqueue( WP_Agent_Bridge_Queue_Item $item ): WP_Agent_Bridge_Queue_Item {
+		$queue                    = $this->read_queue();
+		$queue[ $item->queue_id ] = $item->to_array();
+		update_option( self::QUEUE_OPTION, $queue, false );
+		return $item;
+	}
+
+	public function pending( string $client_id, int $limit = 25, array $session_ids = array() ): array {
+		$client_id   = $this->normalize_id( $client_id );
+		$limit       = max( 1, $limit );
+		$session_ids = array_values( array_filter( array_map( 'strval', $session_ids ) ) );
+		$items       = array();
+
+		foreach ( $this->read_queue() as $data ) {
+			if ( ! is_array( $data ) ) {
+				continue;
+			}
+
+			$item = WP_Agent_Bridge_Queue_Item::from_array( $data );
+			if ( $item->client_id !== $client_id ) {
+				continue;
+			}
+
+			if ( ! empty( $session_ids ) && ( null === $item->session_id || ! in_array( $item->session_id, $session_ids, true ) ) ) {
+				continue;
+			}
+
+			$items[] = $item;
+			if ( count( $items ) >= $limit ) {
+				break;
+			}
+		}
+
+		return $items;
+	}
+
+	public function ack( string $client_id, array $queue_ids ): int {
+		$client_id = $this->normalize_id( $client_id );
+		$queue_ids = array_fill_keys( array_map( 'strval', $queue_ids ), true );
+		$queue     = $this->read_queue();
+		$acked     = 0;
+
+		foreach ( $queue as $queue_id => $data ) {
+			if ( ! isset( $queue_ids[ (string) $queue_id ] ) || ! is_array( $data ) ) {
+				continue;
+			}
+
+			$item = WP_Agent_Bridge_Queue_Item::from_array( $data );
+			if ( $item->client_id !== $client_id ) {
+				continue;
+			}
+
+			unset( $queue[ $queue_id ] );
+			++$acked;
+		}
+
+		if ( $acked > 0 ) {
+			update_option( self::QUEUE_OPTION, $queue, false );
+		}
+
+		return $acked;
+	}
+
+	/**
+	 * @return array<string,mixed>
+	 */
+	private function read_clients(): array {
+		$clients = get_option( self::CLIENTS_OPTION, array() );
+		return is_array( $clients ) ? $clients : array();
+	}
+
+	/**
+	 * @return array<string,mixed>
+	 */
+	private function read_queue(): array {
+		$queue = get_option( self::QUEUE_OPTION, array() );
+		return is_array( $queue ) ? $queue : array();
+	}
+
+	private function normalize_id( string $value ): string {
+		$value = trim( strtolower( str_replace( '_', '-', $value ) ) );
+		$value = preg_replace( '/[^a-z0-9-]+/', '-', $value );
+		return trim( (string) $value, '-' );
+	}
+}

--- a/tests/bootstrap-smoke.php
+++ b/tests/bootstrap-smoke.php
@@ -113,6 +113,11 @@ agents_api_smoke_assert_equals( true, class_exists( 'AgentsAPI\AI\Channels\WP_Ag
 agents_api_smoke_assert_equals( true, interface_exists( 'AgentsAPI\AI\Channels\WP_Agent_Message_Idempotency_Store' ), 'WP_Agent_Message_Idempotency_Store contract is available', $failures, $passes );
 agents_api_smoke_assert_equals( true, class_exists( 'AgentsAPI\AI\Channels\WP_Agent_Transient_Message_Idempotency_Store' ), 'WP_Agent_Transient_Message_Idempotency_Store implementation is available', $failures, $passes );
 agents_api_smoke_assert_equals( true, class_exists( 'AgentsAPI\AI\Channels\WP_Agent_Message_Idempotency' ), 'WP_Agent_Message_Idempotency facade is available', $failures, $passes );
+agents_api_smoke_assert_equals( true, class_exists( 'AgentsAPI\AI\Channels\WP_Agent_Bridge_Client' ), 'WP_Agent_Bridge_Client value object is available', $failures, $passes );
+agents_api_smoke_assert_equals( true, class_exists( 'AgentsAPI\AI\Channels\WP_Agent_Bridge_Queue_Item' ), 'WP_Agent_Bridge_Queue_Item value object is available', $failures, $passes );
+agents_api_smoke_assert_equals( true, interface_exists( 'AgentsAPI\AI\Channels\WP_Agent_Bridge_Store' ), 'WP_Agent_Bridge_Store contract is available', $failures, $passes );
+agents_api_smoke_assert_equals( true, class_exists( 'AgentsAPI\AI\Channels\WP_Agent_Option_Bridge_Store' ), 'WP_Agent_Option_Bridge_Store implementation is available', $failures, $passes );
+agents_api_smoke_assert_equals( true, class_exists( 'AgentsAPI\AI\Channels\WP_Agent_Bridge' ), 'WP_Agent_Bridge facade is available', $failures, $passes );
 foreach ( $namespace_map as $legacy_class => $target_class ) {
 	agents_api_smoke_assert_equals( true, class_exists( $target_class ) || interface_exists( $target_class ), $target_class . ' contract is available', $failures, $passes );
 	agents_api_smoke_assert_equals( false, class_exists( $legacy_class, false ) || interface_exists( $legacy_class, false ), $legacy_class . ' compatibility alias is not loaded', $failures, $passes );

--- a/tests/remote-bridge-smoke.php
+++ b/tests/remote-bridge-smoke.php
@@ -1,0 +1,126 @@
+<?php
+/**
+ * Pure-PHP smoke test for remote bridge primitives.
+ *
+ * Run with: php tests/remote-bridge-smoke.php
+ *
+ * @package AgentsAPI\Tests
+ */
+
+defined( 'ABSPATH' ) || define( 'ABSPATH', __DIR__ . '/' );
+
+$failures = array();
+$passes   = 0;
+
+echo "agents-api-remote-bridge-smoke\n";
+
+$GLOBALS['__remote_bridge_options'] = array();
+$GLOBALS['__remote_bridge_connectors'] = array(
+	'matrix-bridge' => array(
+		'name'           => 'Matrix Bridge',
+		'description'    => 'Generic Matrix bridge connector metadata.',
+		'type'           => 'agent_bridge',
+		'authentication' => array( 'method' => 'none' ),
+	),
+);
+
+function get_option( string $key, $default = '' ) {
+	return $GLOBALS['__remote_bridge_options'][ $key ] ?? $default;
+}
+
+function update_option( string $key, $value, $autoload = null ): bool {
+	unset( $autoload );
+	$GLOBALS['__remote_bridge_options'][ $key ] = $value;
+	return true;
+}
+
+function wp_get_connector( string $id ): ?array {
+	return $GLOBALS['__remote_bridge_connectors'][ $id ] ?? null;
+}
+
+function remote_bridge_assert( $expected, $actual, string $name, array &$failures, int &$passes ): void {
+	if ( $expected === $actual ) {
+		++$passes;
+		echo "  PASS {$name}\n";
+		return;
+	}
+
+	$failures[] = $name;
+	echo "  FAIL {$name}\n";
+	echo '    expected: ' . var_export( $expected, true ) . "\n";
+	echo '    actual:   ' . var_export( $actual, true ) . "\n";
+}
+
+require_once __DIR__ . '/../src/Channels/class-wp-agent-bridge-client.php';
+require_once __DIR__ . '/../src/Channels/class-wp-agent-bridge-queue-item.php';
+require_once __DIR__ . '/../src/Channels/class-wp-agent-bridge-store.php';
+require_once __DIR__ . '/../src/Channels/class-wp-agent-option-bridge-store.php';
+require_once __DIR__ . '/../src/Channels/class-wp-agent-bridge.php';
+
+use AgentsAPI\AI\Channels\WP_Agent_Bridge;
+
+$client = WP_Agent_Bridge::register_client(
+	'Beeper_Relay',
+	'https://bridge.example.test/callback',
+	array( 'label' => 'Beeper relay' ),
+	'matrix_bridge'
+);
+
+remote_bridge_assert( 'beeper-relay', $client->client_id, 'client_id_is_normalized', $failures, $passes );
+remote_bridge_assert( 'matrix-bridge', $client->connector_id, 'connector_id_is_normalized', $failures, $passes );
+remote_bridge_assert( 'Matrix Bridge', $client->connector()['name'] ?? null, 'client_resolves_core_connector_metadata', $failures, $passes );
+
+$stored_client = WP_Agent_Bridge::get_client( 'beeper-relay' );
+remote_bridge_assert( true, null !== $stored_client, 'registered_client_is_stored', $failures, $passes );
+remote_bridge_assert( 'https://bridge.example.test/callback', $stored_client?->callback_url, 'registered_client_preserves_callback_url', $failures, $passes );
+
+$item_one = WP_Agent_Bridge::enqueue(
+	array(
+		'client_id'    => 'beeper-relay',
+		'connector_id' => 'matrix-bridge',
+		'agent'        => 'support-agent',
+		'session_id'   => 'sess-1',
+		'role'         => 'assistant',
+		'content'      => 'First reply',
+		'completed'    => true,
+		'metadata'     => array( 'model' => 'test' ),
+	)
+);
+$item_two = WP_Agent_Bridge::enqueue(
+	array(
+		'client_id'  => 'beeper-relay',
+		'agent'      => 'support-agent',
+		'session_id' => 'sess-2',
+		'content'    => 'Second reply',
+	)
+);
+WP_Agent_Bridge::enqueue(
+	array(
+		'client_id' => 'other-relay',
+		'agent'     => 'support-agent',
+		'content'   => 'Other relay reply',
+	)
+);
+
+$pending = WP_Agent_Bridge::pending( 'beeper-relay' );
+remote_bridge_assert( 2, count( $pending ), 'pending_returns_client_items_only', $failures, $passes );
+remote_bridge_assert( $item_one->queue_id, $pending[0]->queue_id, 'pending_preserves_queue_order', $failures, $passes );
+remote_bridge_assert( 'First reply', $pending[0]->content, 'pending_preserves_content', $failures, $passes );
+remote_bridge_assert( array( 'model' => 'test' ), $pending[0]->metadata, 'pending_preserves_metadata', $failures, $passes );
+
+$filtered = WP_Agent_Bridge::pending( 'beeper-relay', 25, array( 'sess-2' ) );
+remote_bridge_assert( 1, count( $filtered ), 'pending_can_filter_by_session', $failures, $passes );
+remote_bridge_assert( $item_two->queue_id, $filtered[0]->queue_id, 'pending_session_filter_returns_matching_item', $failures, $passes );
+
+remote_bridge_assert( 1, WP_Agent_Bridge::ack( 'beeper-relay', array( $item_one->queue_id ) ), 'ack_removes_matching_item', $failures, $passes );
+remote_bridge_assert( 1, count( WP_Agent_Bridge::pending( 'beeper-relay' ) ), 'acked_item_is_no_longer_pending', $failures, $passes );
+remote_bridge_assert( 0, WP_Agent_Bridge::ack( 'beeper-relay', array( 'missing-id' ) ), 'ack_ignores_missing_items', $failures, $passes );
+remote_bridge_assert( 0, WP_Agent_Bridge::ack( 'wrong-client', array( $item_two->queue_id ) ), 'ack_is_scoped_by_client', $failures, $passes );
+remote_bridge_assert( 1, count( WP_Agent_Bridge::pending( 'beeper-relay' ) ), 'wrong_client_ack_does_not_remove_item', $failures, $passes );
+
+if ( ! empty( $failures ) ) {
+	echo "\nFailures: " . implode( ', ', $failures ) . "\n";
+	exit( 1 );
+}
+
+echo "\nAll {$passes} remote bridge assertions passed.\n";


### PR DESCRIPTION
## Summary
- Add generic remote bridge client registration and queue item value objects.
- Add a replaceable bridge store contract with an option-backed default and facade for register/enqueue/pending/ack.
- Keep Core Connectors API as optional connector metadata via `connector_id`/`wp_get_connector()` instead of duplicating connector settings.
- Document the queue-first bridge protocol separately from direct `WP_Agent_Channel` transports.

Closes #101.

## Testing
- `php tests/remote-bridge-smoke.php`
- `composer test`
- `homeboy lint --force-hot`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the implementation, smoke coverage, protocol docs, lint cleanup, and PR description; Chris remains responsible for review and merge.