### PR TITLE
Add package capability compatibility contracts

### DIFF
--- a/agents-api.php
+++ b/agents-api.php
@@ -38,6 +38,8 @@ require_once AGENTS_API_PATH . 'src/Packages/class-wp-agent-package-update-plan.
 require_once AGENTS_API_PATH . 'src/Packages/class-wp-agent-package-update-planner.php';
 require_once AGENTS_API_PATH . 'src/Packages/class-wp-agent-package-artifact-callbacks.php';
 require_once AGENTS_API_PATH . 'src/Packages/class-wp-agent-package.php';
+require_once AGENTS_API_PATH . 'src/Packages/class-wp-agent-package-capability-report.php';
+require_once AGENTS_API_PATH . 'src/Packages/class-wp-agent-package-capability-checker.php';
 require_once AGENTS_API_PATH . 'src/Packages/class-wp-agent-package-adoption-diff.php';
 require_once AGENTS_API_PATH . 'src/Packages/class-wp-agent-package-artifact-state-store.php';
 require_once AGENTS_API_PATH . 'src/Packages/class-wp-agent-package-adoption-request.php';

--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
       "php tests/message-envelope-smoke.php",
       "php tests/registry-smoke.php",
       "php tests/package-lifecycle-smoke.php",
+      "php tests/package-capability-contract-smoke.php",
       "php tests/package-adoption-orchestration-smoke.php",
       "php tests/execution-principal-smoke.php",
       "php tests/effective-agent-resolver-smoke.php",

--- a/docs/registry-and-packages.md
+++ b/docs/registry-and-packages.md
@@ -123,6 +123,8 @@ Core classes:
 | `WP_Agent_Package_Update_Plan` | Bucketed plan value object. |
 | `WP_Agent_Package_Artifact_Callbacks` | Helper for invoking registered artifact type lifecycle callbacks. |
 | `WP_Agent_Package_Artifact_State_Store` | Storage-neutral contract for installed, current, target, and recorded artifact snapshots. |
+| `WP_Agent_Package_Capability_Report` | Stable compatibility report for package requirements, host capabilities, unknown artifact types, and artifact-level blockers. |
+| `WP_Agent_Package_Capability_Checker` | Pure checker that compares a package declaration with host-supported capabilities. |
 | `WP_Agent_Package_Adoption_Request` | Value object describing install, upgrade, reconcile, uninstall, or dry-run adoption. |
 | `WP_Agent_Package_Adoption_Result` | Value object describing plans, applied/skipped/failed entries, and recorded snapshots. |
 | `WP_Agent_Package_Adoption_Orchestrator` | Storage-neutral coordinator that composes the planner, artifact callbacks, and state store. |
@@ -168,6 +170,26 @@ plugin package definition
 | `context` | Consumer metadata forwarded to state store and artifact callbacks. |
 
 `WP_Agent_Package_Adoption_Result` reports the plan, applied entries, skipped entries, failed entries, and installed snapshots recorded for applied artifacts. This lets plugin updates ship improved bundled agents while customized prompts, flows, memory, or settings remain reviewable instead of being blindly overwritten.
+
+## Package capability compatibility
+
+Portable packages can declare runtime needs without assuming every host can satisfy them. Package-level `capabilities` describe requirements for the whole package. Artifact-level `requires` describe requirements for one artifact. Hosts compare those strings against their supported capabilities before adoption.
+
+Use `WP_Agent_Package_Capability_Checker::check( $package, $host_capabilities )` to produce a `WP_Agent_Package_Capability_Report`. The checker also reports unknown artifact types from the artifact registry, or from an explicit `known_artifact_types` argument for tests and non-WordPress package readers.
+
+Report fields:
+
+| Field | Purpose |
+| --- | --- |
+| `compatible` | Boolean summary for whether all required capabilities and artifact types are supported. |
+| `status` | Stable string: `compatible` or `unsupported`. |
+| `required_capabilities` | Sorted union of package capabilities and artifact `requires` values. |
+| `host_capabilities` | Sorted capabilities supplied by the host. |
+| `unsupported_capabilities` | Required capabilities absent from host support. |
+| `unknown_artifact_types` | Artifact type slugs with no registered/known handler. |
+| `unsupported_artifacts` | Artifact-level details keyed by `artifact_type:artifact_slug`, including missing requirements and unknown type status. |
+
+Capability reports are advisory and storage-neutral. Hosts decide whether unsupported package pieces block adoption, become skipped artifacts, or are staged for user/admin approval. The checker must not create fallback runtime behavior for a host-specific artifact; the host adapter either supports the declared capability/type or reports it clearly.
 
 ## Artifact type registry
 

