### PR TITLE
Add agent access abilities

### DIFF
--- a/agents-api.php
+++ b/agents-api.php
@@ -37,12 +37,14 @@ require_once AGENTS_API_PATH . 'src/Packages/class-wp-agent-package-adopter.php'
 require_once AGENTS_API_PATH . 'src/Auth/class-wp-agent-capability-ceiling.php';
 require_once AGENTS_API_PATH . 'src/Auth/class-wp-agent-access-grant.php';
 require_once AGENTS_API_PATH . 'src/Auth/class-wp-agent-access-store.php';
+require_once AGENTS_API_PATH . 'src/Auth/class-wp-agent-access.php';
 require_once AGENTS_API_PATH . 'src/Auth/class-wp-agent-token.php';
 require_once AGENTS_API_PATH . 'src/Auth/class-wp-agent-token-store.php';
 require_once AGENTS_API_PATH . 'src/Auth/class-wp-agent-caller-context.php';
 require_once AGENTS_API_PATH . 'src/Auth/class-wp-agent-authorization-policy.php';
 require_once AGENTS_API_PATH . 'src/Auth/class-wp-agent-token-authenticator.php';
 require_once AGENTS_API_PATH . 'src/Auth/class-wp-agent-wordpress-authorization-policy.php';
+require_once AGENTS_API_PATH . 'src/Auth/register-agent-access-abilities.php';
 require_once AGENTS_API_PATH . 'src/Context/class-wp-agent-context-injection-policy.php';
 require_once AGENTS_API_PATH . 'src/Context/class-wp-agent-memory-layer.php';
 require_once AGENTS_API_PATH . 'src/Context/class-wp-agent-memory-registry.php';

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
       "php tests/effective-agent-resolver-smoke.php",
       "php tests/caller-context-smoke.php",
       "php tests/authorization-smoke.php",
+      "php tests/agents-access-ability-smoke.php",
       "php tests/action-policy-values-smoke.php",
       "php tests/consent-policy-smoke.php",
       "php tests/tool-policy-contracts-smoke.php",

