### PR TITLE
Use main ref for reusable Docs Agent workflow

### DIFF
--- a/.github/workflows/docs-agent.yml
+++ b/.github/workflows/docs-agent.yml
@@ -101,7 +101,7 @@ jobs:
   docs-agent:
     name: Run Docs Agent
     needs: prepare
-    uses: Extra-Chill/homeboy-extensions/.github/workflows/datamachine-agent-ci.yml@feat/agent-ci-runner-extensions
+    uses: Extra-Chill/homeboy-extensions/.github/workflows/datamachine-agent-ci.yml@main
     with:
       bundle_path: bundles/docs-agent
       bundle_repo: https://github.com/Automattic/docs-agent.git


### PR DESCRIPTION
## Summary
- Switch the Docs Agent reusable workflow reference from the temporary feature branch to `homeboy-extensions@main` now that Extra-Chill/homeboy-extensions#528 has merged.

## Validation
- `git diff --check`
- `ruby -e 'require \"yaml\"; YAML.load_file(\".github/workflows/docs-agent.yml\"); puts \"yaml ok\"'`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Applied the post-merge workflow reference cleanup.