### PR TITLE
Preserve request metadata for transcript persisters

### DIFF
--- a/src/Runtime/class-wp-agent-conversation-loop.php
+++ b/src/Runtime/class-wp-agent-conversation-loop.php
@@ -89,6 +89,7 @@ class WP_Agent_Conversation_Loop {
 		$tool_results          = array();
 		$conversation_complete = false;
 		$exceeded_budget       = null;
+		$last_request_metadata = array();
 
 		if ( null !== $transcript_lock && '' !== $lock_session_id ) {
 			$lock_token = $transcript_lock->acquire_session_lock( $lock_session_id, $lock_ttl );
@@ -181,6 +182,9 @@ class WP_Agent_Conversation_Loop {
 					$messages     = $result['messages'];
 					$tool_results = array_merge( $tool_results, $result['tool_execution_results'] );
 					$events       = array_merge( $events, self::normalize_events( $result['events'] ?? array() ) );
+					if ( isset( $result['request_metadata'] ) && is_array( $result['request_metadata'] ) ) {
+						$last_request_metadata = $result['request_metadata'];
+					}
 
 					// Apply completion policy to tool results from the turn runner
 					// when the loop owns policy but the turn runner handled execution.
@@ -234,6 +238,10 @@ class WP_Agent_Conversation_Loop {
 				'tool_execution_results' => $tool_results,
 				'events'                 => $events,
 			);
+
+			if ( ! empty( $last_request_metadata ) ) {
+				$final_result_data['request_metadata'] = $last_request_metadata;
+			}
 
 			if ( null !== $exceeded_budget ) {
 				$final_result_data['status'] = 'budget_exceeded';

--- a/tests/conversation-loop-transcript-persister-smoke.php
+++ b/tests/conversation-loop-transcript-persister-smoke.php
@@ -31,10 +31,11 @@ $persister     = new class( $persister_log ) implements AgentsAPI\AI\WP_Agent_Tr
 
 	public function persist( array $messages, AgentsAPI\AI\WP_Agent_Conversation_Request $request, array $result ): string {
 		$this->log[] = array(
-			'message_count' => count( $messages ),
-			'request_turns' => $request->maxTurns(),
-			'workspace'     => $request->workspace() ? $request->workspace()->to_array() : null,
-			'result_keys'   => array_keys( $result ),
+			'message_count'    => count( $messages ),
+			'request_turns'    => $request->maxTurns(),
+			'workspace'        => $request->workspace() ? $request->workspace()->to_array() : null,
+			'result_keys'      => array_keys( $result ),
+			'request_metadata' => $result['request_metadata'] ?? null,
 		);
 
 		return 'transcript-' . count( $this->log );
@@ -53,6 +54,11 @@ $result = AgentsAPI\AI\WP_Agent_Conversation_Loop::run(
 			'messages'               => $messages,
 			'tool_execution_results' => array(),
 			'events'                 => array(),
+			'request_metadata'       => array(
+				'memory_files' => array(
+					array( 'filename' => 'SITE.md' ),
+				),
+			),
 		);
 	},
 	array(
@@ -64,6 +70,8 @@ $result = AgentsAPI\AI\WP_Agent_Conversation_Loop::run(
 agents_api_smoke_assert_equals( 1, count( $persister_log ), 'persister was called once on success', $failures, $passes );
 agents_api_smoke_assert_equals( 2, $persister_log[0]['message_count'], 'persister received final messages', $failures, $passes );
 agents_api_smoke_assert_equals( 1, $persister_log[0]['request_turns'], 'persister received request with correct max_turns', $failures, $passes );
+agents_api_smoke_assert_equals( 'SITE.md', $result['request_metadata']['memory_files'][0]['filename'] ?? '', 'loop result preserves caller request metadata', $failures, $passes );
+agents_api_smoke_assert_equals( 'SITE.md', $persister_log[0]['request_metadata']['memory_files'][0]['filename'] ?? '', 'persister receives caller request metadata', $failures, $passes );
 
 echo "\n[2] Persister fires on the failure path (turn runner throws):\n";
 $persister_log = array();


### PR DESCRIPTION
## Summary
- Carries caller-managed `request_metadata` through the conversation loop final result.
- Extends transcript persister smoke coverage so request metadata reaches both the loop result and the persister.

## Why
Data Machine already records compact request metadata, including injected memory files such as `SITE.md`, but the generic loop dropped that metadata before transcript persistence. Preserving it makes CI transcript artifacts auditable for what context the agent actually saw.

## Verification
- `php tests/conversation-loop-transcript-persister-smoke.php`
- `php -l src/Runtime/class-wp-agent-conversation-loop.php`
- `php -l tests/conversation-loop-transcript-persister-smoke.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Investigating the Data Machine transcript audit gap, drafting the metadata preservation patch and regression coverage, and running targeted validation. Chris remains responsible for review and merge.