### PR TITLE
Add event trigger contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,8 @@ wp_register_agent(
 - `WP_Agent`
 - `WP_Agent_Runtime_Overrides`
 - `WP_Agents_Registry`
+- `WP_Agent_Event_Trigger`
+- `WP_Agent_Event_Trigger_Registry`
 - `WP_Agent_Package*` value objects and artifact registry helpers
 - `WP_Agent_Access_Grant`
 - `WP_Agent_Access_Store`

--- a/agents-api.php
+++ b/agents-api.php
@@ -178,6 +178,10 @@ require_once AGENTS_API_PATH . 'src/Routines/class-wp-agent-routine-action-sched
 require_once AGENTS_API_PATH . 'src/Routines/register-routines.php';
 require_once AGENTS_API_PATH . 'src/Routines/register-routine-bridge-sync.php';
 require_once AGENTS_API_PATH . 'src/Routines/register-action-scheduler-listener.php';
+require_once AGENTS_API_PATH . 'src/Triggers/class-wp-agent-event-trigger.php';
+require_once AGENTS_API_PATH . 'src/Triggers/class-wp-agent-event-trigger-registry.php';
+require_once AGENTS_API_PATH . 'src/Triggers/register-event-triggers.php';
+require_once AGENTS_API_PATH . 'src/Triggers/register-event-trigger-handler.php';
 
 add_action( 'init', array( 'WP_Agents_Registry', 'init' ), 10 );
 add_action( 'init', array( 'WP_Guidelines_Substrate', 'register' ), 9 );

--- a/composer.json
+++ b/composer.json
@@ -74,6 +74,7 @@
       "php tests/workflow-lifecycle-smoke.php",
       "php tests/agents-workflow-ability-smoke.php",
       "php tests/routine-smoke.php",
+      "php tests/event-trigger-smoke.php",
       "php tests/subagents-smoke.php",
       "php tests/no-product-imports-smoke.php"
     ]

--- a/src/Triggers/class-wp-agent-event-trigger-registry.php
+++ b/src/Triggers/class-wp-agent-event-trigger-registry.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * In-memory registry of code-defined event triggers.
+ *
+ * @package AgentsAPI
+ */
+
+namespace AgentsAPI\AI\Triggers;
+
+use WP_Error;
+
+defined( 'ABSPATH' ) || exit;
+
+final class WP_Agent_Event_Trigger_Registry {
+
+	/** @var array<string, WP_Agent_Event_Trigger> */
+	private static array $triggers = array();
+
+	/**
+	 * @param array<string, mixed> $args See {@see WP_Agent_Event_Trigger::__construct()}.
+	 * @return WP_Agent_Event_Trigger|WP_Error
+	 */
+	public static function register( string $id, array $args ) {
+		try {
+			$trigger = new WP_Agent_Event_Trigger( $id, $args );
+		} catch ( \InvalidArgumentException $e ) {
+			return new WP_Error( 'invalid_event_trigger', $e->getMessage() );
+		}
+
+		self::$triggers[ $trigger->get_id() ] = $trigger;
+
+		/**
+		 * Fires after an event trigger is added to the in-memory registry.
+		 *
+		 * @param WP_Agent_Event_Trigger $trigger Registered trigger.
+		 */
+		do_action( 'wp_agent_event_trigger_registered', $trigger );
+
+		return $trigger;
+	}
+
+	/** @return true|WP_Error */
+	public static function unregister( string $trigger_id ) {
+		if ( ! isset( self::$triggers[ $trigger_id ] ) ) {
+			return new WP_Error(
+				'not_registered',
+				sprintf( 'no event trigger registered with id `%s`', $trigger_id )
+			);
+		}
+
+		$trigger = self::$triggers[ $trigger_id ];
+		unset( self::$triggers[ $trigger_id ] );
+
+		/**
+		 * Fires after an event trigger is removed from the in-memory registry.
+		 *
+		 * @param WP_Agent_Event_Trigger $trigger Removed trigger.
+		 */
+		do_action( 'wp_agent_event_trigger_unregistered', $trigger );
+
+		return true;
+	}
+
+	public static function find( string $trigger_id ): ?WP_Agent_Event_Trigger {
+		return self::$triggers[ $trigger_id ] ?? null;
+	}
+
+	/** @return WP_Agent_Event_Trigger[] */
+	public static function all(): array {
+		return array_values( self::$triggers );
+	}
+
+	public static function reset(): void {
+		self::$triggers = array();
+	}
+}

