### PR TITLE
Add canonical session owner contract

### DIFF
--- a/src/Channels/register-agents-chat-ability.php
+++ b/src/Channels/register-agents-chat-ability.php
@@ -207,6 +207,7 @@ function agents_chat_input_schema(): array {
 				'type'        => array( 'string', 'null' ),
 				'description' => 'Existing session ID to continue, or null to start a new session.',
 			),
+			'session_owner'  => agents_chat_session_owner_schema(),
 			'attachments'    => array(
 				'type'        => 'array',
 				'description' => 'Channel-side attachments (images, voice notes, files, link previews). Shape is runtime-defined; runtimes ignore unknown attachment types.',
@@ -264,6 +265,39 @@ function agents_chat_input_schema(): array {
 						'description' => 'Whether this turn is an explicit agent-to-agent delegation call.',
 					),
 				),
+			),
+		),
+	);
+}
+
+/**
+ * Canonical conversation-session owner schema.
+ *
+ * Session owners isolate persisted transcripts. They are intentionally separate
+ * from access principals: `audience:public` can authorize a request, but a
+ * stored transcript needs an owner such as `user:<id>`, `browser:<opaque id>`,
+ * or a channel-specific conversation key.
+ *
+ * @since 0.103.0
+ *
+ * @return array
+ */
+function agents_chat_session_owner_schema(): array {
+	return array(
+		'type'        => array( 'object', 'null' ),
+		'description' => 'Opaque, isolating owner for persisted conversation sessions. Use for anonymous browser or external-channel chats when no logged-in user owns the transcript. Do not use a shared public audience as a session owner.',
+		'properties'  => array(
+			'type'  => array(
+				'type'        => 'string',
+				'description' => 'Owner namespace such as user, browser, channel, token, or system.',
+			),
+			'key'   => array(
+				'type'        => 'string',
+				'description' => 'Opaque owner key within the namespace. Runtimes should hash before storage.',
+			),
+			'label' => array(
+				'type'        => 'string',
+				'description' => 'Optional human-readable owner label for diagnostics.',
 			),
 		),
 	);

--- a/src/Transcripts/register-agents-conversation-session-abilities.php
+++ b/src/Transcripts/register-agents-conversation-session-abilities.php
@@ -267,7 +267,14 @@ function agents_conversation_sessions_context( array $input ) {
 		return new \WP_Error( 'agents_conversation_session_unauthenticated', 'A conversation session principal could not be resolved.' );
 	}
 
-	$owner = $principal->conversation_owner();
+	$owner = agents_conversation_session_owner_from_input( $input, $principal );
+	if ( is_wp_error( $owner ) ) {
+		return $owner;
+	}
+
+	if ( null === $owner ) {
+		$owner = $principal->conversation_owner();
+	}
 	if ( null === $owner ) {
 		return new \WP_Error( 'agents_conversation_session_owner_required', 'The current principal does not provide a conversation session owner key.' );
 	}
@@ -286,6 +293,49 @@ function agents_conversation_sessions_context( array $input ) {
 		'principal' => $principal,
 		'owner'     => $owner,
 		'input'     => $input,
+	);
+}
+
+/**
+ * Resolve an explicit canonical session owner from ability input.
+ *
+ * @param array                        $input     Ability input.
+ * @param WP_Agent_Execution_Principal $principal Authenticated execution principal.
+ * @return array{type:string,key:string}|null|\WP_Error
+ */
+function agents_conversation_session_owner_from_input( array $input, WP_Agent_Execution_Principal $principal ) {
+	$owner = is_array( $input['session_owner'] ?? null ) ? $input['session_owner'] : null;
+	if ( null === $owner ) {
+		$client_context = is_array( $input['client_context'] ?? null ) ? $input['client_context'] : array();
+		$owner          = is_array( $client_context['session_owner'] ?? null ) ? $client_context['session_owner'] : null;
+	}
+
+	if ( null === $owner ) {
+		return null;
+	}
+
+	$type = sanitize_key( (string) ( $owner['type'] ?? $owner['owner_type'] ?? '' ) );
+	$key  = trim( (string) ( $owner['key'] ?? $owner['owner_key'] ?? '' ) );
+	if ( '' === $type || '' === $key ) {
+		return new \WP_Error( 'agents_conversation_session_invalid_owner', 'Conversation session owner type and key are required.' );
+	}
+
+	if ( WP_Agent_Execution_Principal::OWNER_TYPE_AUDIENCE === $type && in_array( $key, array( 'public', 'audience:public' ), true ) ) {
+		return new \WP_Error( 'agents_conversation_session_non_isolating_owner', 'Public audience is not an isolating conversation session owner.' );
+	}
+
+	$principal_owner = $principal->conversation_owner();
+	if ( WP_Agent_Execution_Principal::OWNER_TYPE_USER === $type ) {
+		if ( ! is_array( $principal_owner ) || WP_Agent_Execution_Principal::OWNER_TYPE_USER !== $principal_owner['type'] || preg_replace( '/^user:/', '', $key ) !== (string) $principal_owner['key'] ) {
+			return new \WP_Error( 'agents_conversation_session_user_owner_forbidden', 'User conversation session owners must match the authenticated user principal.' );
+		}
+
+		$key = (string) $principal_owner['key'];
+	}
+
+	return array(
+		'type' => $type,
+		'key'  => $key,
 	);
 }
 
