### PR TITLE
Workflows: close the cron loop — listener for wp_agent_workflow_run_scheduled

### DIFF
--- a/agents-api.php
+++ b/agents-api.php
@@ -140,6 +140,7 @@ require_once AGENTS_API_PATH . 'src/Workflows/class-wp-agent-workflow-registry.p
 require_once AGENTS_API_PATH . 'src/Workflows/class-wp-agent-workflow-action-scheduler-bridge.php';
 require_once AGENTS_API_PATH . 'src/Workflows/register-workflows.php';
 require_once AGENTS_API_PATH . 'src/Workflows/register-agents-workflow-abilities.php';
+require_once AGENTS_API_PATH . 'src/Workflows/register-action-scheduler-listener.php';
 
 add_action( 'init', array( 'WP_Agents_Registry', 'init' ), 10 );
 add_action( 'init', array( 'WP_Guidelines_Substrate', 'register' ), 9 );

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,9 @@
   "require": {
     "php": ">=8.1"
   },
+  "suggest": {
+    "woocommerce/action-scheduler": "Required to actually run cron-triggered workflows. The substrate detects Action Scheduler at runtime and no-ops cleanly when absent; install this package (or any plugin that ships it, like WooCommerce) to enable scheduled workflow runs."
+  },
   "scripts": {
     "test": [
       "php tests/bootstrap-smoke.php",

--- a/src/Workflows/register-action-scheduler-listener.php
+++ b/src/Workflows/register-action-scheduler-listener.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * Action Scheduler listener for `cron`-triggered workflows.
+ *
+ * The bridge ({@see WP_Agent_Workflow_Action_Scheduler_Bridge}) registers
+ * recurring/cron actions under the `wp_agent_workflow_run_scheduled` hook
+ * with `args = [ 'workflow_id' => '...' ]`. This file closes the loop by
+ * hooking into that action and dispatching the canonical `agents/run-workflow`
+ * ability — same code path admins / channels use to trigger an on-demand run.
+ *
+ * Without this listener, schedules would land in Action Scheduler's queue
+ * but never fire a workflow run.
+ *
+ * @package AgentsAPI
+ * @since   0.104.0
+ */
+
+namespace AgentsAPI\AI\Workflows;
+
+defined( 'ABSPATH' ) || exit;
+
+add_action(
+	WP_Agent_Workflow_Action_Scheduler_Bridge::SCHEDULED_HOOK,
+	__NAMESPACE__ . '\\dispatch_scheduled_workflow_run',
+	10,
+	1
+);
+
+/**
+ * Run the scheduled workflow via the canonical dispatcher.
+ *
+ * Action Scheduler invokes the registered hook with the action's args
+ * spread as positional arguments; we only register a single arg (the
+ * `workflow_id` key) so the callback receives the full args array as the
+ * first positional. AS internally uses `array_values` for the spread —
+ * so what arrives is the bare workflow_id string.
+ *
+ * Errors are swallowed to a `do_action` for observability; throwing here
+ * would mark the AS action as failed and back-off the schedule, which is
+ * usually desirable, but we surface the failure through agents-api's own
+ * dispatch-failure hook instead so consumers can decide policy.
+ *
+ * @since 0.104.0
+ *
+ * @param string|array $args Either the bare workflow_id string (when the
+ *                           bridge scheduled a single-arg payload) or the
+ *                           full args array (when AS spreads).
+ */
+function dispatch_scheduled_workflow_run( $args ): void {
+	$workflow_id = '';
+	if ( is_string( $args ) ) {
+		$workflow_id = $args;
+	} elseif ( is_array( $args ) ) {
+		$workflow_id = (string) ( $args['workflow_id'] ?? '' );
+	}
+
+	if ( '' === $workflow_id ) {
+		do_action( 'agents_run_workflow_dispatch_failed', 'no_workflow_id', array( 'source' => 'action_scheduler' ) );
+		return;
+	}
+
+	if ( ! function_exists( 'wp_get_ability' ) ) {
+		do_action( 'agents_run_workflow_dispatch_failed', 'abilities_api_missing', array( 'workflow_id' => $workflow_id ) );
+		return;
+	}
+
+	$ability = wp_get_ability( AGENTS_RUN_WORKFLOW_ABILITY );
+	if ( null === $ability ) {
+		do_action( 'agents_run_workflow_dispatch_failed', 'ability_missing', array( 'workflow_id' => $workflow_id ) );
+		return;
+	}
+
+	// Action Scheduler runs as the loopback / cron user — bypass the
+	// `manage_options` gate for this scheduled invocation only. We scope
+	// the temporary widening with add/remove so we don't influence
+	// concurrent requests.
+	$grant = static fn() => true;
+	add_filter( 'agents_run_workflow_permission', $grant );
+	try {
+		$result = $ability->execute(
+			array(
+				'workflow_id' => $workflow_id,
+				'inputs'      => array(),
+				'options'     => array( 'source' => 'action_scheduler' ),
+			)
+		);
+	} finally {
+		remove_filter( 'agents_run_workflow_permission', $grant );
+	}
+
+	if ( is_wp_error( $result ) ) {
+		do_action(
+			'agents_run_workflow_dispatch_failed',
+			$result->get_error_code(),
+			array(
+				'workflow_id' => $workflow_id,
+				'source'      => 'action_scheduler',
+			)
+		);
+	}
+}


### PR DESCRIPTION
## Summary

The Action Scheduler bridge has shipped since #114, but only the half that *registers* schedules. When AS fires the recurring action under \`wp_agent_workflow_run_scheduled\`, nothing was listening — so cron-triggered workflows queued correctly and then never ran.

This adds the missing handler. On every fired action it:

- Reads the \`workflow_id\` from the scheduled args.
- Looks up the canonical \`agents/run-workflow\` ability.
- Temporarily widens \`agents_run_workflow_permission\` (AS runs as the loopback / cron user, which doesn't have \`manage_options\`).
- Dispatches through the same code path admins / channels use for on-demand runs.

Failures fire \`agents_run_workflow_dispatch_failed\` with a structured reason (\`no_workflow_id\`, \`abilities_api_missing\`, \`ability_missing\`, or the dispatcher's own error code) and otherwise stay quiet — throwing out of an AS callback would mark the action as failed and exponentially back-off the schedule, which is rarely what you want when the failure is "the consumer plugin is mid-deploy."

\`composer.json\` picks up \`woocommerce/action-scheduler\` as a \`suggest\`. The substrate stays runtime-detect: the bridge already no-ops cleanly when AS isn't loaded.

## Test plan

- [x] Static check: file loads and registers the action listener at boot (verified via existing smoke test pattern).
- [ ] Live: schedule a cron-triggered workflow in a host that loads Action Scheduler, observe a Run record appear after the first interval (consumer-side verification).