### PR TITLE
Add loop interrupt source

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Agents API sits between tool/action discovery and product-specific automation. I
 - Agent access grant, token, token authenticator, authorization policy, and capability ceiling contracts.
 - Multi-turn orchestration contracts.
 - Opt-in mediated tool result truncation for oversized transcript payloads.
+- Opt-in between-turn interrupt sources for cancel, redirect, or additional instruction messages.
 - Agent package and package-artifact contracts.
 - Shared `wp_guideline` / `wp_guideline_type` storage substrate polyfill when Core/Gutenberg do not provide it.
 - Agent memory store contracts and value objects.
@@ -782,6 +783,11 @@ $result = AgentsAPI\AI\WP_Agent_Conversation_Loop::run(
 		// Optional tool result truncation for oversized mediated results.
 		'tool_result_truncator' => new AgentsAPI\AI\WP_Agent_Byte_Limit_Tool_Result_Truncator( 8192 ),
 
+		// Optional between-turn interruption. Return a message array or null.
+		'interrupt_source' => static function ( AgentsAPI\AI\WP_Agent_Conversation_Request $request ): ?array {
+			return $interrupt_queue->next_message_for( $request );
+		},
+
 		// Transcript persistence (#43)
 		'transcript_persister' => $my_persister,        // WP_Agent_Transcript_Persister
 
@@ -793,7 +799,7 @@ $result = AgentsAPI\AI\WP_Agent_Conversation_Loop::run(
 
 		// Lifecycle events (#44)
 		'on_event' => static function ( string $event, array $payload ): void {
-			// Events: turn_started, tool_call, tool_result, tool_result_truncated, budget_exceeded, completed, failed
+			// Events: turn_started, tool_call, tool_result, tool_result_truncated, interrupt_received, budget_exceeded, completed, failed
 			$logger->log( $event, $payload );
 		},
 
@@ -815,6 +821,8 @@ $result = AgentsAPI\AI\WP_Agent_Conversation_Loop::run(
 All new options are opt-in. Existing callers passing only the original options continue to work identically.
 
 When `tool_result_truncator` is provided, the loop asks it to normalize mediated tool results before adding them to `tool_execution_results` and transcript `tool_result` messages. `WP_Agent_Byte_Limit_Tool_Result_Truncator` replaces oversized JSON-encoded results with an excerpt plus byte-count metadata and emits `tool_result_truncated`; the event payload includes `original_result` for observer-owned storage, logging, or artifact capture.
+
+When `interrupt_source` is provided, the loop checks it between turns with the current `WP_Agent_Conversation_Request`. Returning a message appends that message to the transcript and emits `interrupt_received`. Message metadata can set `interrupt_action` to `message`, `redirect`, or `cancel`; `cancel` stops the loop with `status: interrupted`, while `message` and `redirect` continue through the normal continuation policy.
 
 The loop treats all adapter inputs and outputs as JSON-friendly arrays so products can map them to their own storage, streaming, audit, and transport layers without Agents API owning those layers.
 

--- a/composer.json
+++ b/composer.json
@@ -63,6 +63,7 @@
       "php tests/conversation-loop-completion-policy-smoke.php",
       "php tests/conversation-loop-transcript-persister-smoke.php",
       "php tests/conversation-loop-events-smoke.php",
+      "php tests/conversation-loop-interrupt-source-smoke.php",
       "php tests/iteration-budget-smoke.php",
       "php tests/conversation-loop-budgets-smoke.php",
       "php tests/channels-smoke.php",

--- a/src/Runtime/class-wp-agent-conversation-loop.php
+++ b/src/Runtime/class-wp-agent-conversation-loop.php
@@ -58,6 +58,7 @@ class WP_Agent_Conversation_Loop {
 	 * - `spin_detector` (WP_Agent_Spin_Detector|null): Optional repeated tool-call detector.
 	 * - `identical_failure_tracker` (WP_Agent_Identical_Failure_Tracker|null): Optional repeated failure nudger.
 	 * - `tool_result_truncator` (WP_Agent_Tool_Result_Truncator|null): Optional mediated tool result truncator.
+	 * - `interrupt_source` (callable|null): Optional source checked between turns. Returns a message array or null.
 	 * - `transcript_lock` or `transcript_lock_store` (WP_Agent_Conversation_Lock|null): Optional transcript lock.
 	 * - `transcript_session_id` (string): Session ID to lock when a lock store is provided.
 	 * - `transcript_lock_ttl` (int): Lock TTL in seconds. Defaults to 300.
@@ -84,6 +85,7 @@ class WP_Agent_Conversation_Loop {
 		$spin_detector         = self::resolve_spin_detector( $options );
 		$failure_tracker       = self::resolve_identical_failure_tracker( $options );
 		$result_truncator      = self::resolve_tool_result_truncator( $options );
+		$interrupt_source      = self::resolve_interrupt_source( $options );
 		$request               = self::resolve_request( $messages, $options );
 		$lock_session_id       = self::resolve_lock_session_id( $options, $request );
 		$lock_ttl              = self::resolve_lock_ttl( $options );
@@ -101,6 +103,7 @@ class WP_Agent_Conversation_Loop {
 		$conversation_complete = false;
 		$exceeded_budget       = null;
 		$stalled               = null;
+		$interrupted           = null;
 
 		// Universal observability accumulators. Turn runners may report
 		// `usage` (token counts) and `request_metadata` (last provider request
@@ -270,6 +273,20 @@ class WP_Agent_Conversation_Loop {
 					break;
 				}
 
+				$interrupt = self::check_interrupt_source( $interrupt_source, $messages, $options, $turn_context, $on_event );
+				if ( null !== $interrupt ) {
+					$messages[] = $interrupt['message'];
+					$events[]   = array(
+						'type'     => 'interrupt_received',
+						'metadata' => $interrupt['metadata'],
+					);
+
+					if ( 'cancel' === $interrupt['action'] ) {
+						$interrupted = $interrupt['metadata'];
+						break;
+					}
+				}
+
 				// Increment the turns budget after a completed turn.
 				// Synthesized turns budgets (from max_turns) break the loop silently
 				// to preserve backwards compatibility. Explicit turns budgets signal
@@ -309,6 +326,12 @@ class WP_Agent_Conversation_Loop {
 				$final_result_data['status']    = 'stalled';
 				$final_result_data['stalled']   = $stalled;
 				$final_result_data['completed'] = false;
+			}
+
+			if ( null !== $interrupted ) {
+				$final_result_data['status']      = 'interrupted';
+				$final_result_data['interrupted'] = $interrupted;
+				$final_result_data['completed']   = false;
 			}
 
 			$final_result = WP_Agent_Conversation_Result::normalize( $final_result_data );
@@ -593,6 +616,96 @@ class WP_Agent_Conversation_Loop {
 			'truncated' => (bool) ( $truncated['truncated'] ?? false ),
 			'metadata'  => isset( $truncated['metadata'] ) && is_array( $truncated['metadata'] ) ? $truncated['metadata'] : array(),
 		);
+	}
+
+	/**
+	 * Check the optional interrupt source for a between-turn message.
+	 *
+	 * @param callable|null        $interrupt_source Optional interrupt source.
+	 * @param array<int, array>    $messages         Current transcript messages.
+	 * @param array<string, mixed> $options          Loop options.
+	 * @param array<string, mixed> $context          Current turn context.
+	 * @param callable|null        $on_event         Event sink.
+	 * @return array{message: array<string, mixed>, metadata: array<string, mixed>, action: string}|null Interrupt payload.
+	 */
+	private static function check_interrupt_source( ?callable $interrupt_source, array $messages, array $options, array $context, ?callable $on_event ): ?array {
+		if ( null === $interrupt_source ) {
+			return null;
+		}
+
+		$request = self::interrupt_request( $messages, $options );
+		$message = call_user_func( $interrupt_source, $request, $context );
+
+		if ( null === $message ) {
+			return null;
+		}
+
+		if ( ! is_array( $message ) ) {
+			self::emit_event( $on_event, 'interrupt_ignored', array(
+				'reason' => 'invalid_message',
+				'turn'   => (int) ( $context['turn'] ?? 0 ),
+			) );
+
+			return null;
+		}
+
+		$normalized       = WP_Agent_Message::normalize( $message );
+		$message_metadata = isset( $normalized['metadata'] ) && is_array( $normalized['metadata'] ) ? $normalized['metadata'] : array();
+		$action           = self::normalize_interrupt_action( $message_metadata['interrupt_action'] ?? ( $message_metadata['action'] ?? 'message' ) );
+		$metadata         = array(
+			'turn'    => (int) ( $context['turn'] ?? 0 ),
+			'action'  => $action,
+			'message' => $normalized,
+		);
+
+		self::emit_event( $on_event, 'interrupt_received', $metadata );
+
+		return array(
+			'message'  => $normalized,
+			'metadata' => $metadata,
+			'action'   => $action,
+		);
+	}
+
+	/**
+	 * Build an interrupt-source request with the current transcript.
+	 *
+	 * @param array<int, array>    $messages Current transcript messages.
+	 * @param array<string, mixed> $options  Loop options.
+	 * @return WP_Agent_Conversation_Request
+	 */
+	private static function interrupt_request( array $messages, array $options ): WP_Agent_Conversation_Request {
+		$request = $options['request'] ?? null;
+		if ( $request instanceof WP_Agent_Conversation_Request ) {
+			return new WP_Agent_Conversation_Request(
+				$messages,
+				$request->tools(),
+				$request->principal(),
+				$request->runtimeContext(),
+				$request->metadata(),
+				$request->maxTurns(),
+				$request->singleTurn(),
+				$request->workspace(),
+				$request->runtimeOverrides()
+			);
+		}
+
+		return self::resolve_request( $messages, $options );
+	}
+
+	/**
+	 * Normalize interrupt action vocabulary.
+	 *
+	 * @param mixed $action Raw action.
+	 * @return string Normalized action.
+	 */
+	private static function normalize_interrupt_action( $action ): string {
+		if ( ! is_string( $action ) ) {
+			return 'message';
+		}
+
+		$action = strtolower( trim( $action ) );
+		return in_array( $action, array( 'cancel', 'redirect', 'message' ), true ) ? $action : 'message';
 	}
 
 	/**
@@ -1103,6 +1216,17 @@ class WP_Agent_Conversation_Loop {
 	private static function resolve_tool_result_truncator( array $options ): ?WP_Agent_Tool_Result_Truncator {
 		$truncator = $options['tool_result_truncator'] ?? null;
 		return $truncator instanceof WP_Agent_Tool_Result_Truncator ? $truncator : null;
+	}
+
+	/**
+	 * Resolve the interrupt source from options.
+	 *
+	 * @param array $options Loop options.
+	 * @return callable|null
+	 */
+	private static function resolve_interrupt_source( array $options ): ?callable {
+		$source = $options['interrupt_source'] ?? null;
+		return is_callable( $source ) ? $source : null;
 	}
 
 	/**

--- a/tests/conversation-loop-interrupt-source-smoke.php
+++ b/tests/conversation-loop-interrupt-source-smoke.php
@@ -1,0 +1,144 @@
+<?php
+/**
+ * Pure-PHP smoke test for WP_Agent_Conversation_Loop interrupt sources.
+ *
+ * Run with: php tests/conversation-loop-interrupt-source-smoke.php
+ *
+ * @package AgentsAPI\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+$failures = array();
+$passes   = 0;
+
+echo "agents-api-conversation-loop-interrupt-source-smoke\n";
+
+require_once __DIR__ . '/agents-api-smoke-helpers.php';
+agents_api_smoke_require_module();
+
+echo "\n[1] Interrupt source can cancel between turns:\n";
+
+$events               = array();
+$source_calls         = 0;
+$source_message_count = 0;
+$source_turn          = 0;
+$cancel_result        = AgentsAPI\AI\WP_Agent_Conversation_Loop::run(
+	array( array( 'role' => 'user', 'content' => 'start' ) ),
+	static function ( array $messages, array $context ): array {
+		$messages[] = AgentsAPI\AI\WP_Agent_Message::text( 'assistant', 'turn ' . $context['turn'] );
+
+		return array(
+			'messages'               => $messages,
+			'tool_execution_results' => array(),
+			'events'                 => array(),
+		);
+	},
+	array(
+		'max_turns'        => 3,
+		'should_continue'  => static function (): bool {
+			return true;
+		},
+		'interrupt_source' => static function ( AgentsAPI\AI\WP_Agent_Conversation_Request $request, array $context ) use ( &$source_calls, &$source_message_count, &$source_turn ): ?array {
+			++$source_calls;
+			$source_message_count = count( $request->messages() );
+			$source_turn          = (int) $context['turn'];
+
+			return AgentsAPI\AI\WP_Agent_Message::text(
+				'user',
+				'Cancel this run.',
+				array(
+					'interrupt_action' => 'cancel',
+					'source'           => 'operator',
+				)
+			);
+		},
+		'on_event'         => static function ( string $event, array $payload ) use ( &$events ): void {
+			$events[] = array(
+				'event'   => $event,
+				'payload' => $payload,
+			);
+		},
+	)
+);
+
+agents_api_smoke_assert_equals( 1, $source_calls, 'interrupt source was checked once before cancel', $failures, $passes );
+agents_api_smoke_assert_equals( 2, $source_message_count, 'interrupt source receives current transcript', $failures, $passes );
+agents_api_smoke_assert_equals( 1, $source_turn, 'interrupt source receives turn context', $failures, $passes );
+agents_api_smoke_assert_equals( 'interrupted', $cancel_result['status'] ?? '', 'cancel interrupt returns interrupted status', $failures, $passes );
+agents_api_smoke_assert_equals( false, $cancel_result['completed'], 'cancel interrupt marks result incomplete', $failures, $passes );
+agents_api_smoke_assert_equals( 'cancel', $cancel_result['interrupted']['action'] ?? '', 'interrupted diagnostics record cancel action', $failures, $passes );
+agents_api_smoke_assert_equals( 3, count( $cancel_result['messages'] ), 'cancel interrupt is appended to transcript', $failures, $passes );
+agents_api_smoke_assert_equals( 'Cancel this run.', $cancel_result['messages'][2]['content'] ?? '', 'cancel interrupt content is preserved', $failures, $passes );
+
+$interrupt_events = array_values(
+	array_filter(
+		$events,
+		static function ( array $event ): bool {
+			return 'interrupt_received' === $event['event'];
+		}
+	)
+);
+
+agents_api_smoke_assert_equals( 1, count( $interrupt_events ), 'interrupt_received event is emitted once', $failures, $passes );
+agents_api_smoke_assert_equals( 'cancel', $interrupt_events[0]['payload']['action'] ?? '', 'interrupt event records action', $failures, $passes );
+agents_api_smoke_assert_equals( 'operator', $interrupt_events[0]['payload']['message']['metadata']['source'] ?? '', 'interrupt event includes normalized message', $failures, $passes );
+
+$result_events = array_values(
+	array_filter(
+		$cancel_result['events'],
+		static function ( array $event ): bool {
+			return 'interrupt_received' === ( $event['type'] ?? '' );
+		}
+	)
+);
+
+agents_api_smoke_assert_equals( 1, count( $result_events ), 'result includes interrupt event', $failures, $passes );
+
+echo "\n[2] Non-cancel interrupt source injects context and loop continues:\n";
+
+$turn_two_saw_interrupt = false;
+$redirect_calls         = 0;
+$redirect_result        = AgentsAPI\AI\WP_Agent_Conversation_Loop::run(
+	array( array( 'role' => 'user', 'content' => 'start' ) ),
+	static function ( array $messages, array $context ) use ( &$turn_two_saw_interrupt ): array {
+		if ( 2 === $context['turn'] ) {
+			$turn_two_saw_interrupt = 'Please use the shorter path.' === ( $messages[2]['content'] ?? '' );
+		}
+
+		$messages[] = AgentsAPI\AI\WP_Agent_Message::text( 'assistant', 'turn ' . $context['turn'] );
+
+		return array(
+			'messages'               => $messages,
+			'tool_execution_results' => array(),
+			'events'                 => array(),
+		);
+	},
+	array(
+		'max_turns'        => 2,
+		'should_continue'  => static function ( array $result, array $context ): bool {
+			return 1 === $context['turn'];
+		},
+		'interrupt_source' => static function () use ( &$redirect_calls ): ?array {
+			++$redirect_calls;
+
+			if ( 1 < $redirect_calls ) {
+				return null;
+			}
+
+			return AgentsAPI\AI\WP_Agent_Message::text(
+				'user',
+				'Please use the shorter path.',
+				array( 'interrupt_action' => 'redirect' )
+			);
+		},
+	)
+);
+
+agents_api_smoke_assert_equals( true, $turn_two_saw_interrupt, 'next turn receives injected interrupt message', $failures, $passes );
+agents_api_smoke_assert_equals( true, $redirect_result['completed'], 'redirect interrupt does not mark run incomplete', $failures, $passes );
+agents_api_smoke_assert_equals( 4, count( $redirect_result['messages'] ), 'redirect interrupt preserves full transcript', $failures, $passes );
+
+agents_api_smoke_finish( 'Agents API conversation loop interrupt source', $failures, $passes );


### PR DESCRIPTION
## Summary
- Adds an opt-in `interrupt_source` loop option checked between turns with the current `WP_Agent_Conversation_Request`.
- Appends returned interrupt messages to the transcript, emits `interrupt_received`, and supports `interrupt_action: cancel` as `status: interrupted`.
- Documents the option and adds smoke coverage for cancel and redirect/additional-instruction flows.

Refs #183.

## Testing
- `php -l src/Runtime/class-wp-agent-conversation-loop.php && php -l tests/conversation-loop-interrupt-source-smoke.php`
- `php tests/conversation-loop-interrupt-source-smoke.php`
- `git diff --check`
- `composer test`
- `homeboy lint --path /Users/chubes/Developer/agents-api@add-interrupt-source-183 --extension wordpress`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the implementation, docs, and smoke coverage; Chris retains responsibility for review and merge decisions.