### PR TITLE
Add package adoption orchestration contracts

### DIFF
--- a/agents-api.php
+++ b/agents-api.php
@@ -39,7 +39,10 @@ require_once AGENTS_API_PATH . 'src/Packages/class-wp-agent-package-update-plann
 require_once AGENTS_API_PATH . 'src/Packages/class-wp-agent-package-artifact-callbacks.php';
 require_once AGENTS_API_PATH . 'src/Packages/class-wp-agent-package.php';
 require_once AGENTS_API_PATH . 'src/Packages/class-wp-agent-package-adoption-diff.php';
+require_once AGENTS_API_PATH . 'src/Packages/class-wp-agent-package-artifact-state-store.php';
+require_once AGENTS_API_PATH . 'src/Packages/class-wp-agent-package-adoption-request.php';
 require_once AGENTS_API_PATH . 'src/Packages/class-wp-agent-package-adoption-result.php';
+require_once AGENTS_API_PATH . 'src/Packages/class-wp-agent-package-adoption-orchestrator.php';
 require_once AGENTS_API_PATH . 'src/Packages/class-wp-agent-package-adopter.php';
 require_once AGENTS_API_PATH . 'src/Auth/class-wp-agent-capability-ceiling.php';
 require_once AGENTS_API_PATH . 'src/Auth/class-wp-agent-access-grant.php';

--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
       "php tests/message-envelope-smoke.php",
       "php tests/registry-smoke.php",
       "php tests/package-lifecycle-smoke.php",
+      "php tests/package-adoption-orchestration-smoke.php",
       "php tests/execution-principal-smoke.php",
       "php tests/effective-agent-resolver-smoke.php",
       "php tests/caller-context-smoke.php",

--- a/docs/registry-and-packages.md
+++ b/docs/registry-and-packages.md
@@ -122,6 +122,10 @@ Core classes:
 | `WP_Agent_Package_Update_Planner` | Pure planner that compares installed, current, and target artifact state. |
 | `WP_Agent_Package_Update_Plan` | Bucketed plan value object. |
 | `WP_Agent_Package_Artifact_Callbacks` | Helper for invoking registered artifact type lifecycle callbacks. |
+| `WP_Agent_Package_Artifact_State_Store` | Storage-neutral contract for installed, current, target, and recorded artifact snapshots. |
+| `WP_Agent_Package_Adoption_Request` | Value object describing install, upgrade, reconcile, uninstall, or dry-run adoption. |
+| `WP_Agent_Package_Adoption_Result` | Value object describing plans, applied/skipped/failed entries, and recorded snapshots. |
+| `WP_Agent_Package_Adoption_Orchestrator` | Storage-neutral coordinator that composes the planner, artifact callbacks, and state store. |
 
 `WP_Agent_Package_Update_Planner::plan()` returns buckets:
 
@@ -135,6 +139,35 @@ Core classes:
 Planner entries include artifact identity, hashes, a reason, a summary, and a redacted before/after diff payload. Secret-like keys such as `token`, `password`, `api_key`, `authorization`, and `credential` are redacted recursively.
 
 `WP_Agent_Package_Adoption_Diff` accepts an optional `WP_Agent_Package_Update_Plan` so adopters can return bucketed artifact plans alongside the existing flat `changes` and `warnings` fields.
+
+## Package adoption orchestration
+
+Plugin authors can ship package definitions with their plugin releases while still preserving user-customized runtime state. The plugin release answers which package definition is available; package adoption answers how that definition reconciles with installed and current artifacts.
+
+The generic adoption flow is:
+
+```text
+plugin package definition
+  -> state store reads installed/current/target artifacts
+  -> update planner creates buckets
+  -> orchestrator applies auto-apply plus approved artifacts
+  -> artifact callbacks materialize product-specific runtime state
+  -> state store records installed snapshots for applied artifacts
+```
+
+`WP_Agent_Package_Adoption_Orchestrator` owns only that neutral sequencing. It does not store rows, expose UI, approve user decisions, fetch remote package sources, or understand product artifacts. Consumers provide a `WP_Agent_Package_Artifact_State_Store`, registered artifact type callbacks, and any approval surface.
+
+`WP_Agent_Package_Adoption_Request` controls the operation and policy knobs:
+
+| Field | Purpose |
+| --- | --- |
+| `operation` | `install`, `upgrade`, `reconcile`, `uninstall`, or `dry-run`. |
+| `dry_run` | Returns a plan without invoking import callbacks or recording snapshots. |
+| `auto_apply` | Allows or blocks the `auto_apply` bucket from materializing. |
+| `approved_artifact_keys` | Explicit artifact keys that may be applied from non-auto buckets. |
+| `context` | Consumer metadata forwarded to state store and artifact callbacks. |
+
+`WP_Agent_Package_Adoption_Result` reports the plan, applied entries, skipped entries, failed entries, and installed snapshots recorded for applied artifacts. This lets plugin updates ship improved bundled agents while customized prompts, flows, memory, or settings remain reviewable instead of being blindly overwritten.
 
 ## Artifact type registry
 

