### PR TITLE
Abilities: bridge wp_ability_execute_result onto agents_api_ability_executed

### DIFF
--- a/agents-api.php
+++ b/agents-api.php
@@ -124,6 +124,7 @@ require_once AGENTS_API_PATH . 'src/Memory/class-wp-agent-memory-read-result.php
 require_once AGENTS_API_PATH . 'src/Memory/class-wp-agent-memory-write-result.php';
 require_once AGENTS_API_PATH . 'src/Memory/class-wp-agent-memory-store.php';
 require_once AGENTS_API_PATH . 'src/Memory/class-wp-agent-memory-stores.php';
+require_once AGENTS_API_PATH . 'src/Abilities/class-wp-agent-ability-lifecycle-bridge.php';
 require_once AGENTS_API_PATH . 'src/Guidelines/guidelines.php';
 require_once AGENTS_API_PATH . 'src/Guidelines/class-wp-guidelines-substrate.php';
 require_once AGENTS_API_PATH . 'src/Channels/class-wp-agent-external-message.php';
@@ -166,3 +167,4 @@ require_once AGENTS_API_PATH . 'src/Routines/register-action-scheduler-listener.
 
 add_action( 'init', array( 'WP_Agents_Registry', 'init' ), 10 );
 add_action( 'init', array( 'WP_Guidelines_Substrate', 'register' ), 9 );
+add_action( 'init', array( 'AgentsAPI\\AI\\Abilities\\WP_Agent_Ability_Lifecycle_Bridge', 'register' ), 5 );

--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,7 @@
       "php tests/identity-smoke.php",
       "php tests/memory-metadata-contract-smoke.php",
       "php tests/memory-store-resolver-smoke.php",
+      "php tests/ability-lifecycle-bridge-smoke.php",
       "php tests/approval-action-value-shape-smoke.php",
       "php tests/workspace-scope-smoke.php",
       "php tests/compaction-item-smoke.php",

