### PR TITLE
Fix principal-owned session reads

### DIFF
--- a/agents-api.php
+++ b/agents-api.php
@@ -61,6 +61,7 @@ require_once AGENTS_API_PATH . 'src/Identity/class-wp-agent-materialized-identit
 require_once AGENTS_API_PATH . 'src/Identity/class-wp-agent-identity-store.php';
 require_once AGENTS_API_PATH . 'src/Transcripts/class-wp-agent-conversation-store.php';
 require_once AGENTS_API_PATH . 'src/Transcripts/class-wp-agent-principal-conversation-store.php';
+require_once AGENTS_API_PATH . 'src/Transcripts/class-wp-agent-principal-conversation-session-reader.php';
 require_once AGENTS_API_PATH . 'src/Transcripts/class-wp-agent-conversation-sessions.php';
 require_once AGENTS_API_PATH . 'src/Transcripts/class-wp-agent-conversation-lock.php';
 require_once AGENTS_API_PATH . 'src/Transcripts/class-wp-agent-null-conversation-lock.php';

--- a/src/Transcripts/class-wp-agent-principal-conversation-session-reader.php
+++ b/src/Transcripts/class-wp-agent-principal-conversation-session-reader.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Principal-owned conversation session read contract.
+ *
+ * @package AgentsAPI
+ */
+
+namespace AgentsAPI\Core\Database\Chat;
+
+use AgentsAPI\Core\Workspace\WP_Agent_Workspace_Scope;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Optional owner-aware single-session read contract.
+ *
+ * Stores that keep opaque owner keys hashed can implement this to verify a
+ * session ID belongs to a principal without exposing the raw owner key in
+ * generic session rows.
+ */
+interface WP_Agent_Principal_Conversation_Session_Reader extends WP_Agent_Principal_Conversation_Store {
+
+	/**
+	 * Read one transcript session for a canonical principal owner.
+	 *
+	 * @param WP_Agent_Workspace_Scope      $workspace  Workspace owning the session.
+	 * @param array{type:string,key:string} $owner      Canonical principal owner.
+	 * @param string                        $session_id Session ID.
+	 * @return array<string,mixed>|null Session row, or null when missing/not owned.
+	 */
+	public function get_session_for_owner( WP_Agent_Workspace_Scope $workspace, array $owner, string $session_id ): ?array;
+}

--- a/src/Transcripts/register-agents-conversation-session-abilities.php
+++ b/src/Transcripts/register-agents-conversation-session-abilities.php
@@ -260,7 +260,7 @@ function agents_conversation_sessions_permission( array $input ): bool {
 	return (bool) apply_filters( 'agents_conversation_sessions_permission', $allowed, $input );
 }
 