--- a/src/Packages/class-wp-agent-package-adoption-orchestrator.php
+++ b/src/Packages/class-wp-agent-package-adoption-orchestrator.php
@@ -1,0 +1,216 @@
+<?php
+/**
+ * WP_Agent_Package_Adoption_Orchestrator service.
+ *
+ * @package AgentsAPI
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+if ( ! class_exists( 'WP_Agent_Package_Adoption_Orchestrator' ) ) {
+	/**
+	 * Coordinates storage-neutral package adoption primitives.
+	 */
+	final class WP_Agent_Package_Adoption_Orchestrator {
+
+		private WP_Agent_Package_Artifact_State_Store $state_store;
+
+		public function __construct( WP_Agent_Package_Artifact_State_Store $state_store ) {
+			$this->state_store = $state_store;
+		}
+
+		/**
+		 * Builds an update plan without applying changes.
+		 *
+		 * @param WP_Agent_Package   $package Package definition.
+		 * @param array<string,mixed> $context Consumer context.
+		 * @return WP_Agent_Package_Update_Plan
+		 */
+		public function plan( WP_Agent_Package $package, array $context = array() ): WP_Agent_Package_Update_Plan {
+			return WP_Agent_Package_Update_Planner::plan(
+				$this->state_store->get_installed_artifacts( $package, $context ),
+				$this->state_store->get_current_artifacts( $package, $context ),
+				$this->state_store->get_target_artifacts( $package, $context ),
+				array(
+					'package_slug'    => $package->get_slug(),
+					'package_version' => $package->get_version(),
+				) + $context
+			);
+		}
+
+		/**
+		 * Applies safe or approved package artifacts.
+		 *
+		 * @param WP_Agent_Package_Adoption_Request $request Adoption request.
+		 * @return WP_Agent_Package_Adoption_Result
+		 */
+		public function adopt( WP_Agent_Package_Adoption_Request $request ): WP_Agent_Package_Adoption_Result {
+			$package = $request->get_package();
+			$context = $request->get_context();
+			$target  = $this->state_store->get_target_artifacts( $package, $context );
+			$plan    = WP_Agent_Package_Update_Planner::plan(
+				$this->state_store->get_installed_artifacts( $package, $context ),
+				$this->state_store->get_current_artifacts( $package, $context ),
+				$target,
+				array(
+					'package_slug'    => $package->get_slug(),
+					'package_version' => $package->get_version(),
+					'operation'       => $request->get_operation(),
+				) + $context
+			);
+
+			if ( $request->is_dry_run() || 'dry-run' === $request->get_operation() ) {
+				return new WP_Agent_Package_Adoption_Result( 'planned', $package->get_agent()->get_slug(), array(), $plan );
+			}
+
+			$approved_keys = array_fill_keys( $request->get_approved_artifact_keys(), true );
+			$target_index  = self::index_artifacts( $target );
+			$applied       = array();
+			$skipped       = array();
+			$failed        = array();
+			$snapshots     = array();
+
+			foreach ( $plan->get_buckets() as $bucket => $entries ) {
+				foreach ( $entries as $entry ) {
+					$artifact_key = (string) ( $entry['artifact_key'] ?? '' );
+					$can_apply    = ( 'auto_apply' === $bucket && $request->allows_auto_apply() ) || isset( $approved_keys[ $artifact_key ] );
+
+					if ( ! $can_apply ) {
+						$skipped[] = self::entry_with_status( $entry, 'skipped', 'not_approved' );
+						continue;
+					}
+
+					$target_row = $target_index[ $artifact_key ] ?? null;
+					if ( null === $target_row ) {
+						$failed[] = self::entry_with_status( $entry, 'failed', 'target_missing' );
+						continue;
+					}
+
+					$artifact = self::artifact_from_entry( $package, $entry, $target_row );
+					$result   = WP_Agent_Package_Artifact_Callbacks::import(
+						$artifact,
+						array(
+							'package' => $package,
+							'request' => $request,
+							'entry'   => $entry,
+							'target'  => $target_row,
+						) + $context
+					);
+
+					if ( false === $result ) {
+						$failed[] = self::entry_with_status( $entry, 'failed', 'callback_failed' );
+						continue;
+					}
+
+					$applied[]   = self::entry_with_status( $entry, 'applied', 'applied' );
+					$snapshots[] = self::snapshot_from_target( $package, $target_row, $context );
+				}
+			}
+
+			$recorded = array();
+			if ( $snapshots ) {
+				$recorded = $this->state_store->record_installed_artifacts( $package, $snapshots, $context ) ? $snapshots : array();
+			}
+
+			return new WP_Agent_Package_Adoption_Result(
+				self::result_status( $applied, $skipped, $failed ),
+				$package->get_agent()->get_slug(),
+				array(),
+				$plan,
+				$applied,
+				$skipped,
+				$failed,
+				$recorded
+			);
+		}
+
+		/** @param array<int,array<string,mixed>> $artifacts */
+		private static function index_artifacts( array $artifacts ): array {
+			$indexed = array();
+			foreach ( $artifacts as $artifact ) {
+				$type = WP_Agent_Package_Artifact::prepare_type( $artifact['artifact_type'] ?? ( $artifact['type'] ?? '' ) );
+				$id   = self::artifact_id( $artifact );
+				$indexed[ self::artifact_key( $type, $id ) ] = array_merge(
+					$artifact,
+					array(
+						'artifact_type' => $type,
+						'artifact_id'   => $id,
+					)
+				);
+			}
+
+			return $indexed;
+		}
+
+		/** @param array<string,mixed> $entry */
+		private static function artifact_from_entry( WP_Agent_Package $package, array $entry, array $target ): WP_Agent_Package_Artifact {
+			$type = (string) ( $entry['artifact_type'] ?? $target['artifact_type'] );
+			$id   = (string) ( $entry['artifact_id'] ?? $target['artifact_id'] );
+			foreach ( $package->get_artifacts() as $artifact ) {
+				if ( $artifact->get_type() === $type && $artifact->get_slug() === sanitize_title( $id ) ) {
+					return $artifact;
+				}
+			}
+
+			return new WP_Agent_Package_Artifact(
+				array(
+					'type'   => $type,
+					'slug'   => $id,
+					'source' => (string) ( $target['source'] ?? $entry['source'] ?? '' ),
+				)
+			);
+		}
+
+		/** @param array<string,mixed> $target */
+		private static function snapshot_from_target( WP_Agent_Package $package, array $target, array $context ): WP_Agent_Package_Installed_Artifact {
+			$hash      = (string) ( $target['hash'] ?? WP_Agent_Package_Artifact_Hasher::hash( $target['payload'] ?? null ) );
+			$timestamp = (string) ( $context['timestamp'] ?? gmdate( 'c' ) );
+
+			return new WP_Agent_Package_Installed_Artifact(
+				array(
+					'package_slug'      => $package->get_slug(),
+					'package_version'   => $package->get_version(),
+					'artifact_type'     => (string) $target['artifact_type'],
+					'artifact_id'       => self::artifact_id( $target ),
+					'source'            => (string) ( $target['source'] ?? '' ),
+					'installed_hash'    => $hash,
+					'current_hash'      => $hash,
+					'installed_payload' => $target['payload'] ?? null,
+					'installed_at'      => $timestamp,
+					'updated_at'        => $timestamp,
+				)
+			);
+		}
+
+		private static function artifact_id( array $artifact ): string {
+			return trim( str_replace( '\\', '/', (string) ( $artifact['artifact_id'] ?? ( $artifact['slug'] ?? '' ) ) ) );
+		}
+
+		private static function artifact_key( string $type, string $id ): string {
+			return $type . ':' . $id;
+		}
+
+		/** @param array<string,mixed> $entry */
+		private static function entry_with_status( array $entry, string $status, string $reason ): array {
+			return array_merge(
+				$entry,
+				array(
+					'apply_status' => $status,
+					'apply_reason' => $reason,
+				)
+			);
+		}
+
+		private static function result_status( array $applied, array $skipped, array $failed ): string {
+			if ( $failed ) {
+				return $applied ? 'partial' : 'failed';
+			}
+
+			if ( $applied && $skipped ) {
+				return 'partial';
+			}
+
+			return $applied ? 'applied' : 'skipped';
+		}
+	}
+}

