### PR TITLE
Prepare Agents API 0.1.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,28 @@ Products can require Agents API because they build on the substrate. Agents API 
 
 Agents API requires **WordPress 7.0 or higher**. The substrate itself is provider-agnostic and loads on earlier versions, but every realistic consumer needs an AI provider. The only WordPress-native provider story is `wp-ai-client`, which ships in WordPress 7.0 core. Sites running 6.8–6.9 can install Agents API without errors but won't have a working AI provider unless they manually install the deprecated `wp-ai-client` plugin.
 
+## Installation
+
+Agents API supports the same two delivery shapes used by other shared WordPress runtime packages such as Action Scheduler: install it as a normal WordPress plugin, or require it through Composer and load Composer's autoloader from the host project.
+
+Both paths load the same `agents-api.php` bootstrap. The bootstrap is idempotent, so loading it through Composer and WordPress in the same request is safe.
+
+### WordPress Plugin
+
+Install and activate the Agents API plugin through the normal WordPress plugin mechanism. This is the recommended path for site owners and plugins that declare Agents API as a plugin dependency.
+
+### Composer
+
+Require the package from a host plugin, mu-plugin, or Composer-managed WordPress project:
+
+```sh
+composer require automattic/agents-api:^0.1
+```
+
+Composer autoloads `agents-api.php` through the package `files` autoload entry. The consuming project must load Composer's generated `vendor/autoload.php` during WordPress bootstrap. After that, the same public API is available as in the plugin activation path.
+
+Pin released tags (`^0.1`, `0.1.x`, or an exact `0.1.0` tag) for reproducible production installs. Track `main` only for active substrate development.
+
 ## Consumer Integration
 
 Product plugins should treat Agents API as an optional or required runtime dependency depending on their feature surface.

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,11 @@
   "require": {
     "php": ">=8.1"
   },
+  "autoload": {
+    "files": [
+      "agents-api.php"
+    ]
+  },
   "suggest": {
     "woocommerce/action-scheduler": "Required to actually run cron-triggered workflows. The substrate detects Action Scheduler at runtime and no-ops cleanly when absent; install this package (or any plugin that ships it, like WooCommerce) to enable scheduled workflow runs."
   },

