### PR TITLE
fix: target active wp-content deploy path

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -7,7 +7,7 @@
     }
   },
   "id": "agents-api",
-  "remote_path": "wp-content/plugins/agents-api",
+  "remote_path": "../wp-content/plugins/agents-api",
   "version_targets": [
     {
       "file": "agents-api.php",


### PR DESCRIPTION
## Summary
- update the Homeboy remote path to deploy Agents API into the active WP Cloud wp-content directory
- keeps Intelligence Horse component deploys aligned with the project base path

## Testing
- homeboy lint --path . --extension wordpress --changed-only

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the Intelligence Horse deploy-path mismatch and drafted the Homeboy config change; Chris remains responsible for review and merge.