### PR TITLE
Add identical failure tracker contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,9 @@ wp_register_agent(
 - `AgentsAPI\AI\WP_Agent_Spin_Signature`
 - `AgentsAPI\AI\WP_Agent_Spin_Detector`
 - `AgentsAPI\AI\WP_Agent_Consecutive_Spin_Detector`
+- `AgentsAPI\AI\WP_Agent_Identical_Failure_Signature`
+- `AgentsAPI\AI\WP_Agent_Identical_Failure_Tracker`
+- `AgentsAPI\AI\WP_Agent_Consecutive_Identical_Failure_Tracker`
 - `AgentsAPI\AI\WP_Agent_Conversation_Result`
 - `AgentsAPI\AI\WP_Agent_Conversation_Loop`
 - `WP_Agent_Consent_Policy`

--- a/agents-api.php
+++ b/agents-api.php
@@ -121,6 +121,9 @@ require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-iteration-budget.php'
 require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-spin-signature.php';
 require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-spin-detector.php';
 require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-consecutive-spin-detector.php';
+require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-identical-failure-signature.php';
+require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-identical-failure-tracker.php';
+require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-consecutive-identical-failure-tracker.php';
 require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-conversation-result.php';
 require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-conversation-loop.php';
 require_once AGENTS_API_PATH . 'src/Tools/class-wp-agent-tool-call.php';

--- a/composer.json
+++ b/composer.json
@@ -55,6 +55,7 @@
       "php tests/tool-pair-validator-smoke.php",
       "php tests/markdown-section-compaction-smoke.php",
       "php tests/spin-detector-smoke.php",
+      "php tests/identical-failure-tracker-smoke.php",
       "php tests/context-registry-smoke.php",
       "php tests/conversation-loop-smoke.php",
       "php tests/conversation-loop-tool-execution-smoke.php",

--- a/src/Runtime/class-wp-agent-consecutive-identical-failure-tracker.php
+++ b/src/Runtime/class-wp-agent-consecutive-identical-failure-tracker.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Consecutive identical failure tracker.
+ *
+ * @package AgentsAPI
+ */
+
+namespace AgentsAPI\AI;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Nudges after the same failed tool-call signature repeats consecutively.
+ */
+final class WP_Agent_Consecutive_Identical_Failure_Tracker implements WP_Agent_Identical_Failure_Tracker {
+
+	private int $threshold;
+	private int $repeat_count = 0;
+	private string $last_hash = '';
+
+	public function __construct( int $threshold = 2 ) {
+		$this->threshold = max( 2, $threshold );
+	}
+
+	/** @inheritDoc */
+	public function record_failure( WP_Agent_Identical_Failure_Signature $signature, array $context = array() ): ?string {
+		unset( $context );
+
+		if ( $signature->hash() === $this->last_hash ) {
+			++$this->repeat_count;
+		} else {
+			$this->last_hash    = $signature->hash();
+			$this->repeat_count = 1;
+		}
+
+		if ( $this->repeat_count < $this->threshold ) {
+			return null;
+		}
+
+		return sprintf(
+			'The tool call `%s` has failed %d times with the same arguments and error `%s`. Try a different approach before repeating it.',
+			$signature->tool_name(),
+			$this->repeat_count,
+			$signature->error_code()
+		);
+	}
+
+	public function repeat_count(): int {
+		return $this->repeat_count;
+	}
+
+	public function threshold(): int {
+		return $this->threshold;
+	}
+}

--- a/src/Runtime/class-wp-agent-conversation-loop.php
+++ b/src/Runtime/class-wp-agent-conversation-loop.php
@@ -472,7 +472,7 @@ class WP_Agent_Conversation_Loop {
 					'assistant',
 					$nudge['message'],
 					array(
-						'type'                       => 'identical_failure_nudge',
+						'type'                        => 'identical_failure_nudge',
 						'identical_failure_signature' => $nudge,
 					)
 				);

--- a/src/Runtime/class-wp-agent-conversation-loop.php
+++ b/src/Runtime/class-wp-agent-conversation-loop.php
@@ -56,6 +56,7 @@ class WP_Agent_Conversation_Loop {
 	 * - `tool_declarations` (array|null): Tool declarations keyed by name.
 	 * - `completion_policy` (WP_Agent_Conversation_Completion_Policy|null): Typed completion policy.
 	 * - `spin_detector` (WP_Agent_Spin_Detector|null): Optional repeated tool-call detector.
+	 * - `identical_failure_tracker` (WP_Agent_Identical_Failure_Tracker|null): Optional repeated failure nudger.
 	 * - `transcript_lock` or `transcript_lock_store` (WP_Agent_Conversation_Lock|null): Optional transcript lock.
 	 * - `transcript_session_id` (string): Session ID to lock when a lock store is provided.
 	 * - `transcript_lock_ttl` (int): Lock TTL in seconds. Defaults to 300.
@@ -80,6 +81,7 @@ class WP_Agent_Conversation_Loop {
 		$transcript_lock       = self::resolve_transcript_lock( $options );
 		$on_event              = self::resolve_event_sink( $options );
 		$spin_detector         = self::resolve_spin_detector( $options );
+		$failure_tracker       = self::resolve_identical_failure_tracker( $options );
 		$request               = self::resolve_request( $messages, $options );
 		$lock_session_id       = self::resolve_lock_session_id( $options, $request );
 		$lock_ttl              = self::resolve_lock_ttl( $options );
@@ -207,7 +209,8 @@ class WP_Agent_Conversation_Loop {
 						$turn_context,
 						$turn,
 						$on_event,
-						$budgets
+						$budgets,
+						$failure_tracker
 					);
 
 					$messages              = $mediation_result['messages'];
@@ -341,6 +344,7 @@ class WP_Agent_Conversation_Loop {
 	 * @param int                                               $turn            Current turn number.
 	 * @param callable|null                                     $on_event        Event sink.
 	 * @param array<string, WP_Agent_Iteration_Budget>                    $budgets         Named iteration budgets.
+	 * @param WP_Agent_Identical_Failure_Tracker|null                     $failure_tracker Optional identical-failure tracker.
 	 * @return array{messages: array, tool_execution_results: array, tool_audit_events: array, events: array, conversation_complete: bool, exceeded_budget: string|null, spin_signatures: WP_Agent_Spin_Signature[]}
 	 */
 	private static function mediate_tool_calls(
@@ -351,7 +355,8 @@ class WP_Agent_Conversation_Loop {
 		array $turn_context,
 		int $turn,
 		?callable $on_event,
-		array $budgets = array()
+		array $budgets = array(),
+		?WP_Agent_Identical_Failure_Tracker $failure_tracker = null
 	): array {
 		$core                   = new WP_Agent_Tool_Execution_Core();
 		$messages               = isset( $result['messages'] ) && is_array( $result['messages'] )
@@ -454,6 +459,25 @@ class WP_Agent_Conversation_Loop {
 				array( 'tool_call_id' => $tool_call_id )
 			);
 
+			$nudge = self::check_identical_failure_tracker(
+				$failure_tracker,
+				$tool_name,
+				is_array( $parameters ) ? $parameters : array(),
+				$exec_result,
+				$turn_context,
+				$on_event
+			);
+			if ( null !== $nudge ) {
+				$messages[] = WP_Agent_Message::text(
+					'assistant',
+					$nudge['message'],
+					array(
+						'type'                       => 'identical_failure_nudge',
+						'identical_failure_signature' => $nudge,
+					)
+				);
+			}
+
 			// Increment tool-call budgets: total and per-tool-name.
 			$exceeded_budget = self::increment_budget( $budgets, 'tool_calls', $on_event );
 			if ( null === $exceeded_budget ) {
@@ -543,6 +567,50 @@ class WP_Agent_Conversation_Loop {
 		}
 
 		return null;
+	}
+
+	/**
+	 * Check a repeated failure tracker and return nudge metadata when it fires.
+	 *
+	 * @param WP_Agent_Identical_Failure_Tracker|null $tracker    Optional failure tracker.
+	 * @param string                                  $tool_name  Tool name.
+	 * @param array<string, mixed>                    $parameters Tool parameters.
+	 * @param array<string, mixed>                    $result     Tool execution result.
+	 * @param array<string, mixed>                    $context    Current turn context.
+	 * @param callable|null                           $on_event   Event sink.
+	 * @return array<string, mixed>|null Nudge metadata when the tracker fires.
+	 */
+	private static function check_identical_failure_tracker(
+		?WP_Agent_Identical_Failure_Tracker $tracker,
+		string $tool_name,
+		array $parameters,
+		array $result,
+		array $context,
+		?callable $on_event
+	): ?array {
+		if ( null === $tracker || ! empty( $result['success'] ) ) {
+			return null;
+		}
+
+		$signature = new WP_Agent_Identical_Failure_Signature( $tool_name, $parameters, $result );
+		$message   = $tracker->record_failure( $signature, $context );
+		if ( null === $message || '' === trim( $message ) ) {
+			return null;
+		}
+
+		$payload = array_merge(
+			$signature->to_array(),
+			array(
+				'turn'         => (int) ( $context['turn'] ?? 0 ),
+				'repeat_count' => $tracker->repeat_count(),
+				'threshold'    => $tracker->threshold(),
+				'message'      => $message,
+			)
+		);
+
+		self::emit_event( $on_event, 'identical_failure_nudged', $payload );
+
+		return $payload;
 	}
 
 	/**
@@ -949,6 +1017,17 @@ class WP_Agent_Conversation_Loop {
 	private static function resolve_spin_detector( array $options ): ?WP_Agent_Spin_Detector {
 		$detector = $options['spin_detector'] ?? null;
 		return $detector instanceof WP_Agent_Spin_Detector ? $detector : null;
+	}
+
+	/**
+	 * Resolve the identical failure tracker from options.
+	 *
+	 * @param array $options Loop options.
+	 * @return WP_Agent_Identical_Failure_Tracker|null
+	 */
+	private static function resolve_identical_failure_tracker( array $options ): ?WP_Agent_Identical_Failure_Tracker {
+		$tracker = $options['identical_failure_tracker'] ?? null;
+		return $tracker instanceof WP_Agent_Identical_Failure_Tracker ? $tracker : null;
 	}
 
 	/**

--- a/src/Runtime/class-wp-agent-identical-failure-signature.php
+++ b/src/Runtime/class-wp-agent-identical-failure-signature.php
@@ -1,0 +1,132 @@
+<?php
+/**
+ * Identical failure signature value object.
+ *
+ * @package AgentsAPI
+ */
+
+namespace AgentsAPI\AI;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Deterministic identity for a repeated failed tool call.
+ */
+final class WP_Agent_Identical_Failure_Signature {
+
+	private string $tool_name;
+	private string $parameters_hash;
+	private string $error_code;
+	private string $signature_hash;
+
+	/**
+	 * @param string               $tool_name  Tool name.
+	 * @param array<string, mixed> $parameters Tool call parameters.
+	 * @param array<string, mixed> $result     Tool execution result.
+	 */
+	public function __construct( string $tool_name, array $parameters, array $result ) {
+		$this->tool_name       = trim( $tool_name );
+		$this->parameters_hash = self::stable_sha256( $parameters );
+		$this->error_code      = self::extract_error_code( $result );
+		$this->signature_hash  = self::stable_sha256(
+			array(
+				'tool_name'       => $this->tool_name,
+				'parameters_hash' => $this->parameters_hash,
+				'error_code'      => $this->error_code,
+			)
+		);
+	}
+
+	public function tool_name(): string {
+		return $this->tool_name;
+	}
+
+	public function parameters_hash(): string {
+		return $this->parameters_hash;
+	}
+
+	public function error_code(): string {
+		return $this->error_code;
+	}
+
+	public function hash(): string {
+		return $this->signature_hash;
+	}
+
+	/** @return array<string, mixed> */
+	public function to_array(): array {
+		return array(
+			'tool_name'       => $this->tool_name,
+			'parameters_hash' => $this->parameters_hash,
+			'error_code'      => $this->error_code,
+			'signature_hash'  => $this->signature_hash,
+		);
+	}
+
+	/** @param array<string, mixed> $result Tool execution result. */
+	private static function extract_error_code( array $result ): string {
+		foreach ( array( 'error_code', 'code' ) as $key ) {
+			$value = $result[ $key ] ?? null;
+			if ( is_scalar( $value ) && '' !== trim( (string) $value ) ) {
+				return self::normalize_error_code( (string) $value );
+			}
+		}
+
+		$metadata = isset( $result['metadata'] ) && is_array( $result['metadata'] )
+			? $result['metadata']
+			: array();
+		foreach ( array( 'error_type', 'error_code', 'code' ) as $key ) {
+			$value = $metadata[ $key ] ?? null;
+			if ( is_scalar( $value ) && '' !== trim( (string) $value ) ) {
+				return self::normalize_error_code( (string) $value );
+			}
+		}
+
+		$error = is_string( $result['error'] ?? null ) ? $result['error'] : 'tool_execution_failed';
+		return 'error_' . substr( self::stable_sha256( $error ), 7, 12 );
+	}
+
+	private static function normalize_error_code( string $code ): string {
+		$code = strtolower( trim( $code ) );
+		$code = (string) preg_replace( '/[^a-z0-9_\-]+/', '_', $code );
+		return '' === $code ? 'tool_execution_failed' : $code;
+	}
+
+	/**
+	 * @param mixed $data Data to hash.
+	 */
+	private static function stable_sha256( $data ): string {
+		$encoded = wp_json_encode( self::sort_for_hash( $data ) );
+		if ( false === $encoded ) {
+			$encoded = '';
+		}
+
+		return 'sha256:' . hash( 'sha256', (string) $encoded );
+	}
+
+	/**
+	 * @param mixed $value Value to normalize.
+	 * @return mixed Normalized value.
+	 */
+	private static function sort_for_hash( $value ) {
+		if ( ! is_array( $value ) ) {
+			return $value;
+		}
+
+		$normalized = array();
+		foreach ( $value as $key => $item ) {
+			$normalized[ $key ] = self::sort_for_hash( $item );
+		}
+
+		if (
+			array() !== $normalized
+			&& array_keys( $normalized ) !== range( 0, count( $normalized ) - 1 )
+		) {
+			ksort( $normalized );
+		}
+
+		return $normalized;
+	}
+}

--- a/src/Runtime/class-wp-agent-identical-failure-tracker.php
+++ b/src/Runtime/class-wp-agent-identical-failure-tracker.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Identical failure tracker contract.
+ *
+ * @package AgentsAPI
+ */
+
+namespace AgentsAPI\AI;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Tracks repeated identical failed tool calls during a loop run.
+ */
+interface WP_Agent_Identical_Failure_Tracker {
+
+	/**
+	 * Record a failed tool-call signature.
+	 *
+	 * Return a nudge message when the caller should redirect the model away from
+	 * repeating the same failing call. Return null to continue silently.
+	 *
+	 * @param WP_Agent_Identical_Failure_Signature $signature Failure signature.
+	 * @param array<string, mixed>                 $context   Current turn context.
+	 * @return string|null Nudge content.
+	 */
+	public function record_failure( WP_Agent_Identical_Failure_Signature $signature, array $context = array() ): ?string;
+
+	/** Current repeat count for diagnostics. */
+	public function repeat_count(): int;
+
+	/** Tracker threshold. */
+	public function threshold(): int;
+}

--- a/tests/identical-failure-tracker-smoke.php
+++ b/tests/identical-failure-tracker-smoke.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * Pure-PHP smoke test for identical failure tracker contracts.
+ *
+ * Run with: php tests/identical-failure-tracker-smoke.php
+ *
+ * @package AgentsAPI\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+$failures = array();
+$passes   = 0;
+
+echo "agents-api-identical-failure-tracker-smoke\n";
+
+require_once __DIR__ . '/agents-api-smoke-helpers.php';
+agents_api_smoke_require_module();
+
+echo "\n[1] Identical failure contracts are available:\n";
+agents_api_smoke_assert_equals( true, class_exists( 'AgentsAPI\\AI\\WP_Agent_Identical_Failure_Signature' ), 'failure signature value object is available', $failures, $passes );
+agents_api_smoke_assert_equals( true, interface_exists( 'AgentsAPI\\AI\\WP_Agent_Identical_Failure_Tracker' ), 'failure tracker interface is available', $failures, $passes );
+agents_api_smoke_assert_equals( true, class_exists( 'AgentsAPI\\AI\\WP_Agent_Consecutive_Identical_Failure_Tracker' ), 'consecutive failure tracker is available', $failures, $passes );
+
+echo "\n[2] Failure signatures normalize argument order and error code:\n";
+$signature_a = new AgentsAPI\AI\WP_Agent_Identical_Failure_Signature(
+	'client/search',
+	array(
+		'b' => 2,
+		'a' => 1,
+	),
+	array(
+		'success'    => false,
+		'error_code' => 'Rate Limited',
+	)
+);
+$signature_b = new AgentsAPI\AI\WP_Agent_Identical_Failure_Signature(
+	'client/search',
+	array(
+		'a' => 1,
+		'b' => 2,
+	),
+	array(
+		'success'  => false,
+		'metadata' => array( 'error_type' => 'rate_limited' ),
+	)
+);
+agents_api_smoke_assert_equals( $signature_a->hash(), $signature_b->hash(), 'same failed call hashes identically', $failures, $passes );
+agents_api_smoke_assert_equals( 'rate_limited', $signature_a->error_code(), 'error code is normalized', $failures, $passes );
+
+echo "\n[3] Consecutive tracker nudges at threshold:\n";
+$tracker = new AgentsAPI\AI\WP_Agent_Consecutive_Identical_Failure_Tracker( 2 );
+agents_api_smoke_assert_equals( null, $tracker->record_failure( $signature_a ), 'first failure does not nudge', $failures, $passes );
+$nudge = $tracker->record_failure( $signature_b );
+agents_api_smoke_assert_equals( true, is_string( $nudge ) && str_contains( $nudge, 'client/search' ), 'second matching failure returns nudge', $failures, $passes );
+agents_api_smoke_assert_equals( 2, $tracker->repeat_count(), 'repeat count reaches threshold', $failures, $passes );
+
+echo "\n[4] Conversation loop injects nudge after repeated failures:\n";
+$executor = new class() implements AgentsAPI\AI\Tools\WP_Agent_Tool_Executor {
+	public function executeWP_Agent_Tool_Call( array $tool_call, array $tool_definition, array $context = array() ): array {
+		return array(
+			'success'    => false,
+			'tool_name'  => $tool_call['tool_name'],
+			'error'      => 'The service rejected this request.',
+			'error_code' => 'service_rejected',
+		);
+	}
+};
+$events = array();
+$turns  = 0;
+$result = AgentsAPI\AI\WP_Agent_Conversation_Loop::run(
+	array( array( 'role' => 'user', 'content' => 'go' ) ),
+	static function ( array $messages ) use ( &$turns ): array {
+		++$turns;
+
+		return array(
+			'messages'   => $messages,
+			'tool_calls' => array(
+				array(
+					'name'       => 'client/search',
+					'parameters' => array( 'query' => 'same' ),
+				),
+			),
+		);
+	},
+	array(
+		'max_turns'                 => 2,
+		'tool_executor'             => $executor,
+		'tool_declarations'         => array(
+			'client/search' => array(
+				'name'       => 'client/search',
+				'parameters' => array(),
+			),
+		),
+		'identical_failure_tracker' => new AgentsAPI\AI\WP_Agent_Consecutive_Identical_Failure_Tracker( 2 ),
+		'should_continue'           => static function (): bool {
+			return true;
+		},
+		'on_event'                  => static function ( string $event, array $payload ) use ( &$events ): void {
+			$events[] = array( 'event' => $event, 'payload' => $payload );
+		},
+	)
+);
+
+agents_api_smoke_assert_equals( 2, $turns, 'loop runs until second identical failure', $failures, $passes );
+agents_api_smoke_assert_equals( 2, count( $result['tool_execution_results'] ), 'both failed tool calls are recorded', $failures, $passes );
+$last_message = $result['messages'][ count( $result['messages'] ) - 1 ];
+agents_api_smoke_assert_equals( 'assistant', $last_message['role'] ?? null, 'nudge is appended as assistant guidance', $failures, $passes );
+agents_api_smoke_assert_equals( true, str_contains( (string) ( $last_message['content'] ?? '' ), 'failed 2 times' ), 'nudge explains repeated failure', $failures, $passes );
+
+$nudge_events = array_filter(
+	$events,
+	static function ( array $entry ): bool {
+		return 'identical_failure_nudged' === $entry['event'];
+	}
+);
+agents_api_smoke_assert_equals( 1, count( $nudge_events ), 'identical_failure_nudged event is emitted', $failures, $passes );
+
+agents_api_smoke_finish( 'Identical failure tracker', $failures, $passes );


### PR DESCRIPTION
## Summary
- Add deterministic identical-failure signatures plus an opt-in tracker contract for repeated failed mediated tool calls.
- Provide a default consecutive-failure tracker that returns guidance after the same tool/args/error repeats.
- Wire the conversation loop to append the tracker nudge and emit `identical_failure_nudged` without changing default behavior.

Refs #183

## Testing
- `php tests/identical-failure-tracker-smoke.php`
- `php -l src/Runtime/class-wp-agent-identical-failure-signature.php && php -l src/Runtime/class-wp-agent-identical-failure-tracker.php && php -l src/Runtime/class-wp-agent-consecutive-identical-failure-tracker.php && php -l src/Runtime/class-wp-agent-conversation-loop.php && php -l tests/identical-failure-tracker-smoke.php`
- `git diff --check`
- `composer test`
- `homeboy lint --path /Users/chubes/Developer/agents-api@add-identical-failure-tracker-183 --extension wordpress`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the opt-in identical-failure tracker contracts, loop integration, smoke coverage, and local verification.