### PR TITLE
ci: enable Homeboy lint autofix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,4 +39,5 @@ jobs:
           commands: ${{ matrix.command }}
           expected-commands: lint,test
           app-token: ${{ steps.app-token.outputs.token || '' }}
-          autofix: 'false'
+          autofix: 'true'
+          autofix-commands: 'lint --fix'


### PR DESCRIPTION
## Summary
- Enables Homeboy autofix in CI for lint failures.
- Scopes the autofix command to `lint --fix`, which routes through Homeboy's lint refactor path instead of broader audit/test fixes.
- Closes #188.

## Testing
- Parsed `.github/workflows/ci.yml` with Ruby YAML loader.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the workflow change and PR text; Chris remains responsible for review and merge.