### PR TITLE
Add loop spin detector contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,9 @@ wp_register_agent(
 - `AgentsAPI\AI\WP_Agent_Null_Transcript_Persister`
 - `AgentsAPI\AI\WP_Agent_Conversation_Compaction`
 - `AgentsAPI\AI\WP_Agent_Iteration_Budget`
+- `AgentsAPI\AI\WP_Agent_Spin_Signature`
+- `AgentsAPI\AI\WP_Agent_Spin_Detector`
+- `AgentsAPI\AI\WP_Agent_Consecutive_Spin_Detector`
 - `AgentsAPI\AI\WP_Agent_Conversation_Result`
 - `AgentsAPI\AI\WP_Agent_Conversation_Loop`
 - `WP_Agent_Consent_Policy`

--- a/agents-api.php
+++ b/agents-api.php
@@ -118,6 +118,9 @@ require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-conversation-compacti
 require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-tool-pair-validator.php';
 require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-markdown-section-compaction-adapter.php';
 require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-iteration-budget.php';
+require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-spin-signature.php';
+require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-spin-detector.php';
+require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-consecutive-spin-detector.php';
 require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-conversation-result.php';
 require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-conversation-loop.php';
 require_once AGENTS_API_PATH . 'src/Tools/class-wp-agent-tool-call.php';

--- a/composer.json
+++ b/composer.json
@@ -54,6 +54,7 @@
       "php tests/conversation-compaction-smoke.php",
       "php tests/tool-pair-validator-smoke.php",
       "php tests/markdown-section-compaction-smoke.php",
+      "php tests/spin-detector-smoke.php",
       "php tests/context-registry-smoke.php",
       "php tests/conversation-loop-smoke.php",
       "php tests/conversation-loop-tool-execution-smoke.php",

--- a/src/Runtime/class-wp-agent-consecutive-spin-detector.php
+++ b/src/Runtime/class-wp-agent-consecutive-spin-detector.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Consecutive spin detector.
+ *
+ * @package AgentsAPI
+ */
+
+namespace AgentsAPI\AI;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Detects a repeated identical tool-call signature within one loop run.
+ */
+final class WP_Agent_Consecutive_Spin_Detector implements WP_Agent_Spin_Detector {
+
+	private int $threshold;
+	private int $repeat_count = 0;
+	private string $last_hash = '';
+
+	public function __construct( int $threshold = 3 ) {
+		$this->threshold = max( 2, $threshold );
+	}
+
+	/** @inheritDoc */
+	public function record_signature( WP_Agent_Spin_Signature $signature, array $context = array() ): bool {
+		unset( $context );
+
+		if ( $signature->hash() === $this->last_hash ) {
+			++$this->repeat_count;
+		} else {
+			$this->last_hash    = $signature->hash();
+			$this->repeat_count = 1;
+		}
+
+		return $this->repeat_count >= $this->threshold;
+	}
+
+	public function repeat_count(): int {
+		return $this->repeat_count;
+	}
+
+	public function threshold(): int {
+		return $this->threshold;
+	}
+}

--- a/src/Runtime/class-wp-agent-conversation-loop.php
+++ b/src/Runtime/class-wp-agent-conversation-loop.php
@@ -55,6 +55,7 @@ class WP_Agent_Conversation_Loop {
 	 * - `tool_executor` (WP_Agent_Tool_Executor|null): Tool execution adapter.
 	 * - `tool_declarations` (array|null): Tool declarations keyed by name.
 	 * - `completion_policy` (WP_Agent_Conversation_Completion_Policy|null): Typed completion policy.
+	 * - `spin_detector` (WP_Agent_Spin_Detector|null): Optional repeated tool-call detector.
 	 * - `transcript_lock` or `transcript_lock_store` (WP_Agent_Conversation_Lock|null): Optional transcript lock.
 	 * - `transcript_session_id` (string): Session ID to lock when a lock store is provided.
 	 * - `transcript_lock_ttl` (int): Lock TTL in seconds. Defaults to 300.
@@ -78,6 +79,7 @@ class WP_Agent_Conversation_Loop {
 		$transcript_persister  = self::resolve_transcript_persister( $options );
 		$transcript_lock       = self::resolve_transcript_lock( $options );
 		$on_event              = self::resolve_event_sink( $options );
+		$spin_detector         = self::resolve_spin_detector( $options );
 		$request               = self::resolve_request( $messages, $options );
 		$lock_session_id       = self::resolve_lock_session_id( $options, $request );
 		$lock_ttl              = self::resolve_lock_ttl( $options );
@@ -94,6 +96,7 @@ class WP_Agent_Conversation_Loop {
 		$tool_audit_events     = array();
 		$conversation_complete = false;
 		$exceeded_budget       = null;
+		$stalled               = null;
 
 		// Universal observability accumulators. Turn runners may report
 		// `usage` (token counts) and `request_metadata` (last provider request
@@ -213,6 +216,7 @@ class WP_Agent_Conversation_Loop {
 					$events                = array_merge( $events, $mediation_result['events'] );
 					$conversation_complete = $mediation_result['conversation_complete'];
 					$exceeded_budget       = $mediation_result['exceeded_budget'];
+					$stalled               = self::check_spin_detector( $spin_detector, $mediation_result['spin_signatures'], $turn_context, $on_event );
 				} else {
 					// Caller-managed path: turn runner handles everything internally.
 					$result       = WP_Agent_Conversation_Result::normalize( $result );
@@ -249,6 +253,10 @@ class WP_Agent_Conversation_Loop {
 
 				// Stop conditions: budget exceeded, completion policy, or caller should_continue.
 				if ( null !== $exceeded_budget ) {
+					break;
+				}
+
+				if ( null !== $stalled ) {
 					break;
 				}
 
@@ -291,6 +299,12 @@ class WP_Agent_Conversation_Loop {
 				$final_result_data['completed'] = false;
 			}
 
+			if ( null !== $stalled ) {
+				$final_result_data['status']    = 'stalled';
+				$final_result_data['stalled']   = $stalled;
+				$final_result_data['completed'] = false;
+			}
+
 			$final_result = WP_Agent_Conversation_Result::normalize( $final_result_data );
 
 			self::persist_transcript( $transcript_persister, $messages, $options, $final_result );
@@ -327,7 +341,7 @@ class WP_Agent_Conversation_Loop {
 	 * @param int                                               $turn            Current turn number.
 	 * @param callable|null                                     $on_event        Event sink.
 	 * @param array<string, WP_Agent_Iteration_Budget>                    $budgets         Named iteration budgets.
-	 * @return array{messages: array, tool_execution_results: array, tool_audit_events: array, events: array, conversation_complete: bool, exceeded_budget: string|null}
+	 * @return array{messages: array, tool_execution_results: array, tool_audit_events: array, events: array, conversation_complete: bool, exceeded_budget: string|null, spin_signatures: WP_Agent_Spin_Signature[]}
 	 */
 	private static function mediate_tool_calls(
 		array $result,
@@ -347,6 +361,7 @@ class WP_Agent_Conversation_Loop {
 		$tool_execution_results = array();
 		$tool_audit_events      = array();
 		$events                 = array();
+		$spin_signatures        = array();
 		$complete               = false;
 		$exceeded_budget        = null;
 
@@ -363,6 +378,8 @@ class WP_Agent_Conversation_Loop {
 			if ( ! is_string( $tool_name ) || '' === $tool_name ) {
 				continue;
 			}
+
+			$spin_signatures[] = new WP_Agent_Spin_Signature( $tool_name, is_array( $parameters ) ? $parameters : array() );
 
 			self::emit_event( $on_event, 'tool_call', array(
 				'turn'         => $turn,
@@ -486,7 +503,46 @@ class WP_Agent_Conversation_Loop {
 			'events'                 => $events,
 			'conversation_complete'  => $complete,
 			'exceeded_budget'        => $exceeded_budget,
+			'spin_signatures'        => $spin_signatures,
 		);
+	}
+
+	/**
+	 * Check a spin detector against tool-call signatures from one mediated turn.
+	 *
+	 * @param WP_Agent_Spin_Detector|null $detector   Optional spin detector.
+	 * @param WP_Agent_Spin_Signature[]   $signatures Tool-call signatures.
+	 * @param array<string, mixed>        $context    Current turn context.
+	 * @param callable|null               $on_event   Event sink.
+	 * @return array<string, mixed>|null Stalled diagnostics when the detector fires.
+	 */
+	private static function check_spin_detector( ?WP_Agent_Spin_Detector $detector, array $signatures, array $context, ?callable $on_event ): ?array {
+		if ( null === $detector ) {
+			return null;
+		}
+
+		foreach ( $signatures as $signature ) {
+			if ( ! $signature instanceof WP_Agent_Spin_Signature ) {
+				continue;
+			}
+
+			if ( $detector->record_signature( $signature, $context ) ) {
+				$payload = array_merge(
+					$signature->to_array(),
+					array(
+						'turn'         => (int) ( $context['turn'] ?? 0 ),
+						'repeat_count' => $detector->repeat_count(),
+						'threshold'    => $detector->threshold(),
+					)
+				);
+
+				self::emit_event( $on_event, 'loop_stalled', $payload );
+
+				return $payload;
+			}
+		}
+
+		return null;
 	}
 
 	/**
@@ -882,6 +938,17 @@ class WP_Agent_Conversation_Loop {
 	private static function resolve_completion_policy( array $options ): ?WP_Agent_Conversation_Completion_Policy {
 		$policy = $options['completion_policy'] ?? null;
 		return $policy instanceof WP_Agent_Conversation_Completion_Policy ? $policy : null;
+	}
+
+	/**
+	 * Resolve the spin detector from options.
+	 *
+	 * @param array $options Loop options.
+	 * @return WP_Agent_Spin_Detector|null
+	 */
+	private static function resolve_spin_detector( array $options ): ?WP_Agent_Spin_Detector {
+		$detector = $options['spin_detector'] ?? null;
+		return $detector instanceof WP_Agent_Spin_Detector ? $detector : null;
 	}
 
 	/**

--- a/src/Runtime/class-wp-agent-spin-detector.php
+++ b/src/Runtime/class-wp-agent-spin-detector.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Spin detector contract.
+ *
+ * @package AgentsAPI
+ */
+
+namespace AgentsAPI\AI;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Detects repeated tool-call signatures during a loop run.
+ */
+interface WP_Agent_Spin_Detector {
+
+	/**
+	 * Record a tool-call signature and report whether the loop is stalled.
+	 *
+	 * @param WP_Agent_Spin_Signature $signature Tool-call signature.
+	 * @param array<string, mixed>    $context   Current turn context.
+	 */
+	public function record_signature( WP_Agent_Spin_Signature $signature, array $context = array() ): bool;
+
+	/** Current repeat count for diagnostics. */
+	public function repeat_count(): int;
+
+	/** Detector threshold. */
+	public function threshold(): int;
+}

--- a/src/Runtime/class-wp-agent-spin-signature.php
+++ b/src/Runtime/class-wp-agent-spin-signature.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * Spin signature value object.
+ *
+ * @package AgentsAPI
+ */
+
+namespace AgentsAPI\AI;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Deterministic identity for a tool call shape that may repeat across turns.
+ */
+final class WP_Agent_Spin_Signature {
+
+	private string $tool_name;
+	private array $parameters;
+	private string $parameters_hash;
+	private string $signature_hash;
+
+	/**
+	 * @param string               $tool_name  Tool name.
+	 * @param array<string, mixed> $parameters Tool call parameters.
+	 */
+	public function __construct( string $tool_name, array $parameters = array() ) {
+		$this->tool_name       = trim( $tool_name );
+		$this->parameters      = self::sort_for_hash( $parameters );
+		$this->parameters_hash = self::stable_sha256( $this->parameters );
+		$this->signature_hash  = self::stable_sha256(
+			array(
+				'tool_name'       => $this->tool_name,
+				'parameters_hash' => $this->parameters_hash,
+			)
+		);
+	}
+
+	public function tool_name(): string {
+		return $this->tool_name;
+	}
+
+	public function parameters_hash(): string {
+		return $this->parameters_hash;
+	}
+
+	public function hash(): string {
+		return $this->signature_hash;
+	}
+
+	/** @return array<string, mixed> */
+	public function to_array(): array {
+		return array(
+			'tool_name'       => $this->tool_name,
+			'parameters_hash' => $this->parameters_hash,
+			'signature_hash'  => $this->signature_hash,
+		);
+	}
+
+	/**
+	 * @param mixed $data Data to hash.
+	 */
+	private static function stable_sha256( $data ): string {
+		$encoded = wp_json_encode( self::sort_for_hash( $data ) );
+		if ( false === $encoded ) {
+			$encoded = '';
+		}
+
+		return 'sha256:' . hash( 'sha256', (string) $encoded );
+	}
+
+	/**
+	 * @param mixed $value Value to normalize.
+	 * @return mixed Normalized value.
+	 */
+	private static function sort_for_hash( $value ) {
+		if ( ! is_array( $value ) ) {
+			return $value;
+		}
+
+		$normalized = array();
+		foreach ( $value as $key => $item ) {
+			$normalized[ $key ] = self::sort_for_hash( $item );
+		}
+
+		if ( array() !== $normalized && array_keys( $normalized ) !== range( 0, count( $normalized ) - 1 ) ) {
+			ksort( $normalized );
+		}
+
+		return $normalized;
+	}
+}

--- a/tests/spin-detector-smoke.php
+++ b/tests/spin-detector-smoke.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ * Pure-PHP smoke test for loop spin detector contracts.
+ *
+ * Run with: php tests/spin-detector-smoke.php
+ *
+ * @package AgentsAPI\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+$failures = array();
+$passes   = 0;
+
+echo "agents-api-spin-detector-smoke\n";
+
+require_once __DIR__ . '/agents-api-smoke-helpers.php';
+agents_api_smoke_require_module();
+
+echo "\n[1] Spin detector contracts are available:\n";
+agents_api_smoke_assert_equals( true, class_exists( 'AgentsAPI\\AI\\WP_Agent_Spin_Signature' ), 'spin signature value object is available', $failures, $passes );
+agents_api_smoke_assert_equals( true, interface_exists( 'AgentsAPI\\AI\\WP_Agent_Spin_Detector' ), 'spin detector interface is available', $failures, $passes );
+agents_api_smoke_assert_equals( true, class_exists( 'AgentsAPI\\AI\\WP_Agent_Consecutive_Spin_Detector' ), 'consecutive spin detector is available', $failures, $passes );
+
+echo "\n[2] Signatures normalize argument order deterministically:\n";
+$signature_a = new AgentsAPI\AI\WP_Agent_Spin_Signature(
+	'client/search',
+	array(
+		'b' => 2,
+		'a' => array(
+			'd' => 4,
+			'c' => 3,
+		),
+	)
+);
+$signature_b = new AgentsAPI\AI\WP_Agent_Spin_Signature(
+	'client/search',
+	array(
+		'a' => array(
+			'c' => 3,
+			'd' => 4,
+		),
+		'b' => 2,
+	)
+);
+agents_api_smoke_assert_equals( $signature_a->hash(), $signature_b->hash(), 'same tool call shape hashes identically', $failures, $passes );
+agents_api_smoke_assert_equals( $signature_a->parameters_hash(), $signature_b->parameters_hash(), 'same parameters hash identically', $failures, $passes );
+
+echo "\n[3] Consecutive detector reports repeated signatures at threshold:\n";
+$detector = new AgentsAPI\AI\WP_Agent_Consecutive_Spin_Detector( 2 );
+agents_api_smoke_assert_equals( false, $detector->record_signature( $signature_a ), 'first signature does not stall', $failures, $passes );
+agents_api_smoke_assert_equals( true, $detector->record_signature( $signature_b ), 'second matching signature stalls', $failures, $passes );
+agents_api_smoke_assert_equals( 2, $detector->repeat_count(), 'repeat count reaches threshold', $failures, $passes );
+
+echo "\n[4] Conversation loop stops as stalled when detector fires:\n";
+$executor = new class() implements AgentsAPI\AI\Tools\WP_Agent_Tool_Executor {
+	public function executeWP_Agent_Tool_Call( array $tool_call, array $tool_definition, array $context = array() ): array {
+		return array(
+			'success'   => true,
+			'tool_name' => $tool_call['tool_name'],
+			'result'    => array( 'ok' => true ),
+		);
+	}
+};
+$events   = array();
+$turns    = 0;
+$result   = AgentsAPI\AI\WP_Agent_Conversation_Loop::run(
+	array( array( 'role' => 'user', 'content' => 'go' ) ),
+	static function ( array $messages ) use ( &$turns ): array {
+		++$turns;
+
+		return array(
+			'messages'   => $messages,
+			'tool_calls' => array(
+				array(
+					'name'       => 'client/search',
+					'parameters' => array( 'query' => 'same' ),
+				),
+			),
+		);
+	},
+	array(
+		'max_turns'         => 5,
+		'tool_executor'     => $executor,
+		'tool_declarations' => array(
+			'client/search' => array(
+				'name'       => 'client/search',
+				'parameters' => array(),
+			),
+		),
+		'spin_detector'     => new AgentsAPI\AI\WP_Agent_Consecutive_Spin_Detector( 2 ),
+		'should_continue'   => static function (): bool {
+			return true;
+		},
+		'on_event'          => static function ( string $event, array $payload ) use ( &$events ): void {
+			$events[] = array( 'event' => $event, 'payload' => $payload );
+		},
+	)
+);
+
+agents_api_smoke_assert_equals( 2, $turns, 'loop stops on second repeated tool-call turn', $failures, $passes );
+agents_api_smoke_assert_equals( 'stalled', $result['status'] ?? null, 'result status is stalled', $failures, $passes );
+agents_api_smoke_assert_equals( false, $result['completed'] ?? true, 'stalled result is incomplete', $failures, $passes );
+agents_api_smoke_assert_equals( 2, $result['stalled']['repeat_count'] ?? null, 'stalled diagnostics include repeat count', $failures, $passes );
+agents_api_smoke_assert_equals( 'client/search', $result['stalled']['tool_name'] ?? null, 'stalled diagnostics include tool name', $failures, $passes );
+
+$stall_events = array_filter(
+	$events,
+	static function ( array $entry ): bool {
+		return 'loop_stalled' === $entry['event'];
+	}
+);
+agents_api_smoke_assert_equals( 1, count( $stall_events ), 'loop_stalled event is emitted', $failures, $passes );
+
+agents_api_smoke_finish( 'Spin detector', $failures, $passes );


### PR DESCRIPTION
## Summary
- Add deterministic spin signatures plus an opt-in spin detector contract for repeated mediated tool calls.
- Provide a default consecutive-signature detector and wire the conversation loop to return `status: stalled` with a `loop_stalled` event when the detector fires.
- Add README/bootstrap wiring and smoke coverage for the opt-in stalled path.

Refs #183

## Testing
- `php tests/spin-detector-smoke.php`
- `php -l src/Runtime/class-wp-agent-spin-signature.php && php -l src/Runtime/class-wp-agent-spin-detector.php && php -l src/Runtime/class-wp-agent-consecutive-spin-detector.php && php -l src/Runtime/class-wp-agent-conversation-loop.php && php -l tests/spin-detector-smoke.php`
- `git diff --check`
- `composer test`
- `homeboy lint --path /Users/chubes/Developer/agents-api@add-spin-detector-183 --extension wordpress`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the opt-in spin detector contract slice, loop integration, smoke coverage, and local verification.