--- a/src/Triggers/class-wp-agent-event-trigger.php
+++ b/src/Triggers/class-wp-agent-event-trigger.php
@@ -1,0 +1,232 @@
+<?php
+/**
+ * Event trigger value object.
+ *
+ * @package AgentsAPI
+ */
+
+namespace AgentsAPI\AI\Triggers;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Code-defined WordPress hook trigger for an agent run.
+ */
+final class WP_Agent_Event_Trigger {
+
+	private string $id;
+	private string $label;
+	private string $agent_slug;
+	private bool $enabled;
+	private string $hook_name;
+	private array $args_shape;
+	private array $placeholders;
+	private array $conditions;
+	private string $prompt_template;
+	private string $session_id;
+	private array $meta = array();
+
+	/**
+	 * @param string               $id   Unique trigger slug.
+	 * @param array<string, mixed> $args Trigger arguments.
+	 */
+	public function __construct( string $id, array $args ) {
+		$id = sanitize_title( $id );
+		if ( '' === $id ) {
+			throw new \InvalidArgumentException( 'Event trigger id cannot be empty.' );
+		}
+
+		$agent = isset( $args['agent'] ) ? (string) $args['agent'] : '';
+		if ( '' === $agent ) {
+			throw new \InvalidArgumentException( esc_html( sprintf( 'Event trigger "%s" must specify an agent slug.', $id ) ) );
+		}
+
+		$hook_name = isset( $args['hook_name'] ) ? trim( (string) $args['hook_name'] ) : '';
+		if ( '' === $hook_name ) {
+			throw new \InvalidArgumentException( esc_html( sprintf( 'Event trigger "%s" must specify a hook_name.', $id ) ) );
+		}
+
+		$this->id              = $id;
+		$this->label           = isset( $args['label'] ) ? (string) $args['label'] : $id;
+		$this->agent_slug      = $agent;
+		$this->enabled         = isset( $args['enabled'] ) ? (bool) $args['enabled'] : true;
+		$this->hook_name       = $hook_name;
+		$this->args_shape      = self::normalize_string_list( $args['args_shape'] ?? array() );
+		$this->placeholders    = is_array( $args['placeholders'] ?? null ) ? $args['placeholders'] : array();
+		$this->conditions      = is_array( $args['conditions'] ?? null ) ? $args['conditions'] : array();
+		$this->prompt_template = isset( $args['prompt_template'] ) ? (string) $args['prompt_template'] : '';
+		$this->session_id      = isset( $args['session_id'] ) && '' !== (string) $args['session_id']
+			? (string) $args['session_id']
+			: 'event-trigger:' . $id;
+
+		if ( isset( $args['meta'] ) && is_array( $args['meta'] ) ) {
+			$this->meta = $args['meta'];
+		}
+	}
+
+	public function get_id(): string {
+		return $this->id;
+	}
+
+	public function get_label(): string {
+		return $this->label;
+	}
+
+	public function get_agent_slug(): string {
+		return $this->agent_slug;
+	}
+
+	public function is_enabled(): bool {
+		return $this->enabled;
+	}
+
+	public function get_hook_name(): string {
+		return $this->hook_name;
+	}
+
+	/** @return string[] */
+	public function get_args_shape(): array {
+		return $this->args_shape;
+	}
+
+	/** @return array<string, callable|string> */
+	public function get_placeholders(): array {
+		return $this->placeholders;
+	}
+
+	/** @return array<string, mixed> */
+	public function get_conditions(): array {
+		return $this->conditions;
+	}
+
+	public function get_prompt_template(): string {
+		return $this->prompt_template;
+	}
+
+	public function get_session_id(): string {
+		return $this->session_id;
+	}
+
+	/** @return array<string, mixed> */
+	public function get_meta(): array {
+		return $this->meta;
+	}
+
+	/**
+	 * Project positional hook arguments onto named payload keys.
+	 *
+	 * @param array<int, mixed> $hook_args Positional WordPress hook arguments.
+	 * @return array<string, mixed>
+	 */
+	public function payload_from_hook_args( array $hook_args ): array {
+		$payload = array();
+		foreach ( $this->args_shape as $index => $key ) {
+			$payload[ $key ] = $hook_args[ $index ] ?? null;
+		}
+		return $payload;
+	}
+
+	/**
+	 * Evaluate pre-dispatch conditions against the named payload.
+	 *
+	 * @param array<string, mixed> $payload Named hook payload.
+	 */
+	public function conditions_match( array $payload ): bool {
+		foreach ( $this->conditions as $key => $expected ) {
+			if ( is_callable( $expected ) ) {
+				if ( ! (bool) call_user_func( $expected, $payload ) ) {
+					return false;
+				}
+				continue;
+			}
+
+			if ( self::read_path( $payload, (string) $key ) !== $expected ) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Resolve placeholders and render the prompt template.
+	 *
+	 * @param array<string, mixed> $payload Named hook payload.
+	 */
+	public function render_prompt( array $payload ): string {
+		$values = array();
+		foreach ( $this->placeholders as $name => $extractor ) {
+			$value            = is_callable( $extractor ) ? call_user_func( $extractor, $payload ) : self::read_path( $payload, (string) $extractor );
+			$values[ $name ] = is_scalar( $value ) || null === $value ? (string) $value : wp_json_encode( $value );
+		}
+
+		$prompt = $this->prompt_template;
+		foreach ( $values as $name => $value ) {
+			$prompt = str_replace( '{{' . $name . '}}', $value, $prompt );
+		}
+
+		return $prompt;
+	}
+
+	/** @return array<string, mixed> */
+	public function to_array(): array {
+		return array(
+			'id'              => $this->id,
+			'label'           => $this->label,
+			'agent'           => $this->agent_slug,
+			'enabled'         => $this->enabled,
+			'hook_name'       => $this->hook_name,
+			'args_shape'      => $this->args_shape,
+			'prompt_template' => $this->prompt_template,
+			'session_id'      => $this->session_id,
+			'meta'            => $this->meta,
+		);
+	}
+
+	/**
+	 * @param mixed $values Raw list.
+	 * @return string[]
+	 */
+	private static function normalize_string_list( $values ): array {
+		$values = is_array( $values ) ? $values : array( $values );
+		$values = array_filter(
+			array_map(
+				static fn( $value ): string => trim( (string) $value ),
+				$values
+			),
+			static fn( string $value ): bool => '' !== $value
+		);
+
+		return array_values( $values );
+	}
+
+	/**
+	 * Read a dotted path from arrays or objects.
+	 *
+	 * @param mixed  $source Source value.
+	 * @param string $path   Dotted path.
+	 * @return mixed
+	 */
+	private static function read_path( $source, string $path ) {
+		if ( '' === $path ) {
+			return null;
+		}
+
+		$value = $source;
+		foreach ( explode( '.', $path ) as $segment ) {
+			if ( is_array( $value ) && array_key_exists( $segment, $value ) ) {
+				$value = $value[ $segment ];
+				continue;
+			}
+
+			if ( is_object( $value ) && isset( $value->{$segment} ) ) {
+				$value = $value->{$segment};
+				continue;
+			}
+
+			return null;
+		}
+
+		return $value;
+	}
+}

--- a/src/Triggers/register-event-trigger-handler.php
+++ b/src/Triggers/register-event-trigger-handler.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Event trigger hook wiring helpers.
+ *
+ * @package AgentsAPI
+ */
+
+namespace AgentsAPI\AI\Triggers;
+
+defined( 'ABSPATH' ) || exit;
+
+const WP_AGENT_EVENT_TRIGGER_RUN_HOOK = 'wp_agent_event_trigger_run';
+
+add_action(
+	'wp_agent_event_trigger_registered',
+	__NAMESPACE__ . '\register_event_trigger_handler',
+	10,
+	1
+);
+
+/**
+ * Attach a WordPress action listener for a registered event trigger.
+ */
+function register_event_trigger_handler( WP_Agent_Event_Trigger $trigger ): void {
+	if ( ! $trigger->is_enabled() ) {
+		return;
+	}
+
+	add_action(
+		$trigger->get_hook_name(),
+		static function ( ...$hook_args ) use ( $trigger ): void {
+			dispatch_event_trigger_hook( $trigger, $hook_args );
+		},
+		PHP_INT_MAX,
+		max( 1, count( $trigger->get_args_shape() ) )
+	);
+}
+
+/**
+ * Resolve a hook payload and enqueue an async event-trigger run.
+ *
+ * @param WP_Agent_Event_Trigger $trigger   Event trigger.
+ * @param array<int, mixed>      $hook_args Positional hook arguments.
+ */
+function dispatch_event_trigger_hook( WP_Agent_Event_Trigger $trigger, array $hook_args ): void {
+	$payload = $trigger->payload_from_hook_args( $hook_args );
+	if ( ! $trigger->conditions_match( $payload ) ) {
+		return;
+	}
+
+	$message = $trigger->render_prompt( $payload );
+	$args    = array(
+		'trigger_id' => $trigger->get_id(),
+		'agent'      => $trigger->get_agent_slug(),
+		'message'    => $message,
+		'session_id' => $trigger->get_session_id(),
+		'payload'    => $payload,
+	);
+
+	if ( ! function_exists( 'wp_schedule_single_event' ) || ! wp_schedule_single_event( time(), WP_AGENT_EVENT_TRIGGER_RUN_HOOK, array( $args ) ) ) {
+		do_action(
+			'wp_agent_event_trigger_dispatch_failed',
+			'schedule_failed',
+			array(
+				'trigger_id' => $trigger->get_id(),
+				'hook_name'  => $trigger->get_hook_name(),
+			)
+		);
+		return;
+	}
+
+	do_action( 'wp_agent_event_trigger_dispatched', $trigger, $args );
+}

--- a/src/Triggers/register-event-triggers.php
+++ b/src/Triggers/register-event-triggers.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Global helpers for the in-memory event trigger registry.
+ *
+ * @package AgentsAPI
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+if ( ! function_exists( 'wp_register_event_trigger' ) ) {
+	/**
+	 * Register a code-defined event trigger.
+	 *
+	 * @param string $id   Unique trigger slug.
+	 * @param array  $args Trigger arguments.
+	 * @return AgentsAPI\AI\Triggers\WP_Agent_Event_Trigger|WP_Error
+	 */
+	function wp_register_event_trigger( string $id, array $args ) {
+		return AgentsAPI\AI\Triggers\WP_Agent_Event_Trigger_Registry::register( $id, $args );
+	}
+}
+
+if ( ! function_exists( 'wp_get_event_trigger' ) ) {
+	function wp_get_event_trigger( string $trigger_id ): ?AgentsAPI\AI\Triggers\WP_Agent_Event_Trigger {
+		return AgentsAPI\AI\Triggers\WP_Agent_Event_Trigger_Registry::find( $trigger_id );
+	}
+}
+
+if ( ! function_exists( 'wp_get_event_triggers' ) ) {
+	/** @return AgentsAPI\AI\Triggers\WP_Agent_Event_Trigger[] */
+	function wp_get_event_triggers(): array {
+		return AgentsAPI\AI\Triggers\WP_Agent_Event_Trigger_Registry::all();
+	}
+}
+
+if ( ! function_exists( 'wp_unregister_event_trigger' ) ) {
+	/** @return true|WP_Error */
+	function wp_unregister_event_trigger( string $trigger_id ) {
+		return AgentsAPI\AI\Triggers\WP_Agent_Event_Trigger_Registry::unregister( $trigger_id );
+	}
+}

--- a/tests/bootstrap-smoke.php
+++ b/tests/bootstrap-smoke.php
@@ -187,6 +187,7 @@ $expected_source_directories = array(
 	'Runtime',
 	'Tools',
 	'Transcripts',
+	'Triggers',
 	'Workflows',
 	'Workspace',
 );

--- a/tests/event-trigger-smoke.php
+++ b/tests/event-trigger-smoke.php
@@ -1,0 +1,182 @@
+<?php
+/**
+ * Pure-PHP smoke for the event trigger substrate.
+ *
+ * Run with: php tests/event-trigger-smoke.php
+ *
+ * @package AgentsAPI\Tests
+ */
+
+defined( 'ABSPATH' ) || define( 'ABSPATH', __DIR__ . '/' );
+
+$failures = array();
+$passes   = 0;
+
+echo "event-trigger-smoke\n";
+
+function smoke_assert( $expected, $actual, string $name, array &$failures, int &$passes ): void {
+	if ( $expected === $actual ) {
+		++$passes;
+		echo "  PASS {$name}\n";
+		return;
+	}
+	$failures[] = $name;
+	echo "  FAIL {$name}\n";
+	echo '    expected: ' . var_export( $expected, true ) . "\n";
+	echo '    actual:   ' . var_export( $actual, true ) . "\n";
+}
+
+function smoke_assert_throws( callable $fn, string $message_substring, string $name, array &$failures, int &$passes ): void {
+	try {
+		$fn();
+	} catch ( \Throwable $e ) {
+		if ( false === strpos( $e->getMessage(), $message_substring ) ) {
+			$failures[] = $name;
+			echo "  FAIL {$name}\n";
+			echo '    expected substring: ' . $message_substring . "\n";
+			echo '    actual message:     ' . $e->getMessage() . "\n";
+			return;
+		}
+		++$passes;
+		echo "  PASS {$name}\n";
+		return;
+	}
+	$failures[] = $name;
+	echo "  FAIL {$name} (no exception thrown)\n";
+}
+
+if ( ! function_exists( 'sanitize_title' ) ) {
+	function sanitize_title( $str ) {
+		$str = strtolower( (string) $str );
+		$str = preg_replace( '/[^a-z0-9_-]+/', '-', $str ) ?? '';
+		return trim( $str, '-' );
+	}
+}
+if ( ! function_exists( 'esc_html' ) ) {
+	function esc_html( $s ) { return $s; }
+}
+if ( ! function_exists( 'wp_json_encode' ) ) {
+	function wp_json_encode( $data ) { return json_encode( $data ); }
+}
+if ( ! class_exists( 'WP_Error' ) ) {
+	class WP_Error {
+		public function __construct( private string $code = '', private string $message = '', private $data = null ) {}
+		public function get_error_code(): string { return $this->code; }
+		public function get_error_message(): string { return $this->message; }
+		public function get_error_data() { return $this->data; }
+	}
+}
+
+$GLOBALS['smoke_actions']   = array();
+$GLOBALS['smoke_scheduled'] = array();
+if ( ! function_exists( 'add_action' ) ) {
+	function add_action( string $hook, $callback, int $priority = 10, int $accepted_args = 1 ): void {
+		$GLOBALS['smoke_actions'][] = compact( 'hook', 'callback', 'priority', 'accepted_args' );
+	}
+}
+if ( ! function_exists( 'do_action' ) ) {
+	function do_action( string $hook, ...$args ): void {
+		$GLOBALS['smoke_actions'][] = array( 'hook' => $hook, 'args' => $args );
+	}
+}
+if ( ! function_exists( 'wp_schedule_single_event' ) ) {
+	function wp_schedule_single_event( int $timestamp, string $hook, array $args = array() ): bool {
+		$GLOBALS['smoke_scheduled'][] = compact( 'timestamp', 'hook', 'args' );
+		return true;
+	}
+}
+
+require_once __DIR__ . '/../src/Triggers/class-wp-agent-event-trigger.php';
+require_once __DIR__ . '/../src/Triggers/class-wp-agent-event-trigger-registry.php';
+require_once __DIR__ . '/../src/Triggers/register-event-trigger-handler.php';
+
+use AgentsAPI\AI\Triggers\WP_Agent_Event_Trigger;
+use AgentsAPI\AI\Triggers\WP_Agent_Event_Trigger_Registry;
+use function AgentsAPI\AI\Triggers\dispatch_event_trigger_hook;
+use function AgentsAPI\AI\Triggers\register_event_trigger_handler;
+
+WP_Agent_Event_Trigger_Registry::reset();
+
+echo "\n[1] Event trigger value object normalizes inputs:\n";
+$trigger = new WP_Agent_Event_Trigger(
+	'post-published',
+	array(
+		'agent'           => 'editorial-agent',
+		'hook_name'       => 'transition_post_status',
+		'args_shape'      => array( 'new_status', 'old_status', 'post' ),
+		'placeholders'    => array(
+			'post.title' => 'post.title',
+			'status'     => 'new_status',
+		),
+		'conditions'      => array( 'new_status' => 'publish' ),
+		'prompt_template' => 'Review {{post.title}} now that it is {{status}}.',
+	)
+);
+smoke_assert( 'post-published', $trigger->get_id(), 'trigger id normalizes', $failures, $passes );
+smoke_assert( 'editorial-agent', $trigger->get_agent_slug(), 'trigger agent is preserved', $failures, $passes );
+smoke_assert( true, $trigger->is_enabled(), 'trigger defaults to enabled', $failures, $passes );
+smoke_assert( 'transition_post_status', $trigger->get_hook_name(), 'trigger hook is preserved', $failures, $passes );
+smoke_assert( 'event-trigger:post-published', $trigger->get_session_id(), 'session_id defaults to event-trigger prefix', $failures, $passes );
+
+echo "\n[2] Validation rejects incomplete triggers:\n";
+smoke_assert_throws( static fn() => new WP_Agent_Event_Trigger( '', array( 'agent' => 'a', 'hook_name' => 'h' ) ), 'id cannot be empty', 'rejects empty id', $failures, $passes );
+smoke_assert_throws( static fn() => new WP_Agent_Event_Trigger( 'x', array( 'hook_name' => 'h' ) ), 'must specify an agent slug', 'rejects missing agent', $failures, $passes );
+smoke_assert_throws( static fn() => new WP_Agent_Event_Trigger( 'x', array( 'agent' => 'a' ) ), 'must specify a hook_name', 'rejects missing hook', $failures, $passes );
+
+echo "\n[3] Registry round-trips triggers:\n";
+$registered = WP_Agent_Event_Trigger_Registry::register(
+	'post-published',
+	array(
+		'agent'     => 'editorial-agent',
+		'hook_name' => 'transition_post_status',
+	)
+);
+smoke_assert( true, $registered instanceof WP_Agent_Event_Trigger, 'registry returns trigger object', $failures, $passes );
+smoke_assert( 1, count( WP_Agent_Event_Trigger_Registry::all() ), 'registry has one trigger', $failures, $passes );
+smoke_assert( true, WP_Agent_Event_Trigger_Registry::find( 'post-published' ) instanceof WP_Agent_Event_Trigger, 'find returns trigger', $failures, $passes );
+smoke_assert( null, WP_Agent_Event_Trigger_Registry::find( 'missing' ), 'find returns null for missing trigger', $failures, $passes );
+smoke_assert( true, WP_Agent_Event_Trigger_Registry::unregister( 'post-published' ), 'unregister returns true', $failures, $passes );
+$missing = WP_Agent_Event_Trigger_Registry::unregister( 'missing' );
+smoke_assert( true, is_object( $missing ) && method_exists( $missing, 'get_error_code' ) && 'not_registered' === $missing->get_error_code(), 'unregister returns WP_Error for missing trigger', $failures, $passes );
+
+echo "\n[4] Placeholders and conditions resolve from hook payloads:\n";
+$payload = $trigger->payload_from_hook_args(
+	array(
+		'publish',
+		'draft',
+		array( 'title' => 'Launch Post' ),
+	)
+);
+smoke_assert( true, $trigger->conditions_match( $payload ), 'condition accepts matching payload', $failures, $passes );
+smoke_assert( 'Review Launch Post now that it is publish.', $trigger->render_prompt( $payload ), 'prompt renders placeholders', $failures, $passes );
+$payload['new_status'] = 'draft';
+smoke_assert( false, $trigger->conditions_match( $payload ), 'condition rejects non-matching payload', $failures, $passes );
+
+echo "\n[5] Handler registers hooks and schedules async dispatch:\n";
+$GLOBALS['smoke_actions']   = array();
+$GLOBALS['smoke_scheduled'] = array();
+register_event_trigger_handler( $trigger );
+smoke_assert( 'transition_post_status', $GLOBALS['smoke_actions'][0]['hook'] ?? null, 'handler attaches source hook', $failures, $passes );
+smoke_assert( PHP_INT_MAX, $GLOBALS['smoke_actions'][0]['priority'] ?? null, 'handler uses late priority', $failures, $passes );
+smoke_assert( 3, $GLOBALS['smoke_actions'][0]['accepted_args'] ?? null, 'handler accepts declared hook args', $failures, $passes );
+
+dispatch_event_trigger_hook(
+	$trigger,
+	array(
+		'publish',
+		'draft',
+		array( 'title' => 'Launch Post' ),
+	)
+);
+smoke_assert( 1, count( $GLOBALS['smoke_scheduled'] ), 'matching event schedules one async run', $failures, $passes );
+smoke_assert( AgentsAPI\AI\Triggers\WP_AGENT_EVENT_TRIGGER_RUN_HOOK, $GLOBALS['smoke_scheduled'][0]['hook'] ?? null, 'async run uses event trigger hook', $failures, $passes );
+$scheduled_payload = $GLOBALS['smoke_scheduled'][0]['args'][0] ?? array();
+smoke_assert( 'post-published', $scheduled_payload['trigger_id'] ?? null, 'scheduled payload includes trigger id', $failures, $passes );
+smoke_assert( 'editorial-agent', $scheduled_payload['agent'] ?? null, 'scheduled payload includes agent', $failures, $passes );
+smoke_assert( 'Review Launch Post now that it is publish.', $scheduled_payload['message'] ?? null, 'scheduled payload includes rendered prompt', $failures, $passes );
+
+if ( count( $failures ) > 0 ) {
+	echo 'FAIL ' . count( $failures ) . " failures\n";
+	exit( 1 );
+}
+echo "OK {$passes} passed\n";


### PR DESCRIPTION
## Summary
- Adds `WP_Agent_Event_Trigger` and `WP_Agent_Event_Trigger_Registry` as hook-triggered counterparts to routines.
- Adds helper functions and hook wiring that projects WordPress action args into payloads, evaluates conditions, renders prompt placeholders, and schedules async trigger runs.
- Adds smoke coverage for registration, placeholder resolution, condition evaluation, and async dispatch scheduling.

Closes #182.

## Testing
- `php tests/event-trigger-smoke.php`
- `php -l src/Triggers/class-wp-agent-event-trigger.php && php -l src/Triggers/class-wp-agent-event-trigger-registry.php && php -l src/Triggers/register-event-triggers.php && php -l src/Triggers/register-event-trigger-handler.php && php -l tests/event-trigger-smoke.php`
- `composer test`
- `git diff --check`
- `homeboy lint --path /Users/chubes/Developer/agents-api@add-event-triggers-182 --extension wordpress`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the trigger contracts, hook wiring, smoke coverage, and verification pass for Chris to review.