### PR TITLE
Add tool tier resolver contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,10 @@ wp_register_agent(
 - `WP_Agent_Tool_Policy`
 - `WP_Agent_Tool_Policy_Filter`
 - `WP_Agent_Tool_Access_Policy`
+- `WP_Agent_Tool_Tier_Resolver`
+- `WP_Agent_Default_Tool_Tier_Resolver`
+- `WP_Agent_Tool_Usage_Tracker`
+- `WP_Agent_Null_Tool_Usage_Tracker`
 - `WP_Agent_Action_Policy_Resolver`
 - `WP_Agent_Action_Policy_Provider`
 - `AgentsAPI\Core\Workspace\WP_Agent_Workspace_Scope`

--- a/agents-api.php
+++ b/agents-api.php
@@ -104,6 +104,10 @@ require_once AGENTS_API_PATH . 'src/Tools/class-wp-agent-action-policy-provider.
 require_once AGENTS_API_PATH . 'src/Tools/class-wp-agent-tool-policy-filter.php';
 require_once AGENTS_API_PATH . 'src/Tools/class-wp-agent-tool-policy.php';
 require_once AGENTS_API_PATH . 'src/Tools/class-wp-agent-action-policy-resolver.php';
+require_once AGENTS_API_PATH . 'src/Tools/class-wp-agent-tool-usage-tracker.php';
+require_once AGENTS_API_PATH . 'src/Tools/class-wp-agent-null-tool-usage-tracker.php';
+require_once AGENTS_API_PATH . 'src/Tools/class-wp-agent-tool-tier-resolver.php';
+require_once AGENTS_API_PATH . 'src/Tools/class-wp-agent-default-tool-tier-resolver.php';
 require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-conversation-request.php';
 require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-conversation-runner.php';
 require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-conversation-completion-decision.php';

--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,7 @@
       "php tests/action-policy-values-smoke.php",
       "php tests/consent-policy-smoke.php",
       "php tests/tool-policy-contracts-smoke.php",
+      "php tests/tool-tier-resolver-smoke.php",
       "php tests/action-policy-resolver-smoke.php",
       "php tests/tool-runtime-smoke.php",
       "php tests/pending-action-store-contract-smoke.php",

--- a/src/Tools/class-wp-agent-default-tool-tier-resolver.php
+++ b/src/Tools/class-wp-agent-default-tool-tier-resolver.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * Default tool tier resolver.
+ *
+ * @package AgentsAPI
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+if ( ! class_exists( 'WP_Agent_Default_Tool_Tier_Resolver' ) ) {
+	/**
+	 * Resolves Tier-1 full-schema tools and Tier-2 compact-manifest tools.
+	 */
+	final class WP_Agent_Default_Tool_Tier_Resolver implements WP_Agent_Tool_Tier_Resolver {
+
+		private WP_Agent_Tool_Usage_Tracker $usage_tracker;
+		private int $hard_cap;
+
+		public function __construct( ?WP_Agent_Tool_Usage_Tracker $usage_tracker = null, int $hard_cap = 15 ) {
+			$this->usage_tracker = $usage_tracker ?? new WP_Agent_Null_Tool_Usage_Tracker();
+			$this->hard_cap      = max( 1, $hard_cap );
+		}
+
+		/** @inheritDoc */
+		public function resolve( array $tools, array $context = array() ): array {
+			$cap      = $this->hard_cap( $context );
+			$tier_1   = array();
+			$selected = array();
+
+			foreach ( $this->candidate_names( $tools, $context, $cap ) as $name ) {
+				if ( count( $tier_1 ) >= $cap ) {
+					break;
+				}
+
+				if ( isset( $selected[ $name ] ) || ! isset( $tools[ $name ] ) ) {
+					continue;
+				}
+
+				$selected[ $name ] = true;
+				$tier_1[ $name ]   = $tools[ $name ];
+			}
+
+			$tier_2 = array_diff_key( $tools, $tier_1 );
+
+			return array(
+				'tier_1'   => $tier_1,
+				'tier_2'   => $tier_2,
+				'manifest' => $this->manifest( $tier_2 ),
+			);
+		}
+
+		/**
+		 * @param array<string, array<string, mixed>> $tools   Visible tool declarations.
+		 * @param array<string, mixed>                $context Runtime context.
+		 * @param int                                 $cap     Tier-1 hard cap.
+		 * @return string[] Candidate tool names in selection order.
+		 */
+		private function candidate_names( array $tools, array $context, int $cap ): array {
+			$workspace_id = $this->workspace_id( $context );
+
+			return array_values(
+				array_unique(
+					array_merge(
+						$this->string_list( $context['tier_1_tools'] ?? array() ),
+						$this->usage_tracker->top_n( $workspace_id, $cap ),
+						$this->mandatory_tool_names( $tools ),
+						array_keys( $tools )
+					)
+				)
+			);
+		}
+
+		/**
+		 * @param array<string, array<string, mixed>> $tools Visible tool declarations.
+		 * @return string[] Mandatory tool names.
+		 */
+		private function mandatory_tool_names( array $tools ): array {
+			$names = array();
+			foreach ( $tools as $name => $tool ) {
+				if ( true === ( $tool['mandatory'] ?? false ) ) {
+					$names[] = $name;
+				}
+			}
+			return $names;
+		}
+
+		/**
+		 * @param array<string, array<string, mixed>> $tools Tier-2 tools.
+		 * @return array<int, array<string, mixed>> Compact manifest entries.
+		 */
+		private function manifest( array $tools ): array {
+			$manifest = array();
+			foreach ( $tools as $name => $tool ) {
+				$manifest[] = array(
+					'name'            => $name,
+					'summary'         => trim( (string) ( $tool['description'] ?? '' ) ),
+					'required_fields' => $this->required_fields( $tool ),
+				);
+			}
+			return $manifest;
+		}
+
+		/**
+		 * @param array<string, mixed> $tool Tool declaration.
+		 * @return string[] Required parameter names.
+		 */
+		private function required_fields( array $tool ): array {
+			return $this->string_list( $tool['parameters']['required'] ?? array() );
+		}
+
+		/** @param array<string, mixed> $context Runtime context. */
+		private function hard_cap( array $context ): int {
+			return max( 1, (int) ( $context['tool_tier_hard_cap'] ?? $this->hard_cap ) );
+		}
+
+		/** @param array<string, mixed> $context Runtime context. */
+		private function workspace_id( array $context ): string {
+			$workspace = $context['workspace_id'] ?? ( is_array( $context['workspace'] ?? null ) ? ( $context['workspace']['id'] ?? '' ) : '' );
+			return is_scalar( $workspace ) ? (string) $workspace : '';
+		}
+
+		/**
+		 * @param mixed $values Raw list.
+		 * @return string[] Non-empty strings.
+		 */
+		private function string_list( $values ): array {
+			$values = is_array( $values ) ? $values : array( $values );
+			$values = array_filter(
+				array_map(
+					static fn( $value ): string => trim( (string) $value ),
+					$values
+				),
+				static fn( string $value ): bool => '' !== $value
+			);
+
+			return array_values( array_unique( $values ) );
+		}
+	}
+}

--- a/src/Tools/class-wp-agent-null-tool-usage-tracker.php
+++ b/src/Tools/class-wp-agent-null-tool-usage-tracker.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Null tool usage tracker.
+ *
+ * @package AgentsAPI
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+if ( ! class_exists( 'WP_Agent_Null_Tool_Usage_Tracker' ) ) {
+	/**
+	 * No-op usage tracker for consumers without durable usage storage.
+	 */
+	final class WP_Agent_Null_Tool_Usage_Tracker implements WP_Agent_Tool_Usage_Tracker {
+
+		/** @inheritDoc */
+		public function record_call( string $tool_name, string $workspace_id ): void {
+			unset( $tool_name, $workspace_id );
+		}
+
+		/** @inheritDoc */
+		public function top_n( string $workspace_id, int $limit ): array {
+			unset( $workspace_id, $limit );
+			return array();
+		}
+	}
+}

--- a/src/Tools/class-wp-agent-tool-tier-resolver.php
+++ b/src/Tools/class-wp-agent-tool-tier-resolver.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Tool tier resolver contract.
+ *
+ * @package AgentsAPI
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+if ( ! interface_exists( 'WP_Agent_Tool_Tier_Resolver' ) ) {
+	/**
+	 * Partitions visible tools into full-schema and discovery tiers.
+	 */
+	interface WP_Agent_Tool_Tier_Resolver {
+
+		/**
+		 * Resolve tool tiers from an already-visible tool set.
+		 *
+		 * @param array<string, array<string, mixed>> $tools   Visible tool declarations keyed by tool name.
+		 * @param array<string, mixed>                $context Runtime context.
+		 * @return array{tier_1: array<string, array<string, mixed>>, tier_2: array<string, array<string, mixed>>, manifest: array<int, array<string, mixed>>}
+		 */
+		public function resolve( array $tools, array $context = array() ): array;
+	}
+}

--- a/src/Tools/class-wp-agent-tool-usage-tracker.php
+++ b/src/Tools/class-wp-agent-tool-usage-tracker.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Tool usage tracker contract.
+ *
+ * @package AgentsAPI
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+if ( ! interface_exists( 'WP_Agent_Tool_Usage_Tracker' ) ) {
+	/**
+	 * Tracks recently or frequently used tools for a workspace.
+	 */
+	interface WP_Agent_Tool_Usage_Tracker {
+
+		/**
+		 * Record one tool call.
+		 *
+		 * @param string $tool_name    Tool name.
+		 * @param string $workspace_id Workspace identifier.
+		 */
+		public function record_call( string $tool_name, string $workspace_id ): void;
+
+		/**
+		 * Return the top tool names for a workspace.
+		 *
+		 * @param string $workspace_id Workspace identifier.
+		 * @param int    $limit        Maximum number of names.
+		 * @return string[] Tool names ordered by preference.
+		 */
+		public function top_n( string $workspace_id, int $limit ): array;
+	}
+}

--- a/tests/tool-tier-resolver-smoke.php
+++ b/tests/tool-tier-resolver-smoke.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * Pure-PHP smoke test for tool tier resolver contracts.
+ *
+ * Run with: php tests/tool-tier-resolver-smoke.php
+ *
+ * @package AgentsAPI\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+$failures = array();
+$passes   = 0;
+
+echo "agents-api-tool-tier-resolver-smoke\n";
+
+require_once __DIR__ . '/agents-api-smoke-helpers.php';
+agents_api_smoke_require_module();
+
+echo "\n[1] Tool tier contracts are available:\n";
+agents_api_smoke_assert_equals( true, interface_exists( 'WP_Agent_Tool_Tier_Resolver' ), 'tier resolver interface is available', $failures, $passes );
+agents_api_smoke_assert_equals( true, class_exists( 'WP_Agent_Default_Tool_Tier_Resolver' ), 'default tier resolver is available', $failures, $passes );
+agents_api_smoke_assert_equals( true, interface_exists( 'WP_Agent_Tool_Usage_Tracker' ), 'usage tracker interface is available', $failures, $passes );
+agents_api_smoke_assert_equals( true, class_exists( 'WP_Agent_Null_Tool_Usage_Tracker' ), 'null usage tracker is available', $failures, $passes );
+
+$tools = array(
+	'client/read'      => array(
+		'name'        => 'client/read',
+		'description' => 'Read content.',
+		'parameters'  => array(
+			'type'       => 'object',
+			'required'   => array( 'post_id' ),
+			'properties' => array( 'post_id' => array( 'type' => 'integer' ) ),
+		),
+	),
+	'client/write'     => array(
+		'name'        => 'client/write',
+		'description' => 'Write content.',
+		'parameters'  => array(),
+	),
+	'client/search'    => array(
+		'name'        => 'client/search',
+		'description' => 'Search content.',
+		'parameters'  => array(
+			'type'       => 'object',
+			'required'   => array( 'query' ),
+			'properties' => array( 'query' => array( 'type' => 'string' ) ),
+		),
+	),
+	'client/mandatory' => array(
+		'name'        => 'client/mandatory',
+		'description' => 'Always available.',
+		'mandatory'   => true,
+	),
+);
+
+echo "\n[2] Curated tools land in Tier-1 before fallback tools:\n";
+$resolver = new WP_Agent_Default_Tool_Tier_Resolver( null, 2 );
+$resolved = $resolver->resolve(
+	$tools,
+	array(
+		'tier_1_tools' => array( 'client/search' ),
+	)
+);
+agents_api_smoke_assert_equals( array( 'client/search', 'client/mandatory' ), array_keys( $resolved['tier_1'] ), 'curated and mandatory tools fill Tier-1', $failures, $passes );
+agents_api_smoke_assert_equals( array( 'client/read', 'client/write' ), array_keys( $resolved['tier_2'] ), 'remaining tools fall to Tier-2', $failures, $passes );
+
+echo "\n[3] Usage tracker influences Tier-1 within the hard cap:\n";
+$tracker = new class() implements WP_Agent_Tool_Usage_Tracker {
+	public array $recorded = array();
+	public function record_call( string $tool_name, string $workspace_id ): void {
+		$this->recorded[] = array( $tool_name, $workspace_id );
+	}
+	public function top_n( string $workspace_id, int $limit ): array {
+		unset( $limit );
+		return 'site-1' === $workspace_id ? array( 'client/write', 'client/read' ) : array();
+	}
+};
+$resolver = new WP_Agent_Default_Tool_Tier_Resolver( $tracker, 2 );
+$resolved = $resolver->resolve( $tools, array( 'workspace_id' => 'site-1' ) );
+agents_api_smoke_assert_equals( array( 'client/write', 'client/read' ), array_keys( $resolved['tier_1'] ), 'usage tracker selects top tools', $failures, $passes );
+agents_api_smoke_assert_equals( 2, count( $resolved['tier_1'] ), 'hard cap limits Tier-1 size', $failures, $passes );
+
+echo "\n[4] Tier-2 manifest exposes compact required-field hints:\n";
+$manifest_by_name = array();
+foreach ( $resolved['manifest'] as $entry ) {
+	$manifest_by_name[ $entry['name'] ] = $entry;
+}
+agents_api_smoke_assert_equals( 'Search content.', $manifest_by_name['client/search']['summary'] ?? null, 'manifest carries tool summary', $failures, $passes );
+agents_api_smoke_assert_equals( array( 'query' ), $manifest_by_name['client/search']['required_fields'] ?? null, 'manifest carries required-field hint', $failures, $passes );
+
+echo "\n[5] Null usage tracker is transparent:\n";
+$null_tracker = new WP_Agent_Null_Tool_Usage_Tracker();
+$null_tracker->record_call( 'client/read', 'site-1' );
+agents_api_smoke_assert_equals( array(), $null_tracker->top_n( 'site-1', 5 ), 'null tracker returns no usage', $failures, $passes );
+
+agents_api_smoke_finish( 'Tool tier resolver', $failures, $passes );


### PR DESCRIPTION
## Summary
- Add generic tool tier resolver and usage tracker contracts for splitting visible tools into full-schema Tier 1 and compact-manifest Tier 2 sets.
- Provide a default resolver that prioritizes caller-curated tools, recent/frequent workspace usage, mandatory tools, and deterministic fallback order under a hard cap.
- Wire the contracts into bootstrap, README, and smoke coverage as the first slice of #181.

Closes #181

## Testing
- `php tests/tool-tier-resolver-smoke.php`
- `php -l src/Tools/class-wp-agent-tool-usage-tracker.php && php -l src/Tools/class-wp-agent-null-tool-usage-tracker.php && php -l src/Tools/class-wp-agent-tool-tier-resolver.php && php -l src/Tools/class-wp-agent-default-tool-tier-resolver.php && php -l tests/tool-tier-resolver-smoke.php`
- `git diff --check`
- `composer test`
- `homeboy lint --path /Users/chubes/Developer/agents-api@add-tool-tier-resolver-181 --extension wordpress`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the tool tier resolver contract slice, smoke coverage, docs/bootstrap wiring, and ran local verification.