### PR TITLE
Add mediated tool result truncation

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Agents API sits between tool/action discovery and product-specific automation. I
 - Agent execution principal/context value objects.
 - Agent access grant, token, token authenticator, authorization policy, and capability ceiling contracts.
 - Multi-turn orchestration contracts.
+- Opt-in mediated tool result truncation for oversized transcript payloads.
 - Agent package and package-artifact contracts.
 - Shared `wp_guideline` / `wp_guideline_type` storage substrate polyfill when Core/Gutenberg do not provide it.
 - Agent memory store contracts and value objects.
@@ -171,6 +172,8 @@ wp_register_agent(
 - `AgentsAPI\AI\WP_Agent_Identical_Failure_Signature`
 - `AgentsAPI\AI\WP_Agent_Identical_Failure_Tracker`
 - `AgentsAPI\AI\WP_Agent_Consecutive_Identical_Failure_Tracker`
+- `AgentsAPI\AI\WP_Agent_Tool_Result_Truncator`
+- `AgentsAPI\AI\WP_Agent_Byte_Limit_Tool_Result_Truncator`
 - `AgentsAPI\AI\WP_Agent_Conversation_Result`
 - `AgentsAPI\AI\WP_Agent_Conversation_Loop`
 - `WP_Agent_Consent_Policy`
@@ -776,6 +779,9 @@ $result = AgentsAPI\AI\WP_Agent_Conversation_Loop::run(
 		// Typed completion policy (#42)
 		'completion_policy' => $my_completion_policy,   // WP_Agent_Conversation_Completion_Policy
 
+		// Optional tool result truncation for oversized mediated results.
+		'tool_result_truncator' => new AgentsAPI\AI\WP_Agent_Byte_Limit_Tool_Result_Truncator( 8192 ),
+
 		// Transcript persistence (#43)
 		'transcript_persister' => $my_persister,        // WP_Agent_Transcript_Persister
 
@@ -787,7 +793,7 @@ $result = AgentsAPI\AI\WP_Agent_Conversation_Loop::run(
 
 		// Lifecycle events (#44)
 		'on_event' => static function ( string $event, array $payload ): void {
-			// Events: turn_started, tool_call, tool_result, budget_exceeded, completed, failed
+			// Events: turn_started, tool_call, tool_result, tool_result_truncated, budget_exceeded, completed, failed
 			$logger->log( $event, $payload );
 		},
 
@@ -807,6 +813,8 @@ $result = AgentsAPI\AI\WP_Agent_Conversation_Loop::run(
 ```
 
 All new options are opt-in. Existing callers passing only the original options continue to work identically.
+
+When `tool_result_truncator` is provided, the loop asks it to normalize mediated tool results before adding them to `tool_execution_results` and transcript `tool_result` messages. `WP_Agent_Byte_Limit_Tool_Result_Truncator` replaces oversized JSON-encoded results with an excerpt plus byte-count metadata and emits `tool_result_truncated`; the event payload includes `original_result` for observer-owned storage, logging, or artifact capture.
 
 The loop treats all adapter inputs and outputs as JSON-friendly arrays so products can map them to their own storage, streaming, audit, and transport layers without Agents API owning those layers.
 

--- a/agents-api.php
+++ b/agents-api.php
@@ -124,6 +124,8 @@ require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-consecutive-spin-dete
 require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-identical-failure-signature.php';
 require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-identical-failure-tracker.php';
 require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-consecutive-identical-failure-tracker.php';
+require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-tool-result-truncator.php';
+require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-byte-limit-tool-result-truncator.php';
 require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-conversation-result.php';
 require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-conversation-loop.php';
 require_once AGENTS_API_PATH . 'src/Tools/class-wp-agent-tool-call.php';

--- a/composer.json
+++ b/composer.json
@@ -56,6 +56,7 @@
       "php tests/markdown-section-compaction-smoke.php",
       "php tests/spin-detector-smoke.php",
       "php tests/identical-failure-tracker-smoke.php",
+      "php tests/tool-result-truncator-smoke.php",
       "php tests/context-registry-smoke.php",
       "php tests/conversation-loop-smoke.php",
       "php tests/conversation-loop-tool-execution-smoke.php",

--- a/src/Runtime/class-wp-agent-byte-limit-tool-result-truncator.php
+++ b/src/Runtime/class-wp-agent-byte-limit-tool-result-truncator.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Byte-limit tool result truncator.
+ *
+ * @package AgentsAPI
+ */
+
+namespace AgentsAPI\AI;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Replaces oversized tool payloads with a compact excerpt and diagnostics.
+ */
+final class WP_Agent_Byte_Limit_Tool_Result_Truncator implements WP_Agent_Tool_Result_Truncator {
+
+	private int $max_bytes;
+
+	public function __construct( int $max_bytes = 8192 ) {
+		$this->max_bytes = max( 1, $max_bytes );
+	}
+
+	/** @inheritDoc */
+	public function truncate_result( array $result, string $tool_name, array $context = array() ): array {
+		unset( $tool_name, $context );
+
+		$encoded = wp_json_encode( $result );
+		if ( false === $encoded ) {
+			return array(
+				'result'    => $result,
+				'truncated' => false,
+				'metadata'  => array( 'reason' => 'json_encode_failed' ),
+			);
+		}
+
+		$original_bytes = strlen( (string) $encoded );
+		if ( $original_bytes <= $this->max_bytes ) {
+			return array(
+				'result'    => $result,
+				'truncated' => false,
+				'metadata'  => array( 'original_bytes' => $original_bytes ),
+			);
+		}
+
+		$excerpt   = substr( (string) $encoded, 0, $this->max_bytes );
+		$metadata  = isset( $result['metadata'] ) && is_array( $result['metadata'] ) ? $result['metadata'] : array();
+		$truncated = $result;
+
+		$truncated['result'] = array(
+			'truncated'      => true,
+			'excerpt'        => $excerpt,
+			'original_bytes' => $original_bytes,
+			'excerpt_bytes'  => strlen( $excerpt ),
+		);
+		$truncated['metadata'] = array_merge(
+			$metadata,
+			array(
+				'truncated'      => true,
+				'original_bytes' => $original_bytes,
+				'excerpt_bytes'  => strlen( $excerpt ),
+			)
+		);
+
+		return array(
+			'result'    => $truncated,
+			'truncated' => true,
+			'metadata'  => array(
+				'original_bytes' => $original_bytes,
+				'excerpt_bytes'  => strlen( $excerpt ),
+			),
+		);
+	}
+}

--- a/src/Runtime/class-wp-agent-byte-limit-tool-result-truncator.php
+++ b/src/Runtime/class-wp-agent-byte-limit-tool-result-truncator.php
@@ -48,7 +48,7 @@ final class WP_Agent_Byte_Limit_Tool_Result_Truncator implements WP_Agent_Tool_R
 		$metadata  = isset( $result['metadata'] ) && is_array( $result['metadata'] ) ? $result['metadata'] : array();
 		$truncated = $result;
 
-		$truncated['result'] = array(
+		$truncated['result']   = array(
 			'truncated'      => true,
 			'excerpt'        => $excerpt,
 			'original_bytes' => $original_bytes,

--- a/src/Runtime/class-wp-agent-conversation-loop.php
+++ b/src/Runtime/class-wp-agent-conversation-loop.php
@@ -57,6 +57,7 @@ class WP_Agent_Conversation_Loop {
 	 * - `completion_policy` (WP_Agent_Conversation_Completion_Policy|null): Typed completion policy.
 	 * - `spin_detector` (WP_Agent_Spin_Detector|null): Optional repeated tool-call detector.
 	 * - `identical_failure_tracker` (WP_Agent_Identical_Failure_Tracker|null): Optional repeated failure nudger.
+	 * - `tool_result_truncator` (WP_Agent_Tool_Result_Truncator|null): Optional mediated tool result truncator.
 	 * - `transcript_lock` or `transcript_lock_store` (WP_Agent_Conversation_Lock|null): Optional transcript lock.
 	 * - `transcript_session_id` (string): Session ID to lock when a lock store is provided.
 	 * - `transcript_lock_ttl` (int): Lock TTL in seconds. Defaults to 300.
@@ -82,6 +83,7 @@ class WP_Agent_Conversation_Loop {
 		$on_event              = self::resolve_event_sink( $options );
 		$spin_detector         = self::resolve_spin_detector( $options );
 		$failure_tracker       = self::resolve_identical_failure_tracker( $options );
+		$result_truncator      = self::resolve_tool_result_truncator( $options );
 		$request               = self::resolve_request( $messages, $options );
 		$lock_session_id       = self::resolve_lock_session_id( $options, $request );
 		$lock_ttl              = self::resolve_lock_ttl( $options );
@@ -210,7 +212,8 @@ class WP_Agent_Conversation_Loop {
 						$turn,
 						$on_event,
 						$budgets,
-						$failure_tracker
+						$failure_tracker,
+						$result_truncator
 					);
 
 					$messages              = $mediation_result['messages'];
@@ -345,6 +348,7 @@ class WP_Agent_Conversation_Loop {
 	 * @param callable|null                                     $on_event        Event sink.
 	 * @param array<string, WP_Agent_Iteration_Budget>                    $budgets         Named iteration budgets.
 	 * @param WP_Agent_Identical_Failure_Tracker|null                     $failure_tracker Optional identical-failure tracker.
+	 * @param WP_Agent_Tool_Result_Truncator|null                         $truncator       Optional tool result truncator.
 	 * @return array{messages: array, tool_execution_results: array, tool_audit_events: array, events: array, conversation_complete: bool, exceeded_budget: string|null, spin_signatures: WP_Agent_Spin_Signature[]}
 	 */
 	private static function mediate_tool_calls(
@@ -356,7 +360,8 @@ class WP_Agent_Conversation_Loop {
 		int $turn,
 		?callable $on_event,
 		array $budgets = array(),
-		?WP_Agent_Identical_Failure_Tracker $failure_tracker = null
+		?WP_Agent_Identical_Failure_Tracker $failure_tracker = null,
+		?WP_Agent_Tool_Result_Truncator $truncator = null
 	): array {
 		$core                   = new WP_Agent_Tool_Execution_Core();
 		$messages               = isset( $result['messages'] ) && is_array( $result['messages'] )
@@ -414,6 +419,30 @@ class WP_Agent_Conversation_Loop {
 			);
 
 			$tool_def = $declarations[ $tool_name ] ?? null;
+			$original_exec_result = $exec_result;
+			$truncation           = self::maybe_truncate_tool_result( $truncator, $exec_result, $tool_name, $tool_context );
+			$exec_result          = $truncation['result'];
+
+			if ( $truncation['truncated'] ) {
+				$payload = array_merge(
+					$truncation['metadata'],
+					array(
+						'turn'            => $turn,
+						'tool_name'       => $tool_name,
+						'tool_call_id'    => $tool_call_id,
+						'original_result' => $original_exec_result,
+					)
+				);
+
+				self::emit_event( $on_event, 'tool_result_truncated', $payload );
+				$stored_payload = $payload;
+				unset( $stored_payload['original_result'] );
+
+				$events[] = array(
+					'type'     => 'tool_result_truncated',
+					'metadata' => $stored_payload,
+				);
+			}
 
 			self::emit_event( $on_event, 'tool_result', array(
 				'turn'         => $turn,
@@ -528,6 +557,41 @@ class WP_Agent_Conversation_Loop {
 			'conversation_complete'  => $complete,
 			'exceeded_budget'        => $exceeded_budget,
 			'spin_signatures'        => $spin_signatures,
+		);
+	}
+
+	/**
+	 * Apply the optional tool result truncator and normalize its return shape.
+	 *
+	 * @param WP_Agent_Tool_Result_Truncator|null $truncator Optional truncator.
+	 * @param array<string, mixed>                $result    Tool execution result.
+	 * @param string                              $tool_name Tool name.
+	 * @param array<string, mixed>                $context   Tool context.
+	 * @return array{result: array<string, mixed>, truncated: bool, metadata: array<string, mixed>}
+	 */
+	private static function maybe_truncate_tool_result( ?WP_Agent_Tool_Result_Truncator $truncator, array $result, string $tool_name, array $context ): array {
+		if ( null === $truncator ) {
+			return array(
+				'result'    => $result,
+				'truncated' => false,
+				'metadata'  => array(),
+			);
+		}
+
+		$truncated = $truncator->truncate_result( $result, $tool_name, $context );
+
+		if ( ! is_array( $truncated['result'] ?? null ) ) {
+			return array(
+				'result'    => $result,
+				'truncated' => false,
+				'metadata'  => array( 'reason' => 'invalid_truncator_result' ),
+			);
+		}
+
+		return array(
+			'result'    => $truncated['result'],
+			'truncated' => (bool) ( $truncated['truncated'] ?? false ),
+			'metadata'  => isset( $truncated['metadata'] ) && is_array( $truncated['metadata'] ) ? $truncated['metadata'] : array(),
 		);
 	}
 
@@ -1028,6 +1092,17 @@ class WP_Agent_Conversation_Loop {
 	private static function resolve_identical_failure_tracker( array $options ): ?WP_Agent_Identical_Failure_Tracker {
 		$tracker = $options['identical_failure_tracker'] ?? null;
 		return $tracker instanceof WP_Agent_Identical_Failure_Tracker ? $tracker : null;
+	}
+
+	/**
+	 * Resolve the tool result truncator from options.
+	 *
+	 * @param array $options Loop options.
+	 * @return WP_Agent_Tool_Result_Truncator|null
+	 */
+	private static function resolve_tool_result_truncator( array $options ): ?WP_Agent_Tool_Result_Truncator {
+		$truncator = $options['tool_result_truncator'] ?? null;
+		return $truncator instanceof WP_Agent_Tool_Result_Truncator ? $truncator : null;
 	}
 
 	/**

--- a/src/Runtime/class-wp-agent-conversation-loop.php
+++ b/src/Runtime/class-wp-agent-conversation-loop.php
@@ -418,7 +418,7 @@ class WP_Agent_Conversation_Loop {
 				$tool_context
 			);
 
-			$tool_def = $declarations[ $tool_name ] ?? null;
+			$tool_def             = $declarations[ $tool_name ] ?? null;
 			$original_exec_result = $exec_result;
 			$truncation           = self::maybe_truncate_tool_result( $truncator, $exec_result, $tool_name, $tool_context );
 			$exec_result          = $truncation['result'];

--- a/src/Runtime/class-wp-agent-tool-result-truncator.php
+++ b/src/Runtime/class-wp-agent-tool-result-truncator.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Tool result truncator contract.
+ *
+ * @package AgentsAPI
+ */
+
+namespace AgentsAPI\AI;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Optionally truncates oversized mediated tool results before transcript storage.
+ */
+interface WP_Agent_Tool_Result_Truncator {
+
+	/**
+	 * Truncate a tool execution result when needed.
+	 *
+	 * Return shape:
+	 * - `result` (array): Result to store in transcript/output.
+	 * - `truncated` (bool): Whether the result was truncated.
+	 * - `metadata` (array): Event metadata for observers.
+	 *
+	 * @param array<string, mixed> $result    Tool execution result.
+	 * @param string               $tool_name Tool name.
+	 * @param array<string, mixed> $context   Current tool context.
+	 * @return array{result: array<string, mixed>, truncated: bool, metadata: array<string, mixed>}
+	 */
+	public function truncate_result( array $result, string $tool_name, array $context = array() ): array;
+}

--- a/tests/tool-result-truncator-smoke.php
+++ b/tests/tool-result-truncator-smoke.php
@@ -1,0 +1,130 @@
+<?php
+/**
+ * Pure-PHP smoke test for mediated tool result truncation.
+ *
+ * Run with: php tests/tool-result-truncator-smoke.php
+ *
+ * @package AgentsAPI\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+$failures = array();
+$passes   = 0;
+
+echo "agents-api-tool-result-truncator-smoke\n";
+
+require_once __DIR__ . '/agents-api-smoke-helpers.php';
+agents_api_smoke_require_module();
+
+$executor = new class() implements AgentsAPI\AI\Tools\WP_Agent_Tool_Executor {
+	public function executeWP_Agent_Tool_Call( array $tool_call, array $tool_definition, array $context = array() ): array {
+		unset( $tool_definition, $context );
+
+		return array(
+			'success'   => true,
+			'tool_name' => $tool_call['tool_name'],
+			'result'    => array(
+				'body' => str_repeat( 'x', 200 ),
+			),
+		);
+	}
+};
+
+$tools = array(
+	'client/large-result' => array(
+		'name'        => 'client/large-result',
+		'source'      => 'client',
+		'description' => 'Return a large result.',
+		'parameters'  => array( 'type' => 'object' ),
+		'executor'    => 'client',
+		'scope'       => 'run',
+	),
+);
+
+$events = array();
+$result = AgentsAPI\AI\WP_Agent_Conversation_Loop::run(
+	array( array( 'role' => 'user', 'content' => 'large result please' ) ),
+	static function ( array $messages ): array {
+		return array(
+			'messages'   => $messages,
+			'tool_calls' => array(
+				array(
+					'id'         => 'call_large',
+					'name'       => 'client/large-result',
+					'parameters' => array(),
+				),
+			),
+		);
+	},
+	array(
+		'max_turns'             => 1,
+		'tool_executor'         => $executor,
+		'tool_declarations'     => $tools,
+		'tool_result_truncator' => new AgentsAPI\AI\WP_Agent_Byte_Limit_Tool_Result_Truncator( 80 ),
+		'on_event'              => static function ( string $event, array $payload ) use ( &$events ): void {
+			$events[] = array(
+				'event'   => $event,
+				'payload' => $payload,
+			);
+		},
+	)
+);
+
+$truncated_result = $result['tool_execution_results'][0]['result'] ?? array();
+
+agents_api_smoke_assert_equals( true, (bool) ( $truncated_result['metadata']['truncated'] ?? false ), 'tool execution result is marked truncated', $failures, $passes );
+agents_api_smoke_assert_equals( true, isset( $truncated_result['result']['excerpt'] ), 'tool execution result stores excerpt payload', $failures, $passes );
+agents_api_smoke_assert_equals( false, str_contains( wp_json_encode( $truncated_result ), str_repeat( 'x', 200 ) ), 'truncated execution result omits full original body', $failures, $passes );
+
+$tool_result_messages = array_values(
+	array_filter(
+		$result['messages'],
+		static function ( array $message ): bool {
+			return ( $message['type'] ?? '' ) === AgentsAPI\AI\WP_Agent_Message::TYPE_TOOL_RESULT;
+		}
+	)
+);
+
+agents_api_smoke_assert_equals( true, str_contains( $tool_result_messages[0]['content'] ?? '', '"truncated":true' ), 'tool result transcript stores truncated payload', $failures, $passes );
+agents_api_smoke_assert_equals( false, str_contains( $tool_result_messages[0]['content'] ?? '', str_repeat( 'x', 200 ) ), 'tool result transcript omits full original body', $failures, $passes );
+
+$truncation_events = array_values(
+	array_filter(
+		$events,
+		static function ( array $event ): bool {
+			return 'tool_result_truncated' === $event['event'];
+		}
+	)
+);
+
+agents_api_smoke_assert_equals( 1, count( $truncation_events ), 'tool_result_truncated event is emitted once', $failures, $passes );
+agents_api_smoke_assert_equals( 'client/large-result', $truncation_events[0]['payload']['tool_name'] ?? '', 'truncation event includes tool name', $failures, $passes );
+agents_api_smoke_assert_equals( 'call_large', $truncation_events[0]['payload']['tool_call_id'] ?? '', 'truncation event includes tool call id', $failures, $passes );
+agents_api_smoke_assert_equals( str_repeat( 'x', 200 ), $truncation_events[0]['payload']['original_result']['result']['body'] ?? '', 'truncation event exposes original result to observers', $failures, $passes );
+
+$result_events = array_values(
+	array_filter(
+		$result['events'],
+		static function ( array $event ): bool {
+			return 'tool_result_truncated' === ( $event['type'] ?? '' );
+		}
+	)
+);
+
+agents_api_smoke_assert_equals( 1, count( $result_events ), 'normalized result includes truncation event', $failures, $passes );
+agents_api_smoke_assert_equals( false, isset( $result_events[0]['metadata']['original_result'] ), 'normalized result event omits full original result', $failures, $passes );
+
+$untruncated = ( new AgentsAPI\AI\WP_Agent_Byte_Limit_Tool_Result_Truncator( 10000 ) )->truncate_result(
+	array(
+		'success' => true,
+		'result'  => array( 'ok' => true ),
+	),
+	'client/large-result'
+);
+
+agents_api_smoke_assert_equals( false, $untruncated['truncated'], 'byte-limit truncator leaves small results unchanged', $failures, $passes );
+
+agents_api_smoke_finish( 'Agents API tool result truncator', $failures, $passes );


### PR DESCRIPTION
## Summary
- Adds an opt-in `WP_Agent_Tool_Result_Truncator` contract and byte-limit implementation for mediated tool results.
- Wires `tool_result_truncator` into `WP_Agent_Conversation_Loop` so oversized results use excerpt payloads in transcript/result storage while `tool_result_truncated` observers can capture the original result.
- Documents the option and adds smoke coverage for truncation, event metadata, and unchanged small results.

Refs #183.

## Testing
- `php -l src/Runtime/class-wp-agent-conversation-loop.php && php -l src/Runtime/class-wp-agent-tool-result-truncator.php && php -l src/Runtime/class-wp-agent-byte-limit-tool-result-truncator.php && php -l tests/tool-result-truncator-smoke.php`
- `php tests/tool-result-truncator-smoke.php`
- `git diff --check`
- `composer test`
- `homeboy lint --path /Users/chubes/Developer/agents-api@add-tool-result-truncator-183 --extension wordpress`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the implementation, docs, and smoke coverage; Chris retains responsibility for review and merge decisions.