### PR TITLE
Routines + subagents: persistent agent contexts and coordination graphs

### DIFF
--- a/agents-api.php
+++ b/agents-api.php
@@ -142,6 +142,12 @@ require_once AGENTS_API_PATH . 'src/Workflows/class-wp-agent-workflow-action-sch
 require_once AGENTS_API_PATH . 'src/Workflows/register-workflows.php';
 require_once AGENTS_API_PATH . 'src/Workflows/register-agents-workflow-abilities.php';
 require_once AGENTS_API_PATH . 'src/Workflows/register-action-scheduler-listener.php';
+require_once AGENTS_API_PATH . 'src/Routines/class-wp-agent-routine.php';
+require_once AGENTS_API_PATH . 'src/Routines/class-wp-agent-routine-registry.php';
+require_once AGENTS_API_PATH . 'src/Routines/class-wp-agent-routine-action-scheduler-bridge.php';
+require_once AGENTS_API_PATH . 'src/Routines/register-routines.php';
+require_once AGENTS_API_PATH . 'src/Routines/register-routine-bridge-sync.php';
+require_once AGENTS_API_PATH . 'src/Routines/register-action-scheduler-listener.php';
 
 add_action( 'init', array( 'WP_Agents_Registry', 'init' ), 10 );
 add_action( 'init', array( 'WP_Guidelines_Substrate', 'register' ), 9 );

--- a/composer.json
+++ b/composer.json
@@ -57,6 +57,8 @@
       "php tests/workflow-spec-validator-smoke.php",
       "php tests/workflow-runner-smoke.php",
       "php tests/agents-workflow-ability-smoke.php",
+      "php tests/routine-smoke.php",
+      "php tests/subagents-smoke.php",
       "php tests/no-product-imports-smoke.php"
     ]
   }

