### PR TITLE
Loop: stop on natural completion + preserve messages when turn runner omits them

### DIFF
--- a/src/Runtime/class-wp-agent-conversation-loop.php
+++ b/src/Runtime/class-wp-agent-conversation-loop.php
@@ -389,7 +389,8 @@ class WP_Agent_Conversation_Loop {
 		?WP_Agent_Tool_Result_Truncator $truncator = null,
 		array $prior_messages = array()
 	): array {
-		$core                   = new WP_Agent_Tool_Execution_Core();
+		$core = new WP_Agent_Tool_Execution_Core();
+
 		// Fall back to the prior turn's messages when the turn runner omits
 		// `messages` from its return — without this, mediation starts from an
 		// empty list and silently drops history between rounds.

--- a/src/Runtime/class-wp-agent-conversation-loop.php
+++ b/src/Runtime/class-wp-agent-conversation-loop.php
@@ -46,10 +46,11 @@ class WP_Agent_Conversation_Loop {
 	 *   Defaults to `null` in the caller-managed path (which causes the loop to break
 	 *   after one turn unless the caller supplies a callback). When tool
 	 *   mediation is enabled (`tool_executor` + `tool_declarations` provided),
-	 *   defaults to a `__return_true` callable so the loop continues until
-	 *   `tool_calls` is empty (natural completion), `completion_policy` fires,
-	 *   `max_turns` is reached, or a budget is exceeded — i.e. the caller no
-	 *   longer needs to supply this option just to get multi-turn mediation.
+	 *   defaults to a callable that returns `true` while the latest turn emitted
+	 *   `tool_calls` — so the loop stops on natural completion (empty `tool_calls`)
+	 *   and otherwise keeps going until `completion_policy` fires, `max_turns` is
+	 *   reached, or a budget is exceeded. Callers can pass `'__return_true'` to
+	 *   opt into the historical continue-always behavior.
 	 * - `compaction_policy` (array|null): Optional compaction policy.
 	 * - `summarizer` (callable|null): Optional compaction summarizer.
 	 * - `tool_executor` (WP_Agent_Tool_Executor|null): Tool execution adapter.
@@ -216,7 +217,8 @@ class WP_Agent_Conversation_Loop {
 						$on_event,
 						$budgets,
 						$failure_tracker,
-						$result_truncator
+						$result_truncator,
+						$messages
 					);
 
 					$messages              = $mediation_result['messages'];
@@ -384,12 +386,16 @@ class WP_Agent_Conversation_Loop {
 		?callable $on_event,
 		array $budgets = array(),
 		?WP_Agent_Identical_Failure_Tracker $failure_tracker = null,
-		?WP_Agent_Tool_Result_Truncator $truncator = null
+		?WP_Agent_Tool_Result_Truncator $truncator = null,
+		array $prior_messages = array()
 	): array {
 		$core                   = new WP_Agent_Tool_Execution_Core();
+		// Fall back to the prior turn's messages when the turn runner omits
+		// `messages` from its return — without this, mediation starts from an
+		// empty list and silently drops history between rounds.
 		$messages               = isset( $result['messages'] ) && is_array( $result['messages'] )
 			? WP_Agent_Message::normalize_many( $result['messages'] )
-			: array();
+			: $prior_messages;
 		$tool_calls             = $result['tool_calls'];
 		$tool_execution_results = array();
 		$tool_audit_events      = array();
@@ -1125,11 +1131,12 @@ class WP_Agent_Conversation_Loop {
 	/**
 	 * Resolve the should_continue callable for this run.
 	 *
-	 * When tool mediation is enabled, defaults to a continue-always callable so
-	 * `max_turns`, `completion_policy`, budgets, and natural completion (empty
-	 * `tool_calls`) become the only stop conditions. In the caller-managed path (no
-	 * mediation), preserves the historical break-after-1 behavior unless the
-	 * caller supplies their own continuation policy.
+	 * When tool mediation is enabled, defaults to a callable that returns true
+	 * only while the latest turn emitted `tool_calls` — so the loop stops on
+	 * natural completion and `max_turns` + `completion_policy` + budgets remain
+	 * upper bounds rather than the primary stop condition. In the caller-managed
+	 * path (no mediation), preserves the historical break-after-1 behavior unless
+	 * the caller supplies their own continuation policy.
 	 *
 	 * @param array                       $options           Loop options.
 	 * @param WP_Agent_Tool_Executor|null $tool_executor     Resolved tool executor.
@@ -1152,11 +1159,15 @@ class WP_Agent_Conversation_Loop {
 		}
 
 		// No caller-supplied policy. When mediation is enabled, default to
-		// "keep going" so the loop's other stop conditions can do their job.
+		// "stop when the turn runner emitted no tool_calls" so the loop exits
+		// on natural completion instead of re-running until max_turns. The
+		// caller can still pass `'should_continue' => '__return_true'` to opt
+		// into the historical continue-always behavior, and budgets +
+		// `completion_policy` + `max_turns` continue to act as stop conditions.
 		$mediation_enabled = null !== $tool_executor && ! empty( $tool_declarations );
 		if ( $mediation_enabled ) {
-			return static function (): bool {
-				return true;
+			return static function ( array $result ): bool {
+				return ! empty( $result['tool_calls'] ?? array() );
 			};
 		}
 

--- a/tests/conversation-loop-tool-execution-smoke.php
+++ b/tests/conversation-loop-tool-execution-smoke.php
@@ -360,4 +360,74 @@ $exception_result = AgentsAPI\AI\WP_Agent_Conversation_Loop::run(
 agents_api_smoke_assert_equals( 'executor_exception', $exception_result['tool_audit_events'][0]['error_type'], 'executor exception audit event records error type', $failures, $passes );
 agents_api_smoke_assert_equals( false, $exception_result['tool_audit_events'][0]['success'], 'executor exception audit event records failure', $failures, $passes );
 
+echo "\n[Default should_continue stops on natural completion (#226):\n";
+$executor->executed = array();
+$turn_count         = 0;
+
+$natural_stop_result = AgentsAPI\AI\WP_Agent_Conversation_Loop::run(
+	array( array( 'role' => 'user', 'content' => 'one tool round' ) ),
+	static function ( array $messages, array $context ) use ( &$turn_count ): array {
+		++$turn_count;
+		if ( 1 === $context['turn'] ) {
+			return array(
+				'messages'   => $messages,
+				'tool_calls' => array(
+					array( 'name' => 'client/summarize', 'parameters' => array( 'text' => 'once' ) ),
+				),
+			);
+		}
+		// Turn 2: model answers with text and no tool_calls. The default
+		// should_continue must stop the loop here rather than letting it run
+		// until max_turns.
+		return array(
+			'messages' => $messages,
+			'content'  => 'final answer',
+		);
+	},
+	array(
+		'max_turns'         => 8,
+		'tool_executor'     => $executor,
+		'tool_declarations' => $tools,
+		// No should_continue override on purpose — exercise the substrate default.
+	)
+);
+
+agents_api_smoke_assert_equals( 2, $turn_count, 'loop stops after the natural-completion turn instead of running to max_turns', $failures, $passes );
+agents_api_smoke_assert_equals( 1, count( $executor->executed ), 'executor was called exactly once', $failures, $passes );
+
+echo "\n[Mediation falls back to prior messages when turn runner omits the key (#227):\n";
+$executor->executed = array();
+$omit_turn          = 0;
+
+$omit_result = AgentsAPI\AI\WP_Agent_Conversation_Loop::run(
+	array( array( 'role' => 'user', 'content' => 'kick off' ) ),
+	static function ( array $unused, array $context ) use ( &$omit_turn ): array {
+		++$omit_turn;
+		// Intentionally omit the `messages` key. The substrate must fall back
+		// to the prior turn's messages so transcript history is preserved.
+		if ( 1 === $context['turn'] ) {
+			return array(
+				'tool_calls' => array(
+					array( 'name' => 'client/summarize', 'parameters' => array( 'text' => 'kick off' ) ),
+				),
+			);
+		}
+		// Empty tool_calls trips natural completion inside the mediation path.
+		return array(
+			'content'    => 'done',
+			'tool_calls' => array(),
+		);
+	},
+	array(
+		'max_turns'         => 4,
+		'tool_executor'     => $executor,
+		'tool_declarations' => $tools,
+	)
+);
+
+agents_api_smoke_assert_equals( 2, $omit_turn, 'loop completes naturally even when turn runner omits messages', $failures, $passes );
+agents_api_smoke_assert_equals( true, count( $omit_result['messages'] ) >= 4, 'transcript retains user + tool_call + tool_result + final content despite omitted messages key', $failures, $passes );
+$omit_roles = array_map( static fn( array $m ): string => (string) ( $m['role'] ?? '' ), $omit_result['messages'] );
+agents_api_smoke_assert_equals( 'user', $omit_roles[0] ?? '', 'first transcript message is the original user turn (history preserved)', $failures, $passes );
+
 agents_api_smoke_finish( 'Agents API conversation loop tool execution', $failures, $passes );


### PR DESCRIPTION
Two related fixes to \`WP_Agent_Conversation_Loop\` mediation behavior, raised by @alansmodic from the [Personalized Reader](https://github.com/alansmodic/personalized-reader) integration.

## Closes #226 — default \`should_continue\` keeps looping until \`max_turns\`

Today, when \`tool_executor\` + \`tool_declarations\` are provided and no \`should_continue\` is passed, the substrate defaults to a continue-always callable. That means the loop runs through every available turn — even after the model emits a pure text answer with no \`tool_calls\` — so the final assistant reply gets regenerated N times before the loop exits. Every consumer writes the same shim:

\`\`\`php
'should_continue' => static function ( array \$result ): bool {
    return ! empty( \$result['tool_calls'] ?? array() );
},
\`\`\`

This PR makes that the substrate default in mediation mode. The docblock already described the intent (\"continues until \`tool_calls\` is empty (natural completion)…\") — this aligns the implementation. Callers that want the historical continue-always behavior can pass \`'__return_true'\` explicitly.

## Closes #227 — \`turn_runner\` silently drops history when \`messages\` is omitted

\`mediate_tool_calls\` previously initialized its working transcript from \`\$result['messages']\` or — when the key was missing — from an empty array. A turn runner that forgot to thread \`messages\` through its return caused mediation to start the next turn from \`[]\` and silently drop history between rounds.

This PR threads the prior turn's \`\$messages\` into \`mediate_tool_calls\` as a fallback, so missing \`messages\` no longer drops state. The change is strictly additive — runners that pass \`messages\` continue to be honored.

## Changes

- \`src/Runtime/class-wp-agent-conversation-loop.php\`:
  - Default \`should_continue\` in mediation mode now returns \`true\` only while the latest turn emitted \`tool_calls\` (closes #226).
  - \`mediate_tool_calls()\` accepts \`\$prior_messages\` and uses it as the fallback when the runner omits \`messages\` (closes #227).
  - Docblock updates to reflect the new defaults.
- \`tests/conversation-loop-tool-execution-smoke.php\`: two new smoke cases — \"default should_continue stops on natural completion\" and \"mediation falls back to prior messages when turn runner omits the key\".

## Test plan

- [x] \`php tests/conversation-loop-tool-execution-smoke.php\` — 40 assertions, all pass (including the 2 new ones).
- [x] \`composer test\` — full suite green; existing mediation tests that pass an explicit \`should_continue\` are unaffected.