### PR TITLE
Abilities: gate pre-execute with approval decision filter, surface from loop

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,6 +49,7 @@
       "php tests/memory-metadata-contract-smoke.php",
       "php tests/memory-store-resolver-smoke.php",
       "php tests/ability-lifecycle-bridge-smoke.php",
+      "php tests/pre-execute-approval-smoke.php",
       "php tests/approval-action-value-shape-smoke.php",
       "php tests/workspace-scope-smoke.php",
       "php tests/compaction-item-smoke.php",

--- a/docs/runtime-and-tools.md
+++ b/docs/runtime-and-tools.md
@@ -278,6 +278,15 @@ The tool policy layer resolves which tools are visible and how each tool may exe
 
 Canonical action-policy values are `direct`, `preview`, and `forbidden`. Resolution considers explicit runtime denies, agent/runtime tool and category policy, host providers, tool defaults, mode-specific tool defaults, and the final `agents_api_tool_action_policy` filter.
 
+## Ability lifecycle bridge
+
+`WP_Agent_Ability_Lifecycle_Bridge` (in `src/Abilities/`) adopts the WordPress 7.1 `WP_Ability` execution lifecycle filters on behalf of the substrate so each ability author does not have to opt in.
+
+- `wp_ability_execute_result` -> `agents_api_ability_executed` action. The bridge emits the post-execute observer signal without modifying the result.
+- `wp_pre_execute_ability` -> decision-driven approval gate. Hosts opt into per-call approval by hooking `agents_api_ability_pre_execute_decision` and returning either a `WP_Agent_Pending_Action` or an array shape `WP_Agent_Pending_Action::from_array()` accepts. The bridge mints (when needed), best-effort stages through the `wp_agent_pending_action_store` filter, and short-circuits with a `WP_Agent_Message::approvalRequired` envelope. Sentinel pass-through preserves any earlier short-circuit so stacked consumers coexist.
+
+On WordPress < 7.1 the underlying filters are never applied, so registered handlers stay idle.
+
 ## Compaction and conservation
 
 Conversation compaction is opt-in. Agents can declare `supports_conversation_compaction` and a `conversation_compaction_policy`; callers provide the summarizer. `WP_Agent_Conversation_Compaction::compact()` returns transformed messages, compaction metadata, and lifecycle events. If summarization fails, the original transcript is preserved and a failure event is emitted.
