### PR TITLE
Add host-discoverable memory store resolver

### DIFF
--- a/agents-api.php
+++ b/agents-api.php
@@ -123,6 +123,7 @@ require_once AGENTS_API_PATH . 'src/Memory/class-wp-agent-memory-list-entry.php'
 require_once AGENTS_API_PATH . 'src/Memory/class-wp-agent-memory-read-result.php';
 require_once AGENTS_API_PATH . 'src/Memory/class-wp-agent-memory-write-result.php';
 require_once AGENTS_API_PATH . 'src/Memory/class-wp-agent-memory-store.php';
+require_once AGENTS_API_PATH . 'src/Memory/class-wp-agent-memory-stores.php';
 require_once AGENTS_API_PATH . 'src/Guidelines/guidelines.php';
 require_once AGENTS_API_PATH . 'src/Guidelines/class-wp-guidelines-substrate.php';
 require_once AGENTS_API_PATH . 'src/Channels/class-wp-agent-external-message.php';

--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,7 @@
       "php tests/pending-action-abilities-smoke.php",
       "php tests/identity-smoke.php",
       "php tests/memory-metadata-contract-smoke.php",
+      "php tests/memory-store-resolver-smoke.php",
       "php tests/approval-action-value-shape-smoke.php",
       "php tests/workspace-scope-smoke.php",
       "php tests/compaction-item-smoke.php",

--- a/src/Memory/class-wp-agent-memory-stores.php
+++ b/src/Memory/class-wp-agent-memory-stores.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Host-store discovery for generic agent memory.
+ *
+ * @package AgentsAPI
+ */
+
+namespace AgentsAPI\Core\FilesRepository;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Resolves the host-provided agent memory store.
+ */
+final class WP_Agent_Memory_Stores {
+
+	/**
+	 * Resolve the host-provided memory store.
+	 *
+	 * Host plugins can pass a store directly in `$context['memory_store']`
+	 * or provide one through the `wp_agent_memory_store` filter.
+	 *
+	 * @param array<string,mixed> $context Host-owned request context.
+	 * @return WP_Agent_Memory_Store|null
+	 */
+	public static function get_store( array $context = array() ): ?WP_Agent_Memory_Store {
+		if ( isset( $context['memory_store'] ) && $context['memory_store'] instanceof WP_Agent_Memory_Store ) {
+			return $context['memory_store'];
+		}
+
+		$store = function_exists( 'apply_filters' ) ? apply_filters( 'wp_agent_memory_store', null, $context ) : null;
+		return $store instanceof WP_Agent_Memory_Store ? $store : null;
+	}
+}

