### PR TITLE
Scrub stale channel contract terminology

### DIFF
--- a/README.md
+++ b/README.md
@@ -672,7 +672,7 @@ Boundary selection preserves tool-call/tool-result integrity by default. If summ
 
 It does not assemble prompts, select a provider/model, implement concrete tools, choose durable storage, expose admin UI, or define product workflow semantics. Consumers provide adapters for those concerns and pass them into the loop.
 
-### Minimal usage (legacy, fully backwards compatible)
+### Minimal caller-managed usage
 
 ```php
 $result = AgentsAPI\AI\WP_Agent_Conversation_Loop::run(
@@ -736,7 +736,7 @@ $result = AgentsAPI\AI\WP_Agent_Conversation_Loop::run(
 			$logger->log( $event, $payload );
 		},
 
-		// Legacy escape hatch — both can coexist, typed policy takes precedence
+		// Caller-owned continuation policy; typed completion policy takes precedence.
 		'should_continue' => static function ( array $result, array $context ): bool {
 			return ! empty( $result['tool_execution_results'] );
 		},

--- a/docs/bridge-authorization.md
+++ b/docs/bridge-authorization.md
@@ -133,8 +133,8 @@ Route auth should be a separate layer that validates the bridge credential and m
 ## Non-Goals
 
 - No platform-specific clients.
-- No Data Machine token table names.
-- No Roadie/Beeper/Matrix-specific copy.
+- No runtime-specific token table names.
+- No product- or network-specific onboarding copy.
 - No required onboarding UI.
 - No duplicate connector registry.
 - No bridge route implementation until auth policy is settled.

--- a/docs/external-clients.md
+++ b/docs/external-clients.md
@@ -1,19 +1,19 @@
 # External Clients, Channels, And Bridges
 
-Agents API should provide the generic substrate that lets external conversation
+Agents API provides the generic substrate that lets external conversation
 surfaces talk to WordPress agents without every consumer rebuilding the same
 transport, session, and delivery primitives.
 
 This document describes the boundary. It is intentionally architectural: it
-connects the merged `WP_Agent_Channel` base class to the follow-up bridge and
-Connectors work without committing to a full REST implementation in this slice.
+connects `WP_Agent_Channel`, bridge primitives, session mapping, webhook safety,
+and Connectors metadata without committing to a full REST implementation in this
+slice.
 
 ## Why This Belongs In Agents API
 
 External clients are a common agent runtime requirement. Users should be able to
 talk to WordPress agents from surfaces such as Telegram, Slack, Discord,
-WhatsApp, SMS, email, Matrix, Beeper, CLI relays, browser extensions, and mobile
-apps.
+WhatsApp, SMS, email, Matrix, CLI relays, browser extensions, and mobile apps.
 
 Those integrations repeat the same infrastructure:
 
@@ -28,7 +28,7 @@ external event
 -> suppress duplicates and recover from delivery failures
 ```
 
-Agents API should own the shape and shared infrastructure. Product plugins and
+Agents API owns the shape and shared infrastructure. Product plugins and
 channel plugins should own platform details, product policy, and UI.
 
 ## Two Integration Shapes
@@ -77,7 +77,7 @@ generic bridge protocol. This is useful when the chat surface is not implemented
 as a WordPress plugin process.
 
 ```text
-Beeper / Matrix / external daemon / mobile client
+external daemon / mobile client / message relay
 -> Agents API bridge endpoint
 -> chat ability
 -> queue assistant response
@@ -85,16 +85,15 @@ Beeper / Matrix / external daemon / mobile client
 -> client ack
 ```
 
-The Data Machine chat bridge currently implements this pattern for Data Machine.
-The generic parts should move toward Agents API so other runtimes do not need to
-copy bridge registration, queue-first delivery, pending polling, and ack logic.
+Agents API owns the generic bridge registration, queue-first delivery, pending
+polling, and ack logic so runtimes do not copy product-specific bridge code.
 
 ## Connectors API Boundary
 
-WordPress Connectors API should be the default registry and settings layer for
+WordPress Connectors API is the default registry and settings layer for
 external services when available.
 
-Connectors should own service metadata:
+Connectors own service metadata:
 
 - connector ID
 - display name and description
@@ -105,7 +104,7 @@ Connectors should own service metadata:
 - plugin install/activate metadata
 - connected status metadata where the auth method fits
 
