### PR TITLE
feat(loop): expose turn_count, final_content, usage, request_metadata in result

### DIFF
--- a/src/Runtime/class-wp-agent-conversation-loop.php
+++ b/src/Runtime/class-wp-agent-conversation-loop.php
@@ -89,7 +89,19 @@ class WP_Agent_Conversation_Loop {
 		$tool_results          = array();
 		$conversation_complete = false;
 		$exceeded_budget       = null;
-		$last_request_metadata = array();
+
+		// Universal observability accumulators. Turn runners may report
+		// `usage` (token counts) and `request_metadata` (last provider request
+		// descriptor) in their per-turn return value; the loop accumulates
+		// these and exposes them in the final result so consumers don't have
+		// to track them out-of-band via mutable state.
+		$turns_run        = 0;
+		$total_usage      = array(
+			'prompt_tokens'     => 0,
+			'completion_tokens' => 0,
+			'total_tokens'      => 0,
+		);
+		$request_metadata = array();
 
 		if ( null !== $transcript_lock && '' !== $lock_session_id ) {
 			$lock_token = $transcript_lock->acquire_session_lock( $lock_session_id, $lock_ttl );
@@ -109,6 +121,7 @@ class WP_Agent_Conversation_Loop {
 
 		try {
 			for ( $turn = 1; $turn <= $max_turns; ++$turn ) {
+				$turns_run            = $turn;
 				$turn_context         = $context;
 				$turn_context['turn'] = $turn;
 
@@ -155,6 +168,18 @@ class WP_Agent_Conversation_Loop {
 					) );
 
 					throw $error;
+				}
+
+				// Accumulate optional observability fields from the turn runner.
+				// `usage` is a per-turn token-count array that gets summed into
+				// `$total_usage`. `request_metadata` is the most recent provider
+				// request descriptor and overwrites on each turn — consumers
+				// typically only care about the last one.
+				if ( isset( $result['usage'] ) && is_array( $result['usage'] ) ) {
+					$total_usage = self::accumulate_usage( $total_usage, $result['usage'] );
+				}
+				if ( isset( $result['request_metadata'] ) && is_array( $result['request_metadata'] ) ) {
+					$request_metadata = $result['request_metadata'];
 				}
 
 				// When mediation is enabled, the turn runner returns tool_calls
@@ -237,11 +262,11 @@ class WP_Agent_Conversation_Loop {
 				'messages'               => $messages,
 				'tool_execution_results' => $tool_results,
 				'events'                 => $events,
+				'turn_count'             => $turns_run,
+				'final_content'          => self::extract_final_content( $messages ),
+				'usage'                  => $total_usage,
+				'request_metadata'       => $request_metadata,
 			);
-
-			if ( ! empty( $last_request_metadata ) ) {
-				$final_result_data['request_metadata'] = $last_request_metadata;
-			}
 
 			if ( null !== $exceeded_budget ) {
 				$final_result_data['status'] = 'budget_exceeded';
@@ -253,7 +278,7 @@ class WP_Agent_Conversation_Loop {
 			self::persist_transcript( $transcript_persister, $messages, $options, $final_result );
 
 			self::emit_event( $on_event, 'completed', array(
-				'turn'          => $turn,
+				'turn'          => $turns_run,
 				'message_count' => count( $messages ),
 				'tool_results'  => count( $tool_results ),
 			) );
@@ -750,6 +775,61 @@ class WP_Agent_Conversation_Loop {
 			'messages' => $compaction['messages'],
 			'events'   => self::normalize_events( $compaction['events'] ),
 		);
+	}
+
+	/**
+	 * Accumulate per-turn usage into the running total.
+	 *
+	 * Sums the canonical `prompt_tokens`/`completion_tokens`/`total_tokens`
+	 * fields and preserves any provider-specific keys from the latest turn
+	 * (e.g. `cache_creation_input_tokens`, `reasoning_tokens`) so consumers
+	 * can read provider extensions without the loop having to know about
+	 * each one. Numeric fields are summed; non-numeric fields are taken
+	 * from the latest turn.
+	 *
+	 * @param array<string, mixed> $running Current accumulated usage.
+	 * @param array<string, mixed> $turn    Per-turn usage.
+	 * @return array<string, mixed> Accumulated usage.
+	 */
+	private static function accumulate_usage( array $running, array $turn ): array {
+		foreach ( $turn as $key => $value ) {
+			if ( is_int( $value ) || is_float( $value ) ) {
+				$running[ $key ] = (float) ( $running[ $key ] ?? 0 ) + (float) $value;
+				if ( is_int( $value ) && (float) (int) $running[ $key ] === (float) $running[ $key ] ) {
+					$running[ $key ] = (int) $running[ $key ];
+				}
+				continue;
+			}
+			$running[ $key ] = $value;
+		}
+		return $running;
+	}
+
+	/**
+	 * Extract the text of the last assistant message from a transcript.
+	 *
+	 * Returns an empty string when no assistant message exists or the
+	 * latest assistant message has no text content (e.g. tool-call-only
+	 * turns at the tail).
+	 *
+	 * @param array $messages Normalized transcript messages.
+	 * @return string Final assistant text content.
+	 */
+	private static function extract_final_content( array $messages ): string {
+		for ( $i = count( $messages ) - 1; $i >= 0; --$i ) {
+			$message = $messages[ $i ];
+			if ( ! is_array( $message ) ) {
+				continue;
+			}
+			if ( ( $message['role'] ?? '' ) !== 'assistant' ) {
+				continue;
+			}
+			$content = $message['content'] ?? '';
+			if ( is_string( $content ) && '' !== $content ) {
+				return $content;
+			}
+		}
+		return '';
 	}
 
 	/**

--- a/src/Runtime/class-wp-agent-conversation-result.php
+++ b/src/Runtime/class-wp-agent-conversation-result.php
@@ -97,6 +97,23 @@ class WP_Agent_Conversation_Result {
 			throw self::invalid( 'budget', 'must be a string when present' );
 		}
 
+		// Validate optional observability fields surfaced by the loop.
+		if ( array_key_exists( 'turn_count', $result ) && ! is_int( $result['turn_count'] ) ) {
+			throw self::invalid( 'turn_count', 'must be an integer when present' );
+		}
+
+		if ( array_key_exists( 'final_content', $result ) && ! is_string( $result['final_content'] ) ) {
+			throw self::invalid( 'final_content', 'must be a string when present' );
+		}
+
+		if ( array_key_exists( 'usage', $result ) && ! is_array( $result['usage'] ) ) {
+			throw self::invalid( 'usage', 'must be an array when present' );
+		}
+
+		if ( array_key_exists( 'request_metadata', $result ) && ! is_array( $result['request_metadata'] ) ) {
+			throw self::invalid( 'request_metadata', 'must be an array when present' );
+		}
+
 		return $result;
 	}
 


### PR DESCRIPTION
## Summary

Closes #135. Expose four universally-needed observability fields on the conversation loop result, eliminating the need for consumers to pass mutable state by reference through their turn runner closure.

| Field | Type | Source |
|---|---|---|
| `turn_count` | `int` | Existing internal loop counter, surfaced |
| `final_content` | `string` | Derived from last assistant message in `$messages` |
| `usage` | `array` | Summed from each turn runner's optional `usage` return field |
| `request_metadata` | `array` | Overwritten by each turn runner's optional `request_metadata` field |

## Why

Consumers building agents on top of `WP_Agent_Conversation_Loop` need more than `messages` + `tool_execution_results`. They need to know how many turns ran, what the agent finally said, what it cost (tokens), and what the last provider request looked like. The substrate already had access to all of this — it just didn't formalize it as part of the result contract.

Without these fields, consumers resort to passing mutable state by reference through their turn runner closure. The `data-machine` consumer ([`inc/Engine/AI/conversation-loop.php:datamachine_run_conversation`](https://github.com/Extra-Chill/data-machine/blob/main/inc/Engine/AI/conversation-loop.php)) does exactly this with six `&` parameters threaded through a separate `build_turn_runner` factory just so the outer function can read accumulators after the loop returns. See #135 for full evidence.

## What changes

### Loop (`class-wp-agent-conversation-loop.php`)

* Accumulates `$turns_run` (existing counter), `$total_usage` (summed across turns), `$request_metadata` (latest turn).
* Reads `$result['usage']` and `$result['request_metadata']` from each turn runner return value (both optional — turn runners that don't report them get empty defaults).
* Adds all four fields to the final result.
* Two new private helpers:
  * `accumulate_usage( $running, $turn )` — sums canonical token-count fields and preserves provider-specific keys like `cache_creation_input_tokens` or `reasoning_tokens`. Numeric fields are summed; non-numeric fields are taken from the latest turn.
  * `extract_final_content( $messages )` — walks the transcript backward for the last non-empty assistant text content. Returns `''` when none exists (e.g. tool-call-only tail).

### Result (`class-wp-agent-conversation-result.php`)

Validates the four new fields when present:

* `turn_count` must be `int`
* `final_content` must be `string`
* `usage` must be `array`
* `request_metadata` must be `array`

All four are optional in the schema — `normalize()` won't reject results that don't include them, so callers that construct results without the loop (test fixtures, manual normalization) keep working.

## Compatibility

**100% additive.** Every existing consumer keeps working:

* Consumers reading `messages`, `tool_execution_results`, `status`, `budget` see no change.
* Turn runners that don't return `usage` or `request_metadata` get empty defaults in the result.
* Turn runners that already return `request_metadata` (the existing `conversation-loop-transcript-persister-smoke` test does this) continue to round-trip correctly — the loop reads it from the per-turn return shape and surfaces it on the final result, exactly as before.

## Test plan

All 30 substrate smoke tests pass on this branch:

```
PASS conversation-loop-smoke                              (6 assertions)
PASS conversation-loop-tool-execution-smoke               (19)
PASS conversation-loop-completion-policy-smoke            (6)
PASS conversation-loop-events-smoke                       (17)
PASS conversation-loop-budgets-smoke                      (24)
PASS conversation-loop-transcript-persister-smoke         (18 — including request_metadata round-trip)
PASS conversation-runner-contracts-smoke                  (18)
PASS iteration-budget-smoke                               (22)
PASS conversation-compaction-smoke
PASS conversation-transcript-lock-smoke
PASS effective-agent-resolver-smoke
PASS execution-principal-smoke
PASS guidelines-substrate-smoke
PASS identity-smoke
PASS markdown-section-compaction-smoke
PASS memory-metadata-contract-smoke
PASS message-envelope-smoke
PASS no-product-imports-smoke
PASS pending-action-store-contract-smoke
PASS registry-smoke
PASS remote-bridge-smoke
PASS routine-smoke                                        (22)
PASS subagents-smoke                                      (6)
PASS tool-policy-contracts-smoke
PASS tool-runtime-smoke
PASS webhook-safety-smoke
PASS workflow-bindings-smoke                              (13)
PASS workflow-runner-smoke                                (26)
PASS workflow-spec-validator-smoke                        (24)
PASS workspace-scope-smoke
```

## Follow-up

After this merges, the `data-machine` consumer will refactor to drop its by-reference accumulator dance and read directly from the new result fields. Separate PR forthcoming on `Extra-Chill/data-machine`.