--- a/src/Runtime/class-wp-agent-conversation-loop.php
+++ b/src/Runtime/class-wp-agent-conversation-loop.php
@@ -413,13 +413,10 @@ class WP_Agent_Conversation_Loop {
 				? self::json_encode_safe( $exec_result['result'] ?? array() )
 				: ( $exec_result['error'] ?? 'Tool execution failed.' );
 
-			$tool_result_payload                 = $exec_result;
-			$tool_result_payload['tool_call_id'] = $tool_call_id;
-
 			$messages[] = WP_Agent_Message::toolResult(
 				is_string( $result_content ) ? $result_content : '',
 				$tool_name,
-				$tool_result_payload,
+				$exec_result,
 				array( 'tool_call_id' => $tool_call_id )
 			);
 

--- a/src/Runtime/class-wp-agent-tool-pair-validator.php
+++ b/src/Runtime/class-wp-agent-tool-pair-validator.php
@@ -20,10 +20,9 @@ if ( ! defined( 'ABSPATH' ) ) {
  * happen. This validator gives consumers a substrate-level helper to detect or
  * scrub such transcripts before dispatch.
  *
- * Pairing rule: a tool_call envelope at index `i` matches the next tool_result
- * envelope at index `j > i` with the same `payload.tool_name`. Matching is FIFO
- * per tool name — the oldest unmatched tool_call wins, mirroring how providers
- * resolve tool-use IDs positionally when multiple calls share a name.
+ * Pairing rule: tool_call_id metadata is authoritative when present. Messages
+ * without IDs fall back to FIFO matching by `payload.tool_name`, preserving
+ * compatibility with transcripts written before tool-call IDs were captured.
  */
 class WP_Agent_Tool_Pair_Validator {
 
@@ -37,7 +36,7 @@ class WP_Agent_Tool_Pair_Validator {
 	 * Inspect a message list and return any orphan tool_call / tool_result envelopes.
 	 *
 	 * Returned reports are sorted by ascending message index. Each entry has the
-	 * shape `{ index, kind, type, tool_name }`.
+	 * shape `{ index, kind, type, tool_name, tool_call_id? }`.
 	 *
 	 * @param array<int, array<string, mixed>> $messages Raw or normalized messages.
 	 * @return array<int, array<string, mixed>> Orphan reports.
@@ -52,8 +51,9 @@ class WP_Agent_Tool_Pair_Validator {
 
 			if ( WP_Agent_Message::TYPE_TOOL_CALL === $type ) {
 				$pending[] = array(
-					'index'     => $index,
-					'tool_name' => self::tool_name( $envelope ),
+					'index'        => $index,
+					'tool_name'    => self::tool_name( $envelope ),
+					'tool_call_id' => self::tool_call_id( $envelope ),
 				);
 				continue;
 			}
@@ -62,16 +62,21 @@ class WP_Agent_Tool_Pair_Validator {
 				continue;
 			}
 
-			$tool_name   = self::tool_name( $envelope );
-			$matched_pos = self::match_pending( $pending, $tool_name );
+			$tool_name    = self::tool_name( $envelope );
+			$tool_call_id = self::tool_call_id( $envelope );
+			$matched_pos  = self::match_pending( $pending, $tool_name, $tool_call_id );
 
 			if ( null === $matched_pos ) {
-				$orphans[] = array(
+				$orphan = array(
 					'index'     => $index,
 					'kind'      => self::KIND_ORPHAN_TOOL_RESULT,
 					'type'      => WP_Agent_Message::TYPE_TOOL_RESULT,
 					'tool_name' => $tool_name,
 				);
+				if ( '' !== $tool_call_id ) {
+					$orphan['tool_call_id'] = $tool_call_id;
+				}
+				$orphans[] = $orphan;
 				continue;
 			}
 
@@ -79,12 +84,16 @@ class WP_Agent_Tool_Pair_Validator {
 		}
 
 		foreach ( $pending as $pending_call ) {
-			$orphans[] = array(
+			$orphan = array(
 				'index'     => $pending_call['index'],
 				'kind'      => self::KIND_ORPHAN_TOOL_CALL,
 				'type'      => WP_Agent_Message::TYPE_TOOL_CALL,
 				'tool_name' => $pending_call['tool_name'],
 			);
+			if ( '' !== $pending_call['tool_call_id'] ) {
+				$orphan['tool_call_id'] = $pending_call['tool_call_id'];
+			}
+			$orphans[] = $orphan;
 		}
 
 		usort(
@@ -170,15 +179,26 @@ class WP_Agent_Tool_Pair_Validator {
 	}
 
 	/**
-	 * Find the FIFO-oldest pending tool_call with the given name.
+	 * Find the pending tool_call matching the given ID or legacy name-only pair.
 	 *
-	 * @param array<int, array<string, mixed>> $pending   Pending list.
-	 * @param string                           $tool_name Tool name to match.
+	 * @param array<int, array<string, mixed>> $pending      Pending list.
+	 * @param string                           $tool_name    Tool name to match.
+	 * @param string                           $tool_call_id Tool-call ID to match.
 	 * @return int|null Index in $pending or null when no match.
 	 */
-	private static function match_pending( array $pending, string $tool_name ): ?int {
+	private static function match_pending( array $pending, string $tool_name, string $tool_call_id ): ?int {
+		if ( '' !== $tool_call_id ) {
+			foreach ( $pending as $position => $candidate ) {
+				if ( ( $candidate['tool_call_id'] ?? '' ) === $tool_call_id ) {
+					return $position;
+				}
+			}
+
+			return null;
+		}
+
 		foreach ( $pending as $position => $candidate ) {
-			if ( ( $candidate['tool_name'] ?? '' ) === $tool_name ) {
+			if ( '' === ( $candidate['tool_call_id'] ?? '' ) && ( $candidate['tool_name'] ?? '' ) === $tool_name ) {
 				return $position;
 			}
 		}
@@ -195,6 +215,17 @@ class WP_Agent_Tool_Pair_Validator {
 	private static function tool_name( array $envelope ): string {
 		$name = $envelope['payload']['tool_name'] ?? '';
 		return is_string( $name ) ? $name : '';
+	}
+
+	/**
+	 * Read a normalized envelope's tool-call ID metadata.
+	 *
+	 * @param array<string, mixed> $envelope Normalized envelope.
+	 * @return string
+	 */
+	private static function tool_call_id( array $envelope ): string {
+		$id = $envelope['metadata']['tool_call_id'] ?? '';
+		return is_string( $id ) ? $id : '';
 	}
 
 	/**

--- a/tests/conversation-loop-tool-execution-smoke.php
+++ b/tests/conversation-loop-tool-execution-smoke.php
@@ -98,6 +98,16 @@ agents_api_smoke_assert_equals( true, ! array_key_exists( 'parameters', $result[
 // Messages should contain: user, assistant text, tool_call, tool_result.
 $message_count = count( $result['messages'] );
 agents_api_smoke_assert_equals( true, $message_count >= 4, 'transcript contains user + assistant + tool_call + tool_result messages', $failures, $passes );
+$tool_result_messages = array_values(
+	array_filter(
+		$result['messages'],
+		static function ( array $message ): bool {
+			return ( $message['type'] ?? '' ) === AgentsAPI\AI\WP_Agent_Message::TYPE_TOOL_RESULT;
+		}
+	)
+);
+agents_api_smoke_assert_equals( 'call_123', $tool_result_messages[0]['metadata']['tool_call_id'] ?? '', 'tool result metadata preserves provider tool call id', $failures, $passes );
+agents_api_smoke_assert_equals( false, array_key_exists( 'tool_call_id', $tool_result_messages[0]['payload'] ?? array() ), 'tool result payload does not duplicate tool_call_id', $failures, $passes );
 
 echo "\n[2] Loop runs without mediation when no tool_executor is provided (backwards compatible):\n";
 $executor->executed = array();

--- a/tests/tool-pair-validator-smoke.php
+++ b/tests/tool-pair-validator-smoke.php
@@ -31,6 +31,11 @@ $result_search = WP_Agent_Message::toolResult( 'results', 'search', array( 'succ
 $call_fetch   = WP_Agent_Message::toolCall( 'fetching', 'fetch', array( 'url' => 'https://example.com' ), 2 );
 $result_fetch = WP_Agent_Message::toolResult( 'fetched', 'fetch', array( 'success' => true, 'tool_data' => array( 'status' => 200 ) ) );
 
+$call_search_id_1   = WP_Agent_Message::toolCall( 'searching', 'search', array( 'q' => 'foo' ), 1, array( 'tool_call_id' => 'call_search_1' ) );
+$call_search_id_2   = WP_Agent_Message::toolCall( 'searching again', 'search', array( 'q' => 'bar' ), 1, array( 'tool_call_id' => 'call_search_2' ) );
+$result_search_id_1 = WP_Agent_Message::toolResult( 'results', 'search', array( 'success' => true ), array( 'tool_call_id' => 'call_search_1' ) );
+$result_search_id_2 = WP_Agent_Message::toolResult( 'more results', 'search', array( 'success' => true ), array( 'tool_call_id' => 'call_search_2' ) );
+
 echo "\n[1] Empty transcript has no orphans:\n";
 agents_api_smoke_assert_equals( array(), WP_Agent_Tool_Pair_Validator::validate( array() ), 'empty transcript validates clean', $failures, $passes );
 agents_api_smoke_assert_equals( true, WP_Agent_Tool_Pair_Validator::is_paired( array() ), 'empty transcript is paired', $failures, $passes );
@@ -102,5 +107,22 @@ agents_api_smoke_assert_equals( 4, count( $clean_pruned['messages'] ), 'clean pr
 agents_api_smoke_assert_equals( array(), $clean_pruned['removed'], 'clean prune removes nothing', $failures, $passes );
 agents_api_smoke_assert_equals( WP_Agent_Tool_Pair_Validator::EVENT_VALIDATED, $clean_pruned['events'][0]['type'], 'clean prune emits validated event', $failures, $passes );
 agents_api_smoke_assert_equals( 0, $clean_pruned['events'][0]['metadata']['orphan_count'], 'clean prune event reports orphan_count=0', $failures, $passes );
+
+echo "\n[11] Tool-call IDs match same-name calls out of FIFO order:\n";
+$id_paired = array( $call_search_id_1, $call_search_id_2, $result_search_id_2, $result_search_id_1 );
+agents_api_smoke_assert_equals( array(), WP_Agent_Tool_Pair_Validator::validate( $id_paired ), 'id-paired transcript validates clean', $failures, $passes );
+
+echo "\n[12] ID-less pairs still fall back to FIFO by tool name in mixed transcripts:\n";
+$mixed = array( $call_search_id_1, $call_fetch, $result_fetch, $result_search_id_1 );
+agents_api_smoke_assert_equals( array(), WP_Agent_Tool_Pair_Validator::validate( $mixed ), 'mixed id and name transcript validates clean', $failures, $passes );
+
+echo "\n[13] ID mismatch within the same tool name reports both sides as orphans:\n";
+$id_mismatch = array( $call_search_id_1, $result_search_id_2 );
+$orphans     = WP_Agent_Tool_Pair_Validator::validate( $id_mismatch );
+agents_api_smoke_assert_equals( 2, count( $orphans ), 'id mismatch produces two orphan reports', $failures, $passes );
+agents_api_smoke_assert_equals( WP_Agent_Tool_Pair_Validator::KIND_ORPHAN_TOOL_CALL, $orphans[0]['kind'], 'mismatched call remains orphan', $failures, $passes );
+agents_api_smoke_assert_equals( 'call_search_1', $orphans[0]['tool_call_id'] ?? '', 'orphan call report includes tool_call_id', $failures, $passes );
+agents_api_smoke_assert_equals( WP_Agent_Tool_Pair_Validator::KIND_ORPHAN_TOOL_RESULT, $orphans[1]['kind'], 'mismatched result remains orphan', $failures, $passes );
+agents_api_smoke_assert_equals( 'call_search_2', $orphans[1]['tool_call_id'] ?? '', 'orphan result report includes tool_call_id', $failures, $passes );
 
 agents_api_smoke_finish( 'tool-pair-validator', $failures, $passes );


### PR DESCRIPTION
## Summary
- Match tool-call and tool-result transcript envelopes by `tool_call_id` metadata before falling back to legacy FIFO-by-tool-name pairing.
- Keep mediated tool-result `tool_call_id` in metadata only, avoiding duplicated payload state.
- Make Composer consumption load the same plugin bootstrap via `autoload.files` and document plugin vs Composer installation for `0.1.x` pins.

## Verification
- `composer validate --strict`
- `composer test`
- `homeboy lint --path /Users/chubes/Developer/agents-api@release-0.1.0-prep --extension wordpress`
- `git diff --check`

## Release notes
- Closes #189.
- Closes #190.
- Refs #93. The package/docs side is ready here; the first `0.1.0` tag still happens as the release step after merge.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the release-prep code and docs changes, expanding smoke coverage, and running local verification. Chris remains responsible for review and release execution.