@@ -468,11 +518,24 @@ function agents_conversation_sessions_list_input_schema(): array {
 	return array(
 		'type'       => 'object',
 		'properties' => array(
-			'workspace' => agents_conversation_sessions_workspace_schema(),
-			'limit'     => array( 'type' => 'integer' ),
-			'offset'    => array( 'type' => 'integer' ),
-			'agent'     => array( 'type' => 'string' ),
-			'context'   => array( 'type' => 'string' ),
+			'workspace'     => agents_conversation_sessions_workspace_schema(),
+			'session_owner' => agents_conversation_session_owner_schema(),
+			'limit'         => array( 'type' => 'integer' ),
+			'offset'        => array( 'type' => 'integer' ),
+			'agent'         => array( 'type' => 'string' ),
+			'context'       => array( 'type' => 'string' ),
+		),
+	);
+}
+
+function agents_conversation_session_owner_schema(): array {
+	return array(
+		'type'        => array( 'object', 'null' ),
+		'description' => 'Opaque, isolating owner for persisted conversation sessions. Use for anonymous browser or external-channel chats when no logged-in user owns the transcript. Do not use a shared public audience as a session owner.',
+		'properties'  => array(
+			'type'  => array( 'type' => 'string' ),
+			'key'   => array( 'type' => 'string' ),
+			'label' => array( 'type' => 'string' ),
 		),
 	);
 }
@@ -487,7 +550,10 @@ function agents_conversation_session_id_input_schema(): array {
 	return array(
 		'type'       => 'object',
 		'required'   => array( 'session_id' ),
-		'properties' => array( 'session_id' => array( 'type' => 'string' ) ),
+		'properties' => array(
+			'session_id'    => array( 'type' => 'string' ),
+			'session_owner' => agents_conversation_session_owner_schema(),
+		),
 	);
 }
 

