### PR TITLE
Prevent self-host in chained caller contexts

### DIFF
--- a/src/Auth/class-wp-agent-caller-context.php
+++ b/src/Auth/class-wp-agent-caller-context.php
@@ -65,6 +65,10 @@ if ( ! class_exists( 'WP_Agent_Caller_Context' ) ) {
 				throw self::invalid( 'chain_depth', 'top-of-chain context cannot include remote caller identity' );
 			}
 
+			if ( $this->chain_depth > 0 && self::SELF_HOST === $this->caller_host ) {
+				throw self::invalid( 'caller_host', 'chained context (chain_depth > 0) must specify a remote caller host, not "self"' );
+			}
+
 			if ( false === self::json_encode( $this->metadata ) ) {
 				throw self::invalid( 'metadata', 'must be JSON serializable' );
 			}
@@ -141,6 +145,10 @@ if ( ! class_exists( 'WP_Agent_Caller_Context' ) ) {
 
 			if ( '' === $raw['caller_host'] ) {
 				throw self::invalid( 'caller_host', 'must be present when chain_depth is greater than zero' );
+			}
+
+			if ( self::SELF_HOST === $raw['caller_host'] ) {
+				throw self::invalid( 'caller_host', 'chained context (chain_depth > 0) must specify a remote caller host, not "self"' );
 			}
 
 			if ( '' === $raw['chain_root_request_id'] ) {

--- a/tests/caller-context-smoke.php
+++ b/tests/caller-context-smoke.php
@@ -67,4 +67,25 @@ try {
 	agents_api_smoke_assert_equals( true, str_contains( $e->getMessage(), 'chain_depth' ), 'chain depth limit is enforced', $failures, $passes );
 }
 
+try {
+	WP_Agent_Caller_Context::from_headers(
+		array(
+			WP_Agent_Caller_Context::HEADER_CALLER_AGENT => 'source-agent',
+			WP_Agent_Caller_Context::HEADER_CALLER_HOST  => 'self',
+			WP_Agent_Caller_Context::HEADER_CHAIN_DEPTH  => '1',
+			WP_Agent_Caller_Context::HEADER_CHAIN_ROOT   => 'root-request-123',
+		)
+	);
+	agents_api_smoke_assert_equals( true, false, 'chained context with self host is rejected via from_headers', $failures, $passes );
+} catch ( InvalidArgumentException $e ) {
+	agents_api_smoke_assert_equals( true, str_contains( $e->getMessage(), 'caller_host' ), 'chained context with self host is rejected via from_headers', $failures, $passes );
+}
+
+try {
+	new WP_Agent_Caller_Context( 'source-agent', 0, WP_Agent_Caller_Context::SELF_HOST, 1, 'root-request-123' );
+	agents_api_smoke_assert_equals( true, false, 'chained context with self host is rejected via constructor', $failures, $passes );
+} catch ( InvalidArgumentException $e ) {
+	agents_api_smoke_assert_equals( true, str_contains( $e->getMessage(), 'caller_host' ), 'chained context with self host is rejected via constructor', $failures, $passes );
+}
+
 agents_api_smoke_finish( 'Agents API caller context', $failures, $passes );


### PR DESCRIPTION
## Summary
This PR adds validation to prevent `WP_Agent_Caller_Context` from being created with a "self" caller host when the context is part of a chain (chain_depth > 0). This ensures that chained contexts always specify a remote caller host.

## Key Changes
- Added validation in the `WP_Agent_Caller_Context` constructor to reject chained contexts with `SELF_HOST` as the caller_host
- Added validation in the `from_headers()` static method to reject chained contexts with `SELF_HOST` as the caller_host
- Added comprehensive smoke tests to verify both validation paths (constructor and from_headers) properly reject invalid chained contexts with self host

## Implementation Details
- Both validation checks occur when `chain_depth > 0` and `caller_host === SELF_HOST`
- The validation throws an `InvalidArgumentException` with a descriptive message indicating that chained contexts must specify a remote caller host
- The validation is consistent across both creation methods (constructor and from_headers)

https://claude.ai/code/session_01HyNvBAkX8fecSxgYV8YAj8