### PR TITLE
Prevent queue item overwrites by different clients

### DIFF
--- a/src/Channels/class-wp-agent-option-bridge-store.php
+++ b/src/Channels/class-wp-agent-option-bridge-store.php
@@ -32,7 +32,15 @@ final class WP_Agent_Option_Bridge_Store implements WP_Agent_Bridge_Store {
 	}
 
 	public function enqueue( WP_Agent_Bridge_Queue_Item $item ): WP_Agent_Bridge_Queue_Item {
-		$queue                    = $this->read_queue();
+		$queue = $this->read_queue();
+
+		if ( isset( $queue[ $item->queue_id ] ) && is_array( $queue[ $item->queue_id ] ) ) {
+			$existing = WP_Agent_Bridge_Queue_Item::from_array( $queue[ $item->queue_id ] );
+			if ( $existing->client_id !== $item->client_id ) {
+				throw new \InvalidArgumentException( 'Cannot overwrite a queue item owned by another client.' );
+			}
+		}
+
 		$queue[ $item->queue_id ] = $item->to_array();
 		update_option( self::QUEUE_OPTION, $queue, false );
 		return $item;


### PR DESCRIPTION
## Summary
Added validation to the queue enqueue operation to prevent a client from overwriting a queue item that is owned by another client.

## Key Changes
- Added ownership validation before allowing a queue item to be overwritten
- When enqueueing an item, the system now checks if a queue item with the same ID already exists
- If an existing item is found and belongs to a different client, an `InvalidArgumentException` is thrown with a descriptive error message
- This ensures data integrity by preventing unauthorized modifications to queue items across different clients

## Implementation Details
- The validation reconstructs the existing queue item from stored data using `WP_Agent_Bridge_Queue_Item::from_array()`
- Compares the `client_id` of the existing item with the incoming item
- Only allows the operation to proceed if the client IDs match or if no existing item is found
- Maintains backward compatibility by only validating when an item with the same queue_id already exists

https://claude.ai/code/session_01VxnaBMyXdNAH6xNiJecMK4