### PR TITLE
Complete channel chat contract

### DIFF
--- a/docs/external-clients.md
+++ b/docs/external-clients.md
@@ -144,8 +144,8 @@ native representation. The detailed boundary is defined in [Bridge Authorization
 
 ## Shared Primitives
 
-The following primitives are candidates for Agents API because they are shared
-by direct channels and remote bridges.
+The following primitives are part of Agents API because they are shared by
+direct channels and remote bridges.
 
 ### Chat Ability Contract
 
@@ -170,6 +170,16 @@ array(
 )
 ```
 
+or a legacy adapter response alias:
+
+```php
+array(
+	'session_id' => 'session-id',
+	'response'   => 'assistant text',
+	'completed'  => true,
+)
+```
+
 or assistant messages:
 
 ```php
@@ -180,8 +190,7 @@ array(
 )
 ```
 
-The bridge-ready extension should preserve those fields and add optional
-metadata:
+The bridge-ready input preserves those fields and adds optional metadata:
 
 ```php
 array(
@@ -224,8 +233,8 @@ array(
 )
 ```
 
-Agents API should define this normalized shape as a reusable value contract.
-Channel plugins should still own vendor-specific parsing.
+Agents API defines this normalized shape with `WP_Agent_External_Message`.
+Channel plugins still own vendor-specific parsing.
 
 ### Session Mapping
 
@@ -236,9 +245,9 @@ connector_id + external_conversation_id + agent
 -> session_id
 ```
 
-`WP_Agent_Channel` has an option-backed default. A follow-up service or
-interface should make the mapping reusable across channel subclasses and remote
-bridge services while preserving override points for custom stores.
+`WP_Agent_Channel_Session_Map` provides this mapping with an option-backed
+default and a replaceable store contract for channel subclasses and remote
+bridge services.
 
 ### Webhook Safety
 
@@ -250,8 +259,9 @@ Most webhook channels need the same small safety helpers:
 - TTL-backed inbound duplicate suppression keyed by external message ID
 - explicit silent-skip results for self messages and non-chat events
 
-Agents API should provide these helpers so every channel does not copy slightly
-different security-sensitive code.
+Agents API provides these helpers with `WP_Agent_Webhook_Signature` and
+`WP_Agent_Message_Idempotency` so every channel does not copy slightly different
+security-sensitive code.
 
 ### Remote Bridge Delivery
 
@@ -265,11 +275,11 @@ assistant response generated
 -> allow polling as recovery path
 ```
 
-This implies generic services or REST endpoints for:
+Agents API provides generic PHP services for:
 
 ```text
 register bridge callback
-send inbound message
+queue outbound bridge messages
 list pending outbound messages
 ack delivered messages
 ```
@@ -292,18 +302,6 @@ Agents API should not own product or platform details:
 - product-specific approval UX
 
 Those belong in channel plugins, bridge clients, or runtime adapters.
-
-## Implementation Sequence
-
-The next slices should be small and reviewable:
-
-1. Document and extend the `WP_Agent_Channel` chat ability contract for bridge
-   metadata.
-2. Add normalized external message and session mapping primitives.
-3. Add webhook signature and inbound idempotency helpers.
-4. Design the remote bridge register/send/pending/ack services.
-5. Design bridge authorization around Connectors-backed service identity and
-   Agents API-owned scoped credentials.
 
 Related tracking issues:
 

--- a/docs/external-clients.md
+++ b/docs/external-clients.md
@@ -170,16 +170,6 @@ array(
 )
 ```
 
-or a legacy adapter response alias:
-
-```php
-array(
-	'session_id' => 'session-id',
-	'response'   => 'assistant text',
-	'completed'  => true,
-)
-```
-
 or assistant messages:
 
 ```php

--- a/src/Channels/class-wp-agent-channel.php
+++ b/src/Channels/class-wp-agent-channel.php
@@ -494,9 +494,8 @@ abstract class WP_Agent_Channel {
 	}
 
 	/**
-	 * Pull assistant text out of the agent result. Default supports three
-	 * shapes: `{ reply: string }` (canonical single-turn),
-	 * `{ response: string }` (legacy adapter alias), and
+	 * Pull assistant text out of the agent result. Default supports two
+	 * shapes: `{ reply: string }` (canonical single-turn) and
 	 * `{ messages: [ { role, content } ] }` (multi-message). Override for
 	 * exotic result shapes.
 	 *
@@ -506,10 +505,6 @@ abstract class WP_Agent_Channel {
 	protected function extract_replies( array $result ): array {
 		if ( ! empty( $result['reply'] ) ) {
 			return array( (string) $result['reply'] );
-		}
-
-		if ( ! empty( $result['response'] ) ) {
-			return array( (string) $result['response'] );
 		}
 
 		if ( ! empty( $result['messages'] ) && is_array( $result['messages'] ) ) {

--- a/src/Channels/class-wp-agent-channel.php
+++ b/src/Channels/class-wp-agent-channel.php
@@ -282,7 +282,7 @@ abstract class WP_Agent_Channel {
 	 *
 	 * Default implementation calls the chat ability registered under the slug
 	 * returned by the `wp_agent_channel_chat_ability` filter (default
-	 * `openclawp/chat`). Override to plug in a different runtime — a
+	 * `agents/chat`). Override to plug in a different runtime — a
 	 * direct `wp_ai_client_prompt()` call, an external HTTP service, or a
 	 * host-specific agent factory.
 	 *
@@ -494,8 +494,9 @@ abstract class WP_Agent_Channel {
 	}
 
 	/**
-	 * Pull assistant text out of the agent result. Default supports two
-	 * shapes: `{ reply: string }` (openclawp/chat single-turn) and
+	 * Pull assistant text out of the agent result. Default supports three
+	 * shapes: `{ reply: string }` (canonical single-turn),
+	 * `{ response: string }` (legacy adapter alias), and
 	 * `{ messages: [ { role, content } ] }` (multi-message). Override for
 	 * exotic result shapes.
 	 *
@@ -505,6 +506,10 @@ abstract class WP_Agent_Channel {
 	protected function extract_replies( array $result ): array {
 		if ( ! empty( $result['reply'] ) ) {
 			return array( (string) $result['reply'] );
+		}
+
+		if ( ! empty( $result['response'] ) ) {
+			return array( (string) $result['response'] );
 		}
 
 		if ( ! empty( $result['messages'] ) && is_array( $result['messages'] ) ) {

--- a/tests/channels-smoke.php
+++ b/tests/channels-smoke.php
@@ -305,17 +305,6 @@ smoke_assert(
 	$passes
 );
 
-// 3b. Legacy adapters can return `response` as an alias for canonical `reply`.
-$response_alias_ability = new Fake_Ability(
-	array( 'response' => 'legacy response alias', 'session_id' => 'sess-response-alias' )
-);
-$GLOBALS['__channel_smoke_abilities']['agents/chat'] = $response_alias_ability;
-
-$response_alias_channel = new Test_Channel( 'chat-response-alias' );
-$response_alias_channel->handle( array( 'text' => 'alias please' ) );
-
-smoke_assert( array( 'legacy response alias' ), $response_alias_channel->sent, 'response_alias_is_delivered', $failures, $passes );
-
 // 4. Empty message short-circuits with WP_Error, no agent call.
 $null_ability = new Fake_Ability( array( 'reply' => 'should not be called' ) );
 $GLOBALS['__channel_smoke_abilities']['agents/chat'] = $null_ability;

--- a/tests/channels-smoke.php
+++ b/tests/channels-smoke.php
@@ -305,6 +305,17 @@ smoke_assert(
 	$passes
 );
 
+// 3b. Legacy adapters can return `response` as an alias for canonical `reply`.
+$response_alias_ability = new Fake_Ability(
+	array( 'response' => 'legacy response alias', 'session_id' => 'sess-response-alias' )
+);
+$GLOBALS['__channel_smoke_abilities']['agents/chat'] = $response_alias_ability;
+
+$response_alias_channel = new Test_Channel( 'chat-response-alias' );
+$response_alias_channel->handle( array( 'text' => 'alias please' ) );
+
+smoke_assert( array( 'legacy response alias' ), $response_alias_channel->sent, 'response_alias_is_delivered', $failures, $passes );
+
 // 4. Empty message short-circuits with WP_Error, no agent call.
 $null_ability = new Fake_Ability( array( 'reply' => 'should not be called' ) );
 $GLOBALS['__channel_smoke_abilities']['agents/chat'] = $null_ability;


### PR DESCRIPTION
## Summary
- Keep `WP_Agent_Channel::extract_replies()` aligned with the canonical `agents/chat` output contract: `reply` and assistant `messages` only.
- Refresh external client docs so the channel/bridge primitives read as current contract, not future candidate work.
- Fix the stale `openclawp/chat` default reference in the channel docblock.

Closes #100.

## Testing
- `php tests/channels-smoke.php`
- `composer test`
- `homeboy lint --force-hot`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the channel contract cleanup, smoke/docs updates, validation, and PR description; Chris remains responsible for review and merge.