--- a/src/Packages/class-wp-agent-package-capability-checker.php
+++ b/src/Packages/class-wp-agent-package-capability-checker.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * WP_Agent_Package_Capability_Checker service.
+ *
+ * @package AgentsAPI
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+if ( ! class_exists( 'WP_Agent_Package_Capability_Checker' ) ) {
+	/**
+	 * Compares a package declaration with host-supported capabilities.
+	 */
+	final class WP_Agent_Package_Capability_Checker {
+
+		/**
+		 * Builds a compatibility report for a package and host runtime.
+		 *
+		 * @param WP_Agent_Package  $package           Package declaration.
+		 * @param array<int,string> $host_capabilities Capabilities supported by the host.
+		 * @param array<string,mixed> $args             Optional known artifact type overrides.
+		 * @return WP_Agent_Package_Capability_Report
+		 */
+		public static function check( WP_Agent_Package $package, array $host_capabilities, array $args = array() ): WP_Agent_Package_Capability_Report {
+			$host_capabilities      = self::normalize_string_list( $host_capabilities );
+			$known_artifact_types   = self::known_artifact_types( $args );
+			$required_capabilities  = $package->get_capabilities();
+			$unknown_artifact_types = array();
+			$unsupported_artifacts  = array();
+
+			foreach ( $package->get_artifacts() as $artifact ) {
+				$artifact_requires     = $artifact->get_requires();
+				$required_capabilities = array_merge( $required_capabilities, $artifact_requires );
+				$unsupported_requires  = array_values( array_diff( $artifact_requires, $host_capabilities ) );
+				$artifact_type         = $artifact->get_type();
+				$unknown_artifact_type = ! in_array( $artifact_type, $known_artifact_types, true );
+
+				if ( $unknown_artifact_type ) {
+					$unknown_artifact_types[] = $artifact_type;
+				}
+
+				if ( $unknown_artifact_type || ! empty( $unsupported_requires ) ) {
+					$unsupported_artifacts[] = array(
+						'artifact_key'             => $artifact_type . ':' . $artifact->get_slug(),
+						'artifact_type'            => $artifact_type,
+						'artifact_slug'            => $artifact->get_slug(),
+						'unknown_artifact_type'    => $unknown_artifact_type,
+						'unsupported_capabilities' => self::normalize_string_list( $unsupported_requires ),
+					);
+				}
+			}
+
+			$required_capabilities    = self::normalize_string_list( $required_capabilities );
+			$unsupported_capabilities = array_values( array_diff( $required_capabilities, $host_capabilities ) );
+
+			return new WP_Agent_Package_Capability_Report(
+				$required_capabilities,
+				$host_capabilities,
+				$unsupported_capabilities,
+				$unknown_artifact_types,
+				$unsupported_artifacts
+			);
+		}
+
+		/**
+		 * Resolves known artifact types from explicit args or the artifact registry.
+		 *
+		 * @param array<string,mixed> $args Check arguments.
+		 * @return array<int,string>
+		 */
+		private static function known_artifact_types( array $args ): array {
+			if ( isset( $args['known_artifact_types'] ) ) {
+				return self::normalize_string_list( is_array( $args['known_artifact_types'] ) ? $args['known_artifact_types'] : array() );
+			}
+
+			return self::normalize_string_list( array_keys( wp_get_agent_package_artifact_types() ) );
+		}
+
+		/**
+		 * Normalizes a capability or type list.
+		 *
+		 * @param array<int,string> $values Raw strings.
+		 * @return array<int,string>
+		 */
+		private static function normalize_string_list( array $values ): array {
+			$prepared = array();
+			foreach ( $values as $value ) {
+				$value = trim( strtolower( (string) $value ) );
+				if ( '' !== $value ) {
+					$prepared[] = $value;
+				}
+			}
+
+			$prepared = array_values( array_unique( $prepared ) );
+			sort( $prepared );
+
+			return $prepared;
+		}
+	}
+}