--- a/src/Registry/class-wp-agent.php
+++ b/src/Registry/class-wp-agent.php
@@ -85,6 +85,24 @@ if ( ! class_exists( 'WP_Agent' ) ) {
 		protected array $meta = array();
 
 		/**
+		 * Slugs of subagents this agent coordinates.
+		 *
+		 * When non-empty, the agent acts as a coordinator: each subagent is
+		 * exposed to its main loop as a `delegate-to-<slug>` tool. Consumers
+		 * are responsible for mapping these slugs to other registered
+		 * agents and surfacing them through the tool/ability layer — the
+		 * substrate just persists the declaration.
+		 *
+		 * Mirrors the Anthropic CLI `agents` field on `coordination`-role
+		 * agents: a parent agent declares the subagents it can dispatch to.
+		 *
+		 * @since 0.105.0
+		 *
+		 * @var string[]
+		 */
+		protected array $subagents = array();
+
+		/**
 		 * Constructor.
 		 *
 		 * @param string $slug Unique agent slug.
@@ -166,6 +184,19 @@ if ( ! class_exists( 'WP_Agent' ) ) {
 				}
 
 				$properties['meta'] = $args['meta'];
+			}
+
+			if ( isset( $args['subagents'] ) ) {
+				if ( ! is_array( $args['subagents'] ) ) {
+					throw new InvalidArgumentException( 'Agent subagents property must be an array of slugs.' );
+				}
+
+				$properties['subagents'] = array_values(
+					array_filter(
+						array_map( static fn( $slug ): string => sanitize_title( (string) $slug ), $args['subagents'] ),
+						static fn( string $slug ): bool => '' !== $slug
+					)
+				);
 			}
 
 			foreach ( $args as $property_name => $property_value ) {
@@ -279,6 +310,26 @@ if ( ! class_exists( 'WP_Agent' ) ) {
 		}
 
 		/**
+		 * Subagent slugs this agent coordinates.
+		 *
+		 * @since 0.105.0
+		 *
+		 * @return string[]
+		 */
+		public function get_subagents(): array {
+			return $this->subagents;
+		}
+
+		/**
+		 * Whether this agent declares any subagents (i.e. is a coordinator).
+		 *
+		 * @since 0.105.0
+		 */
+		public function is_coordinator(): bool {
+			return ! empty( $this->subagents );
+		}
+
+		/**
 		 * Return registration arguments for the registry.
 		 *
 		 * @return array
@@ -294,6 +345,7 @@ if ( ! class_exists( 'WP_Agent' ) ) {
 				'supports_conversation_compaction' => $this->supports_conversation_compaction,
 				'conversation_compaction_policy'   => $this->conversation_compaction_policy,
 				'meta'                             => $this->meta,
+				'subagents'                        => $this->subagents,
 			);
 		}
 

--- a/src/Routines/class-wp-agent-routine-action-scheduler-bridge.php
+++ b/src/Routines/class-wp-agent-routine-action-scheduler-bridge.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * Optional Action Scheduler bridge for routines.
+ *
+ * Mirrors {@see \AgentsAPI\AI\Workflows\WP_Agent_Workflow_Action_Scheduler_Bridge}:
+ * agents-api does not require Action Scheduler. When AS is available we
+ * register one recurring (or cron-expression) action per routine with a
+ * stable args array so the listener can resolve the routine on wake.
+ *
+ * @package AgentsAPI
+ * @since   0.105.0
+ */
+
+namespace AgentsAPI\AI\Routines;
+
+defined( 'ABSPATH' ) || exit;
+
+final class WP_Agent_Routine_Action_Scheduler_Bridge {
+
+	/** @since 0.105.0 */
+	public const SCHEDULED_HOOK = 'wp_agent_routine_run_scheduled';
+
+	/** @since 0.105.0 */
+	public const GROUP = 'agents-api';
+
+	public static function is_available(): bool {
+		return function_exists( 'as_schedule_recurring_action' )
+			&& function_exists( 'as_schedule_cron_action' )
+			&& function_exists( 'as_unschedule_all_actions' );
+	}
+
+	/**
+	 * Register the routine's schedule with Action Scheduler. Existing
+	 * schedules for the same routine are unscheduled first to make this
+	 * idempotent — call freely on every plugin boot.
+	 *
+	 * @since 0.105.0
+	 *
+	 * @return bool True when a schedule was registered (or the
+	 *              `wp_agent_routine_schedule_requested` hook was fired
+	 *              even without AS); false on no-op.
+	 */
+	public static function register( WP_Agent_Routine $routine ): bool {
+		/**
+		 * Fires whenever the bridge would schedule a routine, regardless
+		 * of whether Action Scheduler is loaded. Custom schedulers can
+		 * hook this to take over.
+		 *
+		 * @since 0.105.0
+		 *
+		 * @param WP_Agent_Routine $routine
+		 */
+		do_action( 'wp_agent_routine_schedule_requested', $routine );
+
+		if ( ! self::is_available() ) {
+			return false;
+		}
+
+		$args = array( 'routine_id' => $routine->get_id() );
+
+		// Unschedule prior occurrences for idempotency.
+		as_unschedule_all_actions( self::SCHEDULED_HOOK, $args, self::GROUP );
+
+		if ( WP_Agent_Routine::TRIGGER_EXPRESSION === $routine->get_trigger_type() ) {
+			as_schedule_cron_action(
+				time(),
+				$routine->get_expression(),
+				self::SCHEDULED_HOOK,
+				$args,
+				self::GROUP
+			);
+			return true;
+		}
+
+		as_schedule_recurring_action(
+			time(),
+			$routine->get_interval_seconds(),
+			self::SCHEDULED_HOOK,
+			$args,
+			self::GROUP
+		);
+		return true;
+	}
+
+	/**
+	 * Cancel every scheduled action this bridge owns for the given routine.
+	 *
+	 * @since 0.105.0
+	 */
+	public static function unregister( string $routine_id ): void {
+		if ( ! self::is_available() ) {
+			return;
+		}
+		as_unschedule_all_actions(
+			self::SCHEDULED_HOOK,
+			array( 'routine_id' => $routine_id ),
+			self::GROUP
+		);
+	}
+}

--- a/src/Routines/class-wp-agent-routine-registry.php
+++ b/src/Routines/class-wp-agent-routine-registry.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * In-memory registry of code-defined routines.
+ *
+ * Mirrors {@see WP_Agent_Workflow_Registry}: plugins call
+ * {@see wp_register_routine()} during boot, the substrate keeps the
+ * resolved Routine in process memory for the duration of the request, and
+ * the Action Scheduler bridge (separate file) reads the registry to
+ * (re-)register cron schedules on each plugin load.
+ *
+ * Like the workflow registry, this is stateless across requests — not a
+ * cache. Persistence (DB-backed routines) is a consumer concern.
+ *
+ * @package AgentsAPI
+ * @since   0.105.0
+ */
+
+namespace AgentsAPI\AI\Routines;
+
+use WP_Error;
+
+defined( 'ABSPATH' ) || exit;
+
+final class WP_Agent_Routine_Registry {
+
+	/**
+	 * @var array<string,WP_Agent_Routine>
+	 */
+	private static array $routines = array();
+
+	/**
+	 * @param array $args See {@see WP_Agent_Routine::__construct()}.
+	 * @return WP_Agent_Routine|WP_Error
+	 */
+	public static function register( string $id, array $args ) {
+		try {
+			$routine = new WP_Agent_Routine( $id, $args );
+		} catch ( \InvalidArgumentException $e ) {
+			return new WP_Error( 'invalid_routine', $e->getMessage() );
+		}
+
+		self::$routines[ $routine->get_id() ] = $routine;
+
+		/**
+		 * Fires after a routine is added to the in-memory registry. The
+		 * Action Scheduler bridge subscribes to this hook to (re-)register
+		 * the cron schedule.
+		 *
+		 * @since 0.105.0
+		 *
+		 * @param WP_Agent_Routine $routine
+		 */
+		do_action( 'wp_agent_routine_registered', $routine );
+
+		return $routine;
+	}
+
+	/**
+	 * @return true|WP_Error
+	 */
+	public static function unregister( string $routine_id ) {
+		if ( ! isset( self::$routines[ $routine_id ] ) ) {
+			return new WP_Error(
+				'not_registered',
+				sprintf( 'no routine registered with id `%s`', $routine_id )
+			);
+		}
+		$routine = self::$routines[ $routine_id ];
+		unset( self::$routines[ $routine_id ] );
+
+		/**
+		 * Fires after a routine is removed from the in-memory registry. The
+		 * AS bridge subscribes to cancel the matching schedule.
+		 *
+		 * @since 0.105.0
+		 *
+		 * @param WP_Agent_Routine $routine
+		 */
+		do_action( 'wp_agent_routine_unregistered', $routine );
+
+		return true;
+	}
+
+	public static function find( string $routine_id ): ?WP_Agent_Routine {
+		return self::$routines[ $routine_id ] ?? null;
+	}
+
+	/**
+	 * @return WP_Agent_Routine[]
+	 */
+	public static function all(): array {
+		return array_values( self::$routines );
+	}
+
+	/**
+	 * Test-only: clear the in-memory registry.
+	 *
+	 * @since 0.105.0
+	 */
+	public static function reset(): void {
+		self::$routines = array();
+	}
+}

--- a/src/Routines/class-wp-agent-routine.php
+++ b/src/Routines/class-wp-agent-routine.php
@@ -36,11 +36,11 @@ final class WP_Agent_Routine {
 	private string $label;
 	private string $agent_slug;
 	private string $trigger_type;
-	private int $interval_s = 0;
+	private int $interval_s    = 0;
 	private string $expression = '';
-	private string $prompt = '';
+	private string $prompt     = '';
 	private string $session_id = '';
-	private array $meta = array();
+	private array $meta        = array();
 
 	/**
 	 * @param string                $id   Unique routine slug.

--- a/src/Routines/class-wp-agent-routine.php
+++ b/src/Routines/class-wp-agent-routine.php
@@ -1,0 +1,162 @@
+<?php
+/**
+ * Routine value object.
+ *
+ * A *routine* is a persistent, scheduled invocation of an agent. Unlike a
+ * workflow (deterministic recipe with fresh inputs per run) or a one-shot
+ * background task (single ability dispatched into Action Scheduler), a
+ * routine reuses the same conversation session across every wake — so
+ * context accumulates and the agent can pick up where the last wake left
+ * off.
+ *
+ * Conceptually the Anthropic deck pattern: an agent that has a "main loop"
+ * separate from a one-shot task, with a long-running session and
+ * active-vs-total time semantics.
+ *
+ * Substrate scope: contracts only. The actual scheduler is the existing
+ * {@see WP_Agent_Routine_Action_Scheduler_Bridge}, the actual dispatch on
+ * wake-up is the canonical `agents/chat` ability (or any other ability
+ * the routine names), and persistence of the per-routine session is the
+ * consumer's responsibility (typically the chat conversation store).
+ *
+ * @package AgentsAPI
+ * @since   0.105.0
+ */
+
+namespace AgentsAPI\AI\Routines;
+
+defined( 'ABSPATH' ) || exit;
+
+final class WP_Agent_Routine {
+
+	public const TRIGGER_INTERVAL   = 'interval';
+	public const TRIGGER_EXPRESSION = 'expression';
+
+	private string $id;
+	private string $label;
+	private string $agent_slug;
+	private string $trigger_type;
+	private int    $interval_s    = 0;
+	private string $expression    = '';
+	private string $prompt        = '';
+	private string $session_id    = '';
+	private array  $meta          = array();
+
+	/**
+	 * @param string $id   Unique routine slug.
+	 * @param array{
+	 *   label?: string,
+	 *   agent: string,
+	 *   interval?: int,
+	 *   expression?: string,
+	 *   prompt?: string,
+	 *   session_id?: string,
+	 *   meta?: array<string, mixed>,
+	 * } $args
+	 */
+	public function __construct( string $id, array $args ) {
+		$id = sanitize_title( $id );
+		if ( '' === $id ) {
+			throw new \InvalidArgumentException( 'Routine id cannot be empty.' );
+		}
+		$this->id = $id;
+
+		$this->label = isset( $args['label'] ) ? (string) $args['label'] : $id;
+
+		$agent = isset( $args['agent'] ) ? (string) $args['agent'] : '';
+		if ( '' === $agent ) {
+			throw new \InvalidArgumentException( sprintf( 'Routine "%s" must specify an agent slug.', $id ) );
+		}
+		$this->agent_slug = $agent;
+
+		$has_interval   = isset( $args['interval'] ) && (int) $args['interval'] > 0;
+		$has_expression = isset( $args['expression'] ) && '' !== trim( (string) $args['expression'] );
+
+		if ( $has_interval && $has_expression ) {
+			throw new \InvalidArgumentException( sprintf( 'Routine "%s" must specify either `interval` or `expression`, not both.', $id ) );
+		}
+		if ( ! $has_interval && ! $has_expression ) {
+			throw new \InvalidArgumentException( sprintf( 'Routine "%s" must specify a trigger via `interval` (seconds) or `expression` (cron string).', $id ) );
+		}
+
+		if ( $has_interval ) {
+			$this->trigger_type = self::TRIGGER_INTERVAL;
+			$this->interval_s   = (int) $args['interval'];
+		} else {
+			$this->trigger_type = self::TRIGGER_EXPRESSION;
+			$this->expression   = trim( (string) $args['expression'] );
+		}
+
+		$this->prompt     = isset( $args['prompt'] ) ? (string) $args['prompt'] : '';
+		$this->session_id = isset( $args['session_id'] ) && '' !== (string) $args['session_id']
+			? (string) $args['session_id']
+			: 'routine:' . $id;
+
+		if ( isset( $args['meta'] ) && is_array( $args['meta'] ) ) {
+			$this->meta = $args['meta'];
+		}
+	}
+
+	public function get_id(): string {
+		return $this->id;
+	}
+
+	public function get_label(): string {
+		return $this->label;
+	}
+
+	public function get_agent_slug(): string {
+		return $this->agent_slug;
+	}
+
+	public function get_trigger_type(): string {
+		return $this->trigger_type;
+	}
+
+	public function get_interval_seconds(): int {
+		return $this->interval_s;
+	}
+
+	public function get_expression(): string {
+		return $this->expression;
+	}
+
+	public function get_prompt(): string {
+		return $this->prompt;
+	}
+
+	/**
+	 * Persistent session id. Reused across every wake so the agent's
+	 * conversation history accumulates.
+	 */
+	public function get_session_id(): string {
+		return $this->session_id;
+	}
+
+	/**
+	 * @return array<string, mixed>
+	 */
+	public function get_meta(): array {
+		return $this->meta;
+	}
+
+	/**
+	 * @return array<string, mixed>
+	 */
+	public function to_array(): array {
+		$out = array(
+			'id'         => $this->id,
+			'label'      => $this->label,
+			'agent'      => $this->agent_slug,
+			'prompt'     => $this->prompt,
+			'session_id' => $this->session_id,
+			'meta'       => $this->meta,
+		);
+		if ( self::TRIGGER_INTERVAL === $this->trigger_type ) {
+			$out['interval'] = $this->interval_s;
+		} else {
+			$out['expression'] = $this->expression;
+		}
+		return $out;
+	}
+}

--- a/src/Routines/class-wp-agent-routine.php
+++ b/src/Routines/class-wp-agent-routine.php
@@ -36,23 +36,20 @@ final class WP_Agent_Routine {
 	private string $label;
 	private string $agent_slug;
 	private string $trigger_type;
-	private int    $interval_s    = 0;
-	private string $expression    = '';
-	private string $prompt        = '';
-	private string $session_id    = '';
-	private array  $meta          = array();
+	private int $interval_s = 0;
+	private string $expression = '';
+	private string $prompt = '';
+	private string $session_id = '';
+	private array $meta = array();
 
 	/**
-	 * @param string $id   Unique routine slug.
-	 * @param array{
-	 *   label?: string,
-	 *   agent: string,
-	 *   interval?: int,
-	 *   expression?: string,
-	 *   prompt?: string,
-	 *   session_id?: string,
-	 *   meta?: array<string, mixed>,
-	 * } $args
+	 * @param string                $id   Unique routine slug.
+	 * @param array<string, mixed>  $args Recognised keys: `label` (string),
+	 *                                    `agent` (string, required),
+	 *                                    `interval` (int seconds) OR
+	 *                                    `expression` (cron string),
+	 *                                    `prompt` (string), `session_id`
+	 *                                    (string), `meta` (array).
 	 */
 	public function __construct( string $id, array $args ) {
 		$id = sanitize_title( $id );
@@ -65,7 +62,7 @@ final class WP_Agent_Routine {
 
 		$agent = isset( $args['agent'] ) ? (string) $args['agent'] : '';
 		if ( '' === $agent ) {
-			throw new \InvalidArgumentException( sprintf( 'Routine "%s" must specify an agent slug.', $id ) );
+			throw new \InvalidArgumentException( esc_html( sprintf( 'Routine "%s" must specify an agent slug.', $id ) ) );
 		}
 		$this->agent_slug = $agent;
 
@@ -73,10 +70,10 @@ final class WP_Agent_Routine {
 		$has_expression = isset( $args['expression'] ) && '' !== trim( (string) $args['expression'] );
 
 		if ( $has_interval && $has_expression ) {
-			throw new \InvalidArgumentException( sprintf( 'Routine "%s" must specify either `interval` or `expression`, not both.', $id ) );
+			throw new \InvalidArgumentException( esc_html( sprintf( 'Routine "%s" must specify either `interval` or `expression`, not both.', $id ) ) );
 		}
 		if ( ! $has_interval && ! $has_expression ) {
-			throw new \InvalidArgumentException( sprintf( 'Routine "%s" must specify a trigger via `interval` (seconds) or `expression` (cron string).', $id ) );
+			throw new \InvalidArgumentException( esc_html( sprintf( 'Routine "%s" must specify a trigger via `interval` (seconds) or `expression` (cron string).', $id ) ) );
 		}
 
 		if ( $has_interval ) {

--- a/src/Routines/register-action-scheduler-listener.php
+++ b/src/Routines/register-action-scheduler-listener.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * Action Scheduler listener for routine wake-ups.
+ *
+ * Closes the loop on the routines side: when AS fires the routine's
+ * scheduled hook, look up the routine, dispatch the canonical
+ * `agents/chat` ability with the routine's persistent session id, and
+ * record success/failure through the standard observability hook.
+ *
+ * Errors are funneled through `agents_run_routine_dispatch_failed` rather
+ * than thrown — throwing from an AS callback marks the action as failed
+ * and triggers exponential back-off, which is rarely the desired outcome
+ * when the failure is transient (consumer plugin redeploy, missing chat
+ * handler, etc.).
+ *
+ * @package AgentsAPI
+ * @since   0.105.0
+ */
+
+namespace AgentsAPI\AI\Routines;
+
+defined( 'ABSPATH' ) || exit;
+
+add_action(
+	WP_Agent_Routine_Action_Scheduler_Bridge::SCHEDULED_HOOK,
+	__NAMESPACE__ . '\\dispatch_scheduled_routine_run',
+	10,
+	1
+);
+
+/**
+ * Run the scheduled routine via the canonical chat dispatcher.
+ *
+ * @since 0.105.0
+ *
+ * @param string|array $args Either the bare routine_id string (when AS
+ *                           passes a single positional) or the full args
+ *                           array.
+ */
+function dispatch_scheduled_routine_run( $args ): void {
+	$routine_id = '';
+	if ( is_string( $args ) ) {
+		$routine_id = $args;
+	} elseif ( is_array( $args ) ) {
+		$routine_id = (string) ( $args['routine_id'] ?? '' );
+	}
+
+	if ( '' === $routine_id ) {
+		do_action( 'agents_run_routine_dispatch_failed', 'no_routine_id', array( 'source' => 'action_scheduler' ) );
+		return;
+	}
+
+	$routine = WP_Agent_Routine_Registry::find( $routine_id );
+	if ( null === $routine ) {
+		// Routine was unregistered between schedule and wake. The bridge
+		// cleans up on `wp_agent_routine_unregistered`, but a half-step
+		// race can land an in-flight wake here.
+		do_action(
+			'agents_run_routine_dispatch_failed',
+			'routine_not_registered',
+			array( 'routine_id' => $routine_id, 'source' => 'action_scheduler' )
+		);
+		return;
+	}
+
+	if ( ! function_exists( 'wp_get_ability' ) ) {
+		do_action( 'agents_run_routine_dispatch_failed', 'abilities_api_missing', array( 'routine_id' => $routine_id ) );
+		return;
+	}
+
+	$chat = wp_get_ability( 'agents/chat' );
+	if ( null === $chat ) {
+		do_action( 'agents_run_routine_dispatch_failed', 'agents_chat_missing', array( 'routine_id' => $routine_id ) );
+		return;
+	}
+
+	// AS runs as the loopback / cron user — bypass the manage_options gate
+	// for this scheduled invocation only. Same pattern as the workflow
+	// listener.
+	$grant = static fn() => true;
+	add_filter( 'agents_chat_permission', $grant );
+	add_filter( 'openclawp_chat_ability_permission', $grant );
+	try {
+		$result = $chat->execute(
+			array(
+				'agent'      => $routine->get_agent_slug(),
+				'message'    => $routine->get_prompt(),
+				'session_id' => $routine->get_session_id(),
+			)
+		);
+	} finally {
+		remove_filter( 'openclawp_chat_ability_permission', $grant );
+		remove_filter( 'agents_chat_permission', $grant );
+	}
+
+	if ( is_wp_error( $result ) ) {
+		do_action(
+			'agents_run_routine_dispatch_failed',
+			$result->get_error_code(),
+			array(
+				'routine_id' => $routine_id,
+				'source'     => 'action_scheduler',
+			)
+		);
+		return;
+	}
+
+	/**
+	 * Fires after a successful scheduled routine dispatch. Consumers wire
+	 * up run-recording (timing, assistant reply, token usage) here.
+	 *
+	 * @since 0.105.0
+	 *
+	 * @param WP_Agent_Routine $routine
+	 * @param array            $result Canonical chat output.
+	 */
+	do_action( 'wp_agent_routine_run_completed', $routine, $result );
+}

--- a/src/Routines/register-action-scheduler-listener.php
+++ b/src/Routines/register-action-scheduler-listener.php
@@ -58,7 +58,10 @@ function dispatch_scheduled_routine_run( $args ): void {
 		do_action(
 			'agents_run_routine_dispatch_failed',
 			'routine_not_registered',
-			array( 'routine_id' => $routine_id, 'source' => 'action_scheduler' )
+			array(
+				'routine_id' => $routine_id,
+				'source'     => 'action_scheduler',
+			)
 		);
 		return;
 	}

--- a/src/Routines/register-routine-bridge-sync.php
+++ b/src/Routines/register-routine-bridge-sync.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Sync the in-memory routine registry to the Action Scheduler bridge.
+ *
+ * When `wp_register_routine()` succeeds, the registry fires
+ * `wp_agent_routine_registered`. We listen here and ask the AS bridge to
+ * (re-)schedule the routine. The bridge no-ops cleanly when AS isn't
+ * loaded — same pattern as the workflow side.
+ *
+ * Same listener handles unregister, cancelling the matching schedule.
+ *
+ * @package AgentsAPI
+ * @since   0.105.0
+ */
+
+namespace AgentsAPI\AI\Routines;
+
+defined( 'ABSPATH' ) || exit;
+
+add_action(
+	'wp_agent_routine_registered',
+	static function ( WP_Agent_Routine $routine ): void {
+		WP_Agent_Routine_Action_Scheduler_Bridge::register( $routine );
+	},
+	10,
+	1
+);
+
+add_action(
+	'wp_agent_routine_unregistered',
+	static function ( WP_Agent_Routine $routine ): void {
+		WP_Agent_Routine_Action_Scheduler_Bridge::unregister( $routine->get_id() );
+	},
+	10,
+	1
+);

--- a/src/Routines/register-routines.php
+++ b/src/Routines/register-routines.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Global helpers for the in-memory routine registry.
+ *
+ * Mirrors `src/Workflows/register-workflows.php`: the class file holds
+ * the class; helper functions live here so a file is either OO or
+ * procedural, never both.
+ *
+ * Calling `wp_register_routine()` also wires the Action Scheduler bridge:
+ * the registry's `wp_agent_routine_registered` action triggers a schedule
+ * sync, so cron-driven wakes are live the moment the routine is
+ * registered (assuming AS is loaded).
+ *
+ * @package AgentsAPI
+ * @since   0.105.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+if ( ! function_exists( 'wp_register_routine' ) ) {
+	/**
+	 * Register a code-defined routine.
+	 *
+	 *     wp_register_routine( 'lunar-monitor', array(
+	 *         'label'    => 'Lunar Monitor',
+	 *         'agent'    => 'commander',
+	 *         'interval' => 3600,
+	 *         'prompt'   => 'Status check. Anything new?',
+	 *     ) );
+	 *
+	 * @since 0.105.0
+	 *
+	 * @param string $id   Unique routine slug.
+	 * @param array  $args Routine arguments. See {@see WP_Agent_Routine::__construct()}.
+	 *
+	 * @return AgentsAPI\AI\Routines\WP_Agent_Routine|WP_Error
+	 */
+	function wp_register_routine( string $id, array $args ) {
+		return AgentsAPI\AI\Routines\WP_Agent_Routine_Registry::register( $id, $args );
+	}
+}
+
+if ( ! function_exists( 'wp_get_routine' ) ) {
+	/**
+	 * Look up a registered routine by id.
+	 *
+	 * @since 0.105.0
+	 */
+	function wp_get_routine( string $routine_id ): ?AgentsAPI\AI\Routines\WP_Agent_Routine {
+		return AgentsAPI\AI\Routines\WP_Agent_Routine_Registry::find( $routine_id );
+	}
+}
+
+if ( ! function_exists( 'wp_get_routines' ) ) {
+	/**
+	 * @since 0.105.0
+	 *
+	 * @return AgentsAPI\AI\Routines\WP_Agent_Routine[]
+	 */
+	function wp_get_routines(): array {
+		return AgentsAPI\AI\Routines\WP_Agent_Routine_Registry::all();
+	}
+}
+
+if ( ! function_exists( 'wp_unregister_routine' ) ) {
+	/**
+	 * @since 0.105.0
+	 *
+	 * @return true|WP_Error
+	 */
+	function wp_unregister_routine( string $routine_id ) {
+		return AgentsAPI\AI\Routines\WP_Agent_Routine_Registry::unregister( $routine_id );
+	}
+}

--- a/tests/bootstrap-smoke.php
+++ b/tests/bootstrap-smoke.php
@@ -174,6 +174,7 @@ $expected_source_directories = array(
 	'Memory',
 	'Packages',
 	'Registry',
+	'Routines',
 	'Runtime',
 	'Tools',
 	'Transcripts',

--- a/tests/routine-smoke.php
+++ b/tests/routine-smoke.php
@@ -52,6 +52,9 @@ if ( ! function_exists( 'sanitize_title' ) ) {
 		return trim( $str, '-' );
 	}
 }
+if ( ! function_exists( 'esc_html' ) ) {
+	function esc_html( $s ) { return $s; }
+}
 
 if ( ! class_exists( 'WP_Error' ) ) {
 	class WP_Error {

--- a/tests/routine-smoke.php
+++ b/tests/routine-smoke.php
@@ -1,0 +1,170 @@
+<?php
+/**
+ * Pure-PHP smoke for the Routines substrate.
+ *
+ * Run with: php tests/routine-smoke.php
+ *
+ * @package AgentsAPI\Tests
+ */
+
+defined( 'ABSPATH' ) || define( 'ABSPATH', __DIR__ . '/' );
+
+$failures = array();
+$passes   = 0;
+
+echo "routine-smoke\n";
+
+function smoke_assert( $expected, $actual, string $name, array &$failures, int &$passes ): void {
+	if ( $expected === $actual ) {
+		++$passes;
+		echo "  PASS {$name}\n";
+		return;
+	}
+	$failures[] = $name;
+	echo "  FAIL {$name}\n";
+	echo '    expected: ' . var_export( $expected, true ) . "\n";
+	echo '    actual:   ' . var_export( $actual, true ) . "\n";
+}
+
+function smoke_assert_throws( callable $fn, string $message_substring, string $name, array &$failures, int &$passes ): void {
+	try {
+		$fn();
+	} catch ( \Throwable $e ) {
+		if ( false === strpos( $e->getMessage(), $message_substring ) ) {
+			$failures[] = $name;
+			echo "  FAIL {$name}\n";
+			echo '    expected substring: ' . $message_substring . "\n";
+			echo '    actual message:     ' . $e->getMessage() . "\n";
+			return;
+		}
+		++$passes;
+		echo "  PASS {$name}\n";
+		return;
+	}
+	$failures[] = $name;
+	echo "  FAIL {$name} (no exception thrown)\n";
+}
+
+if ( ! function_exists( 'sanitize_title' ) ) {
+	function sanitize_title( $str ) {
+		$str = strtolower( (string) $str );
+		$str = preg_replace( '/[^a-z0-9_-]+/', '-', $str ) ?? '';
+		return trim( $str, '-' );
+	}
+}
+
+if ( ! class_exists( 'WP_Error' ) ) {
+	class WP_Error {
+		public function __construct( private string $code = '', private string $message = '', private $data = null ) {}
+		public function get_error_code(): string { return $this->code; }
+		public function get_error_message(): string { return $this->message; }
+		public function get_error_data() { return $this->data; }
+	}
+}
+if ( ! function_exists( 'do_action' ) ) {
+	function do_action( string $hook, ...$args ): void {
+		// no-op for substrate-only smoke; the registry doesn't depend on
+		// listener side effects.
+	}
+}
+
+require_once __DIR__ . '/../src/Routines/class-wp-agent-routine.php';
+require_once __DIR__ . '/../src/Routines/class-wp-agent-routine-registry.php';
+
+use AgentsAPI\AI\Routines\WP_Agent_Routine;
+use AgentsAPI\AI\Routines\WP_Agent_Routine_Registry;
+
+WP_Agent_Routine_Registry::reset();
+
+// 1. Construction with `interval` trigger.
+$routine = new WP_Agent_Routine(
+	'lunar-monitor',
+	array(
+		'label'    => 'Lunar Monitor',
+		'agent'    => 'commander',
+		'interval' => 3600,
+		'prompt'   => 'Status check.',
+	)
+);
+smoke_assert( 'lunar-monitor', $routine->get_id(), 'interval routine: id', $failures, $passes );
+smoke_assert( 'commander', $routine->get_agent_slug(), 'interval routine: agent', $failures, $passes );
+smoke_assert( WP_Agent_Routine::TRIGGER_INTERVAL, $routine->get_trigger_type(), 'interval routine: trigger type', $failures, $passes );
+smoke_assert( 3600, $routine->get_interval_seconds(), 'interval routine: seconds', $failures, $passes );
+smoke_assert( '', $routine->get_expression(), 'interval routine: expression empty', $failures, $passes );
+smoke_assert( 'routine:lunar-monitor', $routine->get_session_id(), 'session_id defaults to routine: prefix + id', $failures, $passes );
+
+// 2. Construction with `expression` trigger.
+$cron_routine = new WP_Agent_Routine(
+	'nightly-digest',
+	array(
+		'agent'      => 'commander',
+		'expression' => '0 9 * * *',
+		'session_id' => 'custom-session',
+	)
+);
+smoke_assert( WP_Agent_Routine::TRIGGER_EXPRESSION, $cron_routine->get_trigger_type(), 'cron routine: trigger type', $failures, $passes );
+smoke_assert( '0 9 * * *', $cron_routine->get_expression(), 'cron routine: expression', $failures, $passes );
+smoke_assert( 0, $cron_routine->get_interval_seconds(), 'cron routine: interval zero', $failures, $passes );
+smoke_assert( 'custom-session', $cron_routine->get_session_id(), 'cron routine: explicit session_id honoured', $failures, $passes );
+
+// 3. Validation failures.
+smoke_assert_throws(
+	static fn() => new WP_Agent_Routine( '', array( 'agent' => 'a', 'interval' => 60 ) ),
+	'id cannot be empty',
+	'rejects empty id',
+	$failures,
+	$passes
+);
+smoke_assert_throws(
+	static fn() => new WP_Agent_Routine( 'r', array( 'interval' => 60 ) ),
+	'must specify an agent slug',
+	'rejects missing agent',
+	$failures,
+	$passes
+);
+smoke_assert_throws(
+	static fn() => new WP_Agent_Routine( 'r', array( 'agent' => 'a' ) ),
+	'must specify a trigger',
+	'rejects missing trigger',
+	$failures,
+	$passes
+);
+smoke_assert_throws(
+	static fn() => new WP_Agent_Routine(
+		'r',
+		array( 'agent' => 'a', 'interval' => 60, 'expression' => '* * * * *' )
+	),
+	'not both',
+	'rejects double trigger',
+	$failures,
+	$passes
+);
+
+// 4. Registry round-trip.
+$registered = WP_Agent_Routine_Registry::register(
+	'lunar-monitor',
+	array( 'agent' => 'commander', 'interval' => 60 )
+);
+smoke_assert( 'lunar-monitor', $registered->get_id(), 'registry returns the registered routine', $failures, $passes );
+smoke_assert( 1, count( WP_Agent_Routine_Registry::all() ), 'registry has one routine', $failures, $passes );
+
+$found = WP_Agent_Routine_Registry::find( 'lunar-monitor' );
+smoke_assert( true, $found instanceof WP_Agent_Routine, 'find returns the routine instance', $failures, $passes );
+smoke_assert( null, WP_Agent_Routine_Registry::find( 'unknown' ), 'find returns null for unknown id', $failures, $passes );
+
+$dropped = WP_Agent_Routine_Registry::unregister( 'lunar-monitor' );
+smoke_assert( true, $dropped, 'unregister returns true on existing id', $failures, $passes );
+smoke_assert( 0, count( WP_Agent_Routine_Registry::all() ), 'registry empty after unregister', $failures, $passes );
+
+$missing = WP_Agent_Routine_Registry::unregister( 'never-registered' );
+smoke_assert( true, is_object( $missing ) && method_exists( $missing, 'get_error_code' ) && 'not_registered' === $missing->get_error_code(), 'unregister returns WP_Error for unknown id', $failures, $passes );
+
+// 5. Registry rejects invalid args via WP_Error.
+$bad = WP_Agent_Routine_Registry::register( 'x', array( 'interval' => 1 ) );
+smoke_assert( true, is_object( $bad ) && method_exists( $bad, 'get_error_code' ) && 'invalid_routine' === $bad->get_error_code(), 'registry returns WP_Error on validation failure', $failures, $passes );
+
+if ( count( $failures ) > 0 ) {
+	echo 'FAIL ' . count( $failures ) . " failures\n";
+	exit( 1 );
+}
+echo "OK {$passes} passed\n";

--- a/tests/subagents-smoke.php
+++ b/tests/subagents-smoke.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * Pure-PHP smoke for the WP_Agent `subagents` field.
+ *
+ * Run with: php tests/subagents-smoke.php
+ *
+ * @package AgentsAPI\Tests
+ */
+
+defined( 'ABSPATH' ) || define( 'ABSPATH', __DIR__ . '/' );
+
+$failures = array();
+$passes   = 0;
+
+echo "subagents-smoke\n";
+
+function smoke_assert( $expected, $actual, string $name, array &$failures, int &$passes ): void {
+	if ( $expected === $actual ) {
+		++$passes;
+		echo "  PASS {$name}\n";
+		return;
+	}
+	$failures[] = $name;
+	echo "  FAIL {$name}\n";
+	echo '    expected: ' . var_export( $expected, true ) . "\n";
+	echo '    actual:   ' . var_export( $actual, true ) . "\n";
+}
+
+function smoke_assert_throws( callable $fn, string $message_substring, string $name, array &$failures, int &$passes ): void {
+	try {
+		$fn();
+	} catch ( \Throwable $e ) {
+		if ( false === strpos( $e->getMessage(), $message_substring ) ) {
+			$failures[] = $name;
+			echo "  FAIL {$name}\n";
+			echo '    expected substring: ' . $message_substring . "\n";
+			echo '    actual message:     ' . $e->getMessage() . "\n";
+			return;
+		}
+		++$passes;
+		echo "  PASS {$name}\n";
+		return;
+	}
+	$failures[] = $name;
+	echo "  FAIL {$name} (no exception thrown)\n";
+}
+
+if ( ! function_exists( 'sanitize_title' ) ) {
+	function sanitize_title( $str ) {
+		$str = strtolower( (string) $str );
+		$str = preg_replace( '/[^a-z0-9_-]+/', '-', $str ) ?? '';
+		return trim( $str, '-' );
+	}
+}
+if ( ! function_exists( 'sanitize_file_name' ) ) {
+	function sanitize_file_name( $str ) { return (string) $str; }
+}
+if ( ! function_exists( '_doing_it_wrong' ) ) {
+	function _doing_it_wrong( $func, $msg, $version ) { /* no-op for smoke */ }
+}
+if ( ! function_exists( 'esc_html' ) ) {
+	function esc_html( $s ) { return $s; }
+}
+
+require_once __DIR__ . '/../src/Registry/class-wp-agent.php';
+
+$plain = new WP_Agent( 'commander', array( 'label' => 'Commander' ) );
+smoke_assert( array(), $plain->get_subagents(), 'agent without subagents: empty array', $failures, $passes );
+smoke_assert( false, $plain->is_coordinator(), 'agent without subagents: not coordinator', $failures, $passes );
+
+$coord = new WP_Agent(
+	'commander',
+	array(
+		'label'     => 'Commander',
+		'subagents' => array( 'Detector', 'navigator', '' ),
+	)
+);
+smoke_assert( array( 'detector', 'navigator' ), $coord->get_subagents(), 'subagents: sanitised + filtered', $failures, $passes );
+smoke_assert( true, $coord->is_coordinator(), 'is_coordinator: true with subagents', $failures, $passes );
+
+// to_array surfaces subagents
+$arr = $coord->to_array();
+smoke_assert( array( 'detector', 'navigator' ), $arr['subagents'] ?? null, 'to_array exposes subagents', $failures, $passes );
+
+smoke_assert_throws(
+	static fn() => new WP_Agent( 'c', array( 'subagents' => 'not-an-array' ) ),
+	'must be an array',
+	'rejects non-array subagents',
+	$failures,
+	$passes
+);
+
+if ( count( $failures ) > 0 ) {
+	echo 'FAIL ' . count( $failures ) . " failures\n";
+	exit( 1 );
+}
+echo "OK {$passes} passed\n";


### PR DESCRIPTION
## Summary

Adds two related primitives to the substrate, motivated by the "routines" and "subagents" framing from Anthropic's recent agent deck (cheap executor + on-demand advisor pattern, agent-as-tool coordination graphs).

### Routines

A *routine* is a persistent, scheduled invocation of an agent. Unlike a workflow (deterministic recipe with fresh inputs per run) or a one-shot background task (single ability dispatched into AS), a routine reuses the same conversation session across every wake — so context accumulates and the agent can pick up where the last wake left off.

\`\`\`php
wp_register_routine( 'lunar-monitor', array(
    'label'    => 'Lunar Monitor',
    'agent'    => 'commander',
    'interval' => 3600,                    // or 'expression' => '0 9 * * *'
    'prompt'   => 'Status check. Anything new?',
) );
\`\`\`

- Triggers: \`interval\` (seconds, recurring) or \`expression\` (cron string). Validator rejects double / missing trigger declarations.
- Wake dispatch: AS fires the listener → look up the routine → call canonical \`agents/chat\` with the routine's persistent \`session_id\` (default \`routine:<id>\`).
- Failures funnel through \`agents_run_routine_dispatch_failed\` instead of throwing — the AS back-off semantics aren't what we want when the failure is a transient consumer-plugin redeploy. Successes fire \`wp_agent_routine_run_completed\` for run recording.
- Bridge mirrors the workflow bridge: idempotent \`register()\` / \`unregister()\`, no-ops cleanly when AS isn't loaded.

### Subagents

Adds \`subagents\` (string[]) to \`WP_Agent\`. Declarative slot only — the substrate persists the declaration, consumers map slugs to other registered agents and surface them through the tool/ability layer.

\`\`\`php
wp_register_agent( 'commander', array(
    'subagents' => array( 'detector', 'navigator' ),
    ...
) );
\`\`\`

\`get_subagents()\` + \`is_coordinator()\` accessors. Sanitisation + empty-string filtering at construction. A coordination dispatcher that exposes subagents as \`delegate-to-<slug>\` tools lands in a follow-up.

## Files

\`\`\`
src/Routines/
  class-wp-agent-routine.php                          (value object)
  class-wp-agent-routine-registry.php                 (in-memory)
  class-wp-agent-routine-action-scheduler-bridge.php  (optional AS bridge)
  register-routines.php                               (wp_register_routine())
  register-routine-bridge-sync.php                    (registry → bridge)
  register-action-scheduler-listener.php              (AS hook → agents/chat)

src/Registry/class-wp-agent.php                       (+ subagents field)
\`\`\`

## Test plan

- [x] \`composer test\` — all assertions pass (\`routine-smoke\` 22, \`subagents-smoke\` 6, \`bootstrap-smoke\` +1).
- [ ] Live: register a routine in a host that loads Action Scheduler, observe a chat session accumulating turns over multiple wakes (consumer-side verification — openclawp PR coming next).