### PR TITLE
Add agent runtime override contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ wp_register_agent(
 - `agents_api_loop_event`
 - `wp_register_agent()` / `wp_get_agent()` / `wp_get_agents()` / `wp_has_agent()` / `wp_unregister_agent()`
 - `WP_Agent`
+- `WP_Agent_Runtime_Overrides`
 - `WP_Agents_Registry`
 - `WP_Agent_Package*` value objects and artifact registry helpers
 - `WP_Agent_Access_Grant`

--- a/agents-api.php
+++ b/agents-api.php
@@ -27,6 +27,7 @@ define( 'AGENTS_API_LOADED', true );
 define( 'AGENTS_API_PATH', __DIR__ . '/' );
 define( 'AGENTS_API_PLUGIN_FILE', __FILE__ );
 
+require_once AGENTS_API_PATH . 'src/Registry/class-wp-agent-runtime-overrides.php';
 require_once AGENTS_API_PATH . 'src/Registry/class-wp-agent.php';
 require_once AGENTS_API_PATH . 'src/Packages/class-wp-agent-package-artifact.php';
 require_once AGENTS_API_PATH . 'src/Packages/class-wp-agent-package-artifact-type.php';

--- a/src/Registry/class-wp-agent-runtime-overrides.php
+++ b/src/Registry/class-wp-agent-runtime-overrides.php
@@ -1,0 +1,149 @@
+<?php
+/**
+ * WP_Agent runtime override value object.
+ *
+ * @package AgentsAPI
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+if ( ! class_exists( 'WP_Agent_Runtime_Overrides' ) ) {
+	/**
+	 * Nullable per-agent runtime overrides for caller-owned runners.
+	 */
+	final class WP_Agent_Runtime_Overrides {
+
+		/** @var string|null */
+		private ?string $system_prompt;
+
+		/** @var string|null */
+		private ?string $provider_id;
+
+		/** @var string|null */
+		private ?string $model_id;
+
+		/** @var float|null */
+		private ?float $temperature;
+
+		/** @var int|null */
+		private ?int $max_iterations;
+
+		/** @var string[] */
+		private array $tier_1_tools;
+
+		/** @var string|null */
+		private ?string $greeting;
+
+		/**
+		 * @param array<string, mixed> $overrides Raw override map.
+		 */
+		public function __construct( array $overrides = array() ) {
+			$this->system_prompt  = self::optional_string( $overrides['system_prompt'] ?? null );
+			$this->provider_id    = self::optional_string( $overrides['provider_id'] ?? null );
+			$this->model_id       = self::optional_string( $overrides['model_id'] ?? null );
+			$this->temperature    = self::optional_float( $overrides['temperature'] ?? null );
+			$this->max_iterations = self::optional_positive_int( $overrides['max_iterations'] ?? null );
+			$this->tier_1_tools   = self::string_list( $overrides['tier_1_tools'] ?? array() );
+			$this->greeting       = self::optional_string( $overrides['greeting'] ?? null );
+		}
+
+		/** @return string|null System prompt override. */
+		public function system_prompt(): ?string {
+			return $this->system_prompt;
+		}
+
+		/** @return string|null Provider ID override. */
+		public function provider_id(): ?string {
+			return $this->provider_id;
+		}
+
+		/** @return string|null Model ID override. */
+		public function model_id(): ?string {
+			return $this->model_id;
+		}
+
+		/** @return float|null Temperature override. */
+		public function temperature(): ?float {
+			return $this->temperature;
+		}
+
+		/** @return int|null Maximum iteration override. */
+		public function max_iterations(): ?int {
+			return $this->max_iterations;
+		}
+
+		/** @return string[] Tier-1 tool names. */
+		public function tier_1_tools(): array {
+			return $this->tier_1_tools;
+		}
+
+		/** @return string|null Greeting override. */
+		public function greeting(): ?string {
+			return $this->greeting;
+		}
+
+		/**
+		 * Export nullable overrides for persistence or diagnostics.
+		 *
+		 * @return array<string, mixed>
+		 */
+		public function to_array(): array {
+			return array(
+				'system_prompt'  => $this->system_prompt,
+				'provider_id'    => $this->provider_id,
+				'model_id'       => $this->model_id,
+				'temperature'    => $this->temperature,
+				'max_iterations' => $this->max_iterations,
+				'tier_1_tools'   => $this->tier_1_tools,
+				'greeting'       => $this->greeting,
+			);
+		}
+
+		/**
+		 * @param mixed $value Raw string-ish value.
+		 * @return string|null Normalized non-empty string or null.
+		 */
+		private static function optional_string( $value ): ?string {
+			if ( null === $value ) {
+				return null;
+			}
+
+			$value = trim( (string) $value );
+			return '' === $value ? null : $value;
+		}
+
+		/**
+		 * @param mixed $value Raw float-ish value.
+		 * @return float|null Normalized float or null.
+		 */
+		private static function optional_float( $value ): ?float {
+			return null === $value || '' === $value ? null : (float) $value;
+		}
+
+		/**
+		 * @param mixed $value Raw int-ish value.
+		 * @return int|null Positive int or null.
+		 */
+		private static function optional_positive_int( $value ): ?int {
+			$value = (int) $value;
+			return $value > 0 ? $value : null;
+		}
+
+		/**
+		 * @param mixed $values Raw list.
+		 * @return string[] Non-empty unique strings.
+		 */
+		private static function string_list( $values ): array {
+			$values = is_array( $values ) ? $values : array( $values );
+			$values = array_filter(
+				array_map(
+					static fn( $value ): string => trim( (string) $value ),
+					$values
+				),
+				static fn( string $value ): bool => '' !== $value
+			);
+
+			return array_values( array_unique( $values ) );
+		}
+	}
+}