--- a/tests/agents-chat-ability-smoke.php
+++ b/tests/agents-chat-ability-smoke.php
@@ -166,6 +166,9 @@ smoke_assert( true, agents_chat_permission( array() ), 'permission_filter_widens
 $in = agents_chat_input_schema();
 smoke_assert( array( 'agent', 'message' ), $in['required'] ?? array(), 'input_schema_required_fields', $failures, $passes );
 smoke_assert( true, isset( $in['properties']['client_context'] ), 'input_schema_has_client_context', $failures, $passes );
+smoke_assert( true, isset( $in['properties']['session_owner'] ), 'input_schema_has_session_owner', $failures, $passes );
+smoke_assert( true, isset( $in['properties']['session_owner']['properties']['type'] ), 'session_owner_schema_has_type', $failures, $passes );
+smoke_assert( true, isset( $in['properties']['session_owner']['properties']['key'] ), 'session_owner_schema_has_key', $failures, $passes );
 smoke_assert( true, isset( $in['properties']['attachments'] ), 'input_schema_has_attachments', $failures, $passes );
 smoke_assert( true, isset( $in['properties']['client_context']['properties']['sender_id'] ), 'client_context_schema_has_sender_id', $failures, $passes );
 smoke_assert( true, in_array( 'peer-agent', $in['properties']['client_context']['properties']['source']['enum'] ?? array(), true ), 'client_context_source_allows_peer_agent', $failures, $passes );

--- a/tests/agents-conversation-session-abilities-smoke.php
+++ b/tests/agents-conversation-session-abilities-smoke.php
@@ -36,6 +36,10 @@ function get_current_blog_id(): int {
 	return 42;
 }
 
+function sanitize_key( string $key ): string {
+	return strtolower( preg_replace( '/[^a-z0-9_\-]/', '', $key ) ?? '' );
+}
+
 $GLOBALS['__smoke_filters']    = array();
 $GLOBALS['__smoke_abilities']  = array();
 $GLOBALS['__smoke_categories'] = array();
@@ -304,6 +308,31 @@ $audience_created = agents_create_conversation_session( array( 'principal' => $a
 smoke_assert( 'p-1', $audience_created['session']['session_id'] ?? null, 'principal store creates audience-owned session', $failures, $passes );
 smoke_assert( 'browser:one', $principal_store->sessions['p-1']['owner_key'] ?? null, 'principal store receives opaque owner key', $failures, $passes );
 
+$explicit_owner_created = agents_create_conversation_session(
+	array(
+		'principal'     => $audience_without_owner,
+		'session_owner' => array(
+			'type' => 'browser',
+			'key'  => 'browser:explicit',
+		),
+		'workspace'     => array( 'workspace_type' => 'site', 'workspace_id' => '42' ),
+	)
+);
+smoke_assert( 'p-2', $explicit_owner_created['session']['session_id'] ?? null, 'explicit session_owner creates audience transcript session', $failures, $passes );
+smoke_assert( 'browser', $principal_store->sessions['p-2']['owner_type'] ?? null, 'principal store receives explicit owner type', $failures, $passes );
+smoke_assert( 'browser:explicit', $principal_store->sessions['p-2']['owner_key'] ?? null, 'principal store receives explicit owner key', $failures, $passes );
+
+$public_owner_rejected = agents_list_conversation_sessions(
+	array(
+		'principal'     => $audience_without_owner,
+		'session_owner' => array(
+			'type' => 'audience',
+			'key'  => 'public',
+		),
+	)
+);
+smoke_assert( 'agents_conversation_session_non_isolating_owner', $public_owner_rejected instanceof WP_Error ? $public_owner_rejected->get_error_code() : '', 'public audience session_owner is rejected', $failures, $passes );
+
 $audience_listed = agents_list_conversation_sessions( array( 'principal' => $audience_with_owner, 'workspace' => array( 'workspace_type' => 'site', 'workspace_id' => '42' ) ) );
 smoke_assert( 'p-1', $audience_listed['sessions'][0]['session_id'] ?? null, 'principal store lists matching owner only', $failures, $passes );
 
@@ -356,6 +385,8 @@ smoke_assert( true, wp_has_ability( AGENTS_GET_CONVERSATION_SESSION_ABILITY ), '
 smoke_assert( true, wp_has_ability( AGENTS_CREATE_CONVERSATION_SESSION_ABILITY ), 'create ability registers', $failures, $passes );
 smoke_assert( true, wp_has_ability( AGENTS_UPDATE_CONVERSATION_SESSION_TITLE_ABILITY ), 'update-title ability registers', $failures, $passes );
 smoke_assert( true, wp_has_ability( AGENTS_DELETE_CONVERSATION_SESSION_ABILITY ), 'delete ability registers', $failures, $passes );
+smoke_assert( true, isset( $GLOBALS['__smoke_abilities'][ AGENTS_CREATE_CONVERSATION_SESSION_ABILITY ]['input_schema']['properties']['session_owner'] ), 'create schema exposes session_owner', $failures, $passes );
+smoke_assert( true, isset( $GLOBALS['__smoke_abilities'][ AGENTS_LIST_CONVERSATION_SESSIONS_ABILITY ]['input_schema']['properties']['session_owner'] ), 'list schema exposes session_owner', $failures, $passes );
 
 if ( $failures ) {
 	echo "\nFAILED: " . count( $failures ) . " agents conversation session ability assertions failed.\n";


### PR DESCRIPTION
## Summary
- add `session_owner` to the canonical `agents/chat` input schema
- allow conversation session abilities to use an explicit isolating `session_owner` when the access principal has no owner
- reject shared public audience owners and keep explicit user owners bound to the authenticated user principal
- add smoke coverage for schema exposure and explicit owner handling

## Testing
- `php tests/agents-chat-ability-smoke.php`
- `php tests/agents-conversation-session-abilities-smoke.php`
- `homeboy lint --path /Users/chubes/Developer/agents-api@fix-session-owner-chat-contract --extension wordpress`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the implementation and smoke coverage; Chris remains responsible for review and validation.