### PR TITLE
docs: add WordPress.org release readme

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -1,0 +1,10 @@
+.claude
+.datamachine
+.github
+.git
+.gitignore
+AGENTS.md
+CHANGELOG.md
+composer.lock
+phpstan.neon
+tests

--- a/README.md
+++ b/README.md
@@ -64,6 +64,12 @@ Products can require Agents API because they build on the substrate. Agents API 
 
 Agents API requires **WordPress 7.0 or higher**. The substrate itself is provider-agnostic and loads on earlier versions, but every realistic consumer needs an AI provider. The only WordPress-native provider story is `wp-ai-client`, which ships in WordPress 7.0 core. Sites running 6.8–6.9 can install Agents API without errors but won't have a working AI provider unless they manually install the deprecated `wp-ai-client` plugin.
 
+## Core-Candidate API Naming
+
+Agents API intentionally exposes WordPress-shaped public APIs such as `wp_register_agent()`, `wp_get_agent()`, `wp_agents_api_init`, and `wp_agent_*` hooks.
+
+These names are not accidental plugin globals. They are the public API surface being evaluated for possible WordPress Core alignment, following existing Core naming conventions for substrate APIs. Plugin Check may report prefix warnings for these symbols; those warnings are expected for this Core-candidate package and should be reviewed in that context.
+
 ## Installation
 
 Agents API supports the same two delivery shapes used by other shared WordPress runtime packages such as Action Scheduler: install it as a normal WordPress plugin, or require it through Composer and load Composer's autoloader from the host project.

--- a/readme.txt
+++ b/readme.txt
@@ -1,0 +1,87 @@
+=== Agents API ===
+Contributors: automattic
+Tags: ai, agents, automation, workflows, tools
+Requires at least: 7.0
+Tested up to: 7.0
+Requires PHP: 8.1
+Stable tag: 0.1.0
+License: GPLv2 or later
+License URI: https://www.gnu.org/licenses/gpl-2.0.html
+
+Shared WordPress runtime substrate for registering AI agents, mediating tools, running workflows, and building product-specific agent experiences.
+
+== Description ==
+
+Agents API is a shared foundation for building AI agents in WordPress.
+
+It provides the reusable substrate that product plugins need when they add agent-backed features: agent registration, runtime value objects, tool mediation contracts, transcript and memory interfaces, approval primitives, messaging-channel adapters, and lightweight workflow scaffolding.
+
+Agents API is intentionally not a full agent product. It does not provide admin screens, provider-specific model execution, product workflows, concrete storage implementations, or an end-user chat application. Those pieces belong to consumer plugins.
+
+= What Agents API Provides =
+
+* Agent registration and lookup helpers.
+* Messaging channel contracts for external transports.
+* Runtime message, request, result, completion, and iteration-budget value objects.
+* Tool declaration, parameter normalization, tool-call mediation, and tool-result contracts.
+* Conversation transcript, memory, context, consent, approval, and authorization contracts.
+* Workflow spec, validation, runner, registry, and optional Action Scheduler bridge primitives.
+* Canonical abilities for agent chat, workflow execution, pending actions, and access checks.
+
+= What Agents API Does Not Provide =
+
+* Provider-specific model request code.
+* Product UI, onboarding, dashboards, or settings screens.
+* Concrete product workflows or product-specific tools.
+* Durable production storage implementations for every host.
+* Product-specific prompt policy, escalation policy, or consent UX.
+
+= Core-Candidate API Naming =
+
+Agents API intentionally exposes WordPress-shaped public APIs such as `wp_register_agent()`, `wp_get_agent()`, `wp_agents_api_init`, and `wp_agent_*` hooks.
+
+These names are not accidental plugin globals. They are the public API surface being evaluated for possible WordPress Core alignment, following existing Core naming conventions for substrate APIs. Plugin Check may report prefix warnings for these symbols; those warnings are expected for this Core-candidate package and should be reviewed in that context.
+
+== Installation ==
+
+Install and activate Agents API like any other WordPress plugin.
+
+Consumer plugins should register agents after the `wp_agents_api_init` action and should feature-detect public APIs when Agents API is an optional dependency.
+
+Example:
+
+`
+add_action(
+	'wp_agents_api_init',
+	static function () {
+		if ( function_exists( 'wp_register_agent' ) ) {
+			wp_register_agent(
+				'example-agent',
+				array(
+					'label' => 'Example Agent',
+				)
+			);
+		}
+	}
+);
+`
+
+== Frequently Asked Questions ==
+
+= Is this a complete AI chatbot plugin? =
+
+No. Agents API is the substrate for other plugins. It provides shared contracts and primitives so product plugins do not need to invent their own agent runtime plumbing.
+
+= Does Agents API send prompts to an AI provider? =
+
+No. Provider-specific prompt execution belongs to `wp-ai-client` or a host plugin adapter. Agents API defines the neutral runtime contracts around agents, tools, transcripts, memory, and workflows.
+
+= Why does this plugin expose `wp_*` functions? =
+
+Agents API is designed as a Core-candidate substrate. Its public API intentionally follows WordPress Core naming conventions so consumer code can target the intended Core-shaped surface.
+
+== Changelog ==
+
+= 0.1.0 =
+
+* Initial public substrate release for agent registration, runtime contracts, tool mediation, approvals, authorization, channels, routines, and workflows.


### PR DESCRIPTION
## Summary
- Add a WordPress.org-style `readme.txt` so Plugin Check no longer fails on missing plugin readme metadata.
- Add `.distignore` for release packaging so dev/test-only files stay out of the distributed plugin.
- Document the intentional Core-candidate `wp_*` / `wp_agent_*` public API naming that Plugin Check reports as prefix warnings.

## Verification
- `composer test`
- `homeboy lint --path /Users/chubes/Developer/agents-api@release-plugin-check-readme --extension wordpress --force-hot`
- `homeboy test --path /Users/chubes/Developer/agents-api@release-plugin-check-readme --extension wordpress --force-hot`
- `studio wp plugin check /Users/chubes/Developer/agents-api@release-plugin-check-readme --slug=agents-api --format=strict-json --exclude-directories=tests,.github,.claude,.datamachine,.git --exclude-files=.distignore,.gitignore,.git,AGENTS.md,CHANGELOG.md,composer.lock,phpstan.neon --skip-plugins=ai-provider-for-openai,ai-provider-for-opencode,data-machine,data-machine-code,frontend-agent-chat,intelligence,markdown-database-integration,mcp-adapter,static-site-importer,wp-ai-gateway`

Plugin Check result: 0 errors, 58 warnings. Remaining warnings are expected prefix warnings for the intentional Core-candidate public API names and hooks.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafting the WordPress.org readme, release packaging exclusions, Core-candidate naming explanation, and running local verification commands. Chris reviewed the direction and requested the PR.