### PR TITLE
Fix runtime override array alignment

### DIFF
--- a/src/Runtime/class-wp-agent-conversation-request.php
+++ b/src/Runtime/class-wp-agent-conversation-request.php
@@ -132,13 +132,13 @@ class WP_Agent_Conversation_Request {
 	 */
 	public function to_array(): array {
 		return array(
-			'messages'        => $this->messages,
-			'tools'           => $this->tools,
-			'principal'       => $this->principal ? $this->principal->to_array() : null,
-			'runtime_context' => $this->runtime_context,
-			'metadata'        => $this->metadata,
-			'max_turns'       => $this->max_turns,
-			'single_turn'     => $this->single_turn,
+			'messages'          => $this->messages,
+			'tools'             => $this->tools,
+			'principal'         => $this->principal ? $this->principal->to_array() : null,
+			'runtime_context'   => $this->runtime_context,
+			'metadata'          => $this->metadata,
+			'max_turns'         => $this->max_turns,
+			'single_turn'       => $this->single_turn,
 			'workspace'         => $this->workspace ? $this->workspace->to_array() : null,
 			'runtime_overrides' => $this->runtime_overrides->to_array(),
 		);


### PR DESCRIPTION
## Summary
- Fixes the PHPCS array alignment warning left after #212 merged.

## Testing
- `php tests/conversation-runner-contracts-smoke.php`
- `php -l src/Runtime/class-wp-agent-conversation-request.php`
- `git diff --check`
- `homeboy lint --path /Users/chubes/Developer/agents-api@fix-runtime-overrides-alignment --extension wordpress`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Applied the lint-only follow-up fix and verified the branch for Chris to review.