--- a/src/Registry/class-wp-agent.php
+++ b/src/Registry/class-wp-agent.php
@@ -74,6 +74,13 @@ if ( ! class_exists( 'WP_Agent' ) ) {
 		protected array $conversation_compaction_policy = array();
 
 		/**
+		 * Nullable runtime overrides for this agent.
+		 *
+		 * @var WP_Agent_Runtime_Overrides
+		 */
+		protected WP_Agent_Runtime_Overrides $runtime_overrides;
+
+		/**
 		 * Optional metadata.
 		 *
 		 * The following optional keys are reserved for source provenance so
@@ -109,7 +116,8 @@ if ( ! class_exists( 'WP_Agent' ) ) {
 		 * @param array  $args Registration arguments.
 		 */
 		public function __construct( string $slug, array $args = array() ) {
-			$this->slug = sanitize_title( $slug );
+			$this->slug              = sanitize_title( $slug );
+			$this->runtime_overrides = new WP_Agent_Runtime_Overrides();
 			if ( '' === $this->slug ) {
 				throw new InvalidArgumentException( 'Agent slug cannot be empty.' );
 			}
@@ -176,6 +184,16 @@ if ( ! class_exists( 'WP_Agent' ) ) {
 				}
 
 				$properties['conversation_compaction_policy'] = \AgentsAPI\AI\WP_Agent_Conversation_Compaction::normalize_policy( $args['conversation_compaction_policy'] );
+			}
+
+			if ( isset( $args['runtime_overrides'] ) ) {
+				if ( $args['runtime_overrides'] instanceof WP_Agent_Runtime_Overrides ) {
+					$properties['runtime_overrides'] = $args['runtime_overrides'];
+				} elseif ( is_array( $args['runtime_overrides'] ) ) {
+					$properties['runtime_overrides'] = new WP_Agent_Runtime_Overrides( $args['runtime_overrides'] );
+				} else {
+					throw new InvalidArgumentException( 'Agent runtime_overrides property must be an array or WP_Agent_Runtime_Overrides.' );
+				}
 			}
 
 			if ( isset( $args['meta'] ) ) {
@@ -301,6 +319,15 @@ if ( ! class_exists( 'WP_Agent' ) ) {
 		}
 
 		/**
+		 * Retrieves runtime overrides.
+		 *
+		 * @return WP_Agent_Runtime_Overrides
+		 */
+		public function runtime_overrides(): WP_Agent_Runtime_Overrides {
+			return $this->runtime_overrides;
+		}
+
+		/**
 		 * Retrieves optional metadata.
 		 *
 		 * @return array<string, mixed>
@@ -344,6 +371,7 @@ if ( ! class_exists( 'WP_Agent' ) ) {
 				'default_config'                   => $this->default_config,
 				'supports_conversation_compaction' => $this->supports_conversation_compaction,
 				'conversation_compaction_policy'   => $this->conversation_compaction_policy,
+				'runtime_overrides'                => $this->runtime_overrides->to_array(),
 				'meta'                             => $this->meta,
 				'subagents'                        => $this->subagents,
 			);

--- a/src/Runtime/class-wp-agent-conversation-loop.php
+++ b/src/Runtime/class-wp-agent-conversation-loop.php
@@ -67,6 +67,8 @@ class WP_Agent_Conversation_Loop {
 	 * @return array Normalized conversation result.
 	 */
 	public static function run( array $messages, callable $turn_runner, array $options = array() ): array {
+		$runtime_overrides     = self::resolve_runtime_overrides( $options );
+		$options               = self::apply_runtime_overrides_to_options( $options, $runtime_overrides );
 		$max_turns             = self::max_turns( $options['max_turns'] ?? 1 );
 		$context               = isset( $options['context'] ) && is_array( $options['context'] ) ? $options['context'] : array();
 		$tool_executor         = self::resolve_tool_executor( $options );
@@ -537,14 +539,62 @@ class WP_Agent_Conversation_Loop {
 			return $request;
 		}
 
+		$runtime_overrides = self::resolve_runtime_overrides( $options );
+
 		return new WP_Agent_Conversation_Request(
 			$messages,
 			array(),
 			null,
 			isset( $options['context'] ) && is_array( $options['context'] ) ? $options['context'] : array(),
 			array(),
-			self::max_turns( $options['max_turns'] ?? 1 )
+			self::max_turns( $options['max_turns'] ?? 1 ),
+			false,
+			null,
+			$runtime_overrides
 		);
+	}
+
+	/**
+	 * Resolve runtime overrides from explicit options or an agent definition.
+	 *
+	 * @param array<string, mixed> $options Loop options.
+	 * @return \WP_Agent_Runtime_Overrides Runtime overrides.
+	 */
+	private static function resolve_runtime_overrides( array $options ): \WP_Agent_Runtime_Overrides {
+		$overrides = $options['runtime_overrides'] ?? null;
+		if ( $overrides instanceof \WP_Agent_Runtime_Overrides ) {
+			return $overrides;
+		}
+
+		if ( is_array( $overrides ) ) {
+			return new \WP_Agent_Runtime_Overrides( $overrides );
+		}
+
+		$agent = $options['agent'] ?? ( is_array( $options['context'] ?? null ) ? ( $options['context']['agent'] ?? null ) : null );
+		return $agent instanceof \WP_Agent ? $agent->runtime_overrides() : new \WP_Agent_Runtime_Overrides();
+	}
+
+	/**
+	 * Apply non-null runtime overrides to loop options.
+	 *
+	 * @param array<string, mixed>          $options   Loop options.
+	 * @param \WP_Agent_Runtime_Overrides $overrides Runtime overrides.
+	 * @return array<string, mixed> Loop options.
+	 */
+	private static function apply_runtime_overrides_to_options( array $options, \WP_Agent_Runtime_Overrides $overrides ): array {
+		if ( null !== $overrides->max_iterations() ) {
+			$options['max_turns'] = min( self::max_turns( $options['max_turns'] ?? $overrides->max_iterations() ), $overrides->max_iterations() );
+		}
+
+		$context = isset( $options['context'] ) && is_array( $options['context'] ) ? $options['context'] : array();
+		foreach ( $overrides->to_array() as $key => $value ) {
+			if ( null !== $value && array() !== $value ) {
+				$context[ $key ] = $value;
+			}
+		}
+		$options['context'] = $context;
+
+		return $options;
 	}
 
 	/**

--- a/src/Runtime/class-wp-agent-conversation-request.php
+++ b/src/Runtime/class-wp-agent-conversation-request.php
@@ -44,6 +44,9 @@ class WP_Agent_Conversation_Request {
 	/** @var WP_Agent_Workspace_Scope|null Workspace scope for persistence/audit adapters. */
 	private ?WP_Agent_Workspace_Scope $workspace;
 
+	/** @var \WP_Agent_Runtime_Overrides Runtime overrides for the request. */
+	private \WP_Agent_Runtime_Overrides $runtime_overrides;
+
 	/**
 	 * @param array                         $messages        Initial conversation messages.
 	 * @param array                         $tools           Runtime tool declarations available to the run.
@@ -52,7 +55,8 @@ class WP_Agent_Conversation_Request {
 	 * @param array<string, mixed>          $metadata        Caller-owned metadata.
 	 * @param int                           $max_turns       Maximum conversation turns.
 	 * @param bool                          $single_turn     Single-turn orchestration flag.
-	 * @param WP_Agent_Workspace_Scope|null      $workspace       Workspace scope for persistence/audit adapters.
+	 * @param WP_Agent_Workspace_Scope|null $workspace         Workspace scope for persistence/audit adapters.
+	 * @param \WP_Agent_Runtime_Overrides|null $runtime_overrides Runtime overrides for the request.
 	 */
 	public function __construct(
 		array $messages,
@@ -62,16 +66,18 @@ class WP_Agent_Conversation_Request {
 		array $metadata = array(),
 		int $max_turns = self::DEFAULT_MAX_TURNS,
 		bool $single_turn = false,
-		?WP_Agent_Workspace_Scope $workspace = null
+		?WP_Agent_Workspace_Scope $workspace = null,
+		?\WP_Agent_Runtime_Overrides $runtime_overrides = null
 	) {
-		$this->messages        = WP_Agent_Message::normalize_many( $messages );
-		$this->tools           = self::normalize_tools( $tools );
-		$this->principal       = $principal;
-		$this->runtime_context = self::normalize_json_array( $runtime_context, 'runtime_context' );
-		$this->metadata        = self::normalize_json_array( $metadata, 'metadata' );
-		$this->max_turns       = max( 1, $max_turns );
-		$this->single_turn     = $single_turn;
-		$this->workspace       = $workspace;
+		$this->messages          = WP_Agent_Message::normalize_many( $messages );
+		$this->tools             = self::normalize_tools( $tools );
+		$this->principal         = $principal;
+		$this->runtime_overrides = $runtime_overrides ?? new \WP_Agent_Runtime_Overrides();
+		$this->runtime_context   = self::normalize_json_array( $this->apply_runtime_overrides_to_context( $runtime_context ), 'runtime_context' );
+		$this->metadata          = self::normalize_json_array( $metadata, 'metadata' );
+		$this->max_turns         = max( 1, $max_turns );
+		$this->single_turn       = $single_turn;
+		$this->workspace         = $workspace;
 	}
 
 	/** @return array<int, array<string, mixed>> Initial conversation messages. */
@@ -114,6 +120,11 @@ class WP_Agent_Conversation_Request {
 		return $this->workspace;
 	}
 
+	/** @return \WP_Agent_Runtime_Overrides Runtime overrides for the request. */
+	public function runtimeOverrides(): \WP_Agent_Runtime_Overrides {
+		return $this->runtime_overrides;
+	}
+
 	/**
 	 * Return a normalized array representation.
 	 *
@@ -128,8 +139,27 @@ class WP_Agent_Conversation_Request {
 			'metadata'        => $this->metadata,
 			'max_turns'       => $this->max_turns,
 			'single_turn'     => $this->single_turn,
-			'workspace'       => $this->workspace ? $this->workspace->to_array() : null,
+			'workspace'         => $this->workspace ? $this->workspace->to_array() : null,
+			'runtime_overrides' => $this->runtime_overrides->to_array(),
 		);
+	}
+
+	/**
+	 * Add runner-facing overrides to runtime context.
+	 *
+	 * @param array<string, mixed> $runtime_context Caller runtime context.
+	 * @return array<string, mixed> Runtime context with nullable overrides removed.
+	 */
+	private function apply_runtime_overrides_to_context( array $runtime_context ): array {
+		$overrides = $this->runtime_overrides->to_array();
+		foreach ( array( 'system_prompt', 'provider_id', 'model_id', 'temperature', 'max_iterations', 'tier_1_tools', 'greeting' ) as $key ) {
+			$value = $overrides[ $key ] ?? null;
+			if ( null !== $value && array() !== $value ) {
+				$runtime_context[ $key ] = $value;
+			}
+		}
+
+		return $runtime_context;
 	}
 
 	/**

--- a/tests/conversation-loop-budgets-smoke.php
+++ b/tests/conversation-loop-budgets-smoke.php
@@ -299,4 +299,41 @@ agents_api_smoke_assert_equals( 3, $turn_count, 'explicit turns budget overrides
 agents_api_smoke_assert_equals( 'budget_exceeded', $result['status'] ?? null, 'explicit turns budget produces budget_exceeded status', $failures, $passes );
 agents_api_smoke_assert_equals( 'turns', $result['budget'] ?? null, 'explicit turns budget identified in result', $failures, $passes );
 
+echo "\n[9] Agent runtime max_iterations clamps loop turns and reaches runner context:\n";
+$turn_count  = 0;
+$provider_id = '';
+$agent       = new WP_Agent(
+	'budgeted-agent',
+	array(
+		'runtime_overrides' => array(
+			'max_iterations' => 2,
+			'provider_id'    => 'openai',
+		),
+	)
+);
+$result     = AgentsAPI\AI\WP_Agent_Conversation_Loop::run(
+	array( array( 'role' => 'user', 'content' => 'go' ) ),
+	static function ( array $messages, array $context ) use ( &$turn_count, &$provider_id ): array {
+		++$turn_count;
+		$provider_id = (string) ( $context['provider_id'] ?? '' );
+		$messages[] = AgentsAPI\AI\WP_Agent_Message::text( 'assistant', 'turn ' . $context['turn'] );
+
+		return array(
+			'messages'               => $messages,
+			'tool_execution_results' => array(),
+			'events'                 => array(),
+		);
+	},
+	array(
+		'agent'           => $agent,
+		'max_turns'       => 10,
+		'should_continue' => static function (): bool {
+			return true;
+		},
+	)
+);
+agents_api_smoke_assert_equals( 'openai', $provider_id, 'runtime provider override reaches runner context', $failures, $passes );
+agents_api_smoke_assert_equals( 2, $turn_count, 'runtime max_iterations clamps loop turns', $failures, $passes );
+agents_api_smoke_assert_equals( false, isset( $result['status'] ), 'runtime max_iterations clamp preserves max_turns exit semantics', $failures, $passes );
+
 agents_api_smoke_finish( 'Agents API conversation loop budgets', $failures, $passes );

--- a/tests/conversation-runner-contracts-smoke.php
+++ b/tests/conversation-runner-contracts-smoke.php
@@ -21,7 +21,15 @@ agents_api_smoke_require_module();
 
 echo "\n[1] Conversation requests normalize runner inputs:\n";
 $principal = AgentsAPI\AI\WP_Agent_Execution_Principal::user_session( 123, 'example-agent', AgentsAPI\AI\WP_Agent_Execution_Principal::REQUEST_CONTEXT_REST );
-$request   = new AgentsAPI\AI\WP_Agent_Conversation_Request(
+$runtime_overrides = new WP_Agent_Runtime_Overrides(
+	array(
+		'provider_id'    => 'openai',
+		'model_id'       => 'gpt-5.5',
+		'temperature'    => 0.3,
+		'max_iterations' => 5,
+	)
+);
+$request           = new AgentsAPI\AI\WP_Agent_Conversation_Request(
 	array(
 		array( 'role' => 'user', 'content' => 'Hello' ),
 	),
@@ -37,7 +45,9 @@ $request   = new AgentsAPI\AI\WP_Agent_Conversation_Request(
 	array( 'request_kind' => 'interactive' ),
 	array( 'trace_id' => 'abc123' ),
 	0,
-	true
+	true,
+	null,
+	$runtime_overrides
 );
 
 agents_api_smoke_assert_equals( AgentsAPI\AI\WP_Agent_Message::SCHEMA, $request->messages()[0]['schema'], 'request messages normalize to envelopes', $failures, $passes );
@@ -45,12 +55,15 @@ agents_api_smoke_assert_equals( $principal, $request->principal(), 'request expo
 agents_api_smoke_assert_equals( 'interactive', $request->runtimeContext()['request_kind'], 'request preserves caller runtime context', $failures, $passes );
 agents_api_smoke_assert_equals( 1, $request->maxTurns(), 'request enforces a positive turn budget', $failures, $passes );
 agents_api_smoke_assert_equals( true, $request->singleTurn(), 'request preserves single-turn flag', $failures, $passes );
+agents_api_smoke_assert_equals( 'openai', $request->runtimeContext()['provider_id'], 'request carries provider override to runtime context', $failures, $passes );
+agents_api_smoke_assert_equals( 'gpt-5.5', $request->runtimeContext()['model_id'], 'request carries model override to runtime context', $failures, $passes );
+agents_api_smoke_assert_equals( 0.3, $request->runtimeContext()['temperature'], 'request carries temperature override to runtime context', $failures, $passes );
 agents_api_smoke_assert_equals( 'abc123', $request->metadata()['trace_id'], 'request preserves caller metadata', $failures, $passes );
 agents_api_smoke_assert_equals( 'client/lookup', $request->tools()[0]['name'], 'request preserves normalized tool list', $failures, $passes );
 agents_api_smoke_assert_equals(
-	array( 'messages', 'tools', 'principal', 'runtime_context', 'metadata', 'max_turns', 'single_turn', 'workspace' ),
+	array( 'messages', 'tools', 'principal', 'runtime_context', 'metadata', 'max_turns', 'single_turn', 'workspace', 'runtime_overrides' ),
 	array_keys( $request->to_array() ),
-	'request array exposes neutral runner and workspace keys',
+	'request array exposes neutral runner, workspace, and override keys',
 	$failures,
 	$passes
 );

--- a/tests/registry-smoke.php
+++ b/tests/registry-smoke.php
@@ -70,4 +70,27 @@ agents_api_smoke_assert_equals(
 	$passes
 );
 
+$override_agent = new WP_Agent(
+	'persona-agent',
+	array(
+		'runtime_overrides' => array(
+			'system_prompt'  => 'Answer as the site concierge.',
+			'provider_id'    => 'openai',
+			'model_id'       => 'gpt-5.5',
+			'temperature'    => '0.2',
+			'max_iterations' => 4,
+			'tier_1_tools'   => array( 'agents/search', '', 'agents/search' ),
+			'greeting'       => 'How can I help?',
+		),
+	)
+);
+
+agents_api_smoke_assert_equals( true, $override_agent->runtime_overrides() instanceof WP_Agent_Runtime_Overrides, 'runtime overrides normalize to value object', $failures, $passes );
+agents_api_smoke_assert_equals( 'openai', $override_agent->runtime_overrides()->provider_id(), 'runtime overrides preserve provider', $failures, $passes );
+agents_api_smoke_assert_equals( 'gpt-5.5', $override_agent->runtime_overrides()->model_id(), 'runtime overrides preserve model', $failures, $passes );
+agents_api_smoke_assert_equals( 0.2, $override_agent->runtime_overrides()->temperature(), 'runtime overrides normalize temperature', $failures, $passes );
+agents_api_smoke_assert_equals( 4, $override_agent->runtime_overrides()->max_iterations(), 'runtime overrides preserve max_iterations', $failures, $passes );
+agents_api_smoke_assert_equals( array( 'agents/search' ), $override_agent->runtime_overrides()->tier_1_tools(), 'runtime overrides normalize tier_1_tools', $failures, $passes );
+agents_api_smoke_assert_equals( null, ( new WP_Agent( 'empty-overrides' ) )->runtime_overrides()->model_id(), 'empty runtime overrides default to null fields', $failures, $passes );
+
 agents_api_smoke_finish( 'Agents API registry', $failures, $passes );

--- a/tests/subagents-smoke.php
+++ b/tests/subagents-smoke.php
@@ -62,6 +62,7 @@ if ( ! function_exists( 'esc_html' ) ) {
 	function esc_html( $s ) { return $s; }
 }
 
+require_once __DIR__ . '/../src/Registry/class-wp-agent-runtime-overrides.php';
 require_once __DIR__ . '/../src/Registry/class-wp-agent.php';
 
 $plain = new WP_Agent( 'commander', array( 'label' => 'Commander' ) );


### PR DESCRIPTION
## Summary
- Adds a `WP_Agent_Runtime_Overrides` value object for per-agent runtime preferences such as provider, model, temperature, max iterations, tier-1 tools, prompts, and greetings.
- Carries runtime overrides through agent registration, conversation requests, and loop context so host runners can honor them without product-specific coupling.
- Adds smoke coverage for override normalization, request serialization, and max-iteration clamping.

Closes #185.

## Testing
- `composer test`
- `php tests/registry-smoke.php`
- `php tests/conversation-runner-contracts-smoke.php`
- `php tests/conversation-loop-budgets-smoke.php`
- `php tests/subagents-smoke.php`
- `git diff --check`
- `homeboy lint --path /Users/chubes/Developer/agents-api@add-runtime-overrides-185 --extension wordpress`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the runtime override implementation, smoke tests, and PR description for Chris to review and validate.