--- a/tests/memory-store-resolver-smoke.php
+++ b/tests/memory-store-resolver-smoke.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Pure-PHP smoke test for memory store resolver semantics.
+ *
+ * Run with: php tests/memory-store-resolver-smoke.php
+ *
+ * @package AgentsAPI\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+$failures = array();
+$passes   = 0;
+
+echo "agents-api-memory-store-resolver-smoke\n";
+
+require_once __DIR__ . '/agents-api-smoke-helpers.php';
+agents_api_smoke_require_module();
+
+$store = new class() implements AgentsAPI\Core\FilesRepository\WP_Agent_Memory_Store {
+	public function capabilities(): AgentsAPI\Core\FilesRepository\WP_Agent_Memory_Store_Capabilities {
+		return AgentsAPI\Core\FilesRepository\WP_Agent_Memory_Store_Capabilities::none();
+	}
+
+	public function read( AgentsAPI\Core\FilesRepository\WP_Agent_Memory_Scope $scope, array $metadata_fields = AgentsAPI\Core\FilesRepository\WP_Agent_Memory_Metadata::FIELDS ): AgentsAPI\Core\FilesRepository\WP_Agent_Memory_Read_Result {
+		unset( $scope, $metadata_fields );
+		return AgentsAPI\Core\FilesRepository\WP_Agent_Memory_Read_Result::not_found();
+	}
+
+	public function write( AgentsAPI\Core\FilesRepository\WP_Agent_Memory_Scope $scope, string $content, ?string $if_match = null, ?AgentsAPI\Core\FilesRepository\WP_Agent_Memory_Metadata $metadata = null ): AgentsAPI\Core\FilesRepository\WP_Agent_Memory_Write_Result {
+		unset( $scope, $content, $if_match, $metadata );
+		return AgentsAPI\Core\FilesRepository\WP_Agent_Memory_Write_Result::ok( '', 0 );
+	}
+
+	public function exists( AgentsAPI\Core\FilesRepository\WP_Agent_Memory_Scope $scope ): bool {
+		unset( $scope );
+		return false;
+	}
+
+	public function delete( AgentsAPI\Core\FilesRepository\WP_Agent_Memory_Scope $scope ): AgentsAPI\Core\FilesRepository\WP_Agent_Memory_Write_Result {
+		unset( $scope );
+		return AgentsAPI\Core\FilesRepository\WP_Agent_Memory_Write_Result::ok( '', 0 );
+	}
+
+	public function list_layer( AgentsAPI\Core\FilesRepository\WP_Agent_Memory_Scope $scope_query, ?AgentsAPI\Core\FilesRepository\WP_Agent_Memory_Query $query = null ): array {
+		unset( $scope_query, $query );
+		return array();
+	}
+
+	public function list_subtree( AgentsAPI\Core\FilesRepository\WP_Agent_Memory_Scope $scope_query, string $prefix, ?AgentsAPI\Core\FilesRepository\WP_Agent_Memory_Query $query = null ): array {
+		unset( $scope_query, $prefix, $query );
+		return array();
+	}
+};
+
+echo "\n[1] Direct context store wins:\n";
+$resolved = AgentsAPI\Core\FilesRepository\WP_Agent_Memory_Stores::get_store( array( 'memory_store' => $store ) );
+agents_api_smoke_assert_equals( true, $resolved === $store, 'context memory_store is returned directly', $failures, $passes );
+
+echo "\n[2] Filter-provided store is resolved:\n";
+add_filter(
+	'wp_agent_memory_store',
+	static function ( $candidate, array $context ) use ( $store ) {
+		unset( $candidate );
+		return ! empty( $context['use_store'] ) ? $store : null;
+	},
+	10,
+	2
+);
+
+$resolved = AgentsAPI\Core\FilesRepository\WP_Agent_Memory_Stores::get_store( array( 'use_store' => true ) );
+agents_api_smoke_assert_equals( true, $resolved === $store, 'wp_agent_memory_store filter can provide the store', $failures, $passes );
+
+echo "\n[3] Missing or invalid stores return null:\n";
+agents_api_smoke_assert_equals( null, AgentsAPI\Core\FilesRepository\WP_Agent_Memory_Stores::get_store(), 'missing store resolves to null', $failures, $passes );
+agents_api_smoke_assert_equals( null, AgentsAPI\Core\FilesRepository\WP_Agent_Memory_Stores::get_store( array( 'memory_store' => new stdClass() ) ), 'invalid context store resolves to null', $failures, $passes );
+
+agents_api_smoke_finish( 'Agents API memory store resolver', $failures, $passes );


### PR DESCRIPTION
## Summary

Adds `AgentsAPI\Core\FilesRepository\WP_Agent_Memory_Stores::get_store( array $context = [] )` as the memory-store equivalent of the existing host-store discovery patterns in Agents API.

Resolution order:

1. Use an explicit `$context['memory_store']` when it is a `WP_Agent_Memory_Store`.
2. Otherwise resolve through the host filter `wp_agent_memory_store`.
3. Return `null` for missing or invalid stores.

## Why this is needed

ClawPress implements a durable `WP_Agent_Memory_Store` adapter for its plugin-managed memory model, including long-term memory and daily memory files. The ClawPress Agents API integration registers that store through a host filter:

- Integration branch: https://github.com/bradvin/clawpress/tree/agents-api
- Filter registration: https://github.com/bradvin/clawpress/blob/agents-api/includes/class-agents-api.php#L80-L90
- Store resolver: https://github.com/bradvin/clawpress/blob/agents-api/includes/class-agents-api.php#L282-L296

This lets Agents API runtime/context code request memory through a substrate contract instead of through ClawPress-specific helpers or option access.

## Why this belongs in Agents API

The missing piece is not ClawPress-specific behavior; it is the generic discovery contract for any host that provides a `WP_Agent_Memory_Store`.

Agents API already has similar product-neutral discovery surfaces for other host-owned stores:

- Conversation stores via `WP_Agent_Conversation_Sessions::get_store()` and `wp_agent_conversation_store`.
- Access stores via `WP_Agent_Access::get_store()` and `wp_agent_access_store`.
- Pending action stores via `agents_get_pending_action_store()` and `wp_agent_pending_action_store`.

Without a memory-store resolver, each consumer has to duplicate the same filter name and type guard, or a product plugin has to become the place where substrate-level store selection happens. That makes memory different from the rest of the Agents API persistence contracts and pushes generic integration logic into ClawPress.

## Changes

- Loads the resolver from `agents-api.php`.
- Adds `src/Memory/class-wp-agent-memory-stores.php`.
- Adds `tests/memory-store-resolver-smoke.php` for explicit context store, filter-provided store, and invalid/missing store behavior.
- Adds the smoke test to `composer test`.

## Evidence

- Fork review issue: https://github.com/bradvin/agents-api/issues/1
- ClawPress uses the host memory-store registration linked above.
- `composer test` passes on branch `bradvin:feature/memory-store-resolver` on May 19, 2026.