--- a/src/Packages/class-wp-agent-package-capability-report.php
+++ b/src/Packages/class-wp-agent-package-capability-report.php
@@ -1,0 +1,122 @@
+<?php
+/**
+ * WP_Agent_Package_Capability_Report value object.
+ *
+ * @package AgentsAPI
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+if ( ! class_exists( 'WP_Agent_Package_Capability_Report' ) ) {
+	/**
+	 * Storage-neutral compatibility report for an agent package and host runtime.
+	 */
+	final class WP_Agent_Package_Capability_Report {
+
+		/** @var array<int,string> */
+		private array $required_capabilities;
+
+		/** @var array<int,string> */
+		private array $host_capabilities;
+
+		/** @var array<int,string> */
+		private array $unsupported_capabilities;
+
+		/** @var array<int,string> */
+		private array $unknown_artifact_types;
+
+		/** @var array<int,array<string,mixed>> */
+		private array $unsupported_artifacts;
+
+		/**
+		 * Constructor.
+		 *
+		 * @param array<int,string>              $required_capabilities    Required package/artifact capabilities.
+		 * @param array<int,string>              $host_capabilities        Capabilities supported by the host runtime.
+		 * @param array<int,string>              $unsupported_capabilities Unsupported required capabilities.
+		 * @param array<int,string>              $unknown_artifact_types   Artifact types the host cannot interpret.
+		 * @param array<int,array<string,mixed>> $unsupported_artifacts    Artifact-level compatibility details.
+		 */
+		public function __construct( array $required_capabilities, array $host_capabilities, array $unsupported_capabilities, array $unknown_artifact_types, array $unsupported_artifacts ) {
+			$this->required_capabilities    = $this->normalize_string_list( $required_capabilities );
+			$this->host_capabilities        = $this->normalize_string_list( $host_capabilities );
+			$this->unsupported_capabilities = $this->normalize_string_list( $unsupported_capabilities );
+			$this->unknown_artifact_types   = $this->normalize_string_list( $unknown_artifact_types );
+			$this->unsupported_artifacts    = array_values( $unsupported_artifacts );
+		}
+
+		/**
+		 * Whether the host can safely adopt every declared package artifact.
+		 *
+		 * @return bool
+		 */
+		public function is_compatible(): bool {
+			return empty( $this->unsupported_capabilities ) && empty( $this->unknown_artifact_types ) && empty( $this->unsupported_artifacts );
+		}
+
+		/**
+		 * Retrieves unsupported required capability strings.
+		 *
+		 * @return array<int,string>
+		 */
+		public function get_unsupported_capabilities(): array {
+			return $this->unsupported_capabilities;
+		}
+
+		/**
+		 * Retrieves artifact types the host does not know how to handle.
+		 *
+		 * @return array<int,string>
+		 */
+		public function get_unknown_artifact_types(): array {
+			return $this->unknown_artifact_types;
+		}
+
+		/**
+		 * Retrieves artifact-level unsupported details.
+		 *
+		 * @return array<int,array<string,mixed>>
+		 */
+		public function get_unsupported_artifacts(): array {
+			return $this->unsupported_artifacts;
+		}
+
+		/**
+		 * Exports the report for adoption results and previews.
+		 *
+		 * @return array<string,mixed>
+		 */
+		public function to_array(): array {
+			return array(
+				'compatible'               => $this->is_compatible(),
+				'status'                   => $this->is_compatible() ? 'compatible' : 'unsupported',
+				'required_capabilities'    => $this->required_capabilities,
+				'host_capabilities'        => $this->host_capabilities,
+				'unsupported_capabilities' => $this->unsupported_capabilities,
+				'unknown_artifact_types'   => $this->unknown_artifact_types,
+				'unsupported_artifacts'    => $this->unsupported_artifacts,
+			);
+		}
+
+		/**
+		 * Normalizes a capability list.
+		 *
+		 * @param array<int,string> $values Raw strings.
+		 * @return array<int,string>
+		 */
+		private function normalize_string_list( array $values ): array {
+			$prepared = array();
+			foreach ( $values as $value ) {
+				$value = trim( strtolower( (string) $value ) );
+				if ( '' !== $value ) {
+					$prepared[] = $value;
+				}
+			}
+
+			$prepared = array_values( array_unique( $prepared ) );
+			sort( $prepared );
+
+			return $prepared;
+		}
+	}
+}

