### PR TITLE
Add WP_Agent_Message::coalesce_consecutive_same_role helper

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
     "test": [
       "php tests/bootstrap-smoke.php",
       "php tests/message-envelope-smoke.php",
+      "php tests/message-coalesce-smoke.php",
       "php tests/registry-smoke.php",
       "php tests/package-lifecycle-smoke.php",
       "php tests/package-capability-contract-smoke.php",

--- a/src/Runtime/class-wp-agent-message.php
+++ b/src/Runtime/class-wp-agent-message.php
@@ -213,6 +213,105 @@ class WP_Agent_Message {
 	}
 
 	/**
+	 * Coalesce consecutive same-role envelopes into multi-part shapes.
+	 *
+	 * When an assistant turn emits both narrative text and one or more tool
+	 * calls, the substrate persists them as separate envelopes (one TYPE_TEXT
+	 * followed by one or more TYPE_TOOL_CALL, all role=assistant). Replay
+	 * against providers that reject consecutive same-role messages
+	 * (Anthropic notably) then fails until the consumer merges them back into
+	 * a single multi-part assistant message before dispatch.
+	 *
+	 * This helper does that merge: consecutive envelopes of the same role are
+	 * combined into one TYPE_MULTIMODAL_PART envelope whose `payload.parts`
+	 * carries each original envelope verbatim. Provider adapters can then map
+	 * the multi-part envelope to whatever shape the target provider expects
+	 * (Anthropic's content-block array, OpenAI's tool_calls + content split,
+	 * etc.) without losing per-part metadata or having to re-derive grouping
+	 * from message order.
+	 *
+	 * The helper is opt-in: it does not change the substrate's persisted
+	 * transcript format. Consumers call it on the message list immediately
+	 * before constructing the provider request. Calling it twice is a no-op
+	 * because already-multipart envelopes are preserved as-is.
+	 *
+	 * @param array<int, array<string, mixed>> $messages Messages to coalesce.
+	 * @return array<int, array<string, mixed>> Messages with consecutive same-role envelopes merged.
+	 */
+	public static function coalesce_consecutive_same_role( array $messages ): array {
+		$normalized = self::normalize_many( $messages );
+		$coalesced  = array();
+
+		foreach ( $normalized as $envelope ) {
+			$role = $envelope['role'] ?? '';
+			$tail = end( $coalesced );
+
+			if ( false === $tail || ( $tail['role'] ?? '' ) !== $role ) {
+				$coalesced[] = $envelope;
+				continue;
+			}
+
+			$tail_key   = array_key_last( $coalesced );
+			$tail_parts = self::extract_parts( $tail );
+			$new_parts  = self::extract_parts( $envelope );
+
+			$coalesced[ $tail_key ] = self::buildEnvelope(
+				$role,
+				self::join_text_content( $tail_parts, $new_parts ),
+				self::TYPE_MULTIMODAL_PART,
+				array(
+					'parts' => array_merge( $tail_parts, $new_parts ),
+				),
+				$tail['metadata'] ?? array(),
+				array()
+			);
+		}
+
+		return $coalesced;
+	}
+
+	/**
+	 * Return the parts that should be carried inside a coalesced envelope.
+	 *
+	 * Already-multipart envelopes contribute their existing parts; all other
+	 * envelopes contribute themselves as a single part so no payload data is
+	 * lost in the merge.
+	 *
+	 * @param array<string, mixed> $envelope Source envelope.
+	 * @return array<int, array<string, mixed>>
+	 */
+	private static function extract_parts( array $envelope ): array {
+		if ( self::TYPE_MULTIMODAL_PART === ( $envelope['type'] ?? '' ) && isset( $envelope['payload']['parts'] ) && is_array( $envelope['payload']['parts'] ) ) {
+			return array_values( $envelope['payload']['parts'] );
+		}
+
+		return array( $envelope );
+	}
+
+	/**
+	 * Produce a human-readable content string for a coalesced envelope.
+	 *
+	 * The substrate keeps the original per-part envelopes inside the payload;
+	 * the top-level `content` is reduced to the concatenated text of any
+	 * TYPE_TEXT parts so logs and transcripts stay readable without provider
+	 * adapter introspection.
+	 *
+	 * @param array<int, array<string, mixed>> $left_parts  Parts already inside the coalesced envelope.
+	 * @param array<int, array<string, mixed>> $right_parts Parts being merged in.
+	 * @return string Joined text content.
+	 */
+	private static function join_text_content( array $left_parts, array $right_parts ): string {
+		$texts = array();
+		foreach ( array_merge( $left_parts, $right_parts ) as $part ) {
+			if ( self::TYPE_TEXT === ( $part['type'] ?? '' ) && is_string( $part['content'] ?? null ) && '' !== $part['content'] ) {
+				$texts[] = $part['content'];
+			}
+		}
+
+		return implode( "\n\n", $texts );
+	}
+
+	/**
 	 * Detect whether an array already uses the envelope shape.
 	 *
 	 * @param array $message Message array.

--- a/tests/message-coalesce-smoke.php
+++ b/tests/message-coalesce-smoke.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * Pure-PHP smoke test for WP_Agent_Message::coalesce_consecutive_same_role().
+ *
+ * Run with: php tests/message-coalesce-smoke.php
+ *
+ * @package AgentsAPI\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+$failures = array();
+$passes   = 0;
+
+echo "agents-api-message-coalesce-smoke\n";
+
+require_once __DIR__ . '/agents-api-smoke-helpers.php';
+agents_api_smoke_require_module();
+
+use AgentsAPI\AI\WP_Agent_Message;
+
+echo "\n[1] Empty input round-trips:\n";
+agents_api_smoke_assert_equals( array(), WP_Agent_Message::coalesce_consecutive_same_role( array() ), 'empty list returns empty list', $failures, $passes );
+
+echo "\n[2] Alternating roles are preserved:\n";
+$alternating = array(
+	WP_Agent_Message::text( 'user', 'hello' ),
+	WP_Agent_Message::text( 'assistant', 'hi' ),
+	WP_Agent_Message::text( 'user', 'how are you' ),
+);
+$result = WP_Agent_Message::coalesce_consecutive_same_role( $alternating );
+agents_api_smoke_assert_equals( 3, count( $result ), 'alternating roles are not merged', $failures, $passes );
+agents_api_smoke_assert_equals( 'user', $result[0]['role'], 'first message stays as user', $failures, $passes );
+agents_api_smoke_assert_equals( 'assistant', $result[1]['role'], 'second message stays as assistant', $failures, $passes );
+
+echo "\n[3] Preamble text + tool_call from same assistant turn are coalesced (Anthropic-safe replay shape):\n";
+$preamble  = WP_Agent_Message::text( 'assistant', 'Let me search the archive first.' );
+$tool_call = WP_Agent_Message::toolCall( 'Calling search', 'archive/search', array( 'q' => 'hello' ), 1 );
+$result    = WP_Agent_Message::coalesce_consecutive_same_role(
+	array(
+		WP_Agent_Message::text( 'user', 'find that note' ),
+		$preamble,
+		$tool_call,
+	)
+);
+
+agents_api_smoke_assert_equals( 2, count( $result ), 'user turn + coalesced assistant turn produces two envelopes', $failures, $passes );
+agents_api_smoke_assert_equals( 'user', $result[0]['role'], 'user envelope kept intact', $failures, $passes );
+agents_api_smoke_assert_equals( 'assistant', $result[1]['role'], 'coalesced envelope keeps assistant role', $failures, $passes );
+agents_api_smoke_assert_equals( WP_Agent_Message::TYPE_MULTIMODAL_PART, $result[1]['type'], 'coalesced envelope is typed multimodal_part', $failures, $passes );
+agents_api_smoke_assert_equals( 2, count( $result[1]['payload']['parts'] ?? array() ), 'coalesced envelope carries both original parts', $failures, $passes );
+agents_api_smoke_assert_equals( WP_Agent_Message::TYPE_TEXT, $result[1]['payload']['parts'][0]['type'] ?? '', 'first part is the original text envelope', $failures, $passes );
+agents_api_smoke_assert_equals( WP_Agent_Message::TYPE_TOOL_CALL, $result[1]['payload']['parts'][1]['type'] ?? '', 'second part is the original tool_call envelope', $failures, $passes );
+agents_api_smoke_assert_equals( 'Let me search the archive first.', $result[1]['content'], 'top-level content reduces to joined text for readability', $failures, $passes );
+
+echo "\n[4] Multiple consecutive tool_calls merge into one envelope:\n";
+$call_a = WP_Agent_Message::toolCall( 'a', 'tool/a', array(), 1 );
+$call_b = WP_Agent_Message::toolCall( 'b', 'tool/b', array(), 1 );
+$call_c = WP_Agent_Message::toolCall( 'c', 'tool/c', array(), 1 );
+$result = WP_Agent_Message::coalesce_consecutive_same_role( array( $call_a, $call_b, $call_c ) );
+
+agents_api_smoke_assert_equals( 1, count( $result ), 'three same-role envelopes collapse to one', $failures, $passes );
+agents_api_smoke_assert_equals( 3, count( $result[0]['payload']['parts'] ?? array() ), 'all three original parts preserved inside coalesced envelope', $failures, $passes );
+
+echo "\n[5] Already-multipart envelopes are merged without losing existing parts:\n";
+$already_merged = WP_Agent_Message::coalesce_consecutive_same_role( array( $call_a, $call_b ) );
+$result         = WP_Agent_Message::coalesce_consecutive_same_role( array( $already_merged[0], $call_c ) );
+
+agents_api_smoke_assert_equals( 1, count( $result ), 'merging an already-coalesced envelope still produces one envelope', $failures, $passes );
+agents_api_smoke_assert_equals( 3, count( $result[0]['payload']['parts'] ?? array() ), 'flattens parts rather than nesting multipart inside multipart', $failures, $passes );
+
+echo "\n[6] Tool_result envelopes (role=user) do not merge with assistant tool_calls:\n";
+$tool_result = WP_Agent_Message::toolResult( 'ok', 'tool/a', array( 'success' => true ) );
+$result      = WP_Agent_Message::coalesce_consecutive_same_role( array( $call_a, $tool_result, $call_b ) );
+
+agents_api_smoke_assert_equals( 3, count( $result ), 'role boundary between assistant and user tool_result is preserved', $failures, $passes );
+
+echo "\n[7] Idempotent: calling twice yields the same result:\n";
+$once  = WP_Agent_Message::coalesce_consecutive_same_role( array( $preamble, $tool_call ) );
+$twice = WP_Agent_Message::coalesce_consecutive_same_role( $once );
+
+agents_api_smoke_assert_equals( count( $once ), count( $twice ), 'idempotent envelope count', $failures, $passes );
+agents_api_smoke_assert_equals( count( $once[0]['payload']['parts'] ?? array() ), count( $twice[0]['payload']['parts'] ?? array() ), 'idempotent parts count', $failures, $passes );
+
+agents_api_smoke_finish( 'WP_Agent_Message coalesce', $failures, $passes );


### PR DESCRIPTION
## Summary

Adds an opt-in helper that merges consecutive same-role envelopes into a single \`TYPE_MULTIMODAL_PART\` envelope, so consumers targeting providers with strict message-ordering rules (Anthropic notably) can replay transcripts without writing the same merge logic by hand.

## Why

@alansmodic raised this in #228 from his [Personalized Reader](https://github.com/alansmodic/personalized-reader) integration: when the model emits narrative preamble text followed by a tool_call in the same assistant turn, the substrate persists them as two separate envelopes (\`TYPE_TEXT\` followed by \`TYPE_TOOL_CALL\`, both \`role=assistant\`). Anthropic provider replay rejects the resulting consecutive same-role messages — and every consumer integrating against Anthropic ends up re-implementing the same merge.

His proposed Option 2 was a merge helper; this PR ships that.

## Why not modify the persisted format

Option 1 from #228 was \"persist as a single multi-part envelope at the source\". I went with Option 2 for three reasons:

1. **Provider-neutrality**: OpenAI and Ollama accept consecutive same-role messages without complaint. Forcing the substrate's persisted format to flatten them would push complexity onto every adopter, not just Anthropic ones.
2. **Lower contract churn**: existing consumers (ClawPress, AbilityGuard, data-machine) already parse two-envelope transcripts. Changing the persisted format is a SemVer-breaking move.
3. **Opt-in semantics**: the helper sits at the provider-adapter boundary where the consumer already owns format conversion. That's the natural seam.

## API

\`\`\`php
\$provider_messages = WP_Agent_Message::coalesce_consecutive_same_role( \$transcript );
\$response          = \$anthropic_client->prompt( \$provider_messages );
\`\`\`

Behavior:

- Empty / role-alternating input → unchanged.
- Consecutive same-role envelopes → one \`TYPE_MULTIMODAL_PART\` whose \`payload.parts\` carries each original envelope verbatim. Per-part metadata (tool_call_id, parameters, turn, etc.) is preserved.
- Already-multipart input → parts flatten rather than nesting.
- Top-level \`content\` reduces to joined text content so logs/transcripts stay readable without provider-adapter introspection.
- Idempotent.

## Changes

- \`src/Runtime/class-wp-agent-message.php\` — new static helper + two small private helpers (\`extract_parts\`, \`join_text_content\`).
- \`tests/message-coalesce-smoke.php\` — 19 assertions covering empty / alternating / preamble+tool_call / multi-tool_call / already-multipart / role-boundary / idempotency cases.
- \`composer.json\` — include the new smoke in \`composer test\`.

## Test plan

- [x] \`php tests/message-coalesce-smoke.php\` — 19 assertions, all pass.
- [x] \`composer test\` — full suite green; existing tests untouched.

Closes #228.