--- a/src/Auth/class-wp-agent-access.php
+++ b/src/Auth/class-wp-agent-access.php
@@ -1,0 +1,169 @@
+<?php
+/**
+ * WP_Agent_Access helpers.
+ *
+ * @package AgentsAPI
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+if ( ! class_exists( 'WP_Agent_Access' ) ) {
+	/**
+	 * Host-store discovery and current-principal access helpers.
+	 */
+	final class WP_Agent_Access {
+
+		private const CURRENT_USER_EFFECTIVE_AGENT_ID = '__wordpress_user__';
+
+		/**
+		 * Resolve the host-provided access store.
+		 *
+		 * @param array<string,mixed> $context Host-owned request context.
+		 */
+		public static function get_store( array $context = array() ): ?WP_Agent_Access_Store {
+			if ( isset( $context['access_store'] ) && $context['access_store'] instanceof WP_Agent_Access_Store ) {
+				return $context['access_store'];
+			}
+
+			$store = function_exists( 'apply_filters' ) ? apply_filters( 'wp_agent_access_store', null, $context ) : null;
+			return $store instanceof WP_Agent_Access_Store ? $store : null;
+		}
+
+		/**
+		 * Resolve the principal for the current request.
+		 *
+		 * @param array<string,mixed> $context Host-owned request context.
+		 */
+		public static function get_current_principal( array $context = array() ): ?AgentsAPI\AI\WP_Agent_Execution_Principal {
+			if ( isset( $context['principal'] ) && $context['principal'] instanceof AgentsAPI\AI\WP_Agent_Execution_Principal ) {
+				return $context['principal'];
+			}
+
+			$principal = AgentsAPI\AI\WP_Agent_Execution_Principal::resolve( $context );
+			if ( null !== $principal ) {
+				return $principal;
+			}
+
+			$user_id = self::get_current_user_id();
+			if ( $user_id <= 0 ) {
+				return null;
+			}
+
+			return AgentsAPI\AI\WP_Agent_Execution_Principal::user_session(
+				$user_id,
+				self::CURRENT_USER_EFFECTIVE_AGENT_ID,
+				isset( $context['request_context'] ) ? (string) $context['request_context'] : AgentsAPI\AI\WP_Agent_Execution_Principal::REQUEST_CONTEXT_REST,
+				isset( $context['request_metadata'] ) && is_array( $context['request_metadata'] ) ? $context['request_metadata'] : array(),
+				array_key_exists( 'workspace_id', $context ) && null !== $context['workspace_id'] ? (string) $context['workspace_id'] : null,
+				array_key_exists( 'client_id', $context ) && null !== $context['client_id'] ? (string) $context['client_id'] : null
+			);
+		}
+
+		/**
+		 * Check whether the current request principal can access an agent.
+		 *
+		 * @param string              $agent_id     Registered agent slug/id.
+		 * @param string              $minimum_role Minimum access role.
+		 * @param array<string,mixed> $context      Host-owned request context.
+		 */
+		public static function can_current_principal_access_agent( string $agent_id, string $minimum_role = WP_Agent_Access_Grant::ROLE_VIEWER, array $context = array() ): bool {
+			$principal = self::get_current_principal( $context );
+			if ( null === $principal ) {
+				return false;
+			}
+
+			return self::can_principal_access_agent( $principal, $agent_id, $minimum_role, $context );
+		}
+
+		/**
+		 * Check whether a principal can access an agent.
+		 *
+		 * @param AgentsAPI\AI\WP_Agent_Execution_Principal $principal    Execution principal.
+		 * @param string                                    $agent_id     Registered agent slug/id.
+		 * @param string                                    $minimum_role Minimum access role.
+		 * @param array<string,mixed>                       $context      Host-owned request context.
+		 */
+		public static function can_principal_access_agent( AgentsAPI\AI\WP_Agent_Execution_Principal $principal, string $agent_id, string $minimum_role = WP_Agent_Access_Grant::ROLE_VIEWER, array $context = array() ): bool {
+			$store  = self::get_store( $context );
+			$policy = new WP_Agent_WordPress_Authorization_Policy( $store );
+
+			return $policy->can_access_agent( $principal, $agent_id, $minimum_role, $context );
+		}
+
+		/**
+		 * List registered agents accessible to the current request principal.
+		 *
+		 * @param string              $minimum_role Minimum access role.
+		 * @param array<string,mixed> $context      Host-owned request context.
+		 * @return array<int,array<string,mixed>>
+		 */
+		public static function list_accessible_agents_for_current_principal( string $minimum_role = WP_Agent_Access_Grant::ROLE_VIEWER, array $context = array() ): array {
+			$principal = self::get_current_principal( $context );
+			if ( null === $principal ) {
+				return array();
+			}
+
+			return self::list_accessible_agents_for_principal( $principal, $minimum_role, $context );
+		}
+
+		/**
+		 * List registered agents accessible to a principal.
+		 *
+		 * @param AgentsAPI\AI\WP_Agent_Execution_Principal $principal    Execution principal.
+		 * @param string                                    $minimum_role Minimum access role.
+		 * @param array<string,mixed>                       $context      Host-owned request context.
+		 * @return array<int,array<string,mixed>>
+		 */
+		public static function list_accessible_agents_for_principal( AgentsAPI\AI\WP_Agent_Execution_Principal $principal, string $minimum_role = WP_Agent_Access_Grant::ROLE_VIEWER, array $context = array() ): array {
+			if ( ! WP_Agent_Access_Grant::is_valid_role( $minimum_role ) ) {
+				return array();
+			}
+
+			$agent_ids = array();
+			$store     = self::get_store( $context );
+			if ( $store instanceof WP_Agent_Access_Store ) {
+				$agent_ids = $store->get_agent_ids_for_user( $principal->acting_user_id, $minimum_role, $principal->workspace_id );
+			}
+
+			if ( self::CURRENT_USER_EFFECTIVE_AGENT_ID !== $principal->effective_agent_id ) {
+				$agent_ids[] = $principal->effective_agent_id;
+			}
+
+			$agent_ids = array_values( array_unique( array_filter( array_map( 'sanitize_title', $agent_ids ) ) ) );
+			$agents    = array();
+			foreach ( $agent_ids as $agent_id ) {
+				$agent = function_exists( 'wp_get_agent' ) ? wp_get_agent( $agent_id ) : null;
+				if ( $agent instanceof WP_Agent ) {
+					$agents[] = self::agent_to_access_summary( $agent );
+				}
+			}
+
+			return $agents;
+		}
+
+		/**
+		 * Export a registered agent summary for access-listing clients.
+		 *
+		 * @return array<string,mixed>
+		 */
+		private static function agent_to_access_summary( WP_Agent $agent ): array {
+			return array(
+				'slug'        => $agent->get_slug(),
+				'label'       => $agent->get_label(),
+				'description' => $agent->get_description(),
+				'meta'        => $agent->get_meta(),
+			);
+		}
+
+		/**
+		 * Return the current WordPress user ID when WordPress is loaded.
+		 */
+		private static function get_current_user_id(): int {
+			if ( function_exists( 'get_current_user_id' ) ) {
+				return (int) get_current_user_id();
+			}
+
+			return 0;
+		}
+	}
+}

