### PR TITLE
Add reusable Docs Agent workflow

### DIFF
--- a/.github/workflows/docs-agent.yml
+++ b/.github/workflows/docs-agent.yml
@@ -1,0 +1,128 @@
+name: Docs Agent
+
+on:
+  workflow_dispatch:
+    inputs:
+      prompt:
+        description: Instruction for Docs Agent.
+        required: true
+        default: Inspect Agents API docs and open a documentation PR only if needed.
+      openai_model:
+        description: OpenAI model to use for the imported agent flow.
+        required: true
+        default: gpt-5.5
+      docs_agent_ref:
+        description: Docs Agent ref.
+        required: true
+        default: main
+      data_machine_ref:
+        description: Data Machine ref.
+        required: true
+        default: main
+      data_machine_code_ref:
+        description: Data Machine Code ref.
+        required: true
+        default: main
+      homeboy_extensions_ref:
+        description: Homeboy Extensions ref.
+        required: true
+        default: main
+      homeboy_ref:
+        description: Homeboy core ref.
+        required: true
+        default: main
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  docs-agent:
+    name: Run Docs Agent
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout Agents API
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Checkout Docs Agent
+        uses: actions/checkout@v4
+        with:
+          repository: Extra-Chill/docs-agent
+          ref: ${{ inputs.docs_agent_ref }}
+          path: .ci/docs-agent
+
+      - name: Checkout Homeboy Extensions
+        uses: actions/checkout@v4
+        with:
+          repository: Extra-Chill/homeboy-extensions
+          ref: ${{ inputs.homeboy_extensions_ref }}
+          path: .ci/homeboy-extensions
+
+      - name: Checkout Homeboy
+        uses: actions/checkout@v4
+        with:
+          repository: Extra-Chill/homeboy
+          ref: ${{ inputs.homeboy_ref }}
+          path: .ci/homeboy
+
+      - name: Checkout Data Machine
+        uses: actions/checkout@v4
+        with:
+          repository: Extra-Chill/data-machine
+          ref: ${{ inputs.data_machine_ref }}
+          path: .ci/data-machine
+
+      - name: Checkout Data Machine Code
+        uses: actions/checkout@v4
+        with:
+          repository: Extra-Chill/data-machine-code
+          ref: ${{ inputs.data_machine_code_ref }}
+          path: .ci/data-machine-code
+
+      - name: Checkout OpenAI provider
+        uses: actions/checkout@v4
+        with:
+          repository: WordPress/ai-provider-for-openai
+          path: .ci/ai-provider-for-openai
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Install Homeboy WordPress extension dependencies
+        working-directory: .ci/homeboy-extensions/wordpress
+        run: |
+          composer install --no-interaction --no-progress --prefer-dist
+          npm install
+
+      - name: Install plugin PHP dependencies
+        run: |
+          composer install --working-dir=.ci/data-machine --no-interaction --no-progress --prefer-dist
+          composer install --working-dir=.ci/data-machine-code --no-interaction --no-progress --prefer-dist
+
+      - name: Validate Docs Agent bundle
+        working-directory: .ci/docs-agent
+        run: php tests/validate-docs-agent-bundle.php
+
+      - name: Run Docs Agent
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          HOMEBOY_EXTENSION_PATH: ${{ github.workspace }}/.ci/homeboy-extensions/wordpress
+          HOMEBOY_RUNTIME_BENCH_HELPER_SH: ${{ github.workspace }}/.ci/homeboy/src/core/extension/runtime/bench-helper.sh
+          HOMEBOY_RUNTIME_BENCH_HELPER_PHP: ${{ github.workspace }}/.ci/homeboy/src/core/extension/runtime/bench-helper.php
+          AGENTS_API_PATH: ${{ github.workspace }}
+          DM_PATH: ${{ github.workspace }}/.ci/data-machine
+          DMC_PATH: ${{ github.workspace }}/.ci/data-machine-code
+          OPENAI_PROVIDER_PATH: ${{ github.workspace }}/.ci/ai-provider-for-openai
+          DOCS_AGENT_OPENAI_MODEL: ${{ inputs.openai_model }}
+          DOCS_AGENT_REF: ${{ inputs.docs_agent_ref }}
+          DOCS_AGENT_TARGET_REPO: Automattic/agents-api
+          DOCS_AGENT_PROMPT: ${{ inputs.prompt }}
+        run: tests/playground-ci/scripts/run-docs-agent.sh

