### PR TITLE
Configure Homeboy release targets

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -1,10 +1,21 @@
 {
   "auto_cleanup": false,
+  "changelog_target": "CHANGELOG.md",
   "extensions": {
     "wordpress": {
       "php": "8.1"
     }
   },
   "id": "agents-api",
-  "remote_path": "wp-content/plugins/agents-api"
+  "remote_path": "wp-content/plugins/agents-api",
+  "version_targets": [
+    {
+      "file": "agents-api.php",
+      "pattern": "Version:\\s*([0-9.]+)"
+    },
+    {
+      "file": "tests/playground-ci/component/agents-api-docs-agent-driver.php",
+      "pattern": "Version:\\s*([0-9.]+)"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- Configure Homeboy's generated changelog target for Agents API releases.
- Add version targets for the main plugin header and playground component header so Homeboy can run the 0.1.0 release path.

## Verification
- `homeboy lint --path /Users/chubes/Developer/agents-api@fix-homeboy-release-config --extension wordpress`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosing the Homeboy release configuration blocker and adding the minimal release metadata needed for Homeboy to run.