--- a/src/Packages/class-wp-agent-package-adoption-request.php
+++ b/src/Packages/class-wp-agent-package-adoption-request.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * WP_Agent_Package_Adoption_Request value object.
+ *
+ * @package AgentsAPI
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+if ( ! class_exists( 'WP_Agent_Package_Adoption_Request' ) ) {
+	/**
+	 * Normalized request for package adoption orchestration.
+	 */
+	final class WP_Agent_Package_Adoption_Request {
+
+		private WP_Agent_Package $package;
+		private string $operation;
+		private bool $dry_run;
+		private bool $auto_apply;
+		/** @var array<int,string> */
+		private array $approved_artifact_keys;
+		/** @var array<string,mixed> */
+		private array $context;
+
+		/**
+		 * Constructor.
+		 *
+		 * @param WP_Agent_Package   $package Package definition.
+		 * @param array<string,mixed> $args Request arguments.
+		 */
+		public function __construct( WP_Agent_Package $package, array $args = array() ) {
+			$this->package                = $package;
+			$this->operation              = self::prepare_operation( $args['operation'] ?? 'upgrade' );
+			$this->dry_run                = (bool) ( $args['dry_run'] ?? false );
+			$this->auto_apply             = (bool) ( $args['auto_apply'] ?? true );
+			$this->approved_artifact_keys = self::prepare_string_list( $args['approved_artifact_keys'] ?? array() );
+			$this->context                = is_array( $args['context'] ?? null ) ? $args['context'] : array();
+		}
+
+		public function get_package(): WP_Agent_Package {
+			return $this->package;
+		}
+
+		public function get_operation(): string {
+			return $this->operation;
+		}
+
+		public function is_dry_run(): bool {
+			return $this->dry_run;
+		}
+
+		public function allows_auto_apply(): bool {
+			return $this->auto_apply;
+		}
+
+		/** @return array<int,string> */
+		public function get_approved_artifact_keys(): array {
+			return $this->approved_artifact_keys;
+		}
+
+		/** @return array<string,mixed> */
+		public function get_context(): array {
+			return $this->context;
+		}
+
+		/** @return array<string,mixed> */
+		public function to_array(): array {
+			return array(
+				'package'                => $this->package->to_array(),
+				'operation'              => $this->operation,
+				'dry_run'                => $this->dry_run,
+				'auto_apply'             => $this->auto_apply,
+				'approved_artifact_keys' => $this->approved_artifact_keys,
+				'context'                => $this->context,
+			);
+		}
+
+		private static function prepare_operation( $operation ): string {
+			$operation = sanitize_title( (string) $operation );
+			$allowed   = array( 'install', 'upgrade', 'reconcile', 'uninstall', 'dry-run' );
+			if ( ! in_array( $operation, $allowed, true ) ) {
+				throw new InvalidArgumentException( 'Package adoption operation must be install, upgrade, reconcile, uninstall, or dry-run.' );
+			}
+
+			return $operation;
+		}
+
+		/**
+		 * @param mixed $values Raw values.
+		 * @return array<int,string>
+		 */
+		private static function prepare_string_list( $values ): array {
+			$prepared = array();
+			foreach ( (array) $values as $value ) {
+				$value = trim( (string) $value );
+				if ( '' !== $value ) {
+					$prepared[] = $value;
+				}
+			}
+
+			return array_values( array_unique( $prepared ) );
+		}
+	}
+}