--- a/tests/bootstrap-smoke.php
+++ b/tests/bootstrap-smoke.php
@@ -84,6 +84,8 @@ agents_api_smoke_assert_equals( true, class_exists( 'WP_Agent_Package_Installed_
 agents_api_smoke_assert_equals( true, class_exists( 'WP_Agent_Package_Update_Plan' ), 'WP_Agent_Package_Update_Plan value object is available', $failures, $passes );
 agents_api_smoke_assert_equals( true, class_exists( 'WP_Agent_Package_Update_Planner' ), 'WP_Agent_Package_Update_Planner service is available', $failures, $passes );
 agents_api_smoke_assert_equals( true, class_exists( 'WP_Agent_Package_Artifact_Callbacks' ), 'WP_Agent_Package_Artifact_Callbacks helper is available', $failures, $passes );
+agents_api_smoke_assert_equals( true, class_exists( 'WP_Agent_Package_Capability_Report' ), 'WP_Agent_Package_Capability_Report value object is available', $failures, $passes );
+agents_api_smoke_assert_equals( true, class_exists( 'WP_Agent_Package_Capability_Checker' ), 'WP_Agent_Package_Capability_Checker service is available', $failures, $passes );
 agents_api_smoke_assert_equals( true, class_exists( 'WP_Agent_Access_Grant' ), 'WP_Agent_Access_Grant value object is available', $failures, $passes );
 agents_api_smoke_assert_equals( true, interface_exists( 'WP_Agent_Access_Store' ), 'WP_Agent_Access_Store contract is available', $failures, $passes );
 agents_api_smoke_assert_equals( true, class_exists( 'WP_Agent_Token' ), 'WP_Agent_Token value object is available', $failures, $passes );

--- a/tests/package-capability-contract-smoke.php
+++ b/tests/package-capability-contract-smoke.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * Pure-PHP smoke test for package capability compatibility contracts.
+ *
+ * Run with: php tests/package-capability-contract-smoke.php
+ *
+ * @package AgentsAPI\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+$failures = array();
+$passes   = 0;
+
+echo "agents-api-package-capability-contract-smoke\n";
+
+require_once __DIR__ . '/agents-api-smoke-helpers.php';
+agents_api_smoke_require_module();
+
+$package = WP_Agent_Package::from_array(
+	array(
+		'slug'         => 'portable-demo',
+		'version'      => '1.0.0',
+		'capabilities' => array( 'chat', 'memory/files' ),
+		'agent'        => array(
+			'slug'  => 'portable-demo-agent',
+			'label' => 'Portable Demo Agent',
+		),
+		'artifacts'    => array(
+			array(
+				'type'     => 'agents/prompt',
+				'slug'     => 'system',
+				'source'   => 'prompts/system.md',
+				'requires' => array( 'prompt/text' ),
+			),
+			array(
+				'type'     => 'datamachine/flow',
+				'slug'     => 'daily-fetch',
+				'source'   => 'flows/daily-fetch.json',
+				'requires' => array( 'schedule/cron', 'queue/actions' ),
+			),
+			array(
+				'type'     => 'vendor/custom',
+				'slug'     => 'custom-shape',
+				'source'   => 'extensions/custom.json',
+				'requires' => array( 'vendor/custom-runtime' ),
+			),
+		),
+	)
+);
+
+echo "\n[1] Host capability reports unsupported runtime needs without applying artifacts:\n";
+$report = WP_Agent_Package_Capability_Checker::check(
+	$package,
+	array( 'chat', 'prompt/text', 'queue/actions' ),
+	array( 'known_artifact_types' => array( 'agents/prompt', 'datamachine/flow' ) )
+);
+$report_array = $report->to_array();
+
+agents_api_smoke_assert_equals( false, $report->is_compatible(), 'report is incompatible when required capabilities are missing', $failures, $passes );
+agents_api_smoke_assert_equals( array( 'memory/files', 'schedule/cron', 'vendor/custom-runtime' ), $report->get_unsupported_capabilities(), 'package and artifact requirements are merged and normalized', $failures, $passes );
+agents_api_smoke_assert_equals( array( 'vendor/custom' ), $report->get_unknown_artifact_types(), 'unknown artifact type is reported', $failures, $passes );
+agents_api_smoke_assert_equals( 'unsupported', $report_array['status'], 'array report carries stable unsupported status', $failures, $passes );
+agents_api_smoke_assert_equals( 2, count( $report->get_unsupported_artifacts() ), 'unsupported artifacts include missing requirements and unknown types', $failures, $passes );
+
+$unsupported_by_key = array();
+foreach ( $report->get_unsupported_artifacts() as $artifact_report ) {
+	$unsupported_by_key[ $artifact_report['artifact_key'] ] = $artifact_report;
+}
+
+agents_api_smoke_assert_equals( array( 'schedule/cron' ), $unsupported_by_key['datamachine/flow:daily-fetch']['unsupported_capabilities'], 'artifact-level report keeps missing capability scoped to the artifact', $failures, $passes );
+agents_api_smoke_assert_equals( true, $unsupported_by_key['vendor/custom:custom-shape']['unknown_artifact_type'], 'artifact-level report flags unknown type', $failures, $passes );
+
+echo "\n[2] A fully capable host reports compatibility:\n";
+$compatible = WP_Agent_Package_Capability_Checker::check(
+	$package,
+	array( 'chat', 'memory/files', 'prompt/text', 'queue/actions', 'schedule/cron', 'vendor/custom-runtime' ),
+	array( 'known_artifact_types' => array( 'agents/prompt', 'datamachine/flow', 'vendor/custom' ) )
+);
+
+agents_api_smoke_assert_equals( true, $compatible->is_compatible(), 'all declared needs are supported', $failures, $passes );
+agents_api_smoke_assert_equals( 'compatible', $compatible->to_array()['status'], 'compatible report exports stable status', $failures, $passes );
+agents_api_smoke_assert_equals( array(), $compatible->get_unsupported_artifacts(), 'compatible report has no artifact blockers', $failures, $passes );
+
+agents_api_smoke_finish( 'Agents API package capability contract', $failures, $passes );


### PR DESCRIPTION
## Summary
- Add storage-neutral package capability compatibility reporting for host/runtime support checks.
- Introduce `WP_Agent_Package_Capability_Report` and `WP_Agent_Package_Capability_Checker` to report unsupported package/artifact requirements and unknown artifact types.
- Document the package capability boundary and add smoke coverage for compatible and unsupported host scenarios.

Closes #204.

## Testing
- `php tests/package-capability-contract-smoke.php`
- `php tests/bootstrap-smoke.php`
- `homeboy lint --path /Users/chubes/Developer/agents-api@feature-portable-package-spec --extension wordpress --changed-only --errors-only`
- `composer test`
- `homeboy test --path /Users/chubes/Developer/agents-api@feature-portable-package-spec --extension wordpress`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafting the package capability compatibility value objects, documentation updates, and smoke coverage. Chris remains responsible for review and final decisions.