### PR TITLE
Require docs bootstrap output files

### DIFF
--- a/tests/playground-ci/scripts/run-docs-agent.sh
+++ b/tests/playground-ci/scripts/run-docs-agent.sh
@@ -184,6 +184,7 @@ jq -n \
         engine_key: "docs_agent",
         tool_results_key: "github_tool_results",
         success_requires_pr: $successRequiresPr,
+        required_written_paths: ($successRequiresPr | if . then ["docs/index.md", "docs/coverage-map.md"] else [] end),
         fallback_pull_request: {
             repo: $targetRepo,
             title: "Bootstrap developer documentation surface",


### PR DESCRIPTION
## Summary
- configures the Docs Agent bootstrap run to require `docs/index.md` and `docs/coverage-map.md`
- lets the reusable runner fail incomplete bootstrap outputs instead of accepting any docs write plus PR

## Testing
- `bash -n tests/playground-ci/scripts/run-docs-agent.sh`
- `jq -n --argjson successRequiresPr true '{ required_written_paths: ($successRequiresPr | if . then ["docs/index.md", "docs/coverage-map.md"] else [] end)}' >/dev/null`
- `git diff --check`

Depends on Extra-Chill/homeboy-extensions#520 for enforcement.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Added the consumer-side required-path configuration after the bootstrap proof exposed incomplete generated documentation; Chris remains responsible for review and merge.