### PR TITLE
Mark successful conversation loops completed

### DIFF
--- a/src/Runtime/class-wp-agent-conversation-loop.php
+++ b/src/Runtime/class-wp-agent-conversation-loop.php
@@ -270,8 +270,8 @@ class WP_Agent_Conversation_Loop {
 			);
 
 			if ( null !== $exceeded_budget ) {
-				$final_result_data['status'] = 'budget_exceeded';
-				$final_result_data['budget'] = $exceeded_budget;
+				$final_result_data['status']    = 'budget_exceeded';
+				$final_result_data['budget']    = $exceeded_budget;
 				$final_result_data['completed'] = false;
 			}
 

--- a/src/Runtime/class-wp-agent-conversation-loop.php
+++ b/src/Runtime/class-wp-agent-conversation-loop.php
@@ -266,11 +266,13 @@ class WP_Agent_Conversation_Loop {
 				'final_content'          => self::extract_final_content( $messages ),
 				'usage'                  => $total_usage,
 				'request_metadata'       => $request_metadata,
+				'completed'              => true,
 			);
 
 			if ( null !== $exceeded_budget ) {
 				$final_result_data['status'] = 'budget_exceeded';
 				$final_result_data['budget'] = $exceeded_budget;
+				$final_result_data['completed'] = false;
 			}
 
 			$final_result = WP_Agent_Conversation_Result::normalize( $final_result_data );

--- a/tests/conversation-loop-transcript-persister-smoke.php
+++ b/tests/conversation-loop-transcript-persister-smoke.php
@@ -35,6 +35,7 @@ $persister     = new class( $persister_log ) implements AgentsAPI\AI\WP_Agent_Tr
 			'request_turns'    => $request->maxTurns(),
 			'workspace'        => $request->workspace() ? $request->workspace()->to_array() : null,
 			'result_keys'      => array_keys( $result ),
+			'completed'        => $result['completed'] ?? null,
 			'request_metadata' => $result['request_metadata'] ?? null,
 		);
 
@@ -70,6 +71,8 @@ $result = AgentsAPI\AI\WP_Agent_Conversation_Loop::run(
 agents_api_smoke_assert_equals( 1, count( $persister_log ), 'persister was called once on success', $failures, $passes );
 agents_api_smoke_assert_equals( 2, $persister_log[0]['message_count'], 'persister received final messages', $failures, $passes );
 agents_api_smoke_assert_equals( 1, $persister_log[0]['request_turns'], 'persister received request with correct max_turns', $failures, $passes );
+agents_api_smoke_assert_equals( true, $result['completed'] ?? null, 'successful loop result is marked completed', $failures, $passes );
+agents_api_smoke_assert_equals( true, $persister_log[0]['completed'], 'persister receives completed successful result', $failures, $passes );
 agents_api_smoke_assert_equals( 'SITE.md', $result['request_metadata']['memory_files'][0]['filename'] ?? '', 'loop result preserves caller request metadata', $failures, $passes );
 agents_api_smoke_assert_equals( 'SITE.md', $persister_log[0]['request_metadata']['memory_files'][0]['filename'] ?? '', 'persister receives caller request metadata', $failures, $passes );
 


### PR DESCRIPTION
## Summary
- Marks normal conversation loop final results as `completed: true` before transcript persistence.
- Marks budget-exceeded loop results as `completed: false`.
- Extends transcript persister smoke coverage so persisted successful results carry the completed flag.

## Testing
- `php -l src/Runtime/class-wp-agent-conversation-loop.php`
- `php -l tests/conversation-loop-transcript-persister-smoke.php`
- `php tests/conversation-loop-transcript-persister-smoke.php`
- `php tests/conversation-loop-smoke.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed successful Data Machine transcripts marked incomplete, drafted the loop result fix, and ran targeted smoke validation.