-Agents API should own agent semantics:
+Agents API owns agent semantics:
 
 - chat ability contract
 - channel and bridge message context
@@ -130,7 +129,7 @@ telegram
 slack
 discord
 whatsapp-cloud
-wacli
+local-relay
 matrix
 beeper
 ```
@@ -274,21 +273,21 @@ list pending outbound messages
 ack delivered messages
 ```
 
-The bridge protocol should call the canonical chat ability contract rather than
+The bridge protocol calls the canonical chat ability contract rather than
 any runtime-specific ability shape.
 
 ## What Stays Out Of Agents API
 
-Agents API should not own product or platform details:
+Agents API does not own product or platform details:
 
 - Slack-specific event envelope parsing
 - Discord-specific interaction handling
 - Telegram-specific bot setup
 - WhatsApp Graph API settings pages
-- wacli process management or QR pairing UI
-- Data Machine token table names
-- Data Machine mode prompts or bridge guidance copy
-- Roadie/Beeper onboarding copy
+- local bridge process management or pairing UI
+- runtime-specific token table names
+- runtime-specific mode prompts or bridge guidance copy
+- product-specific onboarding copy
 - product-specific approval UX
 
 Those belong in channel plugins, bridge clients, or runtime adapters.

--- a/src/Channels/class-wp-agent-channel.php
+++ b/src/Channels/class-wp-agent-channel.php
@@ -300,8 +300,8 @@ abstract class WP_Agent_Channel {
 	 *       }
 	 *     }
 	 *
-	 * Runtimes that don't read the richer fields (e.g. `openclawp/chat`)
-	 * ignore them; runtimes that do get the full transport context without
+	 * Runtimes that don't read the richer fields ignore them; runtimes that do
+	 * get the full transport context without
 	 * having to know about WP_Agent_Channel.
 	 *
 	 * @param string $message_text The user-message string from extract_message().

--- a/src/Channels/register-agents-chat-ability.php
+++ b/src/Channels/register-agents-chat-ability.php
@@ -43,8 +43,7 @@ defined( 'ABSPATH' ) || exit;
 
 /**
  * The slug under which this ability is registered. Stable. Consumers and
- * channels should target this string rather than a runtime-specific slug
- * like `openclawp/chat`.
+	 * channels should target this string rather than a runtime-specific slug.
  *
  * @since 0.103.0
  */
@@ -60,7 +59,7 @@ add_action(
 			'agents-api',
 			array(
 				'label'       => 'Agents API',
-				'description' => 'Cross-cutting abilities provided by the Agents API substrate (channel dispatch, canonical chat contract, future runtime resolvers).',
+				'description' => 'Cross-cutting abilities provided by the Agents API substrate (channel dispatch and canonical chat contract).',
 			)
 		);
 	}
