### PR TITLE
Add canonical ability meta tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Agents API sits between tool/action discovery and product-specific automation. I
 - Multi-turn orchestration contracts.
 - Opt-in mediated tool result truncation for oversized transcript payloads.
 - Opt-in between-turn interrupt sources for cancel, redirect, or additional instruction messages.
+- Canonical ability discovery and dispatch meta-abilities for large tool surfaces.
 - Agent package and package-artifact contracts.
 - Shared `wp_guideline` / `wp_guideline_type` storage substrate polyfill when Core/Gutenberg do not provide it.
 - Agent memory store contracts and value objects.
@@ -201,6 +202,7 @@ wp_register_agent(
 - `AgentsAPI\AI\Tools\WP_Agent_Tool_Executor`
 - `AgentsAPI\AI\Tools\WP_Agent_Tool_Execution_Core`
 - `AgentsAPI\AI\Tools\WP_Agent_Tool_Result`
+- `agents/ability-search` / `agents/ability-call`
 - `AgentsAPI\AI\Approvals\WP_Agent_Approval_Decision`
 - `AgentsAPI\AI\Approvals\WP_Agent_Pending_Action`
 - `AgentsAPI\AI\Approvals\WP_Agent_Pending_Action_Status`
@@ -823,6 +825,8 @@ All new options are opt-in. Existing callers passing only the original options c
 When `tool_result_truncator` is provided, the loop asks it to normalize mediated tool results before adding them to `tool_execution_results` and transcript `tool_result` messages. `WP_Agent_Byte_Limit_Tool_Result_Truncator` replaces oversized JSON-encoded results with an excerpt plus byte-count metadata and emits `tool_result_truncated`; the event payload includes `original_result` for observer-owned storage, logging, or artifact capture.
 
 When `interrupt_source` is provided, the loop checks it between turns with the current `WP_Agent_Conversation_Request`. Returning a message appends that message to the transcript and emits `interrupt_received`. Message metadata can set `interrupt_action` to `message`, `redirect`, or `cancel`; `cancel` stops the loop with `status: interrupted`, while `message` and `redirect` continue through the normal continuation policy.
+
+For large ability surfaces, Agents API registers two canonical meta-abilities. `agents/ability-search` searches registered abilities by name, category, substring, `+keyword`, or `select:foo/bar,baz/qux` and returns compact `{ name, summary, required_fields }` entries. `agents/ability-call` invokes a registered ability by name with JSON parameters, letting consumers keep lower-priority tools out of the prompt while still making them reachable through a stable discovery-and-call path.
 
 The loop treats all adapter inputs and outputs as JSON-friendly arrays so products can map them to their own storage, streaming, audit, and transport layers without Agents API owning those layers.
 

--- a/agents-api.php
+++ b/agents-api.php
@@ -108,6 +108,7 @@ require_once AGENTS_API_PATH . 'src/Tools/class-wp-agent-tool-usage-tracker.php'
 require_once AGENTS_API_PATH . 'src/Tools/class-wp-agent-null-tool-usage-tracker.php';
 require_once AGENTS_API_PATH . 'src/Tools/class-wp-agent-tool-tier-resolver.php';
 require_once AGENTS_API_PATH . 'src/Tools/class-wp-agent-default-tool-tier-resolver.php';
+require_once AGENTS_API_PATH . 'src/Tools/register-agent-ability-meta-abilities.php';
 require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-conversation-request.php';
 require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-conversation-runner.php';
 require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-conversation-completion-decision.php';

--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,7 @@
       "php tests/tool-policy-contracts-smoke.php",
       "php tests/tool-tier-resolver-smoke.php",
       "php tests/action-policy-resolver-smoke.php",
+      "php tests/ability-meta-abilities-smoke.php",
       "php tests/tool-runtime-smoke.php",
       "php tests/pending-action-store-contract-smoke.php",
       "php tests/approval-resolver-contract-smoke.php",

--- a/src/Tools/register-agent-ability-meta-abilities.php
+++ b/src/Tools/register-agent-ability-meta-abilities.php
@@ -1,0 +1,388 @@
+<?php
+/**
+ * Canonical ability discovery and dispatch meta-abilities.
+ *
+ * @package AgentsAPI
+ */
+
+namespace AgentsAPI\AI\Tools;
+
+defined( 'ABSPATH' ) || exit;
+
+const AGENTS_ABILITY_SEARCH_ABILITY = 'agents/ability-search';
+const AGENTS_ABILITY_CALL_ABILITY   = 'agents/ability-call';
+
+add_action(
+	'wp_abilities_api_categories_init',
+	static function (): void {
+		if ( wp_has_ability_category( 'agents-api' ) ) {
+			return;
+		}
+
+		wp_register_ability_category(
+			'agents-api',
+			array(
+				'label'       => 'Agents API',
+				'description' => 'Cross-cutting abilities provided by the Agents API substrate.',
+			)
+		);
+	}
+);
+
+add_action(
+	'wp_abilities_api_init',
+	static function (): void {
+		if ( ! wp_has_ability( AGENTS_ABILITY_SEARCH_ABILITY ) ) {
+			wp_register_ability(
+				AGENTS_ABILITY_SEARCH_ABILITY,
+				array(
+					'label'               => 'Search Abilities',
+					'description'         => 'Search registered abilities by name, category, and keywords. Returns compact entries for tool discovery.',
+					'category'            => 'agents-api',
+					'input_schema'        => agents_ability_search_input_schema(),
+					'output_schema'       => agents_ability_search_output_schema(),
+					'execute_callback'    => __NAMESPACE__ . '\\agents_ability_search',
+					'permission_callback' => __NAMESPACE__ . '\\agents_ability_search_permission',
+					'meta'                => array(
+						'show_in_rest' => true,
+						'annotations'  => array(
+							'readonly'   => true,
+							'idempotent' => true,
+						),
+					),
+				)
+			);
+		}
+
+		if ( ! wp_has_ability( AGENTS_ABILITY_CALL_ABILITY ) ) {
+			wp_register_ability(
+				AGENTS_ABILITY_CALL_ABILITY,
+				array(
+					'label'               => 'Call Ability',
+					'description'         => 'Invoke a registered ability by name with JSON parameters. Used for Tier-2 tools that are discovered at runtime.',
+					'category'            => 'agents-api',
+					'input_schema'        => agents_ability_call_input_schema(),
+					'output_schema'       => agents_ability_call_output_schema(),
+					'execute_callback'    => __NAMESPACE__ . '\\agents_ability_call',
+					'permission_callback' => __NAMESPACE__ . '\\agents_ability_call_permission',
+					'meta'                => array(
+						'show_in_rest' => true,
+						'annotations'  => array(
+							'idempotent' => false,
+						),
+					),
+				)
+			);
+		}
+	}
+);
+
+/**
+ * Search registered abilities and return compact model-facing entries.
+ *
+ * @param array<string, mixed> $input Search input.
+ * @return array<string, mixed>
+ */
+function agents_ability_search( array $input ): array {
+	$query    = is_string( $input['query'] ?? null ) ? trim( $input['query'] ) : '';
+	$category = is_string( $input['category'] ?? null ) ? trim( $input['category'] ) : '';
+	$limit    = max( 1, min( 100, (int) ( $input['limit'] ?? 20 ) ) );
+	$parsed   = agents_parse_ability_search_query( $query );
+	$entries  = array();
+
+	foreach ( wp_get_abilities() as $ability ) {
+		if ( ! $ability instanceof \WP_Ability ) {
+			continue;
+		}
+
+		if ( '' !== $category && $ability->get_category() !== $category ) {
+			continue;
+		}
+
+		if ( ! agents_ability_matches_query( $ability, $parsed ) ) {
+			continue;
+		}
+
+		$entries[] = agents_compact_ability_entry( $ability );
+		if ( count( $entries ) >= $limit ) {
+			break;
+		}
+	}
+
+	return array(
+		'query'     => $query,
+		'count'     => count( $entries ),
+		'abilities' => $entries,
+	);
+}
+
+/**
+ * Invoke an ability by name.
+ *
+ * @param array<string, mixed> $input Call input.
+ * @return array<string, mixed>|\WP_Error
+ */
+function agents_ability_call( array $input ) {
+	$name       = is_string( $input['name'] ?? null ) ? trim( $input['name'] ) : '';
+	$parameters = isset( $input['parameters'] ) && is_array( $input['parameters'] ) ? $input['parameters'] : array();
+
+	if ( '' === $name ) {
+		return new \WP_Error( 'agents_ability_call_missing_name', 'Ability name is required.' );
+	}
+
+	if ( AGENTS_ABILITY_CALL_ABILITY === $name ) {
+		return new \WP_Error( 'agents_ability_call_recursion', 'agents/ability-call cannot call itself.' );
+	}
+
+	$ability = wp_get_ability( $name );
+	if ( ! $ability instanceof \WP_Ability ) {
+		return new \WP_Error( 'agents_ability_call_not_found', 'Ability is not registered.' );
+	}
+
+	$result = $ability->execute( $parameters );
+	if ( is_wp_error( $result ) ) {
+		return $result;
+	}
+
+	return array(
+		'name'   => $name,
+		'result' => $result,
+	);
+}
+
+/**
+ * Permission gate for ability search.
+ *
+ * @param array<string, mixed> $input Search input.
+ * @return bool
+ */
+function agents_ability_search_permission( array $input ): bool {
+	return (bool) apply_filters( 'agents_ability_search_permission', current_user_can( 'manage_options' ), $input );
+}
+
+/**
+ * Permission gate for ability call.
+ *
+ * @param array<string, mixed> $input Call input.
+ * @return bool
+ */
+function agents_ability_call_permission( array $input ): bool {
+	return (bool) apply_filters( 'agents_ability_call_permission', current_user_can( 'manage_options' ), $input );
+}
+
+/**
+ * Parse the compact ability-search query language.
+ *
+ * @param string $query Raw query.
+ * @return array{terms: array<int, string>, required: array<int, string>, selected: array<int, string>}
+ */
+function agents_parse_ability_search_query( string $query ): array {
+	$terms    = array();
+	$required = array();
+	$selected = array();
+
+	foreach ( preg_split( '/\s+/', $query ) ?: array() as $token ) {
+		$token = trim( (string) $token );
+		if ( '' === $token ) {
+			continue;
+		}
+
+		if ( str_starts_with( $token, 'select:' ) ) {
+			$selected = array_merge( $selected, agents_string_list( explode( ',', substr( $token, 7 ) ) ) );
+			continue;
+		}
+
+		if ( str_starts_with( $token, '+' ) ) {
+			$required[] = strtolower( substr( $token, 1 ) );
+			continue;
+		}
+
+		$terms[] = strtolower( $token );
+	}
+
+	return array(
+		'terms'    => agents_string_list( $terms ),
+		'required' => agents_string_list( $required ),
+		'selected' => agents_string_list( $selected ),
+	);
+}
+
+/**
+ * Check whether an ability matches a parsed query.
+ *
+ * @param \WP_Ability $ability Ability object.
+ * @param array       $query   Parsed query.
+ * @return bool
+ */
+function agents_ability_matches_query( \WP_Ability $ability, array $query ): bool {
+	$name = $ability->get_name();
+	if ( ! empty( $query['selected'] ) ) {
+		return in_array( $name, $query['selected'], true );
+	}
+
+	$haystack = strtolower( implode( ' ', array( $name, $ability->get_label(), $ability->get_description(), $ability->get_category() ) ) );
+	foreach ( array_merge( $query['terms'] ?? array(), $query['required'] ?? array() ) as $term ) {
+		if ( '' !== $term && ! str_contains( $haystack, strtolower( (string) $term ) ) ) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
+/**
+ * Build a compact ability entry.
+ *
+ * @param \WP_Ability $ability Ability object.
+ * @return array<string, mixed>
+ */
+function agents_compact_ability_entry( \WP_Ability $ability ): array {
+	return array(
+		'name'            => $ability->get_name(),
+		'summary'         => agents_ability_summary( $ability ),
+		'required_fields' => agents_ability_required_fields( $ability ),
+	);
+}
+
+/**
+ * Build a one-line summary for a compact ability entry.
+ *
+ * @param \WP_Ability $ability Ability object.
+ * @return string
+ */
+function agents_ability_summary( \WP_Ability $ability ): string {
+	$summary = trim( $ability->get_description() );
+	if ( '' === $summary ) {
+		$summary = trim( $ability->get_label() );
+	}
+
+	return preg_replace( '/\s+/', ' ', $summary ) ?: '';
+}
+
+/**
+ * Extract required input fields from an ability schema.
+ *
+ * @param \WP_Ability $ability Ability object.
+ * @return array<int, string>
+ */
+function agents_ability_required_fields( \WP_Ability $ability ): array {
+	$schema = $ability->get_input_schema();
+	return isset( $schema['required'] ) && is_array( $schema['required'] ) ? agents_string_list( $schema['required'] ) : array();
+}
+
+/**
+ * Normalize a list of strings.
+ *
+ * @param array<int, mixed> $items Raw values.
+ * @return array<int, string>
+ */
+function agents_string_list( array $items ): array {
+	$strings = array();
+	foreach ( $items as $item ) {
+		if ( is_string( $item ) && '' !== trim( $item ) ) {
+			$strings[] = trim( $item );
+		}
+	}
+
+	return array_values( array_unique( $strings ) );
+}
+
+/**
+ * Input schema for ability search.
+ *
+ * @return array<string, mixed>
+ */
+function agents_ability_search_input_schema(): array {
+	return array(
+		'type'       => 'object',
+		'properties' => array(
+			'query'    => array(
+				'type'        => 'string',
+				'description' => 'Search query. Supports name/category substrings, +keyword requirements, and select:foo/bar,baz/qux.',
+				'default'     => '',
+			),
+			'category' => array(
+				'type'        => 'string',
+				'description' => 'Optional exact ability category filter.',
+				'default'     => '',
+			),
+			'limit'    => array(
+				'type'        => 'integer',
+				'description' => 'Maximum number of compact ability entries to return.',
+				'default'     => 20,
+				'minimum'     => 1,
+				'maximum'     => 100,
+			),
+		),
+	);
+}
+
+/**
+ * Output schema for ability search.
+ *
+ * @return array<string, mixed>
+ */
+function agents_ability_search_output_schema(): array {
+	return array(
+		'type'       => 'object',
+		'required'   => array( 'query', 'count', 'abilities' ),
+		'properties' => array(
+			'query'     => array( 'type' => 'string' ),
+			'count'     => array( 'type' => 'integer' ),
+			'abilities' => array(
+				'type'  => 'array',
+				'items' => array(
+					'type'       => 'object',
+					'required'   => array( 'name', 'summary', 'required_fields' ),
+					'properties' => array(
+						'name'            => array( 'type' => 'string' ),
+						'summary'         => array( 'type' => 'string' ),
+						'required_fields' => array(
+							'type'  => 'array',
+							'items' => array( 'type' => 'string' ),
+						),
+					),
+				),
+			),
+		),
+	);
+}
+
+/**
+ * Input schema for ability call.
+ *
+ * @return array<string, mixed>
+ */
+function agents_ability_call_input_schema(): array {
+	return array(
+		'type'       => 'object',
+		'required'   => array( 'name' ),
+		'properties' => array(
+			'name'       => array(
+				'type'        => 'string',
+				'description' => 'Registered ability name to invoke.',
+			),
+			'parameters' => array(
+				'type'        => 'object',
+				'description' => 'JSON parameters passed to the target ability.',
+				'default'     => array(),
+			),
+		),
+	);
+}
+
+/**
+ * Output schema for ability call.
+ *
+ * @return array<string, mixed>
+ */
+function agents_ability_call_output_schema(): array {
+	return array(
+		'type'       => 'object',
+		'required'   => array( 'name', 'result' ),
+		'properties' => array(
+			'name'   => array( 'type' => 'string' ),
+			'result' => array( 'type' => array( 'object', 'array', 'string', 'number', 'boolean', 'null' ) ),
+		),
+	);
+}

--- a/tests/ability-meta-abilities-smoke.php
+++ b/tests/ability-meta-abilities-smoke.php
@@ -1,0 +1,172 @@
+<?php
+/**
+ * Pure-PHP smoke test for canonical ability discovery meta-abilities.
+ *
+ * Run with: php tests/ability-meta-abilities-smoke.php
+ *
+ * @package AgentsAPI\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+class WP_Error {
+	public function __construct( private string $code = '', private string $message = '', private $data = null ) {}
+	public function get_error_code(): string { return $this->code; }
+	public function get_error_message(): string { return $this->message; }
+	public function get_error_data() { return $this->data; }
+}
+
+class WP_Ability_Category {}
+
+class WP_Ability {
+	public function __construct( private string $name, private array $args ) {}
+	public function get_name(): string { return $this->name; }
+	public function get_label(): string { return (string) ( $this->args['label'] ?? '' ); }
+	public function get_description(): string { return (string) ( $this->args['description'] ?? '' ); }
+	public function get_category(): string { return (string) ( $this->args['category'] ?? '' ); }
+	public function get_input_schema(): array { return isset( $this->args['input_schema'] ) && is_array( $this->args['input_schema'] ) ? $this->args['input_schema'] : array(); }
+	public function get_output_schema(): array { return isset( $this->args['output_schema'] ) && is_array( $this->args['output_schema'] ) ? $this->args['output_schema'] : array(); }
+	public function get_meta_item( string $key, $default = null ) { return $this->args['meta'][ $key ] ?? $default; }
+	public function execute( $input = null ) {
+		$permission = $this->args['permission_callback'] ?? null;
+		if ( is_callable( $permission ) && true !== call_user_func( $permission, is_array( $input ) ? $input : array() ) ) {
+			return new WP_Error( 'ability_invalid_permissions', 'Permission denied.' );
+		}
+
+		$callback = $this->args['execute_callback'] ?? null;
+		return is_callable( $callback ) ? call_user_func( $callback, is_array( $input ) ? $input : array() ) : null;
+	}
+}
+
+$failures = array();
+$passes   = 0;
+
+echo "agents-api-ability-meta-abilities-smoke\n";
+
+require_once __DIR__ . '/agents-api-smoke-helpers.php';
+
+$GLOBALS['__agents_api_smoke_abilities']          = array();
+$GLOBALS['__agents_api_smoke_ability_categories'] = array();
+$GLOBALS['__agents_api_smoke_can']                = true;
+
+function current_user_can( string $capability ): bool {
+	unset( $capability );
+	return (bool) $GLOBALS['__agents_api_smoke_can'];
+}
+
+function wp_has_ability_category( string $slug ): bool {
+	return isset( $GLOBALS['__agents_api_smoke_ability_categories'][ $slug ] );
+}
+
+function wp_register_ability_category( string $slug, array $args ): ?WP_Ability_Category {
+	$GLOBALS['__agents_api_smoke_ability_categories'][ $slug ] = $args;
+	return null;
+}
+
+function wp_has_ability( string $name ): bool {
+	return isset( $GLOBALS['__agents_api_smoke_abilities'][ $name ] );
+}
+
+function wp_register_ability( string $name, array $args ): ?WP_Ability {
+	$ability = new WP_Ability( $name, $args );
+	$GLOBALS['__agents_api_smoke_abilities'][ $name ] = $ability;
+	return $ability;
+}
+
+function wp_get_ability( string $name ): ?WP_Ability {
+	return $GLOBALS['__agents_api_smoke_abilities'][ $name ] ?? null;
+}
+
+function wp_get_abilities(): array {
+	return array_values( $GLOBALS['__agents_api_smoke_abilities'] );
+}
+
+agents_api_smoke_require_module();
+do_action( 'wp_abilities_api_categories_init' );
+do_action( 'wp_abilities_api_init' );
+
+wp_register_ability(
+	'demo/weather-forecast',
+	array(
+		'label'               => 'Weather Forecast',
+		'description'         => 'Fetch a local weather forecast for a city.',
+		'category'            => 'demo-tools',
+		'input_schema'        => array(
+			'type'       => 'object',
+			'required'   => array( 'city' ),
+			'properties' => array(
+				'city' => array( 'type' => 'string' ),
+			),
+		),
+		'execute_callback'    => static function ( array $input ): array {
+			return array( 'forecast' => 'sunny in ' . ( $input['city'] ?? '' ) );
+		},
+		'permission_callback' => static function (): bool {
+			return true;
+		},
+	)
+);
+
+wp_register_ability(
+	'demo/publish-post',
+	array(
+		'label'               => 'Publish Post',
+		'description'         => 'Publish a draft post by ID.',
+		'category'            => 'content',
+		'input_schema'        => array(
+			'type'     => 'object',
+			'required' => array( 'post_id' ),
+		),
+		'execute_callback'    => static function ( array $input ): array {
+			return array( 'published' => (int) ( $input['post_id'] ?? 0 ) );
+		},
+		'permission_callback' => static function (): bool {
+			return true;
+		},
+	)
+);
+
+echo "\n[1] Meta-abilities register in canonical namespace:\n";
+agents_api_smoke_assert_equals( true, wp_has_ability( 'agents/ability-search' ), 'ability-search is registered', $failures, $passes );
+agents_api_smoke_assert_equals( true, wp_has_ability( 'agents/ability-call' ), 'ability-call is registered', $failures, $passes );
+
+echo "\n[2] ability-search returns compact entries by name and keyword:\n";
+$name_search = AgentsAPI\AI\Tools\agents_ability_search( array( 'query' => 'weather' ) );
+agents_api_smoke_assert_equals( 'demo/weather-forecast', $name_search['abilities'][0]['name'] ?? '', 'search by name substring finds weather ability', $failures, $passes );
+agents_api_smoke_assert_equals( array( 'city' ), $name_search['abilities'][0]['required_fields'] ?? array(), 'search result includes required-field hint', $failures, $passes );
+
+$keyword_search = AgentsAPI\AI\Tools\agents_ability_search( array( 'query' => '+forecast' ) );
+agents_api_smoke_assert_equals( 'demo/weather-forecast', $keyword_search['abilities'][0]['name'] ?? '', 'search by required keyword finds forecast ability', $failures, $passes );
+
+$category_search = AgentsAPI\AI\Tools\agents_ability_search( array( 'category' => 'content' ) );
+agents_api_smoke_assert_equals( 'demo/publish-post', $category_search['abilities'][0]['name'] ?? '', 'search by category finds content ability', $failures, $passes );
+
+$select_search = AgentsAPI\AI\Tools\agents_ability_search( array( 'query' => 'select:demo/publish-post,demo/weather-forecast' ) );
+agents_api_smoke_assert_equals( 2, $select_search['count'], 'select query returns explicitly selected abilities', $failures, $passes );
+
+echo "\n[3] ability-call dispatches through the registered target ability:\n";
+$call = AgentsAPI\AI\Tools\agents_ability_call(
+	array(
+		'name'       => 'demo/weather-forecast',
+		'parameters' => array( 'city' => 'Portland' ),
+	)
+);
+agents_api_smoke_assert_equals( 'demo/weather-forecast', $call['name'] ?? '', 'ability-call returns target ability name', $failures, $passes );
+agents_api_smoke_assert_equals( 'sunny in Portland', $call['result']['forecast'] ?? '', 'ability-call returns target result', $failures, $passes );
+
+$missing = AgentsAPI\AI\Tools\agents_ability_call( array( 'name' => 'demo/missing' ) );
+agents_api_smoke_assert_equals( true, $missing instanceof WP_Error, 'missing ability returns WP_Error', $failures, $passes );
+agents_api_smoke_assert_equals( 'agents_ability_call_not_found', $missing instanceof WP_Error ? $missing->get_error_code() : '', 'missing ability error code is stable', $failures, $passes );
+
+$recursive = AgentsAPI\AI\Tools\agents_ability_call( array( 'name' => 'agents/ability-call' ) );
+agents_api_smoke_assert_equals( true, $recursive instanceof WP_Error, 'ability-call refuses recursion', $failures, $passes );
+
+echo "\n[4] Meta-ability permission gates are filterable:\n";
+$GLOBALS['__agents_api_smoke_can'] = false;
+agents_api_smoke_assert_equals( false, AgentsAPI\AI\Tools\agents_ability_search_permission( array() ), 'search permission denies by default without manage_options', $failures, $passes );
+add_filter( 'agents_ability_search_permission', static fn() => true );
+agents_api_smoke_assert_equals( true, AgentsAPI\AI\Tools\agents_ability_search_permission( array() ), 'search permission filter can allow', $failures, $passes );
+
+agents_api_smoke_finish( 'Agents API ability meta-abilities', $failures, $passes );


### PR DESCRIPTION
## Summary
- Registers canonical `agents/ability-search` and `agents/ability-call` meta-abilities for large ability surfaces.
- Implements compact ability search by substring, category, `+keyword`, and `select:` queries with required-field hints.
- Dispatches `agents/ability-call` through the target ability's normal `execute()` path and documents the discovery/call contract.

Refs #181.

## Testing
- `php -l src/Tools/register-agent-ability-meta-abilities.php && php -l tests/ability-meta-abilities-smoke.php`
- `php tests/ability-meta-abilities-smoke.php`
- `git diff --check`
- `composer test`
- `homeboy lint --path /Users/chubes/Developer/agents-api@add-meta-abilities-181 --extension wordpress`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the implementation, docs, and smoke coverage; Chris retains responsibility for review and merge decisions.