--- a/src/Abilities/class-wp-agent-ability-lifecycle-bridge.php
+++ b/src/Abilities/class-wp-agent-ability-lifecycle-bridge.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Bridges Abilities API execution lifecycle filters into substrate observers.
+ *
+ * @package AgentsAPI
+ */
+
+namespace AgentsAPI\AI\Abilities;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Bridges WP_Ability execution lifecycle filters into substrate-level actions.
+ *
+ * WordPress 7.1 introduced four execution lifecycle filters on `WP_Ability`:
+ * `wp_pre_execute_ability`, `wp_ability_normalize_input`,
+ * `wp_ability_permission_result`, and `wp_ability_execute_result`. This bridge
+ * forwards them onto substrate-level observable actions so consumers can record
+ * ability calls without each ability author opting in and without coupling
+ * observers to the conversation loop's event surface.
+ *
+ * The bridge is a passive observer: handlers return the filter input unchanged.
+ * Only the post-execute `wp_ability_execute_result` hook is wired in this slice
+ * (issue #94 telemetry adoption); the remaining three hooks land in follow-up
+ * slices that add their own substrate envelopes.
+ *
+ * On WordPress < 7.1 the underlying filters are never applied, so registered
+ * handlers stay idle.
+ */
+class WP_Agent_Ability_Lifecycle_Bridge {
+
+	public const ACTION_ABILITY_EXECUTED = 'agents_api_ability_executed';
+
+	/**
+	 * Register lifecycle-filter handlers with WordPress.
+	 *
+	 * Idempotent for repeated calls when WordPress de-duplicates filter
+	 * registration through `has_filter()`. Callers that wire this from a host
+	 * adapter should still call it once at bootstrap.
+	 */
+	public static function register(): void {
+		if ( ! function_exists( 'add_filter' ) ) {
+			return;
+		}
+
+		add_filter( 'wp_ability_execute_result', array( __CLASS__, 'observe_execute_result' ), 10, 4 );
+	}
+
+	/**
+	 * Observer for the `wp_ability_execute_result` filter.
+	 *
+	 * Emits `agents_api_ability_executed` with the same shape exposed by the
+	 * underlying filter, and returns the result unchanged so other handlers
+	 * downstream see exactly what the registered execute_callback produced.
+	 *
+	 * @param mixed  $result       Result returned by the ability's execute_callback, or `WP_Error`.
+	 * @param string $ability_name Ability name.
+	 * @param mixed  $input        Normalized input passed to the ability.
+	 * @param object $ability      `WP_Ability` instance.
+	 * @return mixed The original result, unchanged.
+	 */
+	public static function observe_execute_result( $result, string $ability_name, $input, $ability ) {
+		if ( function_exists( 'do_action' ) ) {
+			do_action( self::ACTION_ABILITY_EXECUTED, $ability_name, $result, $input, $ability );
+		}
+
+		return $result;
+	}
+}

--- a/tests/ability-lifecycle-bridge-smoke.php
+++ b/tests/ability-lifecycle-bridge-smoke.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Pure-PHP smoke test for the Abilities lifecycle bridge.
+ *
+ * Run with: php tests/ability-lifecycle-bridge-smoke.php
+ *
+ * @package AgentsAPI\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+$failures = array();
+$passes   = 0;
+
+echo "agents-api-ability-lifecycle-bridge-smoke\n";
+
+require_once __DIR__ . '/agents-api-smoke-helpers.php';
+agents_api_smoke_require_module();
+
+use AgentsAPI\AI\Abilities\WP_Agent_Ability_Lifecycle_Bridge;
+
+WP_Agent_Ability_Lifecycle_Bridge::register();
+
+$observed = array();
+add_action(
+	WP_Agent_Ability_Lifecycle_Bridge::ACTION_ABILITY_EXECUTED,
+	static function ( string $ability_name, $result, $input, $ability ) use ( &$observed ): void {
+		$observed[] = array(
+			'ability_name' => $ability_name,
+			'result'       => $result,
+			'input'        => $input,
+			'ability'      => $ability,
+		);
+	},
+	10,
+	4
+);
+
+$ability_stub       = new \stdClass();
+$ability_stub->name = 'test/echo';
+
+echo "\n[1] Bridge passes a successful result through and emits the action:\n";
+$result_in   = array( 'echoed' => 'hello' );
+$input_in    = array( 'q' => 'hi' );
+$result_out  = apply_filters( 'wp_ability_execute_result', $result_in, 'test/echo', $input_in, $ability_stub );
+
+agents_api_smoke_assert_equals( $result_in, $result_out, 'filter returns the result unchanged', $failures, $passes );
+agents_api_smoke_assert_equals( 1, count( $observed ), 'observer fired exactly once', $failures, $passes );
+agents_api_smoke_assert_equals( 'test/echo', $observed[0]['ability_name'] ?? null, 'observer received ability name', $failures, $passes );
+agents_api_smoke_assert_equals( $result_in, $observed[0]['result'] ?? null, 'observer received result payload', $failures, $passes );
+agents_api_smoke_assert_equals( $input_in, $observed[0]['input'] ?? null, 'observer received normalized input', $failures, $passes );
+agents_api_smoke_assert_equals( true, ( $observed[0]['ability'] ?? null ) === $ability_stub, 'observer received the ability instance', $failures, $passes );
+
+echo "\n[2] Bridge does not transform a failure result:\n";
+$observed   = array();
+$error_in   = new \RuntimeException( 'pretend WP_Error' );
+$result_out = apply_filters( 'wp_ability_execute_result', $error_in, 'test/fail', array(), $ability_stub );
+
+agents_api_smoke_assert_equals( true, $result_out === $error_in, 'failure result passes through unchanged', $failures, $passes );
+agents_api_smoke_assert_equals( 1, count( $observed ), 'observer fires on failure too', $failures, $passes );
+agents_api_smoke_assert_equals( 'test/fail', $observed[0]['ability_name'] ?? null, 'observer records failing ability name', $failures, $passes );
+
+echo "\n[3] Repeated executions each emit independently:\n";
+$observed = array();
+apply_filters( 'wp_ability_execute_result', 'one', 'test/one', array( 'i' => 1 ), $ability_stub );
+apply_filters( 'wp_ability_execute_result', 'two', 'test/two', array( 'i' => 2 ), $ability_stub );
+apply_filters( 'wp_ability_execute_result', 'three', 'test/three', array( 'i' => 3 ), $ability_stub );
+
+agents_api_smoke_assert_equals( 3, count( $observed ), 'three executions emit three observations', $failures, $passes );
+agents_api_smoke_assert_equals( 'test/one', $observed[0]['ability_name'] ?? null, 'first observation carries ability name', $failures, $passes );
+agents_api_smoke_assert_equals( 'test/three', $observed[2]['ability_name'] ?? null, 'third observation carries ability name', $failures, $passes );
+
+agents_api_smoke_finish( 'ability lifecycle bridge', $failures, $passes );

--- a/tests/bootstrap-smoke.php
+++ b/tests/bootstrap-smoke.php
@@ -164,6 +164,7 @@ agents_api_smoke_assert_equals( false, false !== strpos( $bootstrap_source, 'Dat
 
 echo "\n[3] Module source tree uses Agents API vocabulary:\n";
 $expected_source_directories = array(
+	'Abilities',
 	'Approvals',
 	'Auth',
 	'Channels',


### PR DESCRIPTION
## Summary

Adds `WP_Agent_Ability_Lifecycle_Bridge`, a passive observer that forwards WordPress 7.1's Abilities API execution lifecycle filters onto substrate-level actions.

This first slice wires the `wp_ability_execute_result` filter: every time an ability's `execute_callback` runs (after permission and input checks pass), `agents_api_ability_executed` fires with the same shape as the underlying filter — ability name, result, normalized input, ability instance. The handler returns the result unchanged, so observers cannot accidentally transform an ability's output.

## Why

Tracked in #94. WP core PR [WordPress/wordpress-develop#11731](https://github.com/WordPress/wordpress-develop/pull/11731) landed in trunk on 2026-05-21 via [changeset 62397](https://core.trac.wordpress.org/changeset/62397), adding four execution lifecycle filters to `WP_Ability` (`wp_pre_execute_ability`, `wp_ability_normalize_input`, `wp_ability_permission_result`, `wp_ability_execute_result`). The substrate's adoption plan in #94 mapped each filter to a substrate primitive; this PR is the smallest, lowest-risk first slice: observability via the post-execute filter.

## What this slice does and does not cover

`wp_ability_execute_result` fires inside `do_execute()`, so it sees the result *only* once `execute_callback` was reached. That means `agents_api_ability_executed` fires for:

- successful execution
- `execute_callback` returned a `WP_Error`
- ability had no callable `execute_callback`

It does **not** fire for:

- `wp_pre_execute_ability` short-circuit (handled by a separate slice)
- `wp_ability_normalize_input` returning `WP_Error`
- `validate_input()` failure
- `permission_callback` / `wp_ability_permission_result` denial
- `validate_output()` failure after the filter

Those failure modes get their own observer surfaces in follow-up slices. There is also no `duration_ms` available at this seam — the outer `execute()` has not returned yet — so timing has to come from a later hook.

## Boundary

The bridge is a pure observer:
- Returns the filter input unchanged. No transformation of ability results.
- Emits one action: `agents_api_ability_executed( \$ability_name, \$result, \$input, \$ability )` — mirrors the filter's 4-arg shape verbatim.
- No coupling to `agents_api_loop_event` or the conversation loop. Ability execution can happen outside any agent flow (a REST call, a workflow step, a scheduled job) and the observer surface is consistent for all of them.

On WordPress < 7.1 the underlying filter is never applied, so the registered handler stays idle. No version gate needed. (Note: capability detection by host version is unreliable because the Abilities API also ships standalone; future slices that need to detect host capability should reflect on `WP_Ability::execute()` source rather than checking `\$wp_version`.)

## Changes

- `src/Abilities/class-wp-agent-ability-lifecycle-bridge.php` — new class with one static `register()` and one observer.
- `agents-api.php` — require the new class; register the bridge on `init` at priority 5.
- `tests/ability-lifecycle-bridge-smoke.php` — 12 assertions covering pass-through, failure result, multi-execution.
- `tests/bootstrap-smoke.php` — add `'Abilities'` to the source-directory whitelist.
- `composer.json` — include the new smoke in `composer test`.

## Follow-ups (separate PRs in the #94 family)

- `wp_pre_execute_ability` → approval gate returning a pending-action envelope (resolves the sentinel-shape design question; @ibrahimhajjaj has offered to take this slice).
- `wp_ability_normalize_input` → inject `WP_Agent_Execution_Principal` / `WP_Agent_Caller_Context` into ability input.
- `wp_ability_permission_result` → route through `WP_Agent_Tool_Access_Policy` and capability ceiling.

Each of those reuses the same `WP_Agent_Ability_Lifecycle_Bridge` class (extra static methods + `add_filter` calls in `register()`).

## Test plan

- [x] `php tests/ability-lifecycle-bridge-smoke.php` — 12 assertions, all pass.
- [x] `composer test` — full suite green; bootstrap whitelist updated for the new `src/Abilities/` directory.

Part of #94.