### PR TITLE
Align Docs Agent tool result detection

### DIFF
--- a/tests/playground-ci/scripts/run-docs-agent.sh
+++ b/tests/playground-ci/scripts/run-docs-agent.sh
@@ -181,6 +181,8 @@ jq -n \
         github_profile_id: "docs-agent-ci",
         target_repo: $targetRepo,
         allowed_repos: [$targetRepo],
+        engine_key: "docs_agent",
+        tool_results_key: "github_tool_results",
         success_requires_pr: $successRequiresPr,
         fallback_pull_request: {
             repo: $targetRepo,


### PR DESCRIPTION
## Summary
- set the Docs Agent runner `engine_key` and `tool_results_key` to match the workflow's GitHub tool recorder
- allows the generic runner to detect documentation file writes and trigger the fallback PR path for bootstrap runs

## Testing
- `bash -n tests/playground-ci/scripts/run-docs-agent.sh`
- `git diff --check`
- The previous main proof failed because this wiring was absent from main: https://github.com/Automattic/agents-api/actions/runs/25638558937

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the missing recorder path wiring after the fallback PR proof and prepared this focused CI fix; Chris remains responsible for review and merge.