--- a/src/Packages/class-wp-agent-package-adoption-result.php
+++ b/src/Packages/class-wp-agent-package-adoption-result.php
@@ -34,17 +34,46 @@ if ( ! class_exists( 'WP_Agent_Package_Adoption_Result' ) ) {
 		 */
 		private array $messages;
 
+		private ?WP_Agent_Package_Update_Plan $plan;
+
+		/** @var array<int,array<string,mixed>> */
+		private array $applied_artifacts;
+
+		/** @var array<int,array<string,mixed>> */
+		private array $skipped_artifacts;
+
+		/** @var array<int,array<string,mixed>> */
+		private array $failed_artifacts;
+
+		/** @var array<int,WP_Agent_Package_Installed_Artifact> */
+		private array $recorded_artifacts;
+
+		/** @var array<string,mixed> */
+		private array $meta;
+
 		/**
 		 * Constructor.
 		 *
-		 * @param string             $status     Result status.
-		 * @param string             $agent_slug Adopted agent slug.
-		 * @param array<int, string> $messages   Result messages.
+		 * @param string                                     $status Result status.
+		 * @param string                                     $agent_slug Adopted agent slug.
+		 * @param array<int,string>                          $messages Result messages.
+		 * @param WP_Agent_Package_Update_Plan|null          $plan Optional package plan.
+		 * @param array<int,array<string,mixed>>             $applied_artifacts Applied entries.
+		 * @param array<int,array<string,mixed>>             $skipped_artifacts Skipped entries.
+		 * @param array<int,array<string,mixed>>             $failed_artifacts Failed entries.
+		 * @param array<int,WP_Agent_Package_Installed_Artifact> $recorded_artifacts Recorded snapshots.
+		 * @param array<string,mixed>                        $meta Result metadata.
 		 */
-		public function __construct( string $status, string $agent_slug, array $messages = array() ) {
-			$this->status     = $this->prepare_status( $status );
-			$this->agent_slug = sanitize_title( $agent_slug );
-			$this->messages   = $this->prepare_messages( $messages );
+		public function __construct( string $status, string $agent_slug, array $messages = array(), ?WP_Agent_Package_Update_Plan $plan = null, array $applied_artifacts = array(), array $skipped_artifacts = array(), array $failed_artifacts = array(), array $recorded_artifacts = array(), array $meta = array() ) {
+			$this->status             = $this->prepare_status( $status );
+			$this->agent_slug         = sanitize_title( $agent_slug );
+			$this->messages           = $this->prepare_messages( $messages );
+			$this->plan               = $plan;
+			$this->applied_artifacts  = $applied_artifacts;
+			$this->skipped_artifacts  = $skipped_artifacts;
+			$this->failed_artifacts   = $failed_artifacts;
+			$this->recorded_artifacts = $this->prepare_recorded_artifacts( $recorded_artifacts );
+			$this->meta               = $meta;
 
 			if ( '' === $this->agent_slug ) {
 				throw new InvalidArgumentException( 'Agent package adoption result requires an agent slug.' );
@@ -78,17 +107,62 @@ if ( ! class_exists( 'WP_Agent_Package_Adoption_Result' ) ) {
 			return $this->messages;
 		}
 
+		public function get_plan(): ?WP_Agent_Package_Update_Plan {
+			return $this->plan;
+		}
+
+		/** @return array<int,array<string,mixed>> */
+		public function get_applied_artifacts(): array {
+			return $this->applied_artifacts;
+		}
+
+		/** @return array<int,array<string,mixed>> */
+		public function get_skipped_artifacts(): array {
+			return $this->skipped_artifacts;
+		}
+
+		/** @return array<int,array<string,mixed>> */
+		public function get_failed_artifacts(): array {
+			return $this->failed_artifacts;
+		}
+
+		/** @return array<int,WP_Agent_Package_Installed_Artifact> */
+		public function get_recorded_artifacts(): array {
+			return $this->recorded_artifacts;
+		}
+
+		/** @return array<string,mixed> */
+		public function get_meta(): array {
+			return $this->meta;
+		}
+
 		/**
 		 * Exports the value object.
 		 *
 		 * @return array<string, mixed>
 		 */
 		public function to_array(): array {
-			return array(
+			$data = array(
 				'status'     => $this->status,
 				'agent_slug' => $this->agent_slug,
 				'messages'   => $this->messages,
+				'applied'    => $this->applied_artifacts,
+				'skipped'    => $this->skipped_artifacts,
+				'failed'     => $this->failed_artifacts,
+				'recorded'   => array_map(
+					static function ( WP_Agent_Package_Installed_Artifact $artifact ): array {
+						return $artifact->to_array();
+					},
+					$this->recorded_artifacts
+				),
+				'meta'       => $this->meta,
 			);
+
+			if ( null !== $this->plan ) {
+				$data['plan'] = $this->plan->to_array();
+			}
+
+			return $data;
 		}
 
 		/**
@@ -99,9 +173,9 @@ if ( ! class_exists( 'WP_Agent_Package_Adoption_Result' ) ) {
 		 */
 		private function prepare_status( string $status ): string {
 			$status  = sanitize_title( $status );
-			$allowed = array( 'adopted', 'updated', 'skipped', 'failed' );
+			$allowed = array( 'adopted', 'updated', 'skipped', 'failed', 'planned', 'applied', 'partial', 'needs-approval' );
 			if ( ! in_array( $status, $allowed, true ) ) {
-				throw new InvalidArgumentException( 'Agent package adoption result status must be one of adopted, updated, skipped, failed.' );
+				throw new InvalidArgumentException( 'Agent package adoption result status is invalid.' );
 			}
 
 			return $status;
@@ -119,6 +193,21 @@ if ( ! class_exists( 'WP_Agent_Package_Adoption_Result' ) ) {
 				$message = trim( (string) $message );
 				if ( '' !== $message ) {
 					$prepared[] = $message;
+				}
+			}
+
+			return $prepared;
+		}
+
+		/**
+		 * @param array<int,mixed> $artifacts Raw artifacts.
+		 * @return array<int,WP_Agent_Package_Installed_Artifact>
+		 */
+		private function prepare_recorded_artifacts( array $artifacts ): array {
+			$prepared = array();
+			foreach ( $artifacts as $artifact ) {
+				if ( $artifact instanceof WP_Agent_Package_Installed_Artifact ) {
+					$prepared[] = $artifact;
 				}
 			}
 

--- a/src/Packages/class-wp-agent-package-artifact-state-store.php
+++ b/src/Packages/class-wp-agent-package-artifact-state-store.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * WP_Agent_Package_Artifact_State_Store contract.
+ *
+ * @package AgentsAPI
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+if ( ! interface_exists( 'WP_Agent_Package_Artifact_State_Store' ) ) {
+	/**
+	 * Storage-neutral artifact state contract for package adoption orchestration.
+	 */
+	interface WP_Agent_Package_Artifact_State_Store {
+
+		/**
+		 * Returns install-time artifact snapshots for a package.
+		 *
+		 * @param WP_Agent_Package   $package Package definition.
+		 * @param array<string,mixed> $context Consumer context.
+		 * @return array<int,array<string,mixed>|WP_Agent_Package_Installed_Artifact>
+		 */
+		public function get_installed_artifacts( WP_Agent_Package $package, array $context = array() ): array;
+
+		/**
+		 * Returns current runtime artifact state for a package.
+		 *
+		 * @param WP_Agent_Package   $package Package definition.
+		 * @param array<string,mixed> $context Consumer context.
+		 * @return array<int,array<string,mixed>>
+		 */
+		public function get_current_artifacts( WP_Agent_Package $package, array $context = array() ): array;
+
+		/**
+		 * Returns target artifact state from the package source.
+		 *
+		 * @param WP_Agent_Package   $package Package definition.
+		 * @param array<string,mixed> $context Consumer context.
+		 * @return array<int,array<string,mixed>>
+		 */
+		public function get_target_artifacts( WP_Agent_Package $package, array $context = array() ): array;
+
+		/**
+		 * Records install-time snapshots generated for applied artifacts.
+		 *
+		 * @param WP_Agent_Package                    $package Package definition.
+		 * @param array<int,WP_Agent_Package_Installed_Artifact> $artifacts Applied artifact snapshots.
+		 * @param array<string,mixed>                  $context Consumer context.
+		 * @return bool Whether snapshots were recorded.
+		 */
+		public function record_installed_artifacts( WP_Agent_Package $package, array $artifacts, array $context = array() ): bool;
+	}
+}

--- a/tests/package-adoption-orchestration-smoke.php
+++ b/tests/package-adoption-orchestration-smoke.php
@@ -1,0 +1,192 @@
+<?php
+/**
+ * Pure-PHP smoke test for package adoption orchestration contracts.
+ *
+ * Run with: php tests/package-adoption-orchestration-smoke.php
+ *
+ * @package AgentsAPI\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+$failures = array();
+$passes   = 0;
+
+echo "agents-api-package-adoption-orchestration-smoke\n";
+
+require_once __DIR__ . '/agents-api-smoke-helpers.php';
+agents_api_smoke_require_module();
+
+final class Agents_API_Test_Package_State_Store implements WP_Agent_Package_Artifact_State_Store {
+	/** @var array<int,array<string,mixed>|WP_Agent_Package_Installed_Artifact> */
+	private array $installed;
+	/** @var array<int,array<string,mixed>> */
+	private array $current;
+	/** @var array<int,array<string,mixed>> */
+	private array $target;
+	/** @var array<int,WP_Agent_Package_Installed_Artifact> */
+	public array $recorded = array();
+
+	public function __construct( array $installed, array $current, array $target ) {
+		$this->installed = $installed;
+		$this->current   = $current;
+		$this->target    = $target;
+	}
+
+	public function get_installed_artifacts( WP_Agent_Package $package, array $context = array() ): array {
+		unset( $package, $context );
+		return $this->installed;
+	}
+
+	public function get_current_artifacts( WP_Agent_Package $package, array $context = array() ): array {
+		unset( $package, $context );
+		return $this->current;
+	}
+
+	public function get_target_artifacts( WP_Agent_Package $package, array $context = array() ): array {
+		unset( $package, $context );
+		return $this->target;
+	}
+
+	public function record_installed_artifacts( WP_Agent_Package $package, array $artifacts, array $context = array() ): bool {
+		unset( $package, $context );
+		$this->recorded = $artifacts;
+		return true;
+	}
+}
+
+add_action(
+	'wp_agent_package_artifacts_init',
+	static function (): void {
+		wp_register_agent_package_artifact_type(
+			'example/prompt',
+			array(
+				'import_callback' => static function ( WP_Agent_Package_Artifact $artifact, array $context ): array {
+					$GLOBALS['__agents_api_adoption_imports'][] = array(
+						'artifact' => $artifact->get_slug(),
+						'body'     => $context['target']['payload']['body'] ?? null,
+					);
+
+					return array( 'imported' => $artifact->get_slug() );
+				},
+			)
+		);
+	}
+);
+do_action( 'init' );
+
+$package = WP_Agent_Package::from_array(
+	array(
+		'slug'      => 'demo-package',
+		'version'   => '1.1.0',
+		'agent'     => array(
+			'slug'  => 'demo-agent',
+			'label' => 'Demo Agent',
+		),
+		'artifacts' => array(
+			array( 'type' => 'example/prompt', 'slug' => 'clean-update', 'source' => 'prompts/clean.md' ),
+			array( 'type' => 'example/prompt', 'slug' => 'local-edit', 'source' => 'prompts/local.md' ),
+			array( 'type' => 'example/prompt', 'slug' => 'brand-new', 'source' => 'prompts/new.md' ),
+			array( 'type' => 'example/prompt', 'slug' => 'untracked-local', 'source' => 'prompts/untracked.md' ),
+		),
+	)
+);
+
+$hash_base   = WP_Agent_Package_Artifact_Hasher::hash( array( 'body' => 'base' ) );
+$hash_old    = WP_Agent_Package_Artifact_Hasher::hash( array( 'body' => 'old' ) );
+$hash_local  = WP_Agent_Package_Artifact_Hasher::hash( array( 'body' => 'local' ) );
+$hash_target = WP_Agent_Package_Artifact_Hasher::hash( array( 'body' => 'already-target' ) );
+
+$installed = array(
+	array(
+		'package_slug'    => 'demo-package',
+		'package_version' => '1.0.0',
+		'artifact_type'   => 'example/prompt',
+		'artifact_id'     => 'clean-update',
+		'source'          => 'prompts/clean.md',
+		'installed_hash'  => $hash_old,
+		'current_hash'    => $hash_old,
+		'installed_at'    => '2026-05-25T00:00:00Z',
+		'updated_at'      => '2026-05-25T00:00:00Z',
+	),
+	array(
+		'package_slug'    => 'demo-package',
+		'package_version' => '1.0.0',
+		'artifact_type'   => 'example/prompt',
+		'artifact_id'     => 'local-edit',
+		'source'          => 'prompts/local.md',
+		'installed_hash'  => $hash_base,
+		'current_hash'    => $hash_local,
+		'installed_at'    => '2026-05-25T00:00:00Z',
+		'updated_at'      => '2026-05-25T00:00:00Z',
+	),
+);
+
+$current = array(
+	array( 'artifact_type' => 'example/prompt', 'artifact_id' => 'clean-update', 'source' => 'prompts/clean.md', 'payload' => array( 'body' => 'old' ) ),
+	array( 'artifact_type' => 'example/prompt', 'artifact_id' => 'local-edit', 'source' => 'prompts/local.md', 'payload' => array( 'body' => 'local' ) ),
+	array( 'artifact_type' => 'example/prompt', 'artifact_id' => 'untracked-local', 'source' => 'prompts/untracked.md', 'payload' => array( 'body' => 'local-only' ) ),
+	array( 'artifact_type' => 'example/prompt', 'artifact_id' => 'already-target', 'source' => 'prompts/already.md', 'payload' => array( 'body' => 'already-target' ), 'hash' => $hash_target ),
+);
+
+$target = array(
+	array( 'artifact_type' => 'example/prompt', 'artifact_id' => 'clean-update', 'source' => 'prompts/clean.md', 'payload' => array( 'body' => 'new' ) ),
+	array( 'artifact_type' => 'example/prompt', 'artifact_id' => 'local-edit', 'source' => 'prompts/local.md', 'payload' => array( 'body' => 'remote' ) ),
+	array( 'artifact_type' => 'example/prompt', 'artifact_id' => 'brand-new', 'source' => 'prompts/new.md', 'payload' => array( 'body' => 'new' ) ),
+	array( 'artifact_type' => 'example/prompt', 'artifact_id' => 'untracked-local', 'source' => 'prompts/untracked.md', 'payload' => array( 'body' => 'remote' ) ),
+	array( 'artifact_type' => 'example/prompt', 'artifact_id' => 'already-target', 'source' => 'prompts/already.md', 'payload' => array( 'body' => 'already-target' ), 'hash' => $hash_target ),
+);
+
+$store        = new Agents_API_Test_Package_State_Store( $installed, $current, $target );
+$orchestrator = new WP_Agent_Package_Adoption_Orchestrator( $store );
+
+echo "\n[1] Orchestrator plans through the shared package planner:\n";
+$plan = $orchestrator->plan( $package, array( 'timestamp' => '2026-05-25T01:00:00Z' ) );
+agents_api_smoke_assert_equals( 2, count( $plan->get_bucket( 'auto_apply' ) ), 'auto-apply bucket includes clean and new artifacts', $failures, $passes );
+agents_api_smoke_assert_equals( 2, count( $plan->get_bucket( 'needs_approval' ) ), 'needs-approval bucket includes local edits', $failures, $passes );
+agents_api_smoke_assert_equals( 1, count( $plan->get_bucket( 'no_op' ) ), 'no-op bucket includes already matching artifact', $failures, $passes );
+
+echo "\n[2] Dry run returns a plan without applying artifacts:\n";
+$dry_run = $orchestrator->adopt(
+	new WP_Agent_Package_Adoption_Request(
+		$package,
+		array(
+			'operation' => 'dry-run',
+			'dry_run'   => true,
+			'context'   => array( 'timestamp' => '2026-05-25T01:00:00Z' ),
+		)
+	)
+);
+agents_api_smoke_assert_equals( 'planned', $dry_run->get_status(), 'dry run reports planned status', $failures, $passes );
+agents_api_smoke_assert_equals( 0, count( $GLOBALS['__agents_api_adoption_imports'] ?? array() ), 'dry run does not import artifacts', $failures, $passes );
+
+echo "\n[3] Adoption applies auto-apply plus approved artifacts only:\n";
+$result = $orchestrator->adopt(
+	new WP_Agent_Package_Adoption_Request(
+		$package,
+		array(
+			'operation'              => 'upgrade',
+			'approved_artifact_keys' => array( 'example/prompt:local-edit' ),
+			'context'                => array( 'timestamp' => '2026-05-25T01:00:00Z' ),
+		)
+	)
+);
+
+agents_api_smoke_assert_equals( 'partial', $result->get_status(), 'unapproved local artifact keeps result partial', $failures, $passes );
+agents_api_smoke_assert_equals( 3, count( $result->get_applied_artifacts() ), 'three artifacts applied', $failures, $passes );
+agents_api_smoke_assert_equals( 2, count( $result->get_skipped_artifacts() ), 'unapproved and no-op artifacts are skipped', $failures, $passes );
+agents_api_smoke_assert_equals( 0, count( $result->get_failed_artifacts() ), 'no artifacts failed', $failures, $passes );
+agents_api_smoke_assert_equals( 3, count( $store->recorded ), 'installed snapshots recorded for applied artifacts', $failures, $passes );
+
+$recorded_payloads = array();
+foreach ( $store->recorded as $recorded_artifact ) {
+	$recorded_payloads[ $recorded_artifact->get_artifact_id() ] = $recorded_artifact->get_installed_payload();
+}
+$imported_slugs = array_column( $GLOBALS['__agents_api_adoption_imports'], 'artifact' );
+agents_api_smoke_assert_equals( true, isset( $recorded_payloads['local-edit'] ), 'recorded snapshot preserves approved artifact id', $failures, $passes );
+agents_api_smoke_assert_equals( 'remote', $recorded_payloads['local-edit']['body'], 'recorded snapshot captures target payload', $failures, $passes );
+agents_api_smoke_assert_equals( true, in_array( 'local-edit', $imported_slugs, true ), 'import callback receives approved artifact', $failures, $passes );
+
+agents_api_smoke_finish( 'Agents API package adoption orchestration', $failures, $passes );


### PR DESCRIPTION
## Summary
- Adds storage-neutral package adoption orchestration contracts on top of the package lifecycle planner.
- Introduces a state-store contract, adoption request value object, and orchestrator that applies auto-safe or explicitly approved artifacts through artifact callbacks.
- Extends adoption results and docs so consumers can surface plans, applied/skipped/failed artifacts, and recorded install snapshots.

## Related
- Closes #202
- Builds on #201
- Supports downstream adoption tracked in Extra-Chill/data-machine#2235 and Extra-Chill/data-machine#2236

## Testing
- `homeboy lint --path /Users/chubes/Developer/agents-api@package-adoption-orchestration --extension wordpress --changed-only --errors-only`
- `homeboy test --path /Users/chubes/Developer/agents-api@package-adoption-orchestration --extension wordpress`
- `composer test`

## Notes
- Full unscoped `homeboy lint` currently reports pre-existing PHPStan findings outside this branch. Changed-file lint passes cleanly.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the orchestration contracts, smoke coverage, docs updates, and local verification commands for Chris to review.