### PR TITLE
Add approval memory store contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,8 @@ wp_register_agent(
 - `AgentsAPI\AI\Approvals\WP_Agent_Pending_Action_Status`
 - `AgentsAPI\AI\Approvals\WP_Agent_Pending_Action_Store`
 - `AgentsAPI\AI\Approvals\WP_Agent_Pending_Action_Observer`
+- `AgentsAPI\AI\Approvals\WP_Agent_Approval_Memory_Store`
+- `AgentsAPI\AI\Approvals\WP_Agent_Null_Approval_Memory_Store`
 - `AgentsAPI\AI\Approvals\WP_Agent_Pending_Action_Resolver`
 - `AgentsAPI\AI\Approvals\WP_Agent_Pending_Action_Handler`
 - `AgentsAPI\AI\Context\WP_Agent_Context_Authority_Tier`
@@ -360,10 +362,11 @@ Resolution order is:
 2. Registered agent or runtime `action_policy.tools[tool_name]`.
 3. Registered agent or runtime `action_policy.categories[category]`.
 4. Host-provided `WP_Agent_Action_Policy_Provider` providers.
-5. Tool-declared `action_policy` default.
-6. Tool-declared mode-specific `action_policy_<mode>` default.
-7. Global default `direct`.
-8. Final `agents_api_tool_action_policy` filter, if present.
+5. Host-provided `WP_Agent_Approval_Memory_Store` remembered decisions.
+6. Tool-declared `action_policy` default.
+7. Tool-declared mode-specific `action_policy_<mode>` default.
+8. Global default `direct`.
+9. Final `agents_api_tool_action_policy` filter, if present.
 
 ```php
 $policy = ( new WP_Agent_Action_Policy_Resolver() )->resolve_for_tool(
@@ -382,6 +385,8 @@ $policy = ( new WP_Agent_Action_Policy_Resolver() )->resolve_for_tool(
 	)
 );
 ```
+
+Remembered approvals are host-owned. Pass an `approval_memory_store` context value, constructor argument, or filter-provided store through `agents_api_approval_memory_store` to let a user's "always allow" decision participate in the canonical resolver without maintaining a parallel cache.
 
 ## Workspace Scope
 

--- a/agents-api.php
+++ b/agents-api.php
@@ -80,6 +80,8 @@ require_once AGENTS_API_PATH . 'src/Approvals/class-wp-agent-pending-action-stor
 require_once AGENTS_API_PATH . 'src/Approvals/class-wp-agent-pending-action-status.php';
 require_once AGENTS_API_PATH . 'src/Approvals/class-wp-agent-pending-action.php';
 require_once AGENTS_API_PATH . 'src/Approvals/class-wp-agent-approval-decision.php';
+require_once AGENTS_API_PATH . 'src/Approvals/class-wp-agent-approval-memory-store.php';
+require_once AGENTS_API_PATH . 'src/Approvals/class-wp-agent-null-approval-memory-store.php';
 require_once AGENTS_API_PATH . 'src/Approvals/class-wp-agent-pending-action-observer.php';
 require_once AGENTS_API_PATH . 'src/Approvals/class-wp-agent-pending-action-handler.php';
 require_once AGENTS_API_PATH . 'src/Approvals/class-wp-agent-pending-action-resolver.php';

--- a/src/Approvals/class-wp-agent-approval-decision.php
+++ b/src/Approvals/class-wp-agent-approval-decision.php
@@ -20,15 +20,20 @@ final class WP_Agent_Approval_Decision {
 	/** @var string Normalized decision value. */
 	private string $value;
 
+	/** @var bool Whether the accepted policy should be remembered by the host. */
+	private bool $remember;
+
 	/**
-	 * @param string $value Decision value.
+	 * @param string $value    Decision value.
+	 * @param bool   $remember Whether the accepted policy should be remembered.
 	 */
-	private function __construct( string $value ) {
+	private function __construct( string $value, bool $remember = false ) {
 		if ( ! in_array( $value, array( self::ACCEPTED, self::REJECTED ), true ) ) {
 			throw new \InvalidArgumentException( 'Approval decision must be accepted or rejected.' );
 		}
 
-		$this->value = $value;
+		$this->value    = $value;
+		$this->remember = $remember;
 	}
 
 	/** @return self Accepted decision. */
@@ -51,6 +56,16 @@ final class WP_Agent_Approval_Decision {
 		return new self( $value );
 	}
 
+	/**
+	 * Return a copy with explicit memory intent.
+	 *
+	 * @param bool $remember Whether the accepted policy should be remembered.
+	 * @return self
+	 */
+	public function with_remember( bool $remember = true ): self {
+		return new self( $this->value, $remember );
+	}
+
 	/** @return bool Whether the pending action was accepted. */
 	public function is_accepted(): bool {
 		return self::ACCEPTED === $this->value;
@@ -64,6 +79,11 @@ final class WP_Agent_Approval_Decision {
 	/** @return string Normalized decision value. */
 	public function value(): string {
 		return $this->value;
+	}
+
+	/** @return bool Whether the accepted policy should be remembered by the host. */
+	public function remember(): bool {
+		return $this->remember;
 	}
 
 	/** @return string Normalized decision value. */

--- a/src/Approvals/class-wp-agent-approval-memory-store.php
+++ b/src/Approvals/class-wp-agent-approval-memory-store.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Approval memory store contract.
+ *
+ * @package AgentsAPI
+ */
+
+namespace AgentsAPI\AI\Approvals;
+
+use AgentsAPI\Core\Workspace\WP_Agent_Workspace_Scope;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Host-owned store for remembered per-tool approval decisions.
+ */
+interface WP_Agent_Approval_Memory_Store {
+
+	/**
+	 * Remember a resolved action policy for an agent/tool in a workspace.
+	 *
+	 * @param WP_Agent_Workspace_Scope $workspace Workspace scope.
+	 * @param int                      $user_id   WordPress user ID.
+	 * @param string                   $agent_id  Agent slug or ID.
+	 * @param string                   $tool_name Tool name.
+	 * @param string                   $policy    One of direct, preview, forbidden.
+	 * @return void
+	 */
+	public function remember( WP_Agent_Workspace_Scope $workspace, int $user_id, string $agent_id, string $tool_name, string $policy ): void;
+
+	/**
+	 * Recall a remembered action policy for an agent/tool in a workspace.
+	 *
+	 * @param WP_Agent_Workspace_Scope $workspace Workspace scope.
+	 * @param int                      $user_id   WordPress user ID.
+	 * @param string                   $agent_id  Agent slug or ID.
+	 * @param string                   $tool_name Tool name.
+	 * @return string|null One of direct, preview, forbidden; null when no memory exists.
+	 */
+	public function recall( WP_Agent_Workspace_Scope $workspace, int $user_id, string $agent_id, string $tool_name ): ?string;
+
+	/**
+	 * Forget a remembered action policy for an agent/tool in a workspace.
+	 *
+	 * @param WP_Agent_Workspace_Scope $workspace Workspace scope.
+	 * @param int                      $user_id   WordPress user ID.
+	 * @param string                   $agent_id  Agent slug or ID.
+	 * @param string                   $tool_name Tool name.
+	 * @return void
+	 */
+	public function forget( WP_Agent_Workspace_Scope $workspace, int $user_id, string $agent_id, string $tool_name ): void;
+}

--- a/src/Approvals/class-wp-agent-null-approval-memory-store.php
+++ b/src/Approvals/class-wp-agent-null-approval-memory-store.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Null approval memory store.
+ *
+ * @package AgentsAPI
+ */
+
+namespace AgentsAPI\AI\Approvals;
+
+use AgentsAPI\Core\Workspace\WP_Agent_Workspace_Scope;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Default transparent store for hosts that do not persist approval memories.
+ */
+final class WP_Agent_Null_Approval_Memory_Store implements WP_Agent_Approval_Memory_Store {
+
+	/**
+	 * @inheritDoc
+	 */
+	public function remember( WP_Agent_Workspace_Scope $workspace, int $user_id, string $agent_id, string $tool_name, string $policy ): void {
+		unset( $workspace, $user_id, $agent_id, $tool_name, $policy );
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function recall( WP_Agent_Workspace_Scope $workspace, int $user_id, string $agent_id, string $tool_name ): ?string {
+		unset( $workspace, $user_id, $agent_id, $tool_name );
+		return null;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function forget( WP_Agent_Workspace_Scope $workspace, int $user_id, string $agent_id, string $tool_name ): void {
+		unset( $workspace, $user_id, $agent_id, $tool_name );
+	}
+}

--- a/src/Tools/class-wp-agent-action-policy-resolver.php
+++ b/src/Tools/class-wp-agent-action-policy-resolver.php
@@ -6,6 +6,9 @@
  */
 
 use AgentsAPI\AI\Tools\WP_Agent_Action_Policy;
+use AgentsAPI\AI\Approvals\WP_Agent_Approval_Memory_Store;
+use AgentsAPI\AI\Approvals\WP_Agent_Null_Approval_Memory_Store;
+use AgentsAPI\Core\Workspace\WP_Agent_Workspace_Scope;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -26,14 +29,21 @@ if ( ! class_exists( 'WP_Agent_Action_Policy_Resolver' ) ) {
 		private WP_Agent_Tool_Policy_Filter $tool_filter;
 
 		/**
+		 * @var WP_Agent_Approval_Memory_Store
+		 */
+		private WP_Agent_Approval_Memory_Store $approval_memory_store;
+
+		/**
 		 * Constructor.
 		 *
-		 * @param WP_Agent_Action_Policy_Provider[]|null $policy_providers Host policy providers.
-		 * @param WP_Agent_Tool_Policy_Filter|null                 $tool_filter      Shared tool filter.
+		 * @param WP_Agent_Action_Policy_Provider[]|null $policy_providers      Host policy providers.
+		 * @param WP_Agent_Tool_Policy_Filter|null       $tool_filter           Shared tool filter.
+		 * @param WP_Agent_Approval_Memory_Store|null    $approval_memory_store Approval memory store.
 		 */
-		public function __construct( ?array $policy_providers = null, ?WP_Agent_Tool_Policy_Filter $tool_filter = null ) {
-			$this->policy_providers = is_array( $policy_providers ) ? $policy_providers : array();
-			$this->tool_filter      = $tool_filter ?? new WP_Agent_Tool_Policy_Filter();
+		public function __construct( ?array $policy_providers = null, ?WP_Agent_Tool_Policy_Filter $tool_filter = null, ?WP_Agent_Approval_Memory_Store $approval_memory_store = null ) {
+			$this->policy_providers      = is_array( $policy_providers ) ? $policy_providers : array();
+			$this->tool_filter           = $tool_filter ?? new WP_Agent_Tool_Policy_Filter();
+			$this->approval_memory_store = $approval_memory_store ?? new WP_Agent_Null_Approval_Memory_Store();
 		}
 
 		/**
@@ -73,6 +83,11 @@ if ( ! class_exists( 'WP_Agent_Action_Policy_Resolver' ) ) {
 				}
 			}
 
+			$remembered = $this->remembered_action_policy( $context, $tool_name );
+			if ( null !== $remembered ) {
+				return $this->apply_filter( $remembered, $tool_name, $mode, $context );
+			}
+
 			$tool_default = $this->tool_declared_default( $tool_def );
 			if ( null !== $tool_default ) {
 				return $this->apply_filter( $tool_default, $tool_name, $mode, $context );
@@ -108,6 +123,66 @@ if ( ! class_exists( 'WP_Agent_Action_Policy_Resolver' ) ) {
 					static fn( $provider ): bool => $provider instanceof WP_Agent_Action_Policy_Provider
 				)
 			);
+		}
+
+		/**
+		 * Return approval memory store from context, filters, or constructor.
+		 *
+		 * @param array<string, mixed> $context Runtime context.
+		 * @return WP_Agent_Approval_Memory_Store Store.
+		 */
+		private function get_approval_memory_store( array $context ): WP_Agent_Approval_Memory_Store {
+			$store = $context['approval_memory_store'] ?? $this->approval_memory_store;
+
+			if ( function_exists( 'apply_filters' ) ) {
+				$store = apply_filters( 'agents_api_approval_memory_store', $store, $context, $this );
+			}
+
+			return $store instanceof WP_Agent_Approval_Memory_Store ? $store : new WP_Agent_Null_Approval_Memory_Store();
+		}
+
+		/**
+		 * Recall remembered action policy for the current invocation, when enough identity exists.
+		 *
+		 * @param array<string, mixed> $context   Runtime context.
+		 * @param string               $tool_name Tool name.
+		 * @return string|null Normalized remembered policy or null.
+		 */
+		private function remembered_action_policy( array $context, string $tool_name ): ?string {
+			$workspace = $this->workspace_from_context( $context );
+			$user_id   = (int) ( $context['user_id'] ?? ( $context['acting_user_id'] ?? 0 ) );
+			$agent_id  = (string) ( $context['agent_id'] ?? ( $context['agent_slug'] ?? '' ) );
+
+			if ( null === $workspace || $user_id <= 0 || '' === $agent_id ) {
+				return null;
+			}
+
+			return WP_Agent_Action_Policy::normalize(
+				$this->get_approval_memory_store( $context )->recall( $workspace, $user_id, $agent_id, $tool_name )
+			);
+		}
+
+		/**
+		 * Return workspace scope from context.
+		 *
+		 * @param array<string, mixed> $context Runtime context.
+		 * @return WP_Agent_Workspace_Scope|null Workspace scope when present and valid.
+		 */
+		private function workspace_from_context( array $context ): ?WP_Agent_Workspace_Scope {
+			$workspace = $context['workspace'] ?? null;
+			if ( $workspace instanceof WP_Agent_Workspace_Scope ) {
+				return $workspace;
+			}
+
+			if ( is_array( $workspace ) ) {
+				try {
+					return WP_Agent_Workspace_Scope::from_array( $workspace );
+				} catch ( \InvalidArgumentException $e ) {
+					return null;
+				}
+			}
+
+			return null;
 		}
 
 		/**

--- a/tests/action-policy-resolver-smoke.php
+++ b/tests/action-policy-resolver-smoke.php
@@ -22,6 +22,8 @@ agents_api_smoke_require_module();
 echo "\n[1] Generic action policy contracts are available:\n";
 agents_api_smoke_assert_equals( true, class_exists( 'WP_Agent_Action_Policy_Resolver' ), 'WP_Agent_Action_Policy_Resolver is available', $failures, $passes );
 agents_api_smoke_assert_equals( true, interface_exists( 'WP_Agent_Action_Policy_Provider' ), 'WP_Agent_Action_Policy_Provider is available', $failures, $passes );
+agents_api_smoke_assert_equals( true, interface_exists( 'AgentsAPI\\AI\\Approvals\\WP_Agent_Approval_Memory_Store' ), 'WP_Agent_Approval_Memory_Store is available', $failures, $passes );
+agents_api_smoke_assert_equals( true, class_exists( 'AgentsAPI\\AI\\Approvals\\WP_Agent_Null_Approval_Memory_Store' ), 'WP_Agent_Null_Approval_Memory_Store is available', $failures, $passes );
 
 $resolver = new WP_Agent_Action_Policy_Resolver();
 
@@ -110,5 +112,82 @@ agents_api_smoke_assert_equals(
 	$failures,
 	$passes
 );
+
+echo "\n[4] Approval memory participates before tool-declared defaults:\n";
+$workspace = AgentsAPI\Core\Workspace\WP_Agent_Workspace_Scope::from_parts( 'code_workspace', 'Automattic/agents-api@approval-memory' );
+$memory    = new class() implements AgentsAPI\AI\Approvals\WP_Agent_Approval_Memory_Store {
+	/** @var array<string, string> */
+	public array $values = array();
+
+	public function remember( AgentsAPI\Core\Workspace\WP_Agent_Workspace_Scope $workspace, int $user_id, string $agent_id, string $tool_name, string $policy ): void {
+		$this->values[ $workspace->key() . '|' . $user_id . '|' . $agent_id . '|' . $tool_name ] = $policy;
+	}
+
+	public function recall( AgentsAPI\Core\Workspace\WP_Agent_Workspace_Scope $workspace, int $user_id, string $agent_id, string $tool_name ): ?string {
+		return $this->values[ $workspace->key() . '|' . $user_id . '|' . $agent_id . '|' . $tool_name ] ?? null;
+	}
+
+	public function forget( AgentsAPI\Core\Workspace\WP_Agent_Workspace_Scope $workspace, int $user_id, string $agent_id, string $tool_name ): void {
+		unset( $this->values[ $workspace->key() . '|' . $user_id . '|' . $agent_id . '|' . $tool_name ] );
+	}
+};
+$memory->remember( $workspace, 123, 'release-agent', 'client/publish', AgentsAPI\AI\Tools\WP_Agent_Action_Policy::DIRECT );
+
+agents_api_smoke_assert_equals(
+	AgentsAPI\AI\Tools\WP_Agent_Action_Policy::DIRECT,
+	$resolver->resolve_for_tool(
+		array(
+			'tool_name'             => 'client/publish',
+			'tool_def'              => array( 'action_policy' => 'preview' ),
+			'workspace'             => $workspace,
+			'user_id'               => 123,
+			'agent_id'              => 'release-agent',
+			'approval_memory_store' => $memory,
+		)
+	),
+	'remembered approval policy resolves before tool-declared default',
+	$failures,
+	$passes
+);
+
+$memory->forget( $workspace, 123, 'release-agent', 'client/publish' );
+agents_api_smoke_assert_equals(
+	AgentsAPI\AI\Tools\WP_Agent_Action_Policy::PREVIEW,
+	$resolver->resolve_for_tool(
+		array(
+			'tool_name'             => 'client/publish',
+			'tool_def'              => array( 'action_policy' => 'preview' ),
+			'workspace'             => $workspace,
+			'user_id'               => 123,
+			'agent_id'              => 'release-agent',
+			'approval_memory_store' => $memory,
+		)
+	),
+	'forget clears remembered approval policy',
+	$failures,
+	$passes
+);
+
+agents_api_smoke_assert_equals(
+	AgentsAPI\AI\Tools\WP_Agent_Action_Policy::PREVIEW,
+	$resolver->resolve_for_tool(
+		array(
+			'tool_name'             => 'client/publish',
+			'tool_def'              => array( 'action_policy' => 'preview' ),
+			'workspace'             => $workspace,
+			'user_id'               => 123,
+			'agent_id'              => 'release-agent',
+			'approval_memory_store' => new AgentsAPI\AI\Approvals\WP_Agent_Null_Approval_Memory_Store(),
+		)
+	),
+	'null approval memory store is transparent',
+	$failures,
+	$passes
+);
+
+echo "\n[5] Approval decisions can request remember-on-accept:\n";
+$remembered_decision = AgentsAPI\AI\Approvals\WP_Agent_Approval_Decision::accepted()->with_remember();
+agents_api_smoke_assert_equals( true, $remembered_decision->remember(), 'with_remember marks decision for persistence', $failures, $passes );
+agents_api_smoke_assert_equals( AgentsAPI\AI\Approvals\WP_Agent_Approval_Decision::ACCEPTED, $remembered_decision->value(), 'with_remember preserves decision value', $failures, $passes );
 
 agents_api_smoke_finish( 'Action policy resolver', $failures, $passes );


### PR DESCRIPTION
## Summary
- Add a host-owned `WP_Agent_Approval_Memory_Store` contract plus transparent null implementation for remembered per-tool action policies.
- Let `WP_Agent_Action_Policy_Resolver` consult approval memory after host policy providers and before tool-declared defaults.
- Add `WP_Agent_Approval_Decision::with_remember()` so consumers can mark accepted decisions for persistence.

Closes #184.

## Testing
- `php tests/action-policy-resolver-smoke.php`
- `php -l src/Approvals/class-wp-agent-approval-memory-store.php && php -l src/Approvals/class-wp-agent-null-approval-memory-store.php && php -l src/Approvals/class-wp-agent-approval-decision.php && php -l src/Tools/class-wp-agent-action-policy-resolver.php && php -l tests/action-policy-resolver-smoke.php`
- `composer test`
- `git diff --check`
- `homeboy lint --path /Users/chubes/Developer/agents-api@fix-approval-memory-store-184 --extension wordpress`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the approval memory contract, resolver integration, documentation, and smoke coverage; Chris remains responsible for review and release decisions.