-/** @return array{store:WP_Agent_Conversation_Store,principal:WP_Agent_Execution_Principal,owner:array{type:string,key:string}}|\WP_Error */
+/** @return array{store:WP_Agent_Conversation_Store,principal:WP_Agent_Execution_Principal,owner:array{type:string,key:string},input:array}|\WP_Error */
 function agents_conversation_sessions_context( array $input ) {
 	$principal = agents_conversation_sessions_principal( $input );
 	if ( ! $principal instanceof WP_Agent_Execution_Principal ) {
@@ -285,6 +285,7 @@ function agents_conversation_sessions_context( array $input ) {
 		'store'     => $store,
 		'principal' => $principal,
 		'owner'     => $owner,
+		'input'     => $input,
 	);
 }
 
@@ -381,6 +382,20 @@ function agents_conversation_sessions_default_workspace_id(): string {
 function agents_conversation_sessions_owned_session( string $session_id, array $context ) {
 	if ( '' === trim( $session_id ) ) {
 		return new \WP_Error( 'agents_conversation_session_invalid_id', 'Conversation session ID must be a non-empty string.' );
+	}
+
+	$workspace = agents_conversation_sessions_workspace( is_array( $context['input'] ?? null ) ? $context['input'] : array() );
+	if ( is_wp_error( $workspace ) ) {
+		return $workspace;
+	}
+
+	if ( $context['store'] instanceof WP_Agent_Principal_Conversation_Session_Reader ) {
+		$session = $context['store']->get_session_for_owner( $workspace, $context['owner'], $session_id );
+		if ( ! is_array( $session ) ) {
+			return new \WP_Error( 'agents_conversation_session_not_found', 'Conversation session not found.' );
+		}
+
+		return $session;
 	}
 
 	$session = $context['store']->get_session( $session_id );

--- a/tests/agents-conversation-session-abilities-smoke.php
+++ b/tests/agents-conversation-session-abilities-smoke.php
@@ -103,10 +103,12 @@ require_once __DIR__ . '/../src/Workspace/class-wp-agent-workspace-scope.php';
 require_once __DIR__ . '/../src/Runtime/class-wp-agent-execution-principal.php';
 require_once __DIR__ . '/../src/Transcripts/class-wp-agent-conversation-store.php';
 require_once __DIR__ . '/../src/Transcripts/class-wp-agent-principal-conversation-store.php';
+require_once __DIR__ . '/../src/Transcripts/class-wp-agent-principal-conversation-session-reader.php';
 require_once __DIR__ . '/../src/Transcripts/class-wp-agent-conversation-sessions.php';
 require_once __DIR__ . '/../src/Transcripts/register-agents-conversation-session-abilities.php';
 
 use AgentsAPI\AI\WP_Agent_Execution_Principal;
+use AgentsAPI\Core\Database\Chat\WP_Agent_Principal_Conversation_Session_Reader;
 use AgentsAPI\Core\Database\Chat\WP_Agent_Principal_Conversation_Store;
 use AgentsAPI\Core\Database\Chat\WP_Agent_Conversation_Store;
 use AgentsAPI\Core\Workspace\WP_Agent_Workspace_Scope;
@@ -235,7 +237,7 @@ $deleted = agents_delete_conversation_session( array( 'principal' => $principal,
 smoke_assert( true, $deleted['deleted'] ?? false, 'delete delegates to store', $failures, $passes );
 smoke_assert( null, $store->get_session( 's-1' ), 'delete removes session', $failures, $passes );
 
-$principal_store = new class() implements WP_Agent_Principal_Conversation_Store {
+$principal_store = new class() implements WP_Agent_Principal_Conversation_Session_Reader {
 	/** @var array<string,array<string,mixed>> */
 	public array $sessions = array();
 
@@ -267,6 +269,15 @@ $principal_store = new class() implements WP_Agent_Principal_Conversation_Store 
 		);
 	}
 
+	public function get_session_for_owner( WP_Agent_Workspace_Scope $workspace, array $owner, string $session_id ): ?array {
+		$session = $this->sessions[ $session_id ] ?? null;
+		if ( ! is_array( $session ) ) {
+			return null;
+		}
+
+		return $session['workspace_type'] === $workspace->workspace_type && $session['workspace_id'] === $workspace->workspace_id && $session['owner_type'] === $owner['type'] && $session['owner_key'] === $owner['key'] ? $session : null;
+	}
+
 	public function get_recent_pending_session_for_owner( WP_Agent_Workspace_Scope $workspace, array $owner, int $seconds = 600, string $context = 'chat', ?int $token_id = null ): ?array {
 		unset( $workspace, $owner, $seconds, $context, $token_id );
 		return null;
@@ -296,9 +307,12 @@ smoke_assert( 'browser:one', $principal_store->sessions['p-1']['owner_key'] ?? n
 $audience_listed = agents_list_conversation_sessions( array( 'principal' => $audience_with_owner, 'workspace' => array( 'workspace_type' => 'site', 'workspace_id' => '42' ) ) );
 smoke_assert( 'p-1', $audience_listed['sessions'][0]['session_id'] ?? null, 'principal store lists matching owner only', $failures, $passes );
 
+$audience_loaded = agents_get_conversation_session( array( 'principal' => $audience_with_owner, 'session_id' => 'p-1', 'workspace' => array( 'workspace_type' => 'site', 'workspace_id' => '42' ) ) );
+smoke_assert( 'p-1', $audience_loaded['session']['session_id'] ?? null, 'principal store loads matching owner session', $failures, $passes );
+
 $other_audience = WP_Agent_Execution_Principal::audience( 'audience:public', 'demo-agent', WP_Agent_Execution_Principal::REQUEST_CONTEXT_REST, array(), null, null, array(), 'browser:two' );
-$blocked_owner  = agents_get_conversation_session( array( 'principal' => $other_audience, 'session_id' => 'p-1' ) );
-smoke_assert( 'agents_conversation_session_forbidden', $blocked_owner instanceof WP_Error ? $blocked_owner->get_error_code() : '', 'principal owner key blocks other audience sessions', $failures, $passes );
+$blocked_owner  = agents_get_conversation_session( array( 'principal' => $other_audience, 'session_id' => 'p-1', 'workspace' => array( 'workspace_type' => 'site', 'workspace_id' => '42' ) ) );
+smoke_assert( 'agents_conversation_session_not_found', $blocked_owner instanceof WP_Error ? $blocked_owner->get_error_code() : '', 'principal owner key blocks other audience sessions', $failures, $passes );
 
 do_action( 'wp_abilities_api_categories_init' );
 do_action( 'wp_abilities_api_init' );


### PR DESCRIPTION
## Summary
- Add an optional owner-aware single-session read contract for principal-owned transcript stores.
- Use the owner-aware read path when loading one conversation session, so stores with hashed owner keys can verify ownership internally.
- Extend the conversation session smoke test to cover matching-owner loads and cross-owner denial.

## Testing
- php tests/agents-conversation-session-abilities-smoke.php
- homeboy lint --changed-since origin/main
- homeboy test --changed-since origin/main

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the anonymous session load ownership gap, drafted the contract/test change, and ran scoped verification; Chris remains responsible for review and merge.