@@ -224,7 +223,7 @@ function agents_chat_input_schema(): array {
 					),
 					'client_name'              => array(
 						'type'        => 'string',
-						'description' => 'Specific client identifier within the source (e.g. "wacli", "telegram_<bot>", "data-machine").',
+						'description' => 'Specific client identifier within the source (e.g. "cli-relay" or "messaging-bot").',
 					),
 					'connector_id'             => array(
 						'type'        => 'string',

--- a/src/Runtime/class-wp-agent-compaction-item.php
+++ b/src/Runtime/class-wp-agent-compaction-item.php
@@ -82,7 +82,7 @@ class WP_Agent_Compaction_Item {
 	/**
 	 * Project a message envelope into the generic compaction item contract.
 	 *
-	 * @param array    $message Message envelope or legacy message.
+	 * @param array    $message Message envelope or plain role/content message.
 	 * @param int|null $index   Optional item position used for generated IDs.
 	 * @return array<string, mixed> Normalized compaction item.
 	 */
@@ -110,7 +110,7 @@ class WP_Agent_Compaction_Item {
 	/**
 	 * Project message envelopes into ordered compaction items.
 	 *
-	 * @param array $messages Message envelopes or legacy messages.
+	 * @param array $messages Message envelopes or plain role/content messages.
 	 * @return array<int, array<string, mixed>>
 	 */
 	public static function from_messages( array $messages ): array {

--- a/src/Runtime/class-wp-agent-conversation-loop.php
+++ b/src/Runtime/class-wp-agent-conversation-loop.php
@@ -43,7 +43,7 @@ class WP_Agent_Conversation_Loop {
 	 * - `budgets` (WP_Agent_Iteration_Budget[]): Named iteration budgets for bounded execution.
 	 * - `context` (array): Caller-owned context passed to adapters.
 	 * - `should_continue` (callable|null): Caller-owned continuation policy.
-	 *   Defaults to `null` in the legacy path (which causes the loop to break
+	 *   Defaults to `null` in the caller-managed path (which causes the loop to break
 	 *   after one turn unless the caller supplies a callback). When tool
 	 *   mediation is enabled (`tool_executor` + `tool_declarations` provided),
 	 *   defaults to a `__return_true` callable so the loop continues until
@@ -157,7 +157,7 @@ class WP_Agent_Conversation_Loop {
 				}
 
 				// When mediation is enabled, the turn runner returns tool_calls
-				// and the loop handles execution. Otherwise, the legacy path applies.
+				// and the loop handles execution. Otherwise, the caller-managed path applies.
 				if ( $mediation_enabled && isset( $result['tool_calls'] ) && is_array( $result['tool_calls'] ) ) {
 					$mediation_result = self::mediate_tool_calls(
 						$result,
@@ -176,7 +176,7 @@ class WP_Agent_Conversation_Loop {
 					$conversation_complete = $mediation_result['conversation_complete'];
 					$exceeded_budget       = $mediation_result['exceeded_budget'];
 				} else {
-					// Legacy path: turn runner handles everything internally.
+					// Caller-managed path: turn runner handles everything internally.
 					$result       = WP_Agent_Conversation_Result::normalize( $result );
 					$messages     = $result['messages'];
 					$tool_results = array_merge( $tool_results, $result['tool_execution_results'] );
@@ -203,7 +203,7 @@ class WP_Agent_Conversation_Loop {
 					}
 				}
 
-				// Stop conditions: budget exceeded, completion policy, or legacy should_continue.
+				// Stop conditions: budget exceeded, completion policy, or caller should_continue.
 				if ( null !== $exceeded_budget ) {
 					break;
 				}
@@ -519,7 +519,7 @@ class WP_Agent_Conversation_Loop {
 	 *
 	 * When tool mediation is enabled, defaults to a continue-always callable so
 	 * `max_turns`, `completion_policy`, budgets, and natural completion (empty
-	 * `tool_calls`) become the only stop conditions. In the legacy path (no
+	 * `tool_calls`) become the only stop conditions. In the caller-managed path (no
 	 * mediation), preserves the historical break-after-1 behavior unless the
 	 * caller supplies their own continuation policy.
 	 *
@@ -539,7 +539,7 @@ class WP_Agent_Conversation_Loop {
 				return $caller_supplied;
 			}
 			// Caller passed a non-callable value (e.g. null) — preserve the
-			// legacy break-after-1 behavior they explicitly opted into.
+			// break-after-1 behavior they explicitly opted into.
 			return null;
 		}
 

--- a/src/Runtime/class-wp-agent-message.php
+++ b/src/Runtime/class-wp-agent-message.php
@@ -118,7 +118,7 @@ class WP_Agent_Message {
 	}
 
 	/**
-	 * Normalize a legacy message or typed envelope to the canonical envelope.
+	 * Normalize a plain role/content message or typed envelope to the canonical envelope.
 	 *
 	 * @param array $message Message array.
 	 * @return array<string, mixed> Normalized envelope.
@@ -127,7 +127,7 @@ class WP_Agent_Message {
 	public static function normalize( array $message ): array {
 		$envelope = self::isEnvelope( $message )
 			? self::normalizeEnvelope( $message )
-			: self::fromLegacyMessage( $message );
+			: self::fromPlainMessage( $message );
 
 		if ( false === self::jsonEncode( $envelope ) ) {
 			throw new \InvalidArgumentException( 'invalid_ai_message_envelope: envelope must be JSON serializable' );
@@ -156,7 +156,7 @@ class WP_Agent_Message {
 	/**
 	 * Project an envelope to a provider request message shape.
 	 *
-	 * @param array $message Typed envelope or legacy message.
+	 * @param array $message Typed envelope or plain role/content message.
 	 * @return array<string, mixed> Provider-facing message.
 	 */
 	public static function to_provider_message( array $message ): array {
@@ -187,7 +187,7 @@ class WP_Agent_Message {
 	/**
 	 * Project envelopes to a provider request message shape.
 	 *
-	 * @param array $messages Typed envelopes or legacy messages.
+	 * @param array $messages Typed envelopes or plain role/content messages.
 	 * @return array<int, array<string, mixed>> Provider-facing messages.
 	 */
 	public static function to_provider_messages( array $messages ): array {
@@ -204,7 +204,7 @@ class WP_Agent_Message {
 	/**
 	 * Extract the canonical type from a message.
 	 *
-	 * @param array $message Typed envelope or legacy message.
+	 * @param array $message Typed envelope or plain role/content message.
 	 * @return string Message type.
 	 */
 	public static function type( array $message ): string {
@@ -252,12 +252,12 @@ class WP_Agent_Message {
 	}
 
 	/**
-	 * Normalize the legacy role/content/metadata message shape.
+	 * Normalize the plain role/content/metadata message shape.
 	 *
-	 * @param array $message Legacy message.
+	 * @param array $message Plain role/content message.
 	 * @return array<string, mixed> Canonical envelope.
 	 */
-	private static function fromLegacyMessage( array $message ): array {
+	private static function fromPlainMessage( array $message ): array {
 		$metadata = is_array( $message['metadata'] ?? null ) ? $message['metadata'] : array();
 		$type     = self::inferType( $message, $metadata );
 
@@ -265,7 +265,7 @@ class WP_Agent_Message {
 			$message['role'] ?? self::roleForType( $type ),
 			$message['content'] ?? '',
 			$type,
-			self::payloadFromLegacyMetadata( $type, $metadata ),
+			self::payloadFromPlainMetadata( $type, $metadata ),
 			$metadata,
 			$message
 		);
@@ -311,10 +311,10 @@ class WP_Agent_Message {
 	}
 
 	/**
-	 * Infer the typed envelope event from legacy message fields.
+	 * Infer the typed envelope event from plain message fields.
 	 *
-	 * @param array $message  Legacy message.
-	 * @param array $metadata Legacy metadata.
+	 * @param array $message  Plain role/content message.
+	 * @param array $metadata Plain message metadata.
 	 * @return string Envelope type.
 	 */
 	private static function inferType( array $message, array $metadata ): string {
@@ -346,13 +346,13 @@ class WP_Agent_Message {
 	}
 
 	/**
-	 * Pull common legacy metadata fields into type-specific envelope payload.
+	 * Pull common plain-message metadata fields into type-specific envelope payload.
 	 *
 	 * @param string $type     Envelope type.
-	 * @param array  $metadata Legacy metadata.
+	 * @param array  $metadata Plain message metadata.
 	 * @return array<string, mixed> Type-specific payload.
 	 */
-	private static function payloadFromLegacyMetadata( string $type, array $metadata ): array {
+	private static function payloadFromPlainMetadata( string $type, array $metadata ): array {
 		$payload = array();
 
 		if ( self::TYPE_TOOL_CALL === $type ) {

--- a/src/Tools/class-wp-agent-tool-parameters.php
+++ b/src/Tools/class-wp-agent-tool-parameters.php
@@ -41,7 +41,7 @@ class WP_Agent_Tool_Parameters {
 	 * Validate required parameters declared by a tool definition.
 	 *
 	 * Supports both the compact Agents API shape (`required` as a list of names)
-	 * and legacy per-property `required => true` flags.
+	 * and per-property `required => true` flags.
 	 *
 	 * @param array $tool_parameters Runtime tool-call parameters.
 	 * @param array $tool_definition Normalized tool declaration.

--- a/src/Workflows/register-agents-workflow-abilities.php
+++ b/src/Workflows/register-agents-workflow-abilities.php
@@ -35,7 +35,7 @@ add_action(
 			'agents-api',
 			array(
 				'label'       => 'Agents API',
-				'description' => 'Cross-cutting abilities provided by the Agents API substrate (channel dispatch, canonical chat contract, workflow dispatch, future runtime resolvers).',
+				'description' => 'Cross-cutting abilities provided by the Agents API substrate (channel dispatch, canonical chat contract, and workflow dispatch).',
 			)
 		);
 	}

--- a/tests/agents-chat-ability-smoke.php
+++ b/tests/agents-chat-ability-smoke.php
@@ -113,7 +113,7 @@ $result = agents_chat_dispatch( array(
 	'message'        => 'ping',
 	'session_id'     => null,
 	'attachments'    => array(),
-	'client_context' => array( 'source' => 'channel', 'client_name' => 'wacli' ),
+	'client_context' => array( 'source' => 'channel', 'client_name' => 'cli-relay' ),
 ) );
 
 smoke_assert( 'demo', $captured['agent'] ?? null, 'handler_received_agent', $failures, $passes );

--- a/tests/bootstrap-smoke.php
+++ b/tests/bootstrap-smoke.php
@@ -118,9 +118,9 @@ agents_api_smoke_assert_equals( true, class_exists( 'AgentsAPI\AI\Channels\WP_Ag
 agents_api_smoke_assert_equals( true, interface_exists( 'AgentsAPI\AI\Channels\WP_Agent_Bridge_Store' ), 'WP_Agent_Bridge_Store contract is available', $failures, $passes );
 agents_api_smoke_assert_equals( true, class_exists( 'AgentsAPI\AI\Channels\WP_Agent_Option_Bridge_Store' ), 'WP_Agent_Option_Bridge_Store implementation is available', $failures, $passes );
 agents_api_smoke_assert_equals( true, class_exists( 'AgentsAPI\AI\Channels\WP_Agent_Bridge' ), 'WP_Agent_Bridge facade is available', $failures, $passes );
-foreach ( $namespace_map as $legacy_class => $target_class ) {
+foreach ( $namespace_map as $source_class => $target_class ) {
 	agents_api_smoke_assert_equals( true, class_exists( $target_class ) || interface_exists( $target_class ), $target_class . ' contract is available', $failures, $passes );
-	agents_api_smoke_assert_equals( false, class_exists( $legacy_class, false ) || interface_exists( $legacy_class, false ), $legacy_class . ' compatibility alias is not loaded', $failures, $passes );
+	agents_api_smoke_assert_equals( false, class_exists( $source_class, false ) || interface_exists( $source_class, false ), $source_class . ' compatibility alias is not loaded', $failures, $passes );
 }
 foreach ( $context_contracts as $context_contract ) {
 	agents_api_smoke_assert_equals( true, class_exists( $context_contract ) || interface_exists( $context_contract ), $context_contract . ' contract is available', $failures, $passes );
@@ -191,7 +191,7 @@ sort( $actual_source_directories );
 agents_api_smoke_assert_equals( $expected_source_directories, $actual_source_directories, 'module source directories are agent-native', $failures, $passes );
 agents_api_smoke_assert_equals( false, is_dir( AGENTS_API_PATH . 'inc/Core' ), 'copied inc/Core tree is absent', $failures, $passes );
 agents_api_smoke_assert_equals( false, is_dir( AGENTS_API_PATH . 'inc/AI' ), 'copied inc/AI tree is absent', $failures, $passes );
-agents_api_smoke_assert_equals( false, is_dir( AGENTS_API_PATH . 'inc' ), 'legacy inc source root is absent', $failures, $passes );
+agents_api_smoke_assert_equals( false, is_dir( AGENTS_API_PATH . 'inc' ), 'old inc source root is absent', $failures, $passes );
 
 echo "\n[4] Module owns the generic guideline substrate polyfill:\n";
 agents_api_smoke_assert_equals( true, class_exists( 'WP_Guidelines_Substrate' ), 'guideline substrate class is available', $failures, $passes );

--- a/tests/channels-smoke.php
+++ b/tests/channels-smoke.php
@@ -264,17 +264,17 @@ smoke_assert( 'group', $rich_ability->calls[0]['client_context']['room_kind'] ??
 smoke_assert( 'bridge', $rich_ability->calls[0]['client_context']['source'] ?? null, 'rich_payload_source_overridden', $failures, $passes );
 smoke_assert( 'test-channel', $rich_ability->calls[0]['client_context']['connector_id'] ?? null, 'rich_payload_connector_id', $failures, $passes );
 
-// 1c. Channels with legacy/custom session keys keep that override path.
+// 1c. Channels with custom session keys keep that override path.
 class Custom_Key_Channel extends Test_Channel {
 	protected function session_storage_key(): string {
-		return 'legacy_custom_session_key_' . $this->external_id;
+		return 'custom_session_key_' . $this->external_id;
 	}
 }
-$custom_key_ability = new Fake_Ability( array( 'reply' => 'legacy key', 'session_id' => 'sess-legacy' ) );
+$custom_key_ability = new Fake_Ability( array( 'reply' => 'custom key', 'session_id' => 'sess-custom' ) );
 $GLOBALS['__channel_smoke_abilities']['agents/chat'] = $custom_key_ability;
-$custom_key = new Custom_Key_Channel( 'chat-legacy' );
+$custom_key = new Custom_Key_Channel( 'chat-custom' );
 $custom_key->handle( array( 'text' => 'use custom key' ) );
-smoke_assert( 'sess-legacy', get_option( 'legacy_custom_session_key_chat-legacy' ), 'custom_session_key_override_is_preserved', $failures, $passes );
+smoke_assert( 'sess-custom', get_option( 'custom_session_key_chat-custom' ), 'custom_session_key_override_is_preserved', $failures, $passes );
 
 // 2. Session continuity: second turn passes the stored session_id.
 $happy_ability2 = new Fake_Ability(

--- a/tests/conversation-loop-completion-policy-smoke.php
+++ b/tests/conversation-loop-completion-policy-smoke.php
@@ -147,7 +147,7 @@ $result2 = AgentsAPI\AI\WP_Agent_Conversation_Loop::run(
 agents_api_smoke_assert_equals( 1, count( $policy_log ), 'policy was called once', $failures, $passes );
 agents_api_smoke_assert_equals( 0, $continue_called, 'should_continue was not called when policy stopped the loop', $failures, $passes );
 
-echo "\n[3] Completion policy works in legacy path (turn runner handles tool execution):\n";
+echo "\n[3] Completion policy works in caller-managed path (turn runner handles tool execution):\n";
 $policy_log = array();
 
 // Build a policy that completes on any tool.
@@ -157,11 +157,11 @@ $always_complete_policy = new class() implements AgentsAPI\AI\WP_Agent_Conversat
 	}
 };
 
-$legacy_turns = 0;
+$caller_managed_turns = 0;
 $result3      = AgentsAPI\AI\WP_Agent_Conversation_Loop::run(
 	array( array( 'role' => 'user', 'content' => 'hello' ) ),
-	static function ( array $messages, array $context ) use ( &$legacy_turns ): array {
-		++$legacy_turns;
+	static function ( array $messages, array $context ) use ( &$caller_managed_turns ): array {
+		++$caller_managed_turns;
 		$messages[] = AgentsAPI\AI\WP_Agent_Message::text( 'assistant', 'calling tool' );
 
 		return array(
@@ -187,6 +187,6 @@ $result3      = AgentsAPI\AI\WP_Agent_Conversation_Loop::run(
 	)
 );
 
-agents_api_smoke_assert_equals( 1, $legacy_turns, 'legacy loop stopped after one turn via completion policy', $failures, $passes );
+agents_api_smoke_assert_equals( 1, $caller_managed_turns, 'caller-managed loop stopped after one turn via completion policy', $failures, $passes );
 
 agents_api_smoke_finish( 'Agents API conversation loop completion policy', $failures, $passes );

--- a/tests/conversation-loop-tool-execution-smoke.php
+++ b/tests/conversation-loop-tool-execution-smoke.php
@@ -93,7 +93,7 @@ agents_api_smoke_assert_equals( true, $message_count >= 4, 'transcript contains 
 echo "\n[2] Loop runs without mediation when no tool_executor is provided (backwards compatible):\n";
 $executor->executed = array();
 
-$legacy_result = AgentsAPI\AI\WP_Agent_Conversation_Loop::run(
+$caller_managed_result = AgentsAPI\AI\WP_Agent_Conversation_Loop::run(
 	array( array( 'role' => 'user', 'content' => 'hello' ) ),
 	static function ( array $messages, array $context ): array {
 		$messages[] = AgentsAPI\AI\WP_Agent_Message::text( 'assistant', 'turn ' . $context['turn'] );
@@ -112,8 +112,8 @@ $legacy_result = AgentsAPI\AI\WP_Agent_Conversation_Loop::run(
 	)
 );
 
-agents_api_smoke_assert_equals( 0, count( $executor->executed ), 'tool executor was not called in legacy path', $failures, $passes );
-agents_api_smoke_assert_equals( 3, count( $legacy_result['messages'] ), 'legacy loop returns correct transcript length', $failures, $passes );
+agents_api_smoke_assert_equals( 0, count( $executor->executed ), 'tool executor was not called in caller-managed path', $failures, $passes );
+agents_api_smoke_assert_equals( 3, count( $caller_managed_result['messages'] ), 'caller-managed loop returns correct transcript length', $failures, $passes );
 
 echo "\n[3] Multi-turn mediation continues when tool calls are present:\n";
 $executor->executed = array();
@@ -225,13 +225,13 @@ agents_api_smoke_assert_equals( 1, count( $executor->executed ), 'mediation exec
 agents_api_smoke_assert_equals( 2, $default_turn_count, 'mediation loop ran two turns with no explicit should_continue', $failures, $passes );
 agents_api_smoke_assert_equals( 1, count( $default_result['tool_execution_results'] ), 'mediation default returned the tool result', $failures, $passes );
 
-echo "\n[6] Legacy path (no mediation) preserves break-after-1 default:\n";
-$legacy_default_count = 0;
+echo "\n[6] Caller-managed path (no mediation) preserves break-after-1 default:\n";
+$caller_managed_default_count = 0;
 
-$legacy_default_result = AgentsAPI\AI\WP_Agent_Conversation_Loop::run(
+$caller_managed_default_result = AgentsAPI\AI\WP_Agent_Conversation_Loop::run(
 	array( array( 'role' => 'user', 'content' => 'go' ) ),
-	static function ( array $messages, array $context ) use ( &$legacy_default_count ): array {
-		++$legacy_default_count;
+	static function ( array $messages, array $context ) use ( &$caller_managed_default_count ): array {
+		++$caller_managed_default_count;
 
 		$messages[] = array(
 			'role'    => 'assistant',
@@ -250,7 +250,7 @@ $legacy_default_result = AgentsAPI\AI\WP_Agent_Conversation_Loop::run(
 	)
 );
 
-agents_api_smoke_assert_equals( 1, $legacy_default_count, 'legacy path still breaks after one turn without should_continue', $failures, $passes );
-agents_api_smoke_assert_equals( 2, count( $legacy_default_result['messages'] ), 'legacy transcript has user + one assistant message', $failures, $passes );
+agents_api_smoke_assert_equals( 1, $caller_managed_default_count, 'caller-managed path still breaks after one turn without should_continue', $failures, $passes );
+agents_api_smoke_assert_equals( 2, count( $caller_managed_default_result['messages'] ), 'caller-managed transcript has user + one assistant message', $failures, $passes );
 
 agents_api_smoke_finish( 'Agents API conversation loop tool execution', $failures, $passes );

--- a/tests/remote-bridge-smoke.php
+++ b/tests/remote-bridge-smoke.php
@@ -60,23 +60,23 @@ require_once __DIR__ . '/../src/Channels/class-wp-agent-bridge.php';
 use AgentsAPI\AI\Channels\WP_Agent_Bridge;
 
 $client = WP_Agent_Bridge::register_client(
-	'Beeper_Relay',
+	'Message_Relay',
 	'https://bridge.example.test/callback',
-	array( 'label' => 'Beeper relay' ),
+	array( 'label' => 'Message relay' ),
 	'matrix_bridge'
 );
 
-remote_bridge_assert( 'beeper-relay', $client->client_id, 'client_id_is_normalized', $failures, $passes );
+remote_bridge_assert( 'message-relay', $client->client_id, 'client_id_is_normalized', $failures, $passes );
 remote_bridge_assert( 'matrix-bridge', $client->connector_id, 'connector_id_is_normalized', $failures, $passes );
 remote_bridge_assert( 'Matrix Bridge', $client->connector()['name'] ?? null, 'client_resolves_core_connector_metadata', $failures, $passes );
 
-$stored_client = WP_Agent_Bridge::get_client( 'beeper-relay' );
+$stored_client = WP_Agent_Bridge::get_client( 'message-relay' );
 remote_bridge_assert( true, null !== $stored_client, 'registered_client_is_stored', $failures, $passes );
 remote_bridge_assert( 'https://bridge.example.test/callback', $stored_client?->callback_url, 'registered_client_preserves_callback_url', $failures, $passes );
 
 $item_one = WP_Agent_Bridge::enqueue(
 	array(
-		'client_id'    => 'beeper-relay',
+		'client_id'    => 'message-relay',
 		'connector_id' => 'matrix-bridge',
 		'agent'        => 'support-agent',
 		'session_id'   => 'sess-1',
@@ -88,7 +88,7 @@ $item_one = WP_Agent_Bridge::enqueue(
 );
 $item_two = WP_Agent_Bridge::enqueue(
 	array(
-		'client_id'  => 'beeper-relay',
+		'client_id'  => 'message-relay',
 		'agent'      => 'support-agent',
 		'session_id' => 'sess-2',
 		'content'    => 'Second reply',
@@ -102,21 +102,21 @@ WP_Agent_Bridge::enqueue(
 	)
 );
 
-$pending = WP_Agent_Bridge::pending( 'beeper-relay' );
+$pending = WP_Agent_Bridge::pending( 'message-relay' );
 remote_bridge_assert( 2, count( $pending ), 'pending_returns_client_items_only', $failures, $passes );
 remote_bridge_assert( $item_one->queue_id, $pending[0]->queue_id, 'pending_preserves_queue_order', $failures, $passes );
 remote_bridge_assert( 'First reply', $pending[0]->content, 'pending_preserves_content', $failures, $passes );
 remote_bridge_assert( array( 'model' => 'test' ), $pending[0]->metadata, 'pending_preserves_metadata', $failures, $passes );
 
-$filtered = WP_Agent_Bridge::pending( 'beeper-relay', 25, array( 'sess-2' ) );
+$filtered = WP_Agent_Bridge::pending( 'message-relay', 25, array( 'sess-2' ) );
 remote_bridge_assert( 1, count( $filtered ), 'pending_can_filter_by_session', $failures, $passes );
 remote_bridge_assert( $item_two->queue_id, $filtered[0]->queue_id, 'pending_session_filter_returns_matching_item', $failures, $passes );
 
-remote_bridge_assert( 1, WP_Agent_Bridge::ack( 'beeper-relay', array( $item_one->queue_id ) ), 'ack_removes_matching_item', $failures, $passes );
-remote_bridge_assert( 1, count( WP_Agent_Bridge::pending( 'beeper-relay' ) ), 'acked_item_is_no_longer_pending', $failures, $passes );
-remote_bridge_assert( 0, WP_Agent_Bridge::ack( 'beeper-relay', array( 'missing-id' ) ), 'ack_ignores_missing_items', $failures, $passes );
+remote_bridge_assert( 1, WP_Agent_Bridge::ack( 'message-relay', array( $item_one->queue_id ) ), 'ack_removes_matching_item', $failures, $passes );
+remote_bridge_assert( 1, count( WP_Agent_Bridge::pending( 'message-relay' ) ), 'acked_item_is_no_longer_pending', $failures, $passes );
+remote_bridge_assert( 0, WP_Agent_Bridge::ack( 'message-relay', array( 'missing-id' ) ), 'ack_ignores_missing_items', $failures, $passes );
 remote_bridge_assert( 0, WP_Agent_Bridge::ack( 'wrong-client', array( $item_two->queue_id ) ), 'ack_is_scoped_by_client', $failures, $passes );
-remote_bridge_assert( 1, count( WP_Agent_Bridge::pending( 'beeper-relay' ) ), 'wrong_client_ack_does_not_remove_item', $failures, $passes );
+remote_bridge_assert( 1, count( WP_Agent_Bridge::pending( 'message-relay' ) ), 'wrong_client_ack_does_not_remove_item', $failures, $passes );
 
 if ( ! empty( $failures ) ) {
 	echo "\nFailures: " . implode( ', ', $failures ) . "\n";


### PR DESCRIPTION
## Summary
- Remove stale runtime-specific and product-specific examples from the channel/bridge docs and chat contract comments.
- Rename caller-managed/plain-message wording so current APIs are not documented as legacy behavior.
- Keep smoke tests aligned with generic Agents API terminology.

## Testing
- `php tests/remote-bridge-smoke.php && composer test`
- `homeboy lint --force-hot`
- targeted searches for stale `legacy`, `openclawp`, `response alias`, and product bridge terminology in `src`, `docs`, and `README`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Audited the merged Agents API channel/bridge surface for stale adapter terminology, drafted the terminology cleanup, and ran validation; Chris remains responsible for review and merge.