### PR TITLE
Rename Composer package to wordpress/agents-api

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Install and activate the Agents API plugin through the normal WordPress plugin m
 Require the package from a host plugin, mu-plugin, or Composer-managed WordPress project:
 
 ```sh
-composer require automattic/agents-api:^0.1
+composer require wordpress/agents-api:^0.1
 ```
 
 Composer autoloads `agents-api.php` through the package `files` autoload entry. The consuming project must load Composer's generated `vendor/autoload.php` during WordPress bootstrap. After that, the same public API is available as in the plugin activation path.

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "automattic/agents-api",
+  "name": "wordpress/agents-api",
   "description": "WordPress-shaped agent runtime substrate.",
   "type": "wordpress-plugin",
   "license": "GPL-2.0-or-later",

--- a/docs/default-stores-companion.md
+++ b/docs/default-stores-companion.md
@@ -19,7 +19,7 @@ The companion package should require `agents-api`. `agents-api` must not require
 
 ## Proposed Package Shape
 
-Working package name: `automattic/agents-api-default-stores`.
+Working package name: `wordpress/agents-api-default-stores`.
 
 Working WordPress plugin slug: `agents-api-default-stores`.
 


### PR DESCRIPTION
## Summary

Renames the Composer package from \`automattic/agents-api\` to \`wordpress/agents-api\`, matching the precedent Abilities API set (\`wordpress/abilities-api\`).

## Why

Decision recorded in #93:
- Two independent votes for Composer over subtree (@bradvin from ClawPress integration experience; the WPCOM POC moved off the sibling-plugin path for the same reasons).
- \`wordpress/*\` namespace mirrors Abilities API (\`wordpress/abilities-api\`) — same package family, same install ergonomics. Diverging into \`automattic/*\` for the substrate when the closest sibling lives at \`wordpress/*\` reads as a positioning regression.

## Changes

- \`composer.json\` \`name\` → \`wordpress/agents-api\`
- \`README.md\` install recipe → \`composer require wordpress/agents-api\`
- \`docs/default-stores-companion.md\` proposed companion name → \`wordpress/agents-api-default-stores\` for namespace consistency

## What's still outstanding

Packagist publication itself needs WordPress org access we don't have directly. Pinging @gziolo on #93 for the next step — he opened [WordPress/abilities-api#35](https://github.com/WordPress/abilities-api/pull/35) and [#48](https://github.com/WordPress/abilities-api/pull/48) for Abilities API packaging, so he's the natural coordinator for the same path here.

## Test plan

- [x] \`composer test\` — full suite green; rename is metadata-only, no code paths touched.

Part of #93.