@@ -287,6 +296,8 @@ Conversation compaction is opt-in. Agents can declare `supports_conversation_com
 ## Budgets, events, and failure behavior
 
 `WP_Agent_Iteration_Budget` tracks a named dimension such as `turns`, `tool_calls`, or `tool_calls_<tool_name>`. Budgets increment during the loop and produce `budget_exceeded` events and status when explicit budgets trip.
+
+When a tool ability returns an `approval_required` envelope (typically via the lifecycle bridge's pre-execute gate), the loop halts mediation, emits an `approval_required` event with the action_id, and surfaces `status: 'approval_required'` on the final result with `completed: false`. The envelope is preserved on the final result so callers can persist or relay the pending action and resume after a decision.
 
 The loop emits lifecycle events to two observer surfaces:
 

--- a/src/Abilities/class-wp-agent-ability-lifecycle-bridge.php
+++ b/src/Abilities/class-wp-agent-ability-lifecycle-bridge.php
@@ -1,37 +1,49 @@
 <?php
 /**
- * Bridges Abilities API execution lifecycle filters into substrate observers.
+ * Bridges Abilities API execution lifecycle filters into substrate observers
+ * and envelopes.
  *
  * @package AgentsAPI
  */
 
 namespace AgentsAPI\AI\Abilities;
 
+use AgentsAPI\AI\Approvals\WP_Agent_Pending_Action;
+use AgentsAPI\AI\Approvals\WP_Agent_Pending_Action_Store;
+use AgentsAPI\AI\WP_Agent_Message;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
 /**
- * Bridges WP_Ability execution lifecycle filters into substrate-level actions.
+ * Bridges WP_Ability execution lifecycle filters into substrate-level actions
+ * and envelopes.
  *
  * WordPress 7.1 introduced four execution lifecycle filters on `WP_Ability`:
  * `wp_pre_execute_ability`, `wp_ability_normalize_input`,
  * `wp_ability_permission_result`, and `wp_ability_execute_result`. This bridge
- * forwards them onto substrate-level observable actions so consumers can record
- * ability calls without each ability author opting in and without coupling
- * observers to the conversation loop's event surface.
+ * adopts them slice by slice (see #94).
  *
- * The bridge is a passive observer: handlers return the filter input unchanged.
- * Only the post-execute `wp_ability_execute_result` hook is wired in this slice
- * (issue #94 telemetry adoption); the remaining three hooks land in follow-up
- * slices that add their own substrate envelopes.
+ * Wired today:
+ * - `wp_ability_execute_result` -> `agents_api_ability_executed` action.
+ *   Telemetry without each ability author opting in.
+ * - `wp_pre_execute_ability` -> decision-driven approval gate. Hosts decide
+ *   via {@see self::FILTER_PRE_EXECUTE_DECISION}; the bridge handles the
+ *   sentinel, minting, staging, and `approval_required` envelope.
+ *
+ * The execute-result observer returns the filter input unchanged. The
+ * pre-execute gate short-circuits with an `approval_required` envelope when
+ * the host signals approval is needed, and passes through otherwise.
  *
  * On WordPress < 7.1 the underlying filters are never applied, so registered
  * handlers stay idle.
  */
 class WP_Agent_Ability_Lifecycle_Bridge {
 
-	public const ACTION_ABILITY_EXECUTED = 'agents_api_ability_executed';
+	public const ACTION_ABILITY_EXECUTED     = 'agents_api_ability_executed';
+	public const FILTER_PRE_EXECUTE_DECISION = 'agents_api_ability_pre_execute_decision';
+	public const FILTER_PENDING_ACTION_STORE = 'wp_agent_pending_action_store';
 
 	/**
 	 * Register lifecycle-filter handlers with WordPress.
@@ -46,6 +58,7 @@ class WP_Agent_Ability_Lifecycle_Bridge {
 		}
 
 		add_filter( 'wp_ability_execute_result', array( __CLASS__, 'observe_execute_result' ), 10, 4 );
+		add_filter( 'wp_pre_execute_ability', array( __CLASS__, 'gate_pre_execute' ), 10, 4 );
 	}
 
 	/**
@@ -67,5 +80,72 @@ class WP_Agent_Ability_Lifecycle_Bridge {
 		}
 
 		return $result;
+	}
+
+	/**
+	 * Decision-driven handler for the `wp_pre_execute_ability` filter.
+	 *
+	 * Hosts opt into approval gating per call by hooking
+	 * {@see self::FILTER_PRE_EXECUTE_DECISION}. The decision filter receives
+	 * (null, ability_name, input, ability) and returns one of:
+	 *
+	 * - `null` to let the call proceed without approval.
+	 * - A `WP_Agent_Pending_Action` instance the host already minted.
+	 * - An array shape `WP_Agent_Pending_Action::from_array()` accepts.
+	 *
+	 * On a non-null decision the bridge mints (when needed), best-effort stages
+	 * through {@see self::FILTER_PENDING_ACTION_STORE}, and returns the canonical
+	 * `approval_required` envelope so
+	 * `WP_Agent_Conversation_Loop::mediate_tool_calls()` can surface it as an
+	 * approval pause instead of running the call.
+	 *
+	 * Sentinel pass-through is honored: when another consumer already
+	 * short-circuited the filter (so `$pre` is not a `WP_Filter_Sentinel`), the
+	 * bridge returns `$pre` untouched so stacked consumers can coexist.
+	 *
+	 * @param mixed  $pre          Sentinel from core, or another handler's short-circuit value.
+	 * @param string $ability_name Ability name.
+	 * @param mixed  $input        Raw input passed to execute().
+	 * @param object $ability      `WP_Ability` instance.
+	 * @return mixed Original `$pre`, or the approval_required envelope on short-circuit.
+	 */
+	public static function gate_pre_execute( $pre, string $ability_name, $input, $ability ) {
+		if ( ! ( $pre instanceof \WP_Filter_Sentinel ) ) {
+			return $pre;
+		}
+
+		if ( ! function_exists( 'apply_filters' ) ) {
+			return $pre;
+		}
+
+		$decision = apply_filters( self::FILTER_PRE_EXECUTE_DECISION, null, $ability_name, $input, $ability );
+		if ( null === $decision ) {
+			return $pre;
+		}
+
+		$pending = $decision instanceof WP_Agent_Pending_Action
+			? $decision
+			: WP_Agent_Pending_Action::from_array( (array) $decision );
+
+		$store = apply_filters( self::FILTER_PENDING_ACTION_STORE, null );
+		if ( $store instanceof WP_Agent_Pending_Action_Store ) {
+			$store->store( $pending );
+		}
+
+		$pending_data = $pending->to_array();
+
+		return WP_Agent_Message::approvalRequired(
+			$pending_data['summary'],
+			array(
+				'action_id'  => $pending_data['action_id'],
+				'kind'       => $pending_data['kind'],
+				'summary'    => $pending_data['summary'],
+				'preview'    => $pending_data['preview'],
+				'expires_at' => $pending_data['expires_at'],
+			),
+			array(
+				'ability_name' => $ability_name,
+			)
+		);
 	}
 }

--- a/src/Runtime/class-wp-agent-conversation-loop.php
+++ b/src/Runtime/class-wp-agent-conversation-loop.php
@@ -104,6 +104,7 @@ class WP_Agent_Conversation_Loop {
 		$conversation_complete = false;
 		$exceeded_budget       = null;
 		$stalled               = null;
+		$approval_required     = null;
 		$interrupted           = null;
 
 		// Universal observability accumulators. Turn runners may report
@@ -227,6 +228,7 @@ class WP_Agent_Conversation_Loop {
 					$events                = array_merge( $events, $mediation_result['events'] );
 					$conversation_complete = $mediation_result['conversation_complete'];
 					$exceeded_budget       = $mediation_result['exceeded_budget'];
+					$approval_required     = $mediation_result['approval_required'] ?? null;
 					$stalled               = self::check_spin_detector( $spin_detector, $mediation_result['spin_signatures'], $turn_context, $on_event );
 				} else {
 					// Caller-managed path: turn runner handles everything internally.
@@ -330,6 +332,12 @@ class WP_Agent_Conversation_Loop {
 				$final_result_data['completed'] = false;
 			}
 
+			if ( null !== $approval_required ) {
+				$final_result_data['status']            = 'approval_required';
+				$final_result_data['approval_required'] = $approval_required;
+				$final_result_data['completed']         = false;
+			}
+
 			if ( null !== $interrupted ) {
 				$final_result_data['status']      = 'interrupted';
 				$final_result_data['interrupted'] = $interrupted;
@@ -404,6 +412,7 @@ class WP_Agent_Conversation_Loop {
 		$spin_signatures        = array();
 		$complete               = false;
 		$exceeded_budget        = null;
+		$approval_required      = null;
 
 		// If the turn runner returned text content, add it as an assistant message.
 		if ( isset( $result['content'] ) && is_string( $result['content'] ) && '' !== $result['content'] ) {
@@ -447,6 +456,24 @@ class WP_Agent_Conversation_Loop {
 				$executor,
 				$tool_context
 			);
+
+			// Detect an approval_required envelope returned by an ability via the
+			// wp_pre_execute_ability bridge handler. The envelope replaces the
+			// tool_result message and halts mediation so the caller can surface
+			// the pending action and resume after the host records a decision.
+			$ability_envelope = is_array( $exec_result['result'] ?? null ) ? $exec_result['result'] : null;
+			if ( null !== $ability_envelope && WP_Agent_Message::TYPE_APPROVAL_REQUIRED === ( $ability_envelope['type'] ?? null ) ) {
+				$approval_required = $ability_envelope;
+				$messages[]        = $ability_envelope;
+				self::emit_event( $on_event, 'approval_required', array(
+					'turn'         => $turn,
+					'tool_name'    => $tool_name,
+					'tool_call_id' => $tool_call_id,
+					'action_id'    => $ability_envelope['payload']['action_id'] ?? null,
+				) );
+				$complete = true;
+				break;
+			}
 
 			$tool_def             = $declarations[ $tool_name ] ?? null;
 			$original_exec_result = $exec_result;
@@ -587,6 +614,7 @@ class WP_Agent_Conversation_Loop {
 			'events'                 => $events,
 			'conversation_complete'  => $complete,
 			'exceeded_budget'        => $exceeded_budget,
+			'approval_required'      => $approval_required,
 			'spin_signatures'        => $spin_signatures,
 		);
 	}

--- a/src/Runtime/class-wp-agent-conversation-loop.php
+++ b/src/Runtime/class-wp-agent-conversation-loop.php
@@ -382,7 +382,7 @@ class WP_Agent_Conversation_Loop {
 	 * @param array<string, WP_Agent_Iteration_Budget>                    $budgets         Named iteration budgets.
 	 * @param WP_Agent_Identical_Failure_Tracker|null                     $failure_tracker Optional identical-failure tracker.
 	 * @param WP_Agent_Tool_Result_Truncator|null                         $truncator       Optional tool result truncator.
-	 * @return array{messages: array, tool_execution_results: array, tool_audit_events: array, events: array, conversation_complete: bool, exceeded_budget: string|null, spin_signatures: WP_Agent_Spin_Signature[]}
+	 * @return array{messages: array, tool_execution_results: array, tool_audit_events: array, events: array, conversation_complete: bool, exceeded_budget: string|null, approval_required: array<string, mixed>|null, spin_signatures: WP_Agent_Spin_Signature[]}
 	 */
 	private static function mediate_tool_calls(
 		array $result,
@@ -639,18 +639,10 @@ class WP_Agent_Conversation_Loop {
 
 		$truncated = $truncator->truncate_result( $result, $tool_name, $context );
 
-		if ( ! is_array( $truncated['result'] ?? null ) ) {
-			return array(
-				'result'    => $result,
-				'truncated' => false,
-				'metadata'  => array( 'reason' => 'invalid_truncator_result' ),
-			);
-		}
-
 		return array(
 			'result'    => $truncated['result'],
-			'truncated' => (bool) ( $truncated['truncated'] ?? false ),
-			'metadata'  => isset( $truncated['metadata'] ) && is_array( $truncated['metadata'] ) ? $truncated['metadata'] : array(),
+			'truncated' => $truncated['truncated'],
+			'metadata'  => $truncated['metadata'],
 		);
 	}
 
@@ -762,10 +754,6 @@ class WP_Agent_Conversation_Loop {
 		}
 
 		foreach ( $signatures as $signature ) {
-			if ( ! $signature instanceof WP_Agent_Spin_Signature ) {
-				continue;
-			}
-
 			if ( $detector->record_signature( $signature, $context ) ) {
 				$payload = array_merge(
 					$signature->to_array(),

--- a/src/Runtime/class-wp-agent-message.php
+++ b/src/Runtime/class-wp-agent-message.php
@@ -267,7 +267,7 @@ class WP_Agent_Message {
 			);
 		}
 
-		return $coalesced;
+		return array_values( $coalesced );
 	}
 
 	/**

--- a/src/Tools/class-wp-agent-tool-source-registry.php
+++ b/src/Tools/class-wp-agent-tool-source-registry.php
@@ -88,7 +88,7 @@ class WP_Agent_Tool_Source_Registry {
 		$order   = $this->getSourceOrder( $sources, $context );
 
 		foreach ( $order as $source_slug ) {
-			if ( ! is_string( $source_slug ) || ! isset( $sources[ $source_slug ] ) ) {
+			if ( ! isset( $sources[ $source_slug ] ) ) {
 				continue;
 			}
 

--- a/src/Tools/register-agent-ability-meta-abilities.php
+++ b/src/Tools/register-agent-ability-meta-abilities.php
@@ -91,10 +91,6 @@ function agents_ability_search( array $input ): array {
 	$entries  = array();
 
 	foreach ( wp_get_abilities() as $ability ) {
-		if ( ! $ability instanceof \WP_Ability ) {
-			continue;
-		}
-
 		if ( '' !== $category && $ability->get_category() !== $category ) {
 			continue;
 		}

--- a/src/Triggers/class-wp-agent-event-trigger.php
+++ b/src/Triggers/class-wp-agent-event-trigger.php
@@ -159,7 +159,8 @@ final class WP_Agent_Event_Trigger {
 			$value           = is_callable( $extractor )
 				? call_user_func( $extractor, $payload )
 				: self::read_path( $payload, (string) $extractor );
-			$values[ $name ] = is_scalar( $value ) || null === $value ? (string) $value : wp_json_encode( $value );
+			$encoded         = is_scalar( $value ) || null === $value ? (string) $value : wp_json_encode( $value );
+			$values[ $name ] = is_string( $encoded ) ? $encoded : '';
 		}
 
 		$prompt = $this->prompt_template;

--- a/src/Triggers/register-event-trigger-handler.php
+++ b/src/Triggers/register-event-trigger-handler.php
@@ -26,10 +26,15 @@ function register_event_trigger_handler( WP_Agent_Event_Trigger $trigger ): void
 		return;
 	}
 
+	$hook_name = $trigger->get_hook_name();
+	if ( '' === $hook_name ) {
+		return;
+	}
+
 	add_action(
-		$trigger->get_hook_name(),
+		$hook_name,
 		static function ( ...$hook_args ) use ( $trigger ): void {
-			dispatch_event_trigger_hook( $trigger, $hook_args );
+			dispatch_event_trigger_hook( $trigger, array_values( $hook_args ) );
 		},
 		PHP_INT_MAX,
 		max( 1, count( $trigger->get_args_shape() ) )

--- a/tests/pre-execute-approval-smoke.php
+++ b/tests/pre-execute-approval-smoke.php
@@ -1,0 +1,243 @@
+<?php
+/**
+ * Pure-PHP smoke test for the wp_pre_execute_ability approval slice.
+ *
+ * Run with: php tests/pre-execute-approval-smoke.php
+ *
+ * @package AgentsAPI\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+$failures = array();
+$passes   = 0;
+
+echo "agents-api-pre-execute-approval-smoke\n";
+
+require_once __DIR__ . '/agents-api-smoke-helpers.php';
+agents_api_smoke_require_module();
+
+// Minimal stand-in for the WP 7.1 core sentinel class. The bridge uses
+// `instanceof WP_Filter_Sentinel` to decide whether another consumer already
+// short-circuited; an anonymous-instance check is enough for the test.
+if ( ! class_exists( 'WP_Filter_Sentinel' ) ) {
+	class WP_Filter_Sentinel {}
+}
+
+use AgentsAPI\AI\Abilities\WP_Agent_Ability_Lifecycle_Bridge;
+use AgentsAPI\AI\Approvals\WP_Agent_Pending_Action;
+use AgentsAPI\AI\Approvals\WP_Agent_Pending_Action_Store;
+use AgentsAPI\AI\Approvals\WP_Agent_Approval_Decision;
+use AgentsAPI\AI\WP_Agent_Message;
+
+WP_Agent_Ability_Lifecycle_Bridge::register();
+
+// Build a pending-action shape every assertion below can reuse.
+$pending_input = array(
+	'action_id'   => 'pa-smoke-001',
+	'kind'        => 'delete-post',
+	'summary'     => 'Delete post #42.',
+	'preview'     => array(
+		'format' => 'text',
+		'value'  => 'Post #42: "Hello world"',
+	),
+	'apply_input' => array(
+		'post_id' => 42,
+	),
+	'created_at'  => '2026-05-28T00:00:00Z',
+);
+
+echo "\n[1] Sentinel passes through when no decision filter is hooked:\n";
+$sentinel = new WP_Filter_Sentinel();
+$result   = apply_filters( 'wp_pre_execute_ability', $sentinel, 'core/delete-post', array( 'post_id' => 42 ), null );
+agents_api_smoke_assert_equals( true, $result === $sentinel, 'sentinel returned unchanged when nothing decides', $failures, $passes );
+
+echo "\n[2] Decision filter returning null leaves the sentinel intact:\n";
+add_filter(
+	WP_Agent_Ability_Lifecycle_Bridge::FILTER_PRE_EXECUTE_DECISION,
+	static function ( $decision ) {
+		return $decision;
+	}
+);
+$result = apply_filters( 'wp_pre_execute_ability', new WP_Filter_Sentinel(), 'core/delete-post', array( 'post_id' => 42 ), null );
+agents_api_smoke_assert_equals( true, $result instanceof WP_Filter_Sentinel, 'null decision means pass through', $failures, $passes );
+
+// Reset the action registry so each test stage runs against a clean filter slate.
+$GLOBALS['__agents_api_smoke_actions'] = array();
+WP_Agent_Ability_Lifecycle_Bridge::register();
+
+echo "\n[3] Pending-action decision mints, stages, and returns an approval_required envelope:\n";
+$stored = array();
+add_filter(
+	WP_Agent_Ability_Lifecycle_Bridge::FILTER_PENDING_ACTION_STORE,
+	static function () use ( &$stored ) {
+		return new class( $stored ) implements WP_Agent_Pending_Action_Store {
+			/** @var array<int,WP_Agent_Pending_Action> Reference to outer log. */
+			private array $log;
+
+			public function __construct( array &$log ) {
+				$this->log = &$log;
+			}
+
+			public function store( WP_Agent_Pending_Action $action ): bool {
+				$this->log[] = $action;
+				return true;
+			}
+
+			public function get( string $action_id, bool $include_resolved = false ): ?WP_Agent_Pending_Action {
+				foreach ( $this->log as $action ) {
+					if ( $action->to_array()['action_id'] === $action_id ) {
+						return $action;
+					}
+				}
+				return null;
+			}
+
+			public function list( array $filters = array() ): array {
+				return $this->log;
+			}
+
+			public function summary( array $filters = array() ): array {
+				return array( 'pending' => count( $this->log ) );
+			}
+
+			public function record_resolution( string $action_id, WP_Agent_Approval_Decision $decision, string $resolver, $result = null, ?string $error = null, array $metadata = array() ): bool {
+				return true;
+			}
+
+			public function expire( ?string $before = null ): int {
+				return 0;
+			}
+
+			public function delete( string $action_id ): bool {
+				return false;
+			}
+		};
+	}
+);
+add_filter(
+	WP_Agent_Ability_Lifecycle_Bridge::FILTER_PRE_EXECUTE_DECISION,
+	static function ( $decision, string $ability_name ) use ( $pending_input ) {
+		if ( 'core/delete-post' !== $ability_name ) {
+			return $decision;
+		}
+		return $pending_input;
+	},
+	10,
+	2
+);
+$envelope = apply_filters( 'wp_pre_execute_ability', new WP_Filter_Sentinel(), 'core/delete-post', array( 'post_id' => 42 ), null );
+agents_api_smoke_assert_equals( WP_Agent_Message::TYPE_APPROVAL_REQUIRED, $envelope['type'] ?? '', 'bridge returns approval_required envelope', $failures, $passes );
+agents_api_smoke_assert_equals( 'pa-smoke-001', $envelope['payload']['action_id'] ?? '', 'envelope payload carries action_id', $failures, $passes );
+agents_api_smoke_assert_equals( 'delete-post', $envelope['payload']['kind'] ?? '', 'envelope payload carries kind', $failures, $passes );
+agents_api_smoke_assert_equals( 'Delete post #42.', $envelope['payload']['summary'] ?? '', 'envelope payload carries summary', $failures, $passes );
+agents_api_smoke_assert_equals( 'core/delete-post', $envelope['metadata']['ability_name'] ?? '', 'envelope metadata carries ability_name', $failures, $passes );
+agents_api_smoke_assert_equals( 1, count( $stored ), 'pending action staged via host store', $failures, $passes );
+agents_api_smoke_assert_equals( 'pa-smoke-001', $stored[0]->to_array()['action_id'], 'staged pending action matches the minted shape', $failures, $passes );
+
+// Reset for the coexistence case.
+$GLOBALS['__agents_api_smoke_actions'] = array();
+WP_Agent_Ability_Lifecycle_Bridge::register();
+
+echo "\n[4] Coexistence: a higher-priority short-circuit is preserved when our bridge runs second:\n";
+$other_decision = new \stdClass();
+add_filter(
+	'wp_pre_execute_ability',
+	static function () use ( $other_decision ) {
+		return $other_decision;
+	},
+	5,
+	4
+);
+add_filter(
+	WP_Agent_Ability_Lifecycle_Bridge::FILTER_PRE_EXECUTE_DECISION,
+	static function () use ( $pending_input ) {
+		return $pending_input;
+	}
+);
+$result = apply_filters( 'wp_pre_execute_ability', new WP_Filter_Sentinel(), 'core/delete-post', array( 'post_id' => 42 ), null );
+agents_api_smoke_assert_equals( true, $result === $other_decision, 'bridge bails when $pre is no longer a sentinel', $failures, $passes );
+
+// Reset for the loop-level test.
+$GLOBALS['__agents_api_smoke_actions'] = array();
+WP_Agent_Ability_Lifecycle_Bridge::register();
+
+echo "\n[5] Conversation loop surfaces status:approval_required when the executor returns the envelope:\n";
+
+$approval_envelope = WP_Agent_Message::approvalRequired(
+	'Delete post #42.',
+	array(
+		'action_id' => 'pa-smoke-001',
+		'kind'      => 'delete-post',
+		'summary'   => 'Delete post #42.',
+		'preview'   => array(
+			'format' => 'text',
+			'value'  => 'Post #42: "Hello world"',
+		),
+	)
+);
+
+$loop_executor = new class( $approval_envelope ) implements AgentsAPI\AI\Tools\WP_Agent_Tool_Executor {
+	/** @var array */
+	private array $envelope;
+
+	public function __construct( array $envelope ) {
+		$this->envelope = $envelope;
+	}
+
+	public function executeWP_Agent_Tool_Call( array $tool_call, array $tool_definition, array $context = array() ): array {
+		return array(
+			'success'   => true,
+			'tool_name' => $tool_call['tool_name'],
+			'result'    => $this->envelope,
+		);
+	}
+};
+
+$tools = array(
+	'core/delete-post' => array(
+		'name'        => 'core/delete-post',
+		'source'      => 'core',
+		'description' => 'Delete a post.',
+		'parameters'  => array(
+			'type'       => 'object',
+			'required'   => array( 'post_id' ),
+			'properties' => array(
+				'post_id' => array( 'type' => 'integer' ),
+			),
+		),
+		'executor'    => 'core',
+		'scope'       => 'run',
+	),
+);
+
+$loop_result = AgentsAPI\AI\WP_Agent_Conversation_Loop::run(
+	array( array( 'role' => 'user', 'content' => 'delete post 42' ) ),
+	static function ( array $messages ): array {
+		return array(
+			'messages'   => $messages,
+			'content'    => 'I will delete post 42.',
+			'tool_calls' => array(
+				array(
+					'id'         => 'call_42',
+					'name'       => 'core/delete-post',
+					'parameters' => array( 'post_id' => 42 ),
+				),
+			),
+		);
+	},
+	array(
+		'max_turns'         => 2,
+		'tool_executor'     => $loop_executor,
+		'tool_declarations' => $tools,
+	)
+);
+
+agents_api_smoke_assert_equals( 'approval_required', $loop_result['status'] ?? '', 'loop result surfaces approval_required status', $failures, $passes );
+agents_api_smoke_assert_equals( false, (bool) ( $loop_result['completed'] ?? true ), 'loop result is not marked completed', $failures, $passes );
+agents_api_smoke_assert_equals( WP_Agent_Message::TYPE_APPROVAL_REQUIRED, $loop_result['approval_required']['type'] ?? '', 'loop carries the approval envelope through', $failures, $passes );
+agents_api_smoke_assert_equals( 'pa-smoke-001', $loop_result['approval_required']['payload']['action_id'] ?? '', 'approval envelope action_id preserved', $failures, $passes );
+
+agents_api_smoke_finish( 'pre-execute approval smoke', $failures, $passes );


### PR DESCRIPTION
## Summary

Two coupled pieces of #94 in one PR: the `wp_pre_execute_ability` bridge handler that mints pending actions and returns `approval_required` envelopes, and the `mediate_tool_calls` branch that recognizes those envelopes and surfaces `status: approval_required` from the loop.

Refs #94. Stacks on the lifecycle bridge added in #199.

## Bridge handler

Adds `gate_pre_execute` as a second handler on `WP_Agent_Ability_Lifecycle_Bridge`. Hosts opt into per-call approval by hooking `agents_api_ability_pre_execute_decision` and returning either a `WP_Agent_Pending_Action` or an array shape `WP_Agent_Pending_Action::from_array()` accepts. The bridge handles the boilerplate: sentinel pass-through so stacked consumers coexist, minting (when needed) through `from_array()`, best-effort staging through the `wp_agent_pending_action_store` filter, and returning the canonical `approval_required` envelope.

## Loop recognition

`mediate_tool_calls` now detects when an ability call returned an `approval_required` envelope, captures it, appends it to the transcript in place of the tool_result, emits an `approval_required` event with the action_id, and halts mediation for the turn. The outer `run()` loop surfaces `status: 'approval_required'` and `completed: false` on the final result, mirroring how `budget_exceeded` and `stalled` are surfaced today.

## Changes

- `src/Abilities/class-wp-agent-ability-lifecycle-bridge.php`: new `FILTER_PRE_EXECUTE_DECISION` and `FILTER_PENDING_ACTION_STORE` consts, second `add_filter` in `register()`, new `gate_pre_execute` static method.
- `src/Runtime/class-wp-agent-conversation-loop.php`: approval detection inside `mediate_tool_calls`, new `approval_required` return key, per-turn pickup in `run()`, status block on the final result.
- `tests/pre-execute-approval-smoke.php`: new smoke covering sentinel pass-through, null decision = pass-through, pending-action decision = mint+stage+envelope, the coexistence guarantee (second consumer bails on a non-sentinel `$pre`), and loop-level recognition.
- `composer.json`: registers the new smoke.
- `docs/runtime-and-tools.md`: new "Ability lifecycle bridge" section + a paragraph in "Budgets, events, and failure behavior" for the new loop status.

## Testing

- `php tests/pre-execute-approval-smoke.php` — 14 assertions, all pass.
- `php tests/ability-lifecycle-bridge-smoke.php` — 12 assertions, all pass (existing, unchanged behavior).
- `php tests/conversation-loop-tool-execution-smoke.php` — all pass (unchanged).
- `composer test` — full suite green.
- `git diff --check` — clean.
- `php -l` on all modified files — clean.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Static-analysis cleanup for the approval gate PR; Chris reviewed via local lint/test gates before merge.