### PR TITLE
Add wall-clock loop budget

### DIFF
--- a/src/Runtime/class-wp-agent-conversation-loop.php
+++ b/src/Runtime/class-wp-agent-conversation-loop.php
@@ -85,6 +85,8 @@ class WP_Agent_Conversation_Loop {
 		$budget_resolution     = self::resolve_budgets( $options, $max_turns );
 		$budgets               = $budget_resolution['budgets'];
 		$has_explicit_turns    = $budget_resolution['has_explicit_turns'];
+		$wall_clock_started_at = microtime( true );
+		$wall_clock_initial    = isset( $budgets['wall_clock_seconds'] ) ? $budgets['wall_clock_seconds']->current() : 0;
 		$mediation_enabled     = null !== $tool_executor && ! empty( $tool_declarations );
 		$messages              = WP_Agent_Message::normalize_many( $messages );
 		$events                = array();
@@ -124,6 +126,12 @@ class WP_Agent_Conversation_Loop {
 
 		try {
 			for ( $turn = 1; $turn <= $max_turns; ++$turn ) {
+				$wall_clock_exceeded = self::check_wall_clock_budget( $budgets, $wall_clock_started_at, $wall_clock_initial, $on_event );
+				if ( null !== $wall_clock_exceeded ) {
+					$exceeded_budget = $wall_clock_exceeded;
+					break;
+				}
+
 				$turns_run            = $turn;
 				$turn_context         = $context;
 				$turn_context['turn'] = $turn;
@@ -1006,16 +1014,74 @@ class WP_Agent_Conversation_Loop {
 		$budget->increment();
 
 		if ( $budget->exceeded() ) {
-			self::emit_event( $on_event, 'budget_exceeded', array(
-				'budget'  => $name,
-				'current' => $budget->current(),
-				'ceiling' => $budget->ceiling(),
-			) );
+			self::emit_event( $on_event, 'budget_exceeded', self::budget_event_payload( $budget ) );
 
 			return $name;
 		}
 
 		return null;
+	}
+
+	/**
+	 * Check the opt-in wall-clock budget before starting a turn.
+	 *
+	 * @param array<string, WP_Agent_Iteration_Budget> $budgets             Named budgets.
+	 * @param float                                    $started_at          Loop start timestamp.
+	 * @param int                                      $initial_elapsed_sec Existing elapsed seconds carried by the budget.
+	 * @param callable|null                            $on_event            Event sink.
+	 * @return string|null Exceeded budget name, or null.
+	 */
+	private static function check_wall_clock_budget( array $budgets, float $started_at, int $initial_elapsed_sec, ?callable $on_event ): ?string {
+		$name = 'wall_clock_seconds';
+		if ( ! isset( $budgets[ $name ] ) ) {
+			return null;
+		}
+
+		$budget  = $budgets[ $name ];
+		$elapsed = $initial_elapsed_sec + max( 0, (int) floor( microtime( true ) - $started_at ) );
+		$budget->set_current( $elapsed );
+
+		if ( $budget->exceeded() ) {
+			self::emit_event( $on_event, 'budget_exceeded', self::budget_event_payload( $budget ) );
+			return $name;
+		}
+
+		return null;
+	}
+
+	/**
+	 * Build the standard budget-exceeded event payload.
+	 *
+	 * @param WP_Agent_Iteration_Budget $budget Exceeded budget.
+	 * @return array<string, mixed>
+	 */
+	private static function budget_event_payload( WP_Agent_Iteration_Budget $budget ): array {
+		$name = $budget->name();
+
+		return array(
+			'budget'    => $name,
+			'dimension' => self::budget_dimension( $name ),
+			'current'   => $budget->current(),
+			'ceiling'   => $budget->ceiling(),
+		);
+	}
+
+	/**
+	 * Map budget names to generic dimensions for observers.
+	 *
+	 * @param string $name Budget name.
+	 * @return string Dimension label.
+	 */
+	private static function budget_dimension( string $name ): string {
+		if ( 'wall_clock_seconds' === $name ) {
+			return 'wall_clock';
+		}
+
+		if ( 0 === strpos( $name, 'tool_calls' ) ) {
+			return 'tool_calls';
+		}
+
+		return $name;
 	}
 
 	/**

--- a/src/Runtime/class-wp-agent-iteration-budget.php
+++ b/src/Runtime/class-wp-agent-iteration-budget.php
@@ -2,7 +2,7 @@
 /**
  * Iteration Budget — generic bounded-iteration primitive.
  *
- * Counts a named dimension (turns, tool calls, chain depth, retries)
+ * Counts a named dimension (turns, tool calls, wall-clock seconds, retries)
  * and exposes a uniform API for checking exceedance. A budget is a
  * stateful value object — call {@see increment()} at each iteration,
  * then {@see exceeded()} to decide whether to continue.
@@ -58,6 +58,19 @@ final class WP_Agent_Iteration_Budget {
 	 */
 	public function increment(): void {
 		++$this->current;
+	}
+
+	/**
+	 * Replace the current counter value.
+	 *
+	 * Wall-clock budgets are measured externally by the loop, then recorded on
+	 * this value object so event payloads and diagnostics share the same shape
+	 * as iteration budgets.
+	 *
+	 * @param int $current Current counter value. Negative values are clamped to 0.
+	 */
+	public function set_current( int $current ): void {
+		$this->current = max( 0, $current );
 	}
 
 	/**

--- a/tests/conversation-loop-budgets-smoke.php
+++ b/tests/conversation-loop-budgets-smoke.php
@@ -336,4 +336,41 @@ agents_api_smoke_assert_equals( 'openai', $provider_id, 'runtime provider overri
 agents_api_smoke_assert_equals( 2, $turn_count, 'runtime max_iterations clamps loop turns', $failures, $passes );
 agents_api_smoke_assert_equals( false, isset( $result['status'] ), 'runtime max_iterations clamp preserves max_turns exit semantics', $failures, $passes );
 
+echo "\n[10] Wall-clock budget stops before starting an over-budget turn:\n";
+$turn_count = 0;
+$event_log  = array();
+$result     = AgentsAPI\AI\WP_Agent_Conversation_Loop::run(
+	array( array( 'role' => 'user', 'content' => 'go' ) ),
+	static function ( array $messages ) use ( &$turn_count ): array {
+		++$turn_count;
+
+		return array(
+			'messages'               => $messages,
+			'tool_execution_results' => array(),
+			'events'                 => array(),
+		);
+	},
+	array(
+		'max_turns'       => 3,
+		'budgets'         => array(
+			new AgentsAPI\AI\WP_Agent_Iteration_Budget( 'wall_clock_seconds', 1, 1 ),
+		),
+		'should_continue' => static function (): bool {
+			return true;
+		},
+		'on_event'        => static function ( string $event, array $payload ) use ( &$event_log ): void {
+			$event_log[] = array( 'event' => $event, 'payload' => $payload );
+		},
+	)
+);
+
+$budget_events = array_values( array_filter( $event_log, static function ( array $e ): bool {
+	return 'budget_exceeded' === $e['event'];
+} ) );
+agents_api_smoke_assert_equals( 0, $turn_count, 'wall-clock budget prevents the turn runner from starting', $failures, $passes );
+agents_api_smoke_assert_equals( 'budget_exceeded', $result['status'] ?? null, 'wall-clock budget produces budget_exceeded status', $failures, $passes );
+agents_api_smoke_assert_equals( 'wall_clock_seconds', $result['budget'] ?? null, 'wall-clock budget is identified in result', $failures, $passes );
+agents_api_smoke_assert_equals( 1, count( $budget_events ), 'wall-clock budget emits one budget event', $failures, $passes );
+agents_api_smoke_assert_equals( 'wall_clock', $budget_events[0]['payload']['dimension'] ?? null, 'wall-clock budget event carries wall_clock dimension', $failures, $passes );
+
 agents_api_smoke_finish( 'Agents API conversation loop budgets', $failures, $passes );

--- a/tests/iteration-budget-smoke.php
+++ b/tests/iteration-budget-smoke.php
@@ -68,4 +68,11 @@ agents_api_smoke_assert_equals( 0, $pre_exceeded->remaining(), 'remaining is zer
 $above = new AgentsAPI\AI\WP_Agent_Iteration_Budget( 'depth', 3, 5 );
 agents_api_smoke_assert_equals( true, $above->exceeded(), 'budget starting above ceiling is exceeded', $failures, $passes );
 
+echo "\n[7] Current can be replaced for externally measured budgets:\n";
+$wall_clock = new AgentsAPI\AI\WP_Agent_Iteration_Budget( 'wall_clock_seconds', 5 );
+$wall_clock->set_current( 3 );
+agents_api_smoke_assert_equals( 3, $wall_clock->current(), 'set_current records measured value', $failures, $passes );
+$wall_clock->set_current( -10 );
+agents_api_smoke_assert_equals( 0, $wall_clock->current(), 'set_current clamps negative values', $failures, $passes );
+
 agents_api_smoke_finish( 'Agents API iteration budget', $failures, $passes );


### PR DESCRIPTION
## Summary
- Adds opt-in `wall_clock_seconds` support to `WP_Agent_Iteration_Budget` for loop-level wall-clock enforcement.
- Checks the wall-clock budget before each turn and returns the existing `budget_exceeded` status when elapsed time is already over budget.
- Adds a `dimension` field to budget events so observers can distinguish wall-clock, tool-call, and turn budgets.

Part of #183. Replaces #213 after #212 merged and changed the same loop-budget smoke test area.

## Testing
- `php tests/iteration-budget-smoke.php`
- `php tests/conversation-loop-budgets-smoke.php`
- `php -l src/Runtime/class-wp-agent-conversation-loop.php`
- `composer test`
- `git diff --check`
- `homeboy lint --path /Users/chubes/Developer/agents-api@add-wall-clock-budget-183 --extension wordpress`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the wall-clock budget implementation, resolved the post-#212 rebase overlap, and verified the branch for Chris to review.