### PR TITLE
Conversation sessions: resolve REST principal from request, not body

### DIFF
--- a/src/Transcripts/register-agents-conversation-session-abilities.php
+++ b/src/Transcripts/register-agents-conversation-session-abilities.php
@@ -325,7 +325,7 @@ function agents_conversation_sessions_principal( array $input ): ?WP_Agent_Execu
 	// Caller-supplied principals are honored only outside REST request context.
 	// REST callers go through the standard resolver chain so identity is
 	// established by the request itself rather than declared in the body.
-	$accepts_caller_principal = ! ( defined( 'REST_REQUEST' ) && constant( 'REST_REQUEST' ) );
+	$accepts_caller_principal = ! defined( 'REST_REQUEST' );
 
 	if ( $accepts_caller_principal && isset( $input['principal'] ) ) {
 		if ( $input['principal'] instanceof WP_Agent_Execution_Principal ) {

--- a/src/Transcripts/register-agents-conversation-session-abilities.php
+++ b/src/Transcripts/register-agents-conversation-session-abilities.php
@@ -322,12 +322,18 @@ function agents_conversation_sessions_list_for_owner( WP_Agent_Conversation_Stor
 }
 
 function agents_conversation_sessions_principal( array $input ): ?WP_Agent_Execution_Principal {
-	if ( isset( $input['principal'] ) && $input['principal'] instanceof WP_Agent_Execution_Principal ) {
-		return $input['principal'];
-	}
+	// Caller-supplied principals are honored only outside REST request context.
+	// REST callers go through the standard resolver chain so identity is
+	// established by the request itself rather than declared in the body.
+	$accepts_caller_principal = ! ( defined( 'REST_REQUEST' ) && constant( 'REST_REQUEST' ) );
 
-	if ( isset( $input['principal'] ) && is_array( $input['principal'] ) ) {
-		return WP_Agent_Execution_Principal::from_array( $input['principal'] );
+	if ( $accepts_caller_principal && isset( $input['principal'] ) ) {
+		if ( $input['principal'] instanceof WP_Agent_Execution_Principal ) {
+			return $input['principal'];
+		}
+		if ( is_array( $input['principal'] ) ) {
+			return WP_Agent_Execution_Principal::from_array( $input['principal'] );
+		}
 	}
 
 	$principal = WP_Agent_Execution_Principal::resolve( array( 'request_context' => WP_Agent_Execution_Principal::REQUEST_CONTEXT_REST ) + $input );

--- a/tests/agents-conversation-session-abilities-smoke.php
+++ b/tests/agents-conversation-session-abilities-smoke.php
@@ -314,6 +314,40 @@ $other_audience = WP_Agent_Execution_Principal::audience( 'audience:public', 'de
 $blocked_owner  = agents_get_conversation_session( array( 'principal' => $other_audience, 'session_id' => 'p-1', 'workspace' => array( 'workspace_type' => 'site', 'workspace_id' => '42' ) ) );
 smoke_assert( 'agents_conversation_session_not_found', $blocked_owner instanceof WP_Error ? $blocked_owner->get_error_code() : '', 'principal owner key blocks other audience sessions', $failures, $passes );
 
+// REST callers cannot impersonate other owners via the principal field — the
+// principal is resolved from the request, not from the body.
+defined( 'REST_REQUEST' ) || define( 'REST_REQUEST', true );
+$GLOBALS['__smoke_caps']            = array( 'read' );
+$GLOBALS['__smoke_current_user_id'] = 99;
+
+$forged_principal = array(
+	'effective_agent_id' => 'demo-agent',
+	'auth_source'        => 'user',
+	'request_context'    => 'rest',
+	'owner_type'         => 'audience',
+	'owner_key'          => 'browser:one',
+);
+
+$forged_get = agents_get_conversation_session(
+	array(
+		'principal'  => $forged_principal,
+		'session_id' => 'p-1',
+		'workspace'  => array( 'workspace_type' => 'site', 'workspace_id' => '42' ),
+	)
+);
+smoke_assert( 'agents_conversation_session_not_found', $forged_get instanceof WP_Error ? $forged_get->get_error_code() : '', 'REST principal passthrough is ignored on get', $failures, $passes );
+
+$forged_list = agents_list_conversation_sessions(
+	array(
+		'principal' => $forged_principal,
+		'workspace' => array( 'workspace_type' => 'site', 'workspace_id' => '42' ),
+	)
+);
+smoke_assert( array(), is_array( $forged_list ) ? ( $forged_list['sessions'] ?? null ) : null, 'REST principal passthrough is ignored on list', $failures, $passes );
+
+$GLOBALS['__smoke_caps']            = array();
+$GLOBALS['__smoke_current_user_id'] = 0;
+
 do_action( 'wp_abilities_api_categories_init' );
 do_action( 'wp_abilities_api_init' );
 


### PR DESCRIPTION
## Summary

Tightens `agents_conversation_sessions_principal()` so REST callers no longer have their `\$input['principal']` honored as a passthrough — the principal for a REST request is resolved through the standard chain (the `agents_api_execution_principal` filter, then the current WP user), matching how every other REST-facing ability in the substrate resolves identity.

In-process and programmatic callers (CLI, cron, tests, custom non-REST controllers) can still pass a pre-resolved principal in `\$input`, so the supported invocation contract for hosts driving the abilities outside the REST run controller is unchanged.

## Why

The conversation-session abilities were the only REST-exposed surface that accepted a principal claim from the request body. Every other ability in the substrate resolves identity from the request itself. This change brings them in line.

## Changes

- \`src/Transcripts/register-agents-conversation-session-abilities.php\`: gate the \`\$input['principal']\` passthrough on \`! ( defined('REST_REQUEST') && constant('REST_REQUEST') )\`.
- \`tests/agents-conversation-session-abilities-smoke.php\`: two new assertions covering the REST case — a caller supplying a \`principal\` field naming another owner cannot read or list that owner's sessions.

## Test plan

- [x] \`php tests/agents-conversation-session-abilities-smoke.php\` — 26 assertions, all pass (24 prior + 2 new).
- [x] \`composer test\` — full suite green, no regressions.
- [x] Manually traced: REST caller with forged \`principal\` falls through to \`WP_Agent_Execution_Principal::resolve()\` → host filter or \`get_current_user_id()\` user-session fallback.