### PR TITLE
Fix event trigger placeholder alignment

### DIFF
--- a/src/Triggers/class-wp-agent-event-trigger.php
+++ b/src/Triggers/class-wp-agent-event-trigger.php
@@ -156,7 +156,7 @@ final class WP_Agent_Event_Trigger {
 	public function render_prompt( array $payload ): string {
 		$values = array();
 		foreach ( $this->placeholders as $name => $extractor ) {
-			$value = is_callable( $extractor )
+			$value           = is_callable( $extractor )
 				? call_user_func( $extractor, $payload )
 				: self::read_path( $payload, (string) $extractor );
 			$values[ $name ] = is_scalar( $value ) || null === $value ? (string) $value : wp_json_encode( $value );

--- a/src/Triggers/class-wp-agent-event-trigger.php
+++ b/src/Triggers/class-wp-agent-event-trigger.php
@@ -156,7 +156,9 @@ final class WP_Agent_Event_Trigger {
 	public function render_prompt( array $payload ): string {
 		$values = array();
 		foreach ( $this->placeholders as $name => $extractor ) {
-			$value            = is_callable( $extractor ) ? call_user_func( $extractor, $payload ) : self::read_path( $payload, (string) $extractor );
+			$value = is_callable( $extractor )
+				? call_user_func( $extractor, $payload )
+				: self::read_path( $payload, (string) $extractor );
 			$values[ $name ] = is_scalar( $value ) || null === $value ? (string) $value : wp_json_encode( $value );
 		}
 


### PR DESCRIPTION
## Summary
- Split event trigger placeholder extraction across multiple lines to avoid PHPCS assignment-alignment failures.
- Keeps the post-#216 trigger behavior unchanged while unblocking lint on main.

## Testing
- `php -l src/Triggers/class-wp-agent-event-trigger.php`
- `git diff --check`
- `composer test`
- `homeboy lint --path /Users/chubes/Developer/agents-api@fix-event-trigger-alignment --extension wordpress`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the merged PHPCS alignment failure, drafted the minimal formatting fix, and ran local verification.