### PR TITLE
Allow principal-owned conversation session abilities

### DIFF
--- a/src/Transcripts/register-agents-conversation-session-abilities.php
+++ b/src/Transcripts/register-agents-conversation-session-abilities.php
@@ -252,6 +252,11 @@ function agents_delete_conversation_session( array $input ) {
 
 function agents_conversation_sessions_permission( array $input ): bool {
 	$allowed = function_exists( 'current_user_can' ) ? current_user_can( 'read' ) : false;
+	if ( ! $allowed ) {
+		$principal = agents_conversation_sessions_principal( $input );
+		$allowed   = $principal instanceof WP_Agent_Execution_Principal && null !== $principal->conversation_owner();
+	}
+
 	return (bool) apply_filters( 'agents_conversation_sessions_permission', $allowed, $input );
 }
 


### PR DESCRIPTION
## Summary
- Permit conversation-session abilities when the request carries a valid execution principal with a conversation owner.
- Keep logged-in `read` capability behavior unchanged.

## Testing
- `php -l src/Transcripts/register-agents-conversation-session-abilities.php`
- `php tests/agents-conversation-session-abilities-smoke.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosing the anonymous session-list permission failure and drafting the minimal permission bridge fix; Chris remains responsible for review and validation.