### PR TITLE
Harden execution principal auth sources

### DIFF
--- a/src/Runtime/class-wp-agent-execution-principal.php
+++ b/src/Runtime/class-wp-agent-execution-principal.php
@@ -25,6 +25,14 @@ final class WP_Agent_Execution_Principal {
 	public const AUTH_SOURCE_AUDIENCE             = 'audience';
 	public const AUTH_SOURCE_SYSTEM               = 'system';
 
+	public const KNOWN_AUTH_SOURCES = array(
+		self::AUTH_SOURCE_USER,
+		self::AUTH_SOURCE_APPLICATION_PASSWORD,
+		self::AUTH_SOURCE_AGENT_TOKEN,
+		self::AUTH_SOURCE_AUDIENCE,
+		self::AUTH_SOURCE_SYSTEM,
+	);
+
 	public const OWNER_TYPE_USER     = 'user';
 	public const OWNER_TYPE_AUDIENCE = 'audience';
 	public const OWNER_TYPE_TOKEN    = 'token';
@@ -50,6 +58,7 @@ final class WP_Agent_Execution_Principal {
 	 * @param array<string,mixed>               $audience_claims    Optional host-owned audience claims.
 	 * @param string|null                       $owner_type         Optional canonical transcript owner type.
 	 * @param string|null                       $owner_key          Optional opaque transcript owner key scoped to the owner type.
+	 * @param array<string,mixed>|null          $binding            Optional host-owned cryptographic binding claims.
 	 */
 	public function __construct(
 		public readonly int $acting_user_id,
@@ -66,6 +75,7 @@ final class WP_Agent_Execution_Principal {
 		public readonly array $audience_claims = array(),
 		public readonly ?string $owner_type = null,
 		public readonly ?string $owner_key = null,
+		private readonly ?array $binding = null,
 	) {
 		if ( $this->acting_user_id < 0 ) {
 			throw self::invalid( 'acting_user_id', 'must be zero or a positive integer' );
@@ -77,6 +87,10 @@ final class WP_Agent_Execution_Principal {
 
 		if ( '' === $this->auth_source ) {
 			throw self::invalid( 'auth_source', 'must be a non-empty string' );
+		}
+
+		if ( ! self::is_known_auth_source( $this->auth_source ) ) {
+			throw self::invalid( 'auth_source', 'must be a known authentication source' );
 		}
 
 		if ( '' === $this->request_context ) {
@@ -97,6 +111,10 @@ final class WP_Agent_Execution_Principal {
 
 		if ( false === self::jsonEncode( $this->audience_claims ) ) {
 			throw self::invalid( 'audience_claims', 'must be JSON serializable' );
+		}
+
+		if ( null !== $this->binding && false === self::jsonEncode( $this->binding ) ) {
+			throw self::invalid( 'binding', 'must be null or JSON serializable' );
 		}
 
 		if ( ( null === $this->owner_type ) !== ( null === $this->owner_key ) ) {
@@ -138,6 +156,22 @@ final class WP_Agent_Execution_Principal {
 		}
 
 		throw self::invalid( 'principal', 'resolver must return null, an array, or an WP_Agent_Execution_Principal' );
+	}
+
+	/**
+	 * Whether an auth source is known to Agents API or declared by the host.
+	 *
+	 * @param string $auth_source Authentication source identifier.
+	 * @return bool True when the auth source is allowed.
+	 */
+	public static function is_known_auth_source( string $auth_source ): bool {
+		$allowed = self::KNOWN_AUTH_SOURCES;
+
+		if ( function_exists( 'apply_filters' ) ) {
+			$allowed = apply_filters( 'wp_agent_known_auth_sources', $allowed );
+		}
+
+		return is_array( $allowed ) && in_array( $auth_source, $allowed, true );
 	}
 
 	/**
@@ -222,7 +256,8 @@ final class WP_Agent_Execution_Principal {
 			array_key_exists( 'audience_id', $principal ) && null !== $principal['audience_id'] ? (string) $principal['audience_id'] : null,
 			isset( $principal['audience_claims'] ) && is_array( $principal['audience_claims'] ) ? $principal['audience_claims'] : array(),
 			array_key_exists( 'owner_type', $principal ) && null !== $principal['owner_type'] ? (string) $principal['owner_type'] : null,
-			array_key_exists( 'owner_key', $principal ) && null !== $principal['owner_key'] ? (string) $principal['owner_key'] : null
+			array_key_exists( 'owner_key', $principal ) && null !== $principal['owner_key'] ? (string) $principal['owner_key'] : null,
+			isset( $principal['binding'] ) && is_array( $principal['binding'] ) ? $principal['binding'] : null
 		);
 	}
 
@@ -247,7 +282,17 @@ final class WP_Agent_Execution_Principal {
 			'audience_claims'    => $this->audience_claims,
 			'owner_type'         => $this->owner_type,
 			'owner_key'          => $this->owner_key,
+			'binding'            => $this->binding,
 		);
+	}
+
+	/**
+	 * Return host-owned cryptographic binding claims for this principal.
+	 *
+	 * @return array<string,mixed>|null Binding claims, or null when unbound.
+	 */
+	public function binding(): ?array {
+		return $this->binding;
 	}
 
 	/**
@@ -313,7 +358,8 @@ final class WP_Agent_Execution_Principal {
 			$this->audience_id,
 			$this->audience_claims,
 			$this->owner_type,
-			$this->owner_key
+			$this->owner_key,
+			$this->binding
 		);
 	}
 

--- a/tests/execution-principal-smoke.php
+++ b/tests/execution-principal-smoke.php
@@ -74,6 +74,10 @@ $from_array = AgentsAPI\AI\WP_Agent_Execution_Principal::from_array(
 			'chain_depth'          => 1,
 			'chain_root_request_id' => 'root-1',
 		),
+		'binding'              => array(
+			'kid'       => 'key-1',
+			'signature' => 'sig-1',
+		),
 	)
 );
 agents_api_smoke_assert_equals( 7, $from_array->acting_user_id, 'from_array normalizes acting user id', $failures, $passes );
@@ -86,6 +90,8 @@ agents_api_smoke_assert_equals( 'browser', $from_array->client_id, 'from_array n
 agents_api_smoke_assert_equals( array( 'read' ), $from_array->capability_ceiling->allowed_capabilities, 'from_array normalizes capability ceiling', $failures, $passes );
 agents_api_smoke_assert_equals( 'caller-agent', $from_array->caller_context->caller_agent_id, 'from_array restores caller context', $failures, $passes );
 agents_api_smoke_assert_equals( 'root-1', $from_array->to_array()['caller_context']['chain_root_request_id'], 'principal exports caller context', $failures, $passes );
+agents_api_smoke_assert_equals( array( 'kid' => 'key-1', 'signature' => 'sig-1' ), $from_array->binding(), 'from_array restores binding', $failures, $passes );
+agents_api_smoke_assert_equals( array( 'kid' => 'key-1', 'signature' => 'sig-1' ), $from_array->to_array()['binding'], 'principal exports binding', $failures, $passes );
 
 $user_session = AgentsAPI\AI\WP_Agent_Execution_Principal::user_session(
 	99,
@@ -97,6 +103,8 @@ agents_api_smoke_assert_equals( 99, $user_session->acting_user_id, 'user_session
 agents_api_smoke_assert_equals( 'editor-agent', $user_session->effective_agent_id, 'user_session records effective agent id', $failures, $passes );
 agents_api_smoke_assert_equals( AgentsAPI\AI\WP_Agent_Execution_Principal::AUTH_SOURCE_USER, $user_session->auth_source, 'user_session records user auth source', $failures, $passes );
 agents_api_smoke_assert_equals( null, $user_session->token_id, 'user_session omits token id', $failures, $passes );
+agents_api_smoke_assert_equals( null, $user_session->binding(), 'user_session binding defaults to null', $failures, $passes );
+agents_api_smoke_assert_equals( null, $user_session->to_array()['binding'], 'principal exports null binding as no-op', $failures, $passes );
 agents_api_smoke_assert_equals( array( 'type' => AgentsAPI\AI\WP_Agent_Execution_Principal::OWNER_TYPE_USER, 'key' => '99' ), $user_session->conversation_owner(), 'user_session derives user conversation owner', $failures, $passes );
 
 add_filter(
@@ -189,6 +197,25 @@ try {
 } catch ( InvalidArgumentException $e ) {
 	agents_api_smoke_assert_equals( true, str_contains( $e->getMessage(), 'effective_agent_id' ), 'empty effective agent id is rejected', $failures, $passes );
 }
+
+try {
+	new AgentsAPI\AI\WP_Agent_Execution_Principal( 1, 'agent', 'external_runtime', AgentsAPI\AI\WP_Agent_Execution_Principal::REQUEST_CONTEXT_REST );
+	agents_api_smoke_assert_equals( true, false, 'unknown auth source is rejected', $failures, $passes );
+} catch ( InvalidArgumentException $e ) {
+	agents_api_smoke_assert_equals( true, str_contains( $e->getMessage(), 'auth_source' ), 'unknown auth source is rejected', $failures, $passes );
+}
+
+add_filter(
+	'wp_agent_known_auth_sources',
+	static function ( array $sources ): array {
+		$sources[] = 'external_runtime';
+		return $sources;
+	}
+);
+
+$filtered_auth_source = new AgentsAPI\AI\WP_Agent_Execution_Principal( 1, 'agent', 'external_runtime', AgentsAPI\AI\WP_Agent_Execution_Principal::REQUEST_CONTEXT_REST );
+agents_api_smoke_assert_equals( 'external_runtime', $filtered_auth_source->auth_source, 'filter-allowed auth source is accepted', $failures, $passes );
+agents_api_smoke_assert_equals( true, AgentsAPI\AI\WP_Agent_Execution_Principal::is_known_auth_source( 'external_runtime' ), 'filter declares known auth source', $failures, $passes );
 
 try {
 	new AgentsAPI\AI\WP_Agent_Execution_Principal( 1, 'agent', AgentsAPI\AI\WP_Agent_Execution_Principal::AUTH_SOURCE_USER, AgentsAPI\AI\WP_Agent_Execution_Principal::REQUEST_CONTEXT_REST, 0 );


### PR DESCRIPTION
## Summary
- Adds a nullable execution-principal binding field with accessor and array round-trip support.
- Restricts `auth_source` values to known substrate sources, with `wp_agent_known_auth_sources` for host-declared additions.
- Extends the execution principal smoke coverage for binding and auth-source validation.

Closes #206.

## Testing
- `php tests/execution-principal-smoke.php`
- `composer test`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the focused implementation and smoke-test updates; Chris remains responsible for review and merge.