--- a/.github/workflows/docs-agent.yml
+++ b/.github/workflows/docs-agent.yml
@@ -6,7 +6,7 @@ on:
       prompt:
         description: Instruction for Docs Agent.
         required: true
-        default: Inspect Agents API docs and open a documentation PR only if needed.
+        default: Generate or update technical developer documentation for Agents API from source code. Open a documentation PR only if needed.
       openai_model:
         description: OpenAI model to use for the imported agent flow.
         required: true
@@ -123,6 +123,7 @@ jobs:
           OPENAI_PROVIDER_PATH: ${{ github.workspace }}/.ci/ai-provider-for-openai
           DOCS_AGENT_OPENAI_MODEL: ${{ inputs.openai_model }}
           DOCS_AGENT_REF: ${{ inputs.docs_agent_ref }}
+          DOCS_AGENT_WORKFLOW: technical
           DOCS_AGENT_TARGET_REPO: Automattic/agents-api
           DOCS_AGENT_PROMPT: ${{ inputs.prompt }}
         run: tests/playground-ci/scripts/run-docs-agent.sh

--- a/.github/workflows/docs-agent.yml
+++ b/.github/workflows/docs-agent.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Checkout Docs Agent
         uses: actions/checkout@v4
         with:
-          repository: Extra-Chill/docs-agent
+          repository: Automattic/docs-agent
           ref: ${{ inputs.docs_agent_ref }}
           path: .ci/docs-agent
 

--- a/tests/playground-ci/component/agents-api-docs-agent-driver.php
+++ b/tests/playground-ci/component/agents-api-docs-agent-driver.php
@@ -1,0 +1,8 @@
+<?php
+/**
+ * Plugin Name: Agents API Docs Agent CI Driver
+ * Description: Minimal Playground driver plugin for the reusable Docs Agent workflow.
+ * Version: 0.1.0
+ */
+
+defined( 'ABSPATH' ) || exit;

--- a/tests/playground-ci/scripts/run-docs-agent.sh
+++ b/tests/playground-ci/scripts/run-docs-agent.sh
@@ -14,7 +14,29 @@ STUDIO_SITE_PATH="${STUDIO_SITE_PATH:-/Users/chubes/Studio/intelligence-chubes4}
 DOCS_AGENT_OPENAI_MODEL="${DOCS_AGENT_OPENAI_MODEL:-gpt-5.5}"
 DOCS_AGENT_TARGET_REPO="${DOCS_AGENT_TARGET_REPO:-Automattic/agents-api}"
 DOCS_AGENT_REF="${DOCS_AGENT_REF:-main}"
-DOCS_AGENT_PROMPT="${DOCS_AGENT_PROMPT:-Inspect Agents API docs and open a documentation PR only if needed.}"
+DOCS_AGENT_WORKFLOW="${DOCS_AGENT_WORKFLOW:-technical}"
+DOCS_AGENT_PROMPT="${DOCS_AGENT_PROMPT:-Generate or update technical developer documentation for Agents API from source code. Open a documentation PR only if needed.}"
+
+case "$DOCS_AGENT_WORKFLOW" in
+    technical)
+        DOCS_AGENT_PIPELINE_SLUG="technical-docs-pipeline"
+        DOCS_AGENT_FLOW_SLUG="technical-docs-flow"
+        DOCS_AGENT_WORKLOAD_ID="technical-docs-generation"
+        DOCS_AGENT_WORKLOAD_LABEL="Run Docs Agent technical documentation"
+        DOCS_AGENT_AUDIENCE="technical developer-facing"
+        ;;
+    user)
+        DOCS_AGENT_PIPELINE_SLUG="user-docs-pipeline"
+        DOCS_AGENT_FLOW_SLUG="user-docs-flow"
+        DOCS_AGENT_WORKLOAD_ID="user-docs-generation"
+        DOCS_AGENT_WORKLOAD_LABEL="Run Docs Agent user documentation"
+        DOCS_AGENT_AUDIENCE="non-technical user-facing"
+        ;;
+    *)
+        echo "ERROR: DOCS_AGENT_WORKFLOW must be technical or user" >&2
+        exit 1
+        ;;
+esac
 
 if [ ! -f "$EXTENSION_PATH/scripts/bench/bench-runner.sh" ]; then
     echo "ERROR: Homeboy WordPress extension not found at $EXTENSION_PATH" >&2
