### PR TITLE
Allow selecting Docs Agent flow

### DIFF
--- a/.github/workflows/docs-agent.yml
+++ b/.github/workflows/docs-agent.yml
@@ -11,6 +11,18 @@ on:
         description: OpenAI model to use for the imported agent flow.
         required: true
         default: gpt-5.5
+      docs_agent_flow:
+        description: Docs Agent flow slug to run.
+        type: choice
+        required: true
+        options:
+          - technical-docs-bootstrap-flow
+          - technical-docs-maintenance-flow
+          - technical-docs-flow
+          - user-docs-bootstrap-flow
+          - user-docs-maintenance-flow
+          - user-docs-flow
+        default: technical-docs-maintenance-flow
       docs_agent_ref:
         description: Docs Agent ref.
         required: true
@@ -123,7 +135,7 @@ jobs:
           OPENAI_PROVIDER_PATH: ${{ github.workspace }}/.ci/ai-provider-for-openai
           DOCS_AGENT_OPENAI_MODEL: ${{ inputs.openai_model }}
           DOCS_AGENT_REF: ${{ inputs.docs_agent_ref }}
-          DOCS_AGENT_WORKFLOW: technical
+          DOCS_AGENT_FLOW: ${{ inputs.docs_agent_flow }}
           DOCS_AGENT_TARGET_REPO: Automattic/agents-api
           DOCS_AGENT_PROMPT: ${{ inputs.prompt }}
         run: tests/playground-ci/scripts/run-docs-agent.sh

--- a/tests/playground-ci/scripts/run-docs-agent.sh
+++ b/tests/playground-ci/scripts/run-docs-agent.sh
@@ -15,19 +15,35 @@ DOCS_AGENT_OPENAI_MODEL="${DOCS_AGENT_OPENAI_MODEL:-gpt-5.5}"
 DOCS_AGENT_TARGET_REPO="${DOCS_AGENT_TARGET_REPO:-Automattic/agents-api}"
 DOCS_AGENT_REF="${DOCS_AGENT_REF:-main}"
 DOCS_AGENT_WORKFLOW="${DOCS_AGENT_WORKFLOW:-technical}"
+DOCS_AGENT_FLOW="${DOCS_AGENT_FLOW:-}"
 DOCS_AGENT_PROMPT="${DOCS_AGENT_PROMPT:-Generate or update technical developer documentation for Agents API from source code. Open a documentation PR only if needed.}"
+
+if [ -n "$DOCS_AGENT_FLOW" ]; then
+    case "$DOCS_AGENT_FLOW" in
+        technical-docs-bootstrap-flow|technical-docs-maintenance-flow|technical-docs-flow)
+            DOCS_AGENT_WORKFLOW="technical"
+            ;;
+        user-docs-bootstrap-flow|user-docs-maintenance-flow|user-docs-flow)
+            DOCS_AGENT_WORKFLOW="user"
+            ;;
+        *)
+            echo "ERROR: DOCS_AGENT_FLOW must be a supported docs-agent flow slug" >&2
+            exit 1
+            ;;
+    esac
+fi
 
 case "$DOCS_AGENT_WORKFLOW" in
     technical)
         DOCS_AGENT_PIPELINE_SLUG="technical-docs-pipeline"
-        DOCS_AGENT_FLOW_SLUG="technical-docs-flow"
+        DOCS_AGENT_FLOW_SLUG="${DOCS_AGENT_FLOW:-technical-docs-flow}"
         DOCS_AGENT_WORKLOAD_ID="technical-docs-generation"
         DOCS_AGENT_WORKLOAD_LABEL="Run Docs Agent technical documentation"
         DOCS_AGENT_AUDIENCE="technical developer-facing"
         ;;
     user)
         DOCS_AGENT_PIPELINE_SLUG="user-docs-pipeline"
-        DOCS_AGENT_FLOW_SLUG="user-docs-flow"
+        DOCS_AGENT_FLOW_SLUG="${DOCS_AGENT_FLOW:-user-docs-flow}"
         DOCS_AGENT_WORKLOAD_ID="user-docs-generation"
         DOCS_AGENT_WORKLOAD_LABEL="Run Docs Agent user documentation"
         DOCS_AGENT_AUDIENCE="non-technical user-facing"


### PR DESCRIPTION
## Summary
- Add a `docs_agent_flow` workflow input so the Docs Agent CI can run bootstrap or maintenance flows from the imported bundle.
- Map the selected flow slug to the correct technical/user pipeline in the runner script while preserving the old `DOCS_AGENT_WORKFLOW` fallback.

## Testing
- `bash -n tests/playground-ci/scripts/run-docs-agent.sh`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the workflow/script selector update and ran focused validation; Chris remains responsible for review and merge.