### PR TITLE
Version conversation replay contracts

### DIFF
--- a/docs/runtime-and-tools.md
+++ b/docs/runtime-and-tools.md
@@ -28,10 +28,12 @@ Representative message roles include user, assistant, tool-call, and tool-result
 
 `AgentsAPI\AI\WP_Agent_Conversation_Request` carries the original messages, tool declarations, execution principal, caller-owned context, metadata, and max-turn settings. Runtime and transcript adapters can use the request object to stamp storage or audit records without Agents API choosing storage.
 
-`AgentsAPI\AI\WP_Agent_Conversation_Result` normalizes loop output. Typical keys include:
+`AgentsAPI\AI\WP_Agent_Conversation_Result` normalizes loop output. Replay consumers can pin to `schema: agents-api.conversation-result` and `version: 1` for the stable result envelope. Typical keys include:
 
 ```php
 array(
+	'schema'                 => 'agents-api.conversation-result',
+	'version'                => 1,
 	'messages'               => $messages,
 	'tool_execution_results' => $tool_results,
 	'tool_audit_events'      => $tool_audit_events,
@@ -48,6 +50,28 @@ array(
 ```
 
 When an explicit budget trips, the result includes `status => 'budget_exceeded'` and `budget => '<budget-name>'`.
+
+### Replay-critical result contract
+
+The version 1 conversation result contract is the product-neutral replay surface for downstream orchestrators, regraders, and transcript stores. Consumers should read the versioned fields below instead of inferring behavior from incidental provider adapter fields:
+
+| Field | Stability | Notes |
+| --- | --- | --- |
+| `schema` | Required, stable | Always `agents-api.conversation-result`. |
+| `version` | Required, stable | Integer contract version. Current value is `1`. |
+| `messages[]` | Required, stable | Normalized `agents-api.message` envelopes. Tool-call and tool-result envelopes carry matching `metadata.tool_call_id` when mediation knows the id. |
+| `tool_execution_results[]` | Required, stable | Raw caller-owned tool result data. Mediated entries include `tool_name`, `tool_call_id`, `parameters`, `result`, `runtime` when present, and `turn_count`. |
+| `tool_audit_events[]` | Required, stable | Safe generic replay trace for mediated tool calls. Entries include `schema_version`, `type`, `turn_count`, `tool_name`, `tool_call_id`, hashes, status, and `error_type` when classified. |
+| `events[]` | Required, stable | Loop lifecycle events such as `interrupt_received`, `tool_result_truncated`, and `completion_policy_stop`. |
+| `turn_count` | Required from the loop | Number of turns executed. |
+| `final_content` | Required from the loop | Last assistant text message, excluding synthetic tool-call/tool-result messages. |
+| `usage` | Required from the loop | Aggregated token usage when provided by the caller adapter. |
+| `request_metadata` | Required from the loop | Caller-supplied metadata preserved for transcript persisters and replay. |
+| `completed` | Required from the loop | Boolean completion signal. `false` when stopped by a budget, stall, or cancel interrupt. |
+| `status` | Optional | Machine-readable stop reason such as `budget_exceeded`, `stalled`, `interrupted`, or `transcript_lock_contention`. |
+| `interrupted` | Optional | Interrupt metadata copied from the normalized interrupt message. Includes `action` and any caller metadata such as `source`. |
+
+Transcript persisters receive the normalized versioned result after loop completion and before the `completed` event is emitted. Persisters should persist the result envelope as-is and use `schema` plus `version` to choose replay logic.
 
 ## Conversation loop
 
