### PR TITLE
Preserve provider tool-call IDs through mediated execution

### DIFF
--- a/src/Runtime/class-wp-agent-conversation-loop.php
+++ b/src/Runtime/class-wp-agent-conversation-loop.php
@@ -345,18 +345,20 @@ class WP_Agent_Conversation_Loop {
 			$messages[] = WP_Agent_Message::text( 'assistant', $result['content'] );
 		}
 
-		foreach ( $tool_calls as $raw_call ) {
-			$tool_name  = $raw_call['name'] ?? $raw_call['tool_name'] ?? '';
-			$parameters = $raw_call['parameters'] ?? array();
+		foreach ( $tool_calls as $index => $raw_call ) {
+			$tool_name    = $raw_call['name'] ?? $raw_call['tool_name'] ?? '';
+			$parameters   = $raw_call['parameters'] ?? array();
+			$tool_call_id = self::resolve_tool_call_id( is_array( $raw_call ) ? $raw_call : array(), $turn, (int) $index + 1 );
 
 			if ( ! is_string( $tool_name ) || '' === $tool_name ) {
 				continue;
 			}
 
 			self::emit_event( $on_event, 'tool_call', array(
-				'turn'       => $turn,
-				'tool_name'  => $tool_name,
-				'parameters' => $parameters,
+				'turn'         => $turn,
+				'tool_name'    => $tool_name,
+				'tool_call_id' => $tool_call_id,
+				'parameters'   => $parameters,
 			) );
 
 			// Add tool-call message to transcript.
@@ -364,32 +366,37 @@ class WP_Agent_Conversation_Loop {
 				'Calling ' . $tool_name,
 				$tool_name,
 				is_array( $parameters ) ? $parameters : array(),
-				$turn
+				$turn,
+				array( 'tool_call_id' => $tool_call_id )
 			);
 
 			// Execute through WP_Agent_Tool_Execution_Core.
-			$exec_result = $core->executeTool(
+			$tool_context                 = $turn_context;
+			$tool_context['tool_call_id'] = $tool_call_id;
+			$exec_result                  = $core->executeTool(
 				$tool_name,
 				is_array( $parameters ) ? $parameters : array(),
 				$declarations,
 				$executor,
-				$turn_context
+				$tool_context
 			);
 
 			$tool_def = $declarations[ $tool_name ] ?? null;
 
 			self::emit_event( $on_event, 'tool_result', array(
-				'turn'      => $turn,
-				'tool_name' => $tool_name,
-				'success'   => (bool) ( $exec_result['success'] ?? false ),
+				'turn'         => $turn,
+				'tool_name'    => $tool_name,
+				'tool_call_id' => $tool_call_id,
+				'success'      => (bool) ( $exec_result['success'] ?? false ),
 			) );
 
 			// Build the tool_execution_results entry.
 			$tool_execution_results[] = array(
-				'tool_name'  => $tool_name,
-				'result'     => $exec_result,
-				'parameters' => is_array( $parameters ) ? $parameters : array(),
-				'turn_count' => $turn,
+				'tool_name'    => $tool_name,
+				'tool_call_id' => $tool_call_id,
+				'result'       => $exec_result,
+				'parameters'   => is_array( $parameters ) ? $parameters : array(),
+				'turn_count'   => $turn,
 			);
 
 			$tool_audit_events[] = self::tool_audit_event(
@@ -406,10 +413,14 @@ class WP_Agent_Conversation_Loop {
 				? self::json_encode_safe( $exec_result['result'] ?? array() )
 				: ( $exec_result['error'] ?? 'Tool execution failed.' );
 
+			$tool_result_payload                 = $exec_result;
+			$tool_result_payload['tool_call_id'] = $tool_call_id;
+
 			$messages[] = WP_Agent_Message::toolResult(
 				is_string( $result_content ) ? $result_content : '',
 				$tool_name,
-				$exec_result
+				$tool_result_payload,
+				array( 'tool_call_id' => $tool_call_id )
 			);
 
 			// Increment tool-call budgets: total and per-tool-name.
@@ -462,6 +473,23 @@ class WP_Agent_Conversation_Loop {
 			'conversation_complete'  => $complete,
 			'exceeded_budget'        => $exceeded_budget,
 		);
+	}
+
+	/**
+	 * Resolve a stable tool-call identifier for transcript pairing.
+	 *
+	 * @param array $raw_call Raw tool call emitted by a turn runner.
+	 * @param int   $turn Current turn number.
+	 * @param int   $sequence Tool-call sequence in this turn.
+	 * @return string
+	 */
+	private static function resolve_tool_call_id( array $raw_call, int $turn, int $sequence ): string {
+		$id = $raw_call['id'] ?? $raw_call['tool_call_id'] ?? '';
+		if ( is_string( $id ) && '' !== trim( $id ) ) {
+			return trim( $id );
+		}
+
+		return sprintf( 'tool-call-%d-%d', max( 1, $turn ), max( 1, $sequence ) );
 	}
 
 	/**

--- a/src/Tools/class-wp-agent-tool-call.php
+++ b/src/Tools/class-wp-agent-tool-call.php
@@ -36,10 +36,18 @@ class WP_Agent_Tool_Call {
 			$metadata = array();
 		}
 
-		return array(
+		$normalized = array(
 			'tool_name'  => $tool_name,
 			'parameters' => $parameters,
 			'metadata'   => $metadata,
 		);
+
+		$id = $tool_call['id'] ?? $tool_call['tool_call_id'] ?? $metadata['tool_call_id'] ?? '';
+		if ( is_string( $id ) && '' !== trim( $id ) ) {
+			$normalized['id'] = trim( $id );
+			$normalized['metadata']['tool_call_id'] = $normalized['id'];
+		}
+
+		return $normalized;
 	}
 }

--- a/src/Tools/class-wp-agent-tool-execution-core.php
+++ b/src/Tools/class-wp-agent-tool-execution-core.php
@@ -50,17 +50,22 @@ class WP_Agent_Tool_Execution_Core {
 			);
 		}
 
+		$tool_call = array(
+			'tool_name'  => $tool_name,
+			'parameters' => $parameters,
+			'metadata'   => array(
+				'source' => $tool_definition['source'] ?? WP_Agent_Tool_Declaration::sourceFromName( $tool_name ),
+			),
+		);
+
+		$tool_call_id = $context['tool_call_id'] ?? '';
+		if ( is_string( $tool_call_id ) && '' !== trim( $tool_call_id ) ) {
+			$tool_call['id'] = trim( $tool_call_id );
+		}
+
 		return array(
 			'ready'      => true,
-			'tool_call'  => WP_Agent_Tool_Call::normalize(
-				array(
-					'tool_name'  => $tool_name,
-					'parameters' => $parameters,
-					'metadata'   => array(
-						'source' => $tool_definition['source'] ?? WP_Agent_Tool_Declaration::sourceFromName( $tool_name ),
-					),
-				)
-			),
+			'tool_call'  => WP_Agent_Tool_Call::normalize( $tool_call ),
 			'tool_def'   => $tool_definition,
 		);
 	}

--- a/tests/conversation-loop-tool-execution-smoke.php
+++ b/tests/conversation-loop-tool-execution-smoke.php
@@ -65,12 +65,13 @@ $result = AgentsAPI\AI\WP_Agent_Conversation_Loop::run(
 		return array(
 			'messages'   => $messages,
 			'content'    => 'I will summarize that for you.',
-			'tool_calls' => array(
-				array(
-					'name'       => 'client/summarize',
-					'parameters' => array( 'text' => 'hello world' ),
+				'tool_calls' => array(
+					array(
+						'id'         => 'call_123',
+						'name'       => 'client/summarize',
+						'parameters' => array( 'text' => 'hello world' ),
+					),
 				),
-			),
 		);
 	},
 	array(
@@ -80,11 +81,13 @@ $result = AgentsAPI\AI\WP_Agent_Conversation_Loop::run(
 	)
 );
 
-agents_api_smoke_assert_equals( 1, count( $executor->executed ), 'tool executor was called once', $failures, $passes );
-agents_api_smoke_assert_equals( 'client/summarize', $executor->executed[0]['tool_name'], 'tool executor received correct tool name', $failures, $passes );
-agents_api_smoke_assert_equals( 1, count( $result['tool_execution_results'] ), 'result contains one tool execution result', $failures, $passes );
-agents_api_smoke_assert_equals( 'client/summarize', $result['tool_execution_results'][0]['tool_name'], 'tool execution result has correct tool name', $failures, $passes );
-agents_api_smoke_assert_equals( 'HELLO WORLD', $result['tool_execution_results'][0]['result']['result']['summary'], 'tool execution result carries executor payload', $failures, $passes );
+	agents_api_smoke_assert_equals( 1, count( $executor->executed ), 'tool executor was called once', $failures, $passes );
+	agents_api_smoke_assert_equals( 'client/summarize', $executor->executed[0]['tool_name'], 'tool executor received correct tool name', $failures, $passes );
+	agents_api_smoke_assert_equals( 'call_123', $executor->executed[0]['id'] ?? '', 'tool executor received provider tool call id', $failures, $passes );
+	agents_api_smoke_assert_equals( 1, count( $result['tool_execution_results'] ), 'result contains one tool execution result', $failures, $passes );
+	agents_api_smoke_assert_equals( 'client/summarize', $result['tool_execution_results'][0]['tool_name'], 'tool execution result has correct tool name', $failures, $passes );
+	agents_api_smoke_assert_equals( 'call_123', $result['tool_execution_results'][0]['tool_call_id'] ?? '', 'tool execution result preserves provider tool call id', $failures, $passes );
+	agents_api_smoke_assert_equals( 'HELLO WORLD', $result['tool_execution_results'][0]['result']['result']['summary'], 'tool execution result carries executor payload', $failures, $passes );
 agents_api_smoke_assert_equals( 1, count( $result['tool_audit_events'] ), 'result contains one tool audit event', $failures, $passes );
 agents_api_smoke_assert_equals( 'tool_call', $result['tool_audit_events'][0]['type'], 'tool audit event has stable type', $failures, $passes );
 agents_api_smoke_assert_equals( 'client/summarize', $result['tool_audit_events'][0]['tool_name'], 'tool audit event has correct tool name', $failures, $passes );


### PR DESCRIPTION
## Summary

Preserves provider tool-call IDs through Agents API's mediated tool execution path.

Before this change, a turn runner could return a tool call with a provider-issued `id`, but the mediation path normalized/prepared/executed the call without carrying that ID into the executor, transcript messages, lifecycle events, or `tool_execution_results`. This keeps the ID as the correlation key across the tool call and tool result.

## Why this is needed

ClawPress bridges provider function calls into `WP_Agent_Conversation_Loop`. It reads the provider function-call ID and emits Agents API tool calls with that ID:

- Integration branch: https://github.com/bradvin/clawpress/tree/agents-api
- Provider function call -> Agents API tool call: https://github.com/bradvin/clawpress/blob/agents-api/includes/helpers/class-agent-loop-helper.php#L995-L1017
- ClawPress runs the Agents API loop here: https://github.com/bradvin/clawpress/blob/agents-api/includes/helpers/class-agent-loop-helper.php#L834-L858

After Agents API executes tools, ClawPress appends provider-facing function responses using the matching tool-call ID:

- Agents API tool result -> provider function response: https://github.com/bradvin/clawpress/blob/agents-api/includes/helpers/class-agent-loop-helper.php#L948-L985

That pairing matters because provider APIs commonly require the tool/function response to reference the exact tool-call ID originally emitted by the model. It also lets ClawPress avoid duplicating already-synced tool results when a multi-turn loop is replayed into the provider conversation.

## Why this belongs in Agents API

Once the provider ID enters `WP_Agent_Conversation_Loop`, the substrate owns the mediation sequence: normalize call, validate parameters, execute through the adapter, emit lifecycle events, add tool-call/tool-result transcript messages, and return `tool_execution_results`.

ClawPress can invent a fallback ID after the fact, but it cannot reconstruct the provider-issued ID if the Agents API mediation layer drops it. A fallback ID is not equivalent for providers that validate tool-result pairing by ID. The correlation key is part of the generic tool-call contract, not a ClawPress-specific payload field.

## Changes

- `src/Tools/class-wp-agent-tool-call.php`: normalizes `id`, `tool_call_id`, or `metadata.tool_call_id` into a stable call ID.
- `src/Runtime/class-wp-agent-conversation-loop.php`: resolves a tool-call ID, emits it in events, passes it into execution context, stores it in `tool_execution_results`, and attaches it to tool-call/tool-result transcript messages.
- `src/Tools/class-wp-agent-tool-execution-core.php`: passes `context['tool_call_id']` into the prepared normalized tool call so host executors receive it.
- `tests/conversation-loop-tool-execution-smoke.php`: verifies a provider ID such as `call_123` reaches the executor and is preserved in loop results.

## Evidence

- Fork review issue: https://github.com/bradvin/agents-api/issues/2
- ClawPress depends on this ID round-trip at the linked call sites.
- `composer test` passes on branch `bradvin:feature/preserve-tool-call-ids` on May 19, 2026.