--- a/src/Auth/register-agent-access-abilities.php
+++ b/src/Auth/register-agent-access-abilities.php
@@ -1,0 +1,224 @@
+<?php
+/**
+ * Agent access ability registrations.
+ *
+ * @package AgentsAPI
+ */
+
+namespace AgentsAPI\AI\Auth;
+
+defined( 'ABSPATH' ) || exit;
+
+const AGENTS_CAN_ACCESS_AGENT_ABILITY      = 'agents/can-access-agent';
+const AGENTS_LIST_ACCESSIBLE_AGENTS_ABILITY = 'agents/list-accessible-agents';
+
+add_action(
+	'wp_abilities_api_categories_init',
+	static function (): void {
+		if ( wp_has_ability_category( 'agents-api' ) ) {
+			return;
+		}
+
+		wp_register_ability_category(
+			'agents-api',
+			array(
+				'label'       => 'Agents API',
+				'description' => 'Cross-cutting abilities provided by the Agents API substrate.',
+			)
+		);
+	}
+);
+
+add_action(
+	'wp_abilities_api_init',
+	static function (): void {
+		if ( ! wp_has_ability( AGENTS_CAN_ACCESS_AGENT_ABILITY ) ) {
+			wp_register_ability(
+				AGENTS_CAN_ACCESS_AGENT_ABILITY,
+				array(
+					'label'               => 'Can Access Agent',
+					'description'         => 'Check whether the current request principal can access a registered agent at the requested role.',
+					'category'            => 'agents-api',
+					'input_schema'        => agents_can_access_agent_input_schema(),
+					'output_schema'       => agents_can_access_agent_output_schema(),
+					'execute_callback'    => __NAMESPACE__ . '\\agents_can_access_agent',
+					'permission_callback' => __NAMESPACE__ . '\\agents_access_permission',
+					'meta'                => array(
+						'show_in_rest' => true,
+						'annotations'  => array( 'idempotent' => true ),
+					),
+				)
+			);
+		}
+
+		if ( ! wp_has_ability( AGENTS_LIST_ACCESSIBLE_AGENTS_ABILITY ) ) {
+			wp_register_ability(
+				AGENTS_LIST_ACCESSIBLE_AGENTS_ABILITY,
+				array(
+					'label'               => 'List Accessible Agents',
+					'description'         => 'List registered agents accessible to the current request principal.',
+					'category'            => 'agents-api',
+					'input_schema'        => agents_list_accessible_agents_input_schema(),
+					'output_schema'       => agents_list_accessible_agents_output_schema(),
+					'execute_callback'    => __NAMESPACE__ . '\\agents_list_accessible_agents',
+					'permission_callback' => __NAMESPACE__ . '\\agents_access_permission',
+					'meta'                => array(
+						'show_in_rest' => true,
+						'annotations'  => array( 'idempotent' => true ),
+					),
+				)
+			);
+		}
+	}
+);
+
+/**
+ * Check current-principal access to an agent.
+ *
+ * @param array<string,mixed> $input Ability input.
+ * @return array<string,mixed>
+ */
+function agents_can_access_agent( array $input ): array {
+	$agent_id      = isset( $input['agent'] ) ? sanitize_title( (string) $input['agent'] ) : '';
+	$minimum_role  = isset( $input['minimum_role'] ) ? (string) $input['minimum_role'] : \WP_Agent_Access_Grant::ROLE_VIEWER;
+	$request_scope = agents_access_request_scope( $input );
+
+	$allowed = '' !== $agent_id && \WP_Agent_Access::can_current_principal_access_agent( $agent_id, $minimum_role, $request_scope );
+
+	return array(
+		'allowed'      => $allowed,
+		'agent'        => $agent_id,
+		'minimum_role' => $minimum_role,
+	);
+}
+
+/**
+ * List current-principal accessible agents.
+ *
+ * @param array<string,mixed> $input Ability input.
+ * @return array<string,mixed>
+ */
+function agents_list_accessible_agents( array $input ): array {
+	$minimum_role = isset( $input['minimum_role'] ) ? (string) $input['minimum_role'] : \WP_Agent_Access_Grant::ROLE_VIEWER;
+	$agents       = \WP_Agent_Access::list_accessible_agents_for_current_principal( $minimum_role, agents_access_request_scope( $input ) );
+
+	return array( 'agents' => $agents );
+}
+
+/**
+ * Shared permission gate for access read abilities.
+ *
+ * @param array<string,mixed> $input Ability input.
+ */
+function agents_access_permission( array $input ): bool {
+	$allowed = function_exists( 'is_user_logged_in' ) ? is_user_logged_in() : \WP_Agent_Access::get_current_principal( agents_access_request_scope( $input ) ) instanceof \AgentsAPI\AI\WP_Agent_Execution_Principal;
+
+	return (bool) apply_filters( 'agents_access_permission', $allowed, $input );
+}
+
+/**
+ * Extract request scope fields forwarded to access helpers.
+ *
+ * @param array<string,mixed> $input Ability input.
+ * @return array<string,mixed>
+ */
+function agents_access_request_scope( array $input ): array {
+	$scope = array(
+		'request_context' => \AgentsAPI\AI\WP_Agent_Execution_Principal::REQUEST_CONTEXT_REST,
+	);
+
+	if ( array_key_exists( 'workspace_id', $input ) ) {
+		$scope['workspace_id'] = null !== $input['workspace_id'] ? (string) $input['workspace_id'] : null;
+	}
+
+	if ( array_key_exists( 'client_id', $input ) ) {
+		$scope['client_id'] = null !== $input['client_id'] ? (string) $input['client_id'] : null;
+	}
+
+	return $scope;
+}
+
+/**
+ * Input schema for `agents/can-access-agent`.
+ */
+function agents_can_access_agent_input_schema(): array {
+	return array(
+		'type'       => 'object',
+		'required'   => array( 'agent' ),
+		'properties' => array(
+			'agent'        => array(
+				'type'        => 'string',
+				'description' => 'Registered agent slug/id to check.',
+			),
+			'minimum_role' => agents_access_role_schema(),
+			'workspace_id' => array( 'type' => array( 'string', 'null' ) ),
+			'client_id'    => array( 'type' => array( 'string', 'null' ) ),
+		),
+	);
+}
+
+/**
+ * Output schema for `agents/can-access-agent`.
+ */
+function agents_can_access_agent_output_schema(): array {
+	return array(
+		'type'       => 'object',
+		'required'   => array( 'allowed', 'agent', 'minimum_role' ),
+		'properties' => array(
+			'allowed'      => array( 'type' => 'boolean' ),
+			'agent'        => array( 'type' => 'string' ),
+			'minimum_role' => agents_access_role_schema(),
+		),
+	);
+}
+
+/**
+ * Input schema for `agents/list-accessible-agents`.
+ */
+function agents_list_accessible_agents_input_schema(): array {
+	return array(
+		'type'       => 'object',
+		'properties' => array(
+			'minimum_role' => agents_access_role_schema(),
+			'workspace_id' => array( 'type' => array( 'string', 'null' ) ),
+			'client_id'    => array( 'type' => array( 'string', 'null' ) ),
+		),
+	);
+}
+
+/**
+ * Output schema for `agents/list-accessible-agents`.
+ */
+function agents_list_accessible_agents_output_schema(): array {
+	return array(
+		'type'       => 'object',
+		'required'   => array( 'agents' ),
+		'properties' => array(
+			'agents' => array(
+				'type'  => 'array',
+				'items' => array(
+					'type'       => 'object',
+					'required'   => array( 'slug', 'label' ),
+					'properties' => array(
+						'slug'        => array( 'type' => 'string' ),
+						'label'       => array( 'type' => 'string' ),
+						'description' => array( 'type' => 'string' ),
+						'meta'        => array( 'type' => 'object' ),
+					),
+				),
+			),
+		),
+	);
+}
+
+/**
+ * JSON schema fragment for access roles.
+ */
+function agents_access_role_schema(): array {
+	return array(
+		'type'        => 'string',
+		'enum'        => \WP_Agent_Access_Grant::roles(),
+		'default'     => \WP_Agent_Access_Grant::ROLE_VIEWER,
+		'description' => 'Minimum access role required for the check.',
+	);
+}