@@ -220,6 +244,7 @@ array(
 	'type'                => 'tool_call',
 	'turn_count'          => 1,
 	'tool_name'           => 'client/search_docs',
+	'tool_call_id'        => 'call_123',
 	'tool_source'         => 'client',
 	'parameters_sha256'   => 'sha256:...',
 	'parameters_redacted' => true,

--- a/src/Runtime/class-wp-agent-conversation-loop.php
+++ b/src/Runtime/class-wp-agent-conversation-loop.php
@@ -650,9 +650,9 @@ class WP_Agent_Conversation_Loop {
 			return null;
 		}
 
-		$normalized       = WP_Agent_Message::normalize( $message );
-		$message_metadata = isset( $normalized['metadata'] ) && is_array( $normalized['metadata'] ) ? $normalized['metadata'] : array();
-		$action           = self::normalize_interrupt_action( $message_metadata['interrupt_action'] ?? ( $message_metadata['action'] ?? 'message' ) );
+		$normalized         = WP_Agent_Message::normalize( $message );
+		$message_metadata   = isset( $normalized['metadata'] ) && is_array( $normalized['metadata'] ) ? $normalized['metadata'] : array();
+		$action             = self::normalize_interrupt_action( $message_metadata['interrupt_action'] ?? ( $message_metadata['action'] ?? 'message' ) );
 		$interrupt_metadata = $message_metadata;
 		unset( $interrupt_metadata['action'], $interrupt_metadata['interrupt_action'] );
 

--- a/src/Runtime/class-wp-agent-conversation-loop.php
+++ b/src/Runtime/class-wp-agent-conversation-loop.php
@@ -492,6 +492,7 @@ class WP_Agent_Conversation_Loop {
 
 			$tool_audit_events[] = self::tool_audit_event(
 				$tool_name,
+				$tool_call_id,
 				is_array( $parameters ) ? $parameters : array(),
 				$exec_result,
 				is_array( $tool_def ) ? $tool_def : null,
@@ -652,11 +653,14 @@ class WP_Agent_Conversation_Loop {
 		$normalized       = WP_Agent_Message::normalize( $message );
 		$message_metadata = isset( $normalized['metadata'] ) && is_array( $normalized['metadata'] ) ? $normalized['metadata'] : array();
 		$action           = self::normalize_interrupt_action( $message_metadata['interrupt_action'] ?? ( $message_metadata['action'] ?? 'message' ) );
-		$metadata         = array(
+		$interrupt_metadata = $message_metadata;
+		unset( $interrupt_metadata['action'], $interrupt_metadata['interrupt_action'] );
+
+		$metadata = array_merge( $interrupt_metadata, array(
 			'turn'    => (int) ( $context['turn'] ?? 0 ),
 			'action'  => $action,
 			'message' => $normalized,
-		);
+		) );
 
 		self::emit_event( $on_event, 'interrupt_received', $metadata );
 
@@ -955,6 +959,7 @@ class WP_Agent_Conversation_Loop {
 	 * secrets into generic observers.
 	 *
 	 * @param string     $tool_name       Tool identifier.
+	 * @param string     $tool_call_id    Provider or loop-assigned tool-call id.
 	 * @param array      $parameters      Runtime tool-call parameters.
 	 * @param array      $result          Normalized tool execution result.
 	 * @param array|null $tool_definition Tool declaration, when available.
@@ -962,7 +967,7 @@ class WP_Agent_Conversation_Loop {
 	 * @param int        $turn            Turn number.
 	 * @return array<string, mixed> Audit event.
 	 */
-	private static function tool_audit_event( string $tool_name, array $parameters, array $result, ?array $tool_definition, array $context, int $turn ): array {
+	private static function tool_audit_event( string $tool_name, string $tool_call_id, array $parameters, array $result, ?array $tool_definition, array $context, int $turn ): array {
 		$safe_parameters = self::redact_tool_audit_parameters( $parameters, $tool_name, $tool_definition, $context );
 		$metadata        = isset( $result['metadata'] ) && is_array( $result['metadata'] ) ? $result['metadata'] : array();
 		$error_type      = isset( $metadata['error_type'] ) && is_string( $metadata['error_type'] ) ? $metadata['error_type'] : '';
@@ -972,6 +977,7 @@ class WP_Agent_Conversation_Loop {
 			'type'                => 'tool_call',
 			'turn_count'          => $turn,
 			'tool_name'           => $tool_name,
+			'tool_call_id'        => $tool_call_id,
 			'tool_source'         => is_array( $tool_definition ) && is_string( $tool_definition['source'] ?? null ) ? $tool_definition['source'] : '',
 			'parameters_sha256'   => self::stable_sha256( $safe_parameters ),
 			'parameters_redacted' => true,

--- a/src/Runtime/class-wp-agent-conversation-result.php
+++ b/src/Runtime/class-wp-agent-conversation-result.php
@@ -17,6 +17,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Validation exceptions are not rendered output.
 class WP_Agent_Conversation_Result {
 
+	public const SCHEMA  = 'agents-api.conversation-result';
+	public const VERSION = 1;
+
 	/**
 	 * Validate and normalize a loop result.
 	 *
@@ -28,6 +31,22 @@ class WP_Agent_Conversation_Result {
 	 * @throws \InvalidArgumentException When the result shape is invalid.
 	 */
 	public static function normalize( array $result ): array {
+		if ( ! array_key_exists( 'schema', $result ) ) {
+			$result['schema'] = self::SCHEMA;
+		}
+
+		if ( ! array_key_exists( 'version', $result ) ) {
+			$result['version'] = self::VERSION;
+		}
+
+		if ( self::SCHEMA !== $result['schema'] ) {
+			throw self::invalid( 'schema', 'must be ' . self::SCHEMA );
+		}
+
+		if ( self::VERSION !== (int) $result['version'] ) {
+			throw self::invalid( 'version', 'must be ' . self::VERSION );
+		}
+
 		if ( ! array_key_exists( 'messages', $result ) || ! is_array( $result['messages'] ) ) {
 			throw self::invalid( 'messages', 'must be an array' );
 		}
@@ -107,7 +126,7 @@ class WP_Agent_Conversation_Result {
 				throw self::invalid( $path, 'must be an array' );
 			}
 
-			foreach ( array( 'type', 'tool_name', 'parameters_sha256', 'result_sha256' ) as $field ) {
+			foreach ( array( 'type', 'tool_name', 'tool_call_id', 'parameters_sha256', 'result_sha256' ) as $field ) {
 				if ( ! array_key_exists( $field, $audit_event ) || ! is_string( $audit_event[ $field ] ) || '' === $audit_event[ $field ] ) {
 					throw self::invalid( $path . '.' . $field, 'must be a non-empty string' );
 				}

--- a/tests/conversation-loop-interrupt-source-smoke.php
+++ b/tests/conversation-loop-interrupt-source-smoke.php
@@ -68,10 +68,14 @@ agents_api_smoke_assert_equals( 1, $source_calls, 'interrupt source was checked 
 agents_api_smoke_assert_equals( 2, $source_message_count, 'interrupt source receives current transcript', $failures, $passes );
 agents_api_smoke_assert_equals( 1, $source_turn, 'interrupt source receives turn context', $failures, $passes );
 agents_api_smoke_assert_equals( 'interrupted', $cancel_result['status'] ?? '', 'cancel interrupt returns interrupted status', $failures, $passes );
+agents_api_smoke_assert_equals( AgentsAPI\AI\WP_Agent_Conversation_Result::SCHEMA, $cancel_result['schema'], 'interrupt result exposes replay schema', $failures, $passes );
+agents_api_smoke_assert_equals( AgentsAPI\AI\WP_Agent_Conversation_Result::VERSION, $cancel_result['version'], 'interrupt result exposes replay version', $failures, $passes );
 agents_api_smoke_assert_equals( false, $cancel_result['completed'], 'cancel interrupt marks result incomplete', $failures, $passes );
 agents_api_smoke_assert_equals( 'cancel', $cancel_result['interrupted']['action'] ?? '', 'interrupted diagnostics record cancel action', $failures, $passes );
+agents_api_smoke_assert_equals( 'operator', $cancel_result['interrupted']['source'] ?? '', 'interrupted diagnostics preserve source metadata', $failures, $passes );
 agents_api_smoke_assert_equals( 3, count( $cancel_result['messages'] ), 'cancel interrupt is appended to transcript', $failures, $passes );
 agents_api_smoke_assert_equals( 'Cancel this run.', $cancel_result['messages'][2]['content'] ?? '', 'cancel interrupt content is preserved', $failures, $passes );
+agents_api_smoke_assert_equals( 'operator', $cancel_result['messages'][2]['metadata']['source'] ?? '', 'cancel interrupt transcript preserves source metadata', $failures, $passes );
 
 $interrupt_events = array_values(
 	array_filter(

--- a/tests/conversation-loop-tool-execution-smoke.php
+++ b/tests/conversation-loop-tool-execution-smoke.php
@@ -86,8 +86,11 @@ $result = AgentsAPI\AI\WP_Agent_Conversation_Loop::run(
 );
 
 	agents_api_smoke_assert_equals( 1, count( $executor->executed ), 'tool executor was called once', $failures, $passes );
+	agents_api_smoke_assert_equals( AgentsAPI\AI\WP_Agent_Conversation_Result::SCHEMA, $result['schema'], 'mediated result exposes replay schema', $failures, $passes );
+	agents_api_smoke_assert_equals( AgentsAPI\AI\WP_Agent_Conversation_Result::VERSION, $result['version'], 'mediated result exposes replay version', $failures, $passes );
 	agents_api_smoke_assert_equals( 'client/summarize', $executor->executed[0]['tool_name'], 'tool executor received correct tool name', $failures, $passes );
 	agents_api_smoke_assert_equals( 'call_123', $executor->executed[0]['id'] ?? '', 'tool executor received provider tool call id', $failures, $passes );
+	agents_api_smoke_assert_equals( 'call_123', $executor->executed[0]['metadata']['tool_call_id'] ?? '', 'tool executor received provider tool call id in metadata', $failures, $passes );
 	agents_api_smoke_assert_equals( 1, count( $result['tool_execution_results'] ), 'result contains one tool execution result', $failures, $passes );
 	agents_api_smoke_assert_equals( 'client/summarize', $result['tool_execution_results'][0]['tool_name'], 'tool execution result has correct tool name', $failures, $passes );
 	agents_api_smoke_assert_equals( 'call_123', $result['tool_execution_results'][0]['tool_call_id'] ?? '', 'tool execution result preserves provider tool call id', $failures, $passes );
@@ -98,6 +101,7 @@ $result = AgentsAPI\AI\WP_Agent_Conversation_Loop::run(
 agents_api_smoke_assert_equals( 1, count( $result['tool_audit_events'] ), 'result contains one tool audit event', $failures, $passes );
 agents_api_smoke_assert_equals( 'tool_call', $result['tool_audit_events'][0]['type'], 'tool audit event has stable type', $failures, $passes );
 agents_api_smoke_assert_equals( 'client/summarize', $result['tool_audit_events'][0]['tool_name'], 'tool audit event has correct tool name', $failures, $passes );
+agents_api_smoke_assert_equals( 'call_123', $result['tool_audit_events'][0]['tool_call_id'], 'tool audit event preserves provider tool call id', $failures, $passes );
 agents_api_smoke_assert_equals( true, $result['tool_audit_events'][0]['success'], 'tool audit event records success', $failures, $passes );
 agents_api_smoke_assert_equals( true, str_starts_with( $result['tool_audit_events'][0]['parameters_sha256'], 'sha256:' ), 'tool audit event hashes parameters', $failures, $passes );
 agents_api_smoke_assert_equals( true, ! array_key_exists( 'parameters', $result['tool_audit_events'][0] ), 'tool audit event omits raw parameters', $failures, $passes );
@@ -115,6 +119,17 @@ $tool_result_messages = array_values(
 );
 agents_api_smoke_assert_equals( 'call_123', $tool_result_messages[0]['metadata']['tool_call_id'] ?? '', 'tool result metadata preserves provider tool call id', $failures, $passes );
 agents_api_smoke_assert_equals( false, array_key_exists( 'tool_call_id', $tool_result_messages[0]['payload'] ?? array() ), 'tool result payload does not duplicate tool_call_id', $failures, $passes );
+
+$tool_call_messages = array_values(
+	array_filter(
+		$result['messages'],
+		static function ( array $message ): bool {
+			return ( $message['type'] ?? '' ) === AgentsAPI\AI\WP_Agent_Message::TYPE_TOOL_CALL;
+		}
+	)
+);
+agents_api_smoke_assert_equals( 'call_123', $tool_call_messages[0]['metadata']['tool_call_id'] ?? '', 'tool call metadata preserves provider tool call id', $failures, $passes );
+agents_api_smoke_assert_equals( array( 'text' => 'hello world' ), $tool_call_messages[0]['payload']['parameters'] ?? array(), 'tool call payload preserves provider parameters for runtime replay', $failures, $passes );
 
 echo "\n[2] Loop runs without mediation when no tool_executor is provided (backwards compatible):\n";
 $executor->executed = array();

--- a/tests/conversation-loop-transcript-persister-smoke.php
+++ b/tests/conversation-loop-transcript-persister-smoke.php
@@ -71,7 +71,11 @@ $result = AgentsAPI\AI\WP_Agent_Conversation_Loop::run(
 agents_api_smoke_assert_equals( 1, count( $persister_log ), 'persister was called once on success', $failures, $passes );
 agents_api_smoke_assert_equals( 2, $persister_log[0]['message_count'], 'persister received final messages', $failures, $passes );
 agents_api_smoke_assert_equals( 1, $persister_log[0]['request_turns'], 'persister received request with correct max_turns', $failures, $passes );
+agents_api_smoke_assert_equals( true, in_array( 'schema', $persister_log[0]['result_keys'], true ), 'persister receives replay result schema key', $failures, $passes );
+agents_api_smoke_assert_equals( true, in_array( 'version', $persister_log[0]['result_keys'], true ), 'persister receives replay result version key', $failures, $passes );
 agents_api_smoke_assert_equals( true, $result['completed'] ?? null, 'successful loop result is marked completed', $failures, $passes );
+agents_api_smoke_assert_equals( AgentsAPI\AI\WP_Agent_Conversation_Result::SCHEMA, $result['schema'], 'successful loop result exposes replay schema', $failures, $passes );
+agents_api_smoke_assert_equals( AgentsAPI\AI\WP_Agent_Conversation_Result::VERSION, $result['version'], 'successful loop result exposes replay version', $failures, $passes );
 agents_api_smoke_assert_equals( true, $persister_log[0]['completed'], 'persister receives completed successful result', $failures, $passes );
 agents_api_smoke_assert_equals( 'SITE.md', $result['request_metadata']['memory_files'][0]['filename'] ?? '', 'loop result preserves caller request metadata', $failures, $passes );
 agents_api_smoke_assert_equals( 'SITE.md', $persister_log[0]['request_metadata']['memory_files'][0]['filename'] ?? '', 'persister receives caller request metadata', $failures, $passes );

--- a/tests/conversation-runner-contracts-smoke.php
+++ b/tests/conversation-runner-contracts-smoke.php
@@ -80,6 +80,8 @@ $runner = new class() implements AgentsAPI\AI\WP_Agent_Conversation_Runner {
 };
 
 $runner_result = $runner->run( $request );
+agents_api_smoke_assert_equals( AgentsAPI\AI\WP_Agent_Conversation_Result::SCHEMA, $runner_result['schema'], 'runner result exposes canonical schema', $failures, $passes );
+agents_api_smoke_assert_equals( AgentsAPI\AI\WP_Agent_Conversation_Result::VERSION, $runner_result['version'], 'runner result exposes canonical version', $failures, $passes );
 agents_api_smoke_assert_equals( 1, count( $runner_result['messages'] ), 'runner returns normalized messages', $failures, $passes );
 agents_api_smoke_assert_equals( array(), $runner_result['tool_execution_results'], 'runner result normalization provides empty tool results', $failures, $passes );
 


### PR DESCRIPTION
## Summary
- Add a versioned `agents-api.conversation-result` envelope for normalized conversation results.
- Include `tool_call_id` in mediated tool audit events so replay consumers can pair safe audit traces with transcript/tool-result entries.
- Document the replay-critical result/message/tool trace contract and expand smoke coverage for tool IDs, runtime metadata, interrupts, and transcript persister hooks.

Closes #224.

## Verification
- `php tests/conversation-runner-contracts-smoke.php && php tests/conversation-loop-tool-execution-smoke.php && php tests/conversation-loop-interrupt-source-smoke.php && php tests/conversation-loop-transcript-persister-smoke.php`
- `composer test`
- `php -l src/Runtime/class-wp-agent-conversation-result.php`
- `php -l src/Runtime/class-wp-agent-conversation-loop.php`
- `php -l tests/conversation-runner-contracts-smoke.php`
- `php -l tests/conversation-loop-tool-execution-smoke.php`
- `php -l tests/conversation-loop-interrupt-source-smoke.php`
- `php -l tests/conversation-loop-transcript-persister-smoke.php`
- `git diff --check`

## Note
- `homeboy lint --path /Users/chubes/Developer/agents-api@fix-version-replay-conversation-contracts --extension php` could not run because the auto-selected lab runner is missing the `php` extension before command execution.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the replay contract versioning, documentation updates, and smoke-test coverage; Chris remains responsible for review and merge.