@@ -86,8 +108,9 @@ Target ref: ${TARGET_REF}
 Head SHA: ${HEAD_SHA}
 Workflow run: ${RUN_URL}
 Writable documentation paths: README.md, docs/**
+Selected docs workflow: ${DOCS_AGENT_WORKFLOW} (${DOCS_AGENT_AUDIENCE})
 
-Inspect repository docs and changed context. If no documentation update is needed, finish cleanly without opening a pull request. If an update is needed, write only allowed documentation paths and open one pull request.
+Generate documentation from source code for the selected audience. If no documentation update is needed, finish cleanly without opening a pull request. If an update is needed, write only allowed documentation paths and open one pull request.
 EOF
 )
 
@@ -102,20 +125,24 @@ jq -n \
     --arg model "$DOCS_AGENT_OPENAI_MODEL" \
     --arg targetRepo "$DOCS_AGENT_TARGET_REPO" \
     --arg docsAgentRef "$DOCS_AGENT_REF" \
+    --arg pipelineSlug "$DOCS_AGENT_PIPELINE_SLUG" \
+    --arg flowSlug "$DOCS_AGENT_FLOW_SLUG" \
+    --arg workloadId "$DOCS_AGENT_WORKLOAD_ID" \
+    --arg workloadLabel "$DOCS_AGENT_WORKLOAD_LABEL" \
     --arg prompt "$PROMPT" \
     '{
         component_id: "agents-api-docs-agent-ci-driver",
         component_path: $componentPath,
-        workload_id: "docs-agent-maintenance",
-        workload_label: "Run Docs Agent",
+        workload_id: $workloadId,
+        workload_label: $workloadLabel,
         validation_dependencies: [$agentsApi, $dm, $dmc, $openaiProvider],
         playground_wordpress_version: "7.0",
         bundle_repo: "https://github.com/Automattic/docs-agent.git",
         bundle_ref: $docsAgentRef,
         bundle_path_in_repo: "bundles/docs-agent",
         agent_slug: "docs-agent",
-        pipeline_slug: "docs-agent-pipeline",
-        flow_slug: "docs-maintenance-flow",
+        pipeline_slug: $pipelineSlug,
+        flow_slug: $flowSlug,
         provider: "openai",
         model: $model,
         provider_register_function: "WordPress\\OpenAiAiProvider\\register_provider",
@@ -174,6 +201,7 @@ echo "============================================"
 echo "Target repo:  $DOCS_AGENT_TARGET_REPO"
 echo "OpenAI model: $DOCS_AGENT_OPENAI_MODEL"
 echo "Docs ref:     $DOCS_AGENT_REF"
+echo "Workflow:     $DOCS_AGENT_WORKFLOW"
 echo "Prompt:       $DOCS_AGENT_PROMPT"
 echo ""
 
@@ -190,7 +218,7 @@ fi
 
 cat "$RESULTS_TMPFILE"
 
-scenario='.scenarios[] | select(.id == "docs-agent-maintenance")'
+scenario='.scenarios[] | select(.id == "'"$DOCS_AGENT_WORKLOAD_ID"'")'
 job_status=$(jq -r "$scenario | .metadata.job_status // \"unknown\"" "$RESULTS_TMPFILE")
 success_status=$(jq -r "$scenario | .metadata.success_status // \"unknown\"" "$RESULTS_TMPFILE")
 docs_agent_pr_url=$(jq -r "$scenario | .metadata.engine_data.docs_agent.pr.url // \"\"" "$RESULTS_TMPFILE")

--- a/tests/playground-ci/scripts/run-docs-agent.sh
+++ b/tests/playground-ci/scripts/run-docs-agent.sh
@@ -1,0 +1,219 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+COMPONENT_PATH="$REPO_ROOT/tests/playground-ci/component"
+
+EXTENSION_PATH="${HOMEBOY_EXTENSION_PATH:-/Users/chubes/Developer/homeboy-extensions/wordpress}"
+AGENTS_API_PATH="${AGENTS_API_PATH:-$REPO_ROOT}"
+DM_PATH="${DM_PATH:-/Users/chubes/Developer/data-machine}"
+DMC_PATH="${DMC_PATH:-/Users/chubes/Developer/data-machine-code}"
+OPENAI_PROVIDER_PATH="${OPENAI_PROVIDER_PATH:-/Users/chubes/Studio/intelligence-chubes4/wp-content/plugins/ai-provider-for-openai}"
+STUDIO_SITE_PATH="${STUDIO_SITE_PATH:-/Users/chubes/Studio/intelligence-chubes4}"
+DOCS_AGENT_OPENAI_MODEL="${DOCS_AGENT_OPENAI_MODEL:-gpt-5.5}"
+DOCS_AGENT_TARGET_REPO="${DOCS_AGENT_TARGET_REPO:-Automattic/agents-api}"
+DOCS_AGENT_REF="${DOCS_AGENT_REF:-main}"
+DOCS_AGENT_PROMPT="${DOCS_AGENT_PROMPT:-Inspect Agents API docs and open a documentation PR only if needed.}"
+
+if [ ! -f "$EXTENSION_PATH/scripts/bench/bench-runner.sh" ]; then
+    echo "ERROR: Homeboy WordPress extension not found at $EXTENSION_PATH" >&2
+    exit 1
+fi
+if [ ! -d "$AGENTS_API_PATH" ] || [ ! -d "$DM_PATH" ] || [ ! -d "$DMC_PATH" ]; then
+    echo "ERROR: Agents API, Data Machine, and Data Machine Code checkouts are required" >&2
+    exit 1
+fi
+if [ ! -d "$OPENAI_PROVIDER_PATH" ]; then
+    echo "ERROR: AI Provider for OpenAI plugin not found at $OPENAI_PROVIDER_PATH" >&2
+    exit 1
+fi
+if ! command -v jq >/dev/null 2>&1; then
+    echo "ERROR: jq required" >&2
+    exit 1
+fi
+
+GITHUB_TOKEN="${GITHUB_TOKEN:-${GH_TOKEN:-}}"
+if [ -z "$GITHUB_TOKEN" ] && command -v gh >/dev/null 2>&1; then
+    GITHUB_TOKEN="$(gh auth token 2>/dev/null || true)"
+fi
+if [ -z "$GITHUB_TOKEN" ]; then
+    echo "ERROR: GITHUB_TOKEN or GH_TOKEN is required, or gh must be authenticated" >&2
+    exit 1
+fi
+
+OPENAI_API_KEY="${OPENAI_API_KEY:-}"
+if [ -z "$OPENAI_API_KEY" ] && command -v studio >/dev/null 2>&1 && [ -d "$STUDIO_SITE_PATH" ]; then
+    OPENAI_API_KEY="$(cd "$STUDIO_SITE_PATH" && studio wp option get connectors_ai_openai_api_key 2>/dev/null || true)"
+fi
+if [ -z "$OPENAI_API_KEY" ]; then
+    echo "ERROR: OPENAI_API_KEY is required, or the local Studio site must store connectors_ai_openai_api_key" >&2
+    exit 1
+fi
+
+CONFIG_TMPFILE=$(mktemp "${TMPDIR:-/tmp}/docs-agent-config.XXXXXX.json")
+RESULTS_TMPFILE=$(mktemp "${TMPDIR:-/tmp}/docs-agent-results.XXXXXX.json")
+TRANSCRIPT_ARTIFACT_DIR="$COMPONENT_PATH/artifacts/docs-agent"
+
+cleanup() {
+    rm -f "$CONFIG_TMPFILE" "$RESULTS_TMPFILE"
+}
+trap cleanup EXIT
+
+rm -rf "$TRANSCRIPT_ARTIFACT_DIR"
+mkdir -p "$TRANSCRIPT_ARTIFACT_DIR"
+
+HE_AGENT_RUNNER="$EXTENSION_PATH/scripts/agent/run-datamachine-agent.sh"
+if [ ! -f "$HE_AGENT_RUNNER" ]; then
+    echo "ERROR: generic Data Machine agent runner not found at $HE_AGENT_RUNNER" >&2
+    exit 1
+fi
+
+EVENT_NAME="${GITHUB_EVENT_NAME:-manual}"
+TARGET_REF="${GITHUB_REF_NAME:-main}"
+HEAD_SHA="${GITHUB_SHA:-}"
+RUN_URL=""
+if [ -n "${GITHUB_SERVER_URL:-}" ] && [ -n "${GITHUB_REPOSITORY:-}" ] && [ -n "${GITHUB_RUN_ID:-}" ]; then
+    RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+fi
+
+PROMPT=$(cat <<EOF
+${DOCS_AGENT_PROMPT}
+
+Target repository: ${DOCS_AGENT_TARGET_REPO}
+Event name: ${EVENT_NAME}
+Target ref: ${TARGET_REF}
+Head SHA: ${HEAD_SHA}
+Workflow run: ${RUN_URL}
+Writable documentation paths: README.md, docs/**
+
+Inspect repository docs and changed context. If no documentation update is needed, finish cleanly without opening a pull request. If an update is needed, write only allowed documentation paths and open one pull request.
+EOF
+)
+
+jq -n \
+    --arg componentPath "$COMPONENT_PATH" \
+    --arg agentsApi "$AGENTS_API_PATH" \
+    --arg dm "$DM_PATH" \
+    --arg dmc "$DMC_PATH" \
+    --arg openaiProvider "$OPENAI_PROVIDER_PATH" \
+    --arg githubToken "$GITHUB_TOKEN" \
+    --arg openaiKey "$OPENAI_API_KEY" \
+    --arg model "$DOCS_AGENT_OPENAI_MODEL" \
+    --arg targetRepo "$DOCS_AGENT_TARGET_REPO" \
+    --arg docsAgentRef "$DOCS_AGENT_REF" \
+    --arg prompt "$PROMPT" \
+    '{
+        component_id: "agents-api-docs-agent-ci-driver",
+        component_path: $componentPath,
+        workload_id: "docs-agent-maintenance",
+        workload_label: "Run Docs Agent",
+        validation_dependencies: [$agentsApi, $dm, $dmc, $openaiProvider],
+        playground_wordpress_version: "7.0",
+        bundle_repo: "https://github.com/Extra-Chill/docs-agent.git",
+        bundle_ref: $docsAgentRef,
+        bundle_path_in_repo: "bundles/docs-agent",
+        agent_slug: "docs-agent",
+        pipeline_slug: "docs-agent-pipeline",
+        flow_slug: "docs-maintenance-flow",
+        provider: "openai",
+        model: $model,
+        provider_register_function: "WordPress\\OpenAiAiProvider\\register_provider",
+        provider_credentials: {
+            connectors_ai_openai_api_key: "OPENAI_API_KEY"
+        },
+        github_token_env: "GITHUB_TOKEN",
+        github_profile_id: "docs-agent-ci",
+        target_repo: $targetRepo,
+        allowed_repos: [$targetRepo],
+        success_requires_pr: false,
+        max_turns: 12,
+        prompt: $prompt,
+        step_budget: 16,
+        time_budget_ms: 600000,
+        transcript_dir: "/wordpress/wp-content/plugins/agents-api-docs-agent-ci-driver/artifacts/docs-agent",
+        required_abilities: [
+            "datamachine/import-agent",
+            "datamachine/run-flow",
+            "datamachine/drain-job",
+            "datamachine/create-or-update-github-file"
+        ],
+        tool_recorders: [
+            {
+                tool: "create_or_update_github_file",
+                forced_parameters: {
+                    allowed_file_paths: ["README.md", "docs/**"]
+                },
+                record: {
+                    engine_key: "docs_agent",
+                    tool_results_key: "github_tool_results"
+                }
+            },
+            {
+                tool: "create_github_pull_request",
+                record: {
+                    engine_key: "docs_agent",
+                    tool_results_key: "github_tool_results",
+                    event: {
+                        key: "pr",
+                        type: "pull_request",
+                        only_if_success: true
+                    }
+                }
+            }
+        ],
+        bench_env: {
+            GITHUB_TOKEN: $githubToken,
+            OPENAI_API_KEY: $openaiKey
+        }
+    }' > "$CONFIG_TMPFILE"
+
+echo "============================================"
+echo "Docs Agent maintenance"
+echo "============================================"
+echo "Target repo:  $DOCS_AGENT_TARGET_REPO"
+echo "OpenAI model: $DOCS_AGENT_OPENAI_MODEL"
+echo "Docs ref:     $DOCS_AGENT_REF"
+echo "Prompt:       $DOCS_AGENT_PROMPT"
+echo ""
+
+GITHUB_TOKEN="$GITHUB_TOKEN" \
+OPENAI_API_KEY="$OPENAI_API_KEY" \
+HOMEBOY_BENCH_RESULTS_FILE="$RESULTS_TMPFILE" \
+HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
+    bash "$HE_AGENT_RUNNER" "$CONFIG_TMPFILE"
+
+if [ ! -s "$RESULTS_TMPFILE" ]; then
+    echo "ERROR: results file empty or missing at $RESULTS_TMPFILE" >&2
+    exit 1
+fi
+
+cat "$RESULTS_TMPFILE"
+
+scenario='.scenarios[] | select(.id == "docs-agent-maintenance")'
+job_status=$(jq -r "$scenario | .metadata.job_status // \"unknown\"" "$RESULTS_TMPFILE")
+success_status=$(jq -r "$scenario | .metadata.success_status // \"unknown\"" "$RESULTS_TMPFILE")
+docs_agent_pr_url=$(jq -r "$scenario | .metadata.engine_data.docs_agent.pr.url // \"\"" "$RESULTS_TMPFILE")
+
+echo "============================================"
+echo "Docs Agent summary"
+echo "============================================"
+printf '%-24s %s\n' "Persisted job status:" "$job_status"
+printf '%-24s %s\n' "Success status:" "$success_status"
+printf '%-24s %s\n' "Docs Agent PR URL:" "$docs_agent_pr_url"
+
+if [ -n "${GITHUB_OUTPUT:-}" ]; then
+    {
+        echo "job_status=$job_status"
+        echo "success_status=$success_status"
+        echo "docs_agent_pr_url=$docs_agent_pr_url"
+    } >> "$GITHUB_OUTPUT"
+fi
+
+if [ "$job_status" = "completed" ] && { [ "$success_status" = "pr_opened" ] || [ "$success_status" = "no_changes" ]; }; then
+    echo "Docs Agent maintenance PASSED - $success_status"
+    exit 0
+fi
+
+echo "Docs Agent maintenance FAILED - see envelope above" >&2
+exit 1

--- a/tests/playground-ci/scripts/run-docs-agent.sh
+++ b/tests/playground-ci/scripts/run-docs-agent.sh
@@ -110,7 +110,7 @@ jq -n \
         workload_label: "Run Docs Agent",
         validation_dependencies: [$agentsApi, $dm, $dmc, $openaiProvider],
         playground_wordpress_version: "7.0",
-        bundle_repo: "https://github.com/Extra-Chill/docs-agent.git",
+        bundle_repo: "https://github.com/Automattic/docs-agent.git",
         bundle_ref: $docsAgentRef,
         bundle_path_in_repo: "bundles/docs-agent",
         agent_slug: "docs-agent",


### PR DESCRIPTION
## Summary
- Add a manual Docs Agent workflow that consumes the reusable `Automattic/docs-agent` Data Machine bundle.
- Configure Agents API to run the technical/developer-facing docs workflow (`technical-docs-pipeline` / `technical-docs-flow`).
- Force writable docs paths to `README.md` and `docs/**` through the runner config so generated file writes stay scoped.

## Testing
- `php -l tests/playground-ci/component/agents-api-docs-agent-driver.php && bash -n tests/playground-ci/scripts/run-docs-agent.sh && git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/docs-agent.yml"); puts "workflow yaml ok"'`
- `homeboy lint --path . --extension wordpress --changed-since origin/main`
- Local Docs Agent proof passed with `success_status=no_changes` after Automattic/docs-agent#1 and Extra-Chill/homeboy-extensions#497 merged.

## Dependencies
- Automattic/docs-agent#1 is merged and provides the reusable bundle with technical and user-facing documentation pipelines.
- Extra-Chill/homeboy-extensions#490 is merged and provides `forced_parameters` support for hard path-scope enforcement.
- Extra-Chill/homeboy-extensions#497 is merged and mounts external `bundle_repo` checkouts into Playground.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the workflow, runner script, and validation path for consuming the reusable Docs Agent technical documentation bundle; Chris remains responsible for review and merge.