--- a/src/Auth/register-agent-access-abilities.php
+++ b/src/Auth/register-agent-access-abilities.php
@@ -9,7 +9,7 @@ namespace AgentsAPI\AI\Auth;
 
 defined( 'ABSPATH' ) || exit;
 
-const AGENTS_CAN_ACCESS_AGENT_ABILITY      = 'agents/can-access-agent';
+const AGENTS_CAN_ACCESS_AGENT_ABILITY       = 'agents/can-access-agent';
 const AGENTS_LIST_ACCESSIBLE_AGENTS_ABILITY = 'agents/list-accessible-agents';
 
 add_action(

--- a/tests/agents-access-ability-smoke.php
+++ b/tests/agents-access-ability-smoke.php
@@ -1,0 +1,158 @@
+<?php
+/**
+ * Pure-PHP smoke test for agent access helpers and abilities.
+ *
+ * Run with: php tests/agents-access-ability-smoke.php
+ *
+ * @package AgentsAPI\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+$failures = array();
+$passes   = 0;
+
+echo "agents-access-ability-smoke\n";
+
+require_once __DIR__ . '/agents-api-smoke-helpers.php';
+
+$GLOBALS['__agents_api_smoke_current_user_id'] = 7;
+$GLOBALS['__agents_api_smoke_abilities']       = array();
+$GLOBALS['__agents_api_smoke_categories']      = array();
+
+function get_current_user_id(): int {
+	return (int) $GLOBALS['__agents_api_smoke_current_user_id'];
+}
+
+function is_user_logged_in(): bool {
+	return get_current_user_id() > 0;
+}
+
+function wp_has_ability_category( string $category ): bool {
+	return isset( $GLOBALS['__agents_api_smoke_categories'][ $category ] );
+}
+
+function wp_register_ability_category( string $category, array $args ): void {
+	$GLOBALS['__agents_api_smoke_categories'][ $category ] = $args;
+}
+
+function wp_has_ability( string $ability ): bool {
+	return isset( $GLOBALS['__agents_api_smoke_abilities'][ $ability ] );
+}
+
+function wp_register_ability( string $ability, array $args ): void {
+	$GLOBALS['__agents_api_smoke_abilities'][ $ability ] = $args;
+}
+
+agents_api_smoke_require_module();
+
+add_action(
+	'wp_agents_api_init',
+	static function (): void {
+		wp_register_agent(
+			'editor-agent',
+			array(
+				'label'       => 'Editor Agent',
+				'description' => 'Edits posts.',
+				'meta'        => array( 'source_plugin' => 'tests' ),
+			)
+		);
+
+		wp_register_agent(
+			'admin-agent',
+			array(
+				'label'       => 'Admin Agent',
+				'description' => 'Administers the site.',
+			)
+		);
+	}
+);
+
+do_action( 'init' );
+
+$grant = new WP_Agent_Access_Grant( 'editor-agent', 7, WP_Agent_Access_Grant::ROLE_OPERATOR, 'site:42' );
+
+$access_store = new class( $grant ) implements WP_Agent_Access_Store {
+	/**
+	 * @param WP_Agent_Access_Grant $grant Test grant.
+	 */
+	public function __construct( private WP_Agent_Access_Grant $grant ) {}
+
+	public function grant_access( WP_Agent_Access_Grant $grant ): WP_Agent_Access_Grant {
+		$this->grant = $grant;
+		return $grant;
+	}
+
+	public function revoke_access( string $agent_id, int $user_id, ?string $workspace_id = null ): bool {
+		return $this->grant->agent_id === $agent_id && $this->grant->user_id === $user_id && $this->grant->workspace_id === $workspace_id;
+	}
+
+	public function get_access( string $agent_id, int $user_id, ?string $workspace_id = null ): ?WP_Agent_Access_Grant {
+		return $this->grant->agent_id === $agent_id && $this->grant->user_id === $user_id && $this->grant->workspace_id === $workspace_id ? $this->grant : null;
+	}
+
+	public function get_agent_ids_for_user( int $user_id, ?string $minimum_role = null, ?string $workspace_id = null ): array {
+		if ( $this->grant->user_id !== $user_id || $this->grant->workspace_id !== $workspace_id ) {
+			return array();
+		}
+
+		return null === $minimum_role || $this->grant->role_meets( $minimum_role ) ? array( $this->grant->agent_id ) : array();
+	}
+
+	public function get_users_for_agent( string $agent_id, ?string $workspace_id = null ): array {
+		return $this->grant->agent_id === $agent_id && $this->grant->workspace_id === $workspace_id ? array( $this->grant ) : array();
+	}
+};
+
+add_filter(
+	'wp_agent_access_store',
+	static function ( $store ) use ( $access_store ) {
+		return $store instanceof WP_Agent_Access_Store ? $store : $access_store;
+	}
+);
+
+agents_api_smoke_assert_equals( true, class_exists( 'WP_Agent_Access' ), 'access helper class is available', $failures, $passes );
+agents_api_smoke_assert_equals( $access_store, WP_Agent_Access::get_store(), 'access store resolves through filter', $failures, $passes );
+
+$principal = WP_Agent_Access::get_current_principal( array( 'workspace_id' => 'site:42' ) );
+agents_api_smoke_assert_equals( 7, $principal->acting_user_id, 'current principal falls back to current user', $failures, $passes );
+agents_api_smoke_assert_equals( 'site:42', $principal->workspace_id, 'current principal carries workspace scope', $failures, $passes );
+
+agents_api_smoke_assert_equals( true, WP_Agent_Access::can_current_principal_access_agent( 'editor-agent', WP_Agent_Access_Grant::ROLE_VIEWER, array( 'workspace_id' => 'site:42' ) ), 'current principal can access granted agent at viewer role', $failures, $passes );
+agents_api_smoke_assert_equals( true, WP_Agent_Access::can_current_principal_access_agent( 'editor-agent', WP_Agent_Access_Grant::ROLE_OPERATOR, array( 'workspace_id' => 'site:42' ) ), 'current principal can access granted agent at operator role', $failures, $passes );
+agents_api_smoke_assert_equals( false, WP_Agent_Access::can_current_principal_access_agent( 'editor-agent', WP_Agent_Access_Grant::ROLE_ADMIN, array( 'workspace_id' => 'site:42' ) ), 'current principal cannot access granted agent above grant role', $failures, $passes );
+
+$agents = WP_Agent_Access::list_accessible_agents_for_current_principal( WP_Agent_Access_Grant::ROLE_VIEWER, array( 'workspace_id' => 'site:42' ) );
+agents_api_smoke_assert_equals( 'editor-agent', $agents[0]['slug'] ?? null, 'accessible agents list contains granted registered agent', $failures, $passes );
+agents_api_smoke_assert_equals( 'Editor Agent', $agents[0]['label'] ?? null, 'accessible agents include agent label', $failures, $passes );
+
+$can_access = AgentsAPI\AI\Auth\agents_can_access_agent(
+	array(
+		'agent'        => 'editor-agent',
+		'minimum_role' => WP_Agent_Access_Grant::ROLE_OPERATOR,
+		'workspace_id' => 'site:42',
+	)
+);
+agents_api_smoke_assert_equals( true, $can_access['allowed'] ?? false, 'can-access ability returns allowed true for grant', $failures, $passes );
+
+$cannot_access = AgentsAPI\AI\Auth\agents_can_access_agent(
+	array(
+		'agent'        => 'editor-agent',
+		'minimum_role' => WP_Agent_Access_Grant::ROLE_ADMIN,
+		'workspace_id' => 'site:42',
+	)
+);
+agents_api_smoke_assert_equals( false, $cannot_access['allowed'] ?? true, 'can-access ability returns allowed false below minimum role', $failures, $passes );
+
+$ability_list = AgentsAPI\AI\Auth\agents_list_accessible_agents( array( 'workspace_id' => 'site:42' ) );
+agents_api_smoke_assert_equals( 'editor-agent', $ability_list['agents'][0]['slug'] ?? null, 'list-accessible ability returns granted registered agent', $failures, $passes );
+
+do_action( 'wp_abilities_api_categories_init' );
+do_action( 'wp_abilities_api_init' );
+
+agents_api_smoke_assert_equals( true, wp_has_ability( AgentsAPI\AI\Auth\AGENTS_CAN_ACCESS_AGENT_ABILITY ), 'can-access ability registers with Abilities API', $failures, $passes );
+agents_api_smoke_assert_equals( true, wp_has_ability( AgentsAPI\AI\Auth\AGENTS_LIST_ACCESSIBLE_AGENTS_ABILITY ), 'list-accessible ability registers with Abilities API', $failures, $passes );
+
+agents_api_smoke_finish( 'Agents API access abilities', $failures, $passes );


### PR DESCRIPTION
## Summary
- Adds a host-store discovery seam for `WP_Agent_Access_Store` via `wp_agent_access_store`.
- Adds current-principal access helpers plus `agents/can-access-agent` and `agents/list-accessible-agents` Abilities API registrations.
- Adds pure-PHP smoke coverage and includes it in `composer test`.

Fixes #160.

## Testing
- `php -l src/Auth/class-wp-agent-access.php`
- `php -l src/Auth/register-agent-access-abilities.php`
- `php -l tests/agents-access-ability-smoke.php`
- `php tests/agents-access-ability-smoke.php`
- `composer test`
- `homeboy lint --path /Users/chubes/Developer/agents-api@agent-access-abilities --extension wordpress --errors-only`
- `homeboy test --path /Users/chubes/Developer/agents-api@agent-access-abilities --extension wordpress`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the access helper/ability implementation and smoke tests; Chris remains responsible for review and merge decisions.