### PR TITLE
Provide default chat run control

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ wp_register_agent(
 - `AgentsAPI\AI\Tools\WP_Agent_Tool_Execution_Core`
 - `AgentsAPI\AI\Tools\WP_Agent_Tool_Result`
 - `agents/ability-search` / `agents/ability-call`
-- `agents/chat` / `agents/chat-run-control-capabilities` / `agents/get-chat-run` / `agents/cancel-chat-run` / `agents/queue-chat-message`
+- `agents/chat` / `agents/get-chat-run` / `agents/cancel-chat-run` / `agents/queue-chat-message`
 - `AgentsAPI\AI\Approvals\WP_Agent_Approval_Decision`
 - `AgentsAPI\AI\Approvals\WP_Agent_Pending_Action`
 - `AgentsAPI\AI\Approvals\WP_Agent_Pending_Action_Status`

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ wp_register_agent(
 - `AgentsAPI\AI\Tools\WP_Agent_Tool_Execution_Core`
 - `AgentsAPI\AI\Tools\WP_Agent_Tool_Result`
 - `agents/ability-search` / `agents/ability-call`
-- `agents/chat` / `agents/get-chat-run` / `agents/cancel-chat-run` / `agents/queue-chat-message`
+- `agents/chat` / `agents/chat-run-control-capabilities` / `agents/get-chat-run` / `agents/cancel-chat-run` / `agents/queue-chat-message`
 - `AgentsAPI\AI\Approvals\WP_Agent_Approval_Decision`
 - `AgentsAPI\AI\Approvals\WP_Agent_Pending_Action`
 - `AgentsAPI\AI\Approvals\WP_Agent_Pending_Action_Status`

--- a/docs/channels-workflows-operations.md
+++ b/docs/channels-workflows-operations.md
@@ -70,9 +70,12 @@ Agents API owns the generic run-control ability contracts while runtimes own con
 
 | Ability | Purpose | Runtime hook |
 | --- | --- | --- |
+| `agents/chat-run-control-capabilities` | Report whether the selected agent/runtime supports status, cancel, and queue controls. | Probes all run-control hooks |
 | `agents/get-chat-run` | Return status for a known chat run. | `wp_agent_chat_run_status_handler` |
 | `agents/cancel-chat-run` | Request best-effort cancellation for a known chat run. | `wp_agent_chat_run_cancel_handler` |
 | `agents/queue-chat-message` | Accept a next user message while a session has an active run. | `wp_agent_chat_message_queue_handler` |
+
+Capability detection is contextual. The run-control abilities are registered globally, while each runtime decides what a selected agent can actually honor. Adapters should call `agents/chat-run-control-capabilities` with the selected `agent` before exposing Stop or Queue UI.
 
 Run status vocabulary is bounded to `queued`, `running`, `cancelling`, `cancelled`, `completed`, and `failed`. The canonical run payload is:
 

--- a/docs/channels-workflows-operations.md
+++ b/docs/channels-workflows-operations.md
@@ -66,16 +66,15 @@ The channel can consume either a single `reply` or assistant `messages` from the
 
 ## Chat run control
 
-Agents API owns the generic run-control ability contracts while runtimes own concrete storage, workers, provider aborts, and queue draining.
+Agents API owns the generic run-control ability contracts and default run-control storage. Every `agents/chat` run receives a `run_id`, stores status when a session is known, accepts best-effort cancellation, and accepts queued follow-up messages. Runtimes may override the hooks below only when they can provide stronger behavior such as immediate provider aborts or a custom queue worker.
 
 | Ability | Purpose | Runtime hook |
 | --- | --- | --- |
-| `agents/chat-run-control-capabilities` | Report whether the selected agent/runtime supports status, cancel, and queue controls. | Probes all run-control hooks |
 | `agents/get-chat-run` | Return status for a known chat run. | `wp_agent_chat_run_status_handler` |
 | `agents/cancel-chat-run` | Request best-effort cancellation for a known chat run. | `wp_agent_chat_run_cancel_handler` |
 | `agents/queue-chat-message` | Accept a next user message while a session has an active run. | `wp_agent_chat_message_queue_handler` |
 
-Capability detection is contextual. The run-control abilities are registered globally, while each runtime decides what a selected agent can actually honor. Adapters should call `agents/chat-run-control-capabilities` with the selected `agent` before exposing Stop or Queue UI.
+Clients can expose status, Stop, and Queue controls whenever these canonical abilities are available and the caller has permission for the selected agent. The default handlers preserve safe behavior for synchronous runtimes; runtime-specific handlers are enhancements, not prerequisites.
 
 Run status vocabulary is bounded to `queued`, `running`, `cancelling`, `cancelled`, `completed`, and `failed`. The canonical run payload is:
 

--- a/src/Channels/register-agents-chat-ability.php
+++ b/src/Channels/register-agents-chat-ability.php
@@ -143,9 +143,19 @@ function agents_chat_dispatch( array $input ) {
 		);
 	}
 
+	$run_id     = (string) $input['run_id'];
+	$session_id = trim( (string) ( $input['session_id'] ?? '' ) );
+	if ( '' !== $session_id ) {
+		WP_Agent_Chat_Run_Control::start_run( $run_id, $session_id, array( 'agent' => (string) ( $input['agent'] ?? '' ) ) );
+	}
+
 	$result = call_user_func( $handler, $input );
 
 	if ( is_wp_error( $result ) ) {
+		if ( '' !== $session_id ) {
+			WP_Agent_Chat_Run_Control::finish_run( $run_id, WP_Agent_Chat_Run_Control::STATUS_FAILED );
+		}
+
 		/** This action is documented above. */
 		do_action( 'agents_chat_dispatch_failed', $result->get_error_code(), $input );
 
@@ -153,6 +163,10 @@ function agents_chat_dispatch( array $input ) {
 	}
 
 	if ( ! is_array( $result ) ) {
+		if ( '' !== $session_id ) {
+			WP_Agent_Chat_Run_Control::finish_run( $run_id, WP_Agent_Chat_Run_Control::STATUS_FAILED );
+		}
+
 		/** This action is documented above. */
 		do_action( 'agents_chat_dispatch_failed', 'invalid_result', $input );
 
@@ -164,6 +178,18 @@ function agents_chat_dispatch( array $input ) {
 
 	if ( ! isset( $result['run_id'] ) || '' === trim( (string) $result['run_id'] ) ) {
 		$result['run_id'] = $input['run_id'];
+	}
+
+	$resolved_session_id = trim( (string) ( $result['session_id'] ?? $session_id ) );
+	if ( '' !== $resolved_session_id ) {
+		if ( '' === $session_id ) {
+			WP_Agent_Chat_Run_Control::start_run( (string) $result['run_id'], $resolved_session_id, array( 'agent' => (string) ( $input['agent'] ?? '' ) ) );
+		}
+
+		$status = ! empty( $result['completed'] ) || ! array_key_exists( 'completed', $result )
+			? WP_Agent_Chat_Run_Control::STATUS_COMPLETED
+			: WP_Agent_Chat_Run_Control::STATUS_RUNNING;
+		WP_Agent_Chat_Run_Control::finish_run( (string) $result['run_id'], $status );
 	}
 
 	return $result;
@@ -339,7 +365,7 @@ function agents_chat_output_schema(): array {
 			),
 			'run_id'     => array(
 				'type'        => 'string',
-				'description' => 'Opaque ID for this accepted chat turn. Use with agents/get-chat-run, agents/cancel-chat-run, and agents/queue-chat-message when the runtime supports run control.',
+				'description' => 'Opaque ID for this accepted chat turn. Use with agents/get-chat-run, agents/cancel-chat-run, and agents/queue-chat-message for generic run control.',
 			),
 			'messages'   => array(
 				'type'        => 'array',

--- a/src/Channels/register-agents-chat-ability.php
+++ b/src/Channels/register-agents-chat-ability.php
@@ -43,6 +43,10 @@ use AgentsAPI\AI\WP_Agent_Chat_Run_Control;
 
 defined( 'ABSPATH' ) || exit;
 
+if ( ! class_exists( WP_Agent_Chat_Run_Control::class ) ) {
+	require_once dirname( __DIR__ ) . '/Runtime/class-wp-agent-chat-run-control.php';
+}
+
 /**
  * The slug under which this ability is registered. Stable. Consumers and
 	 * channels should target this string rather than a runtime-specific slug.

--- a/src/Channels/register-agents-chat-run-control-abilities.php
+++ b/src/Channels/register-agents-chat-run-control-abilities.php
@@ -11,23 +11,14 @@ use AgentsAPI\AI\WP_Agent_Chat_Run_Control;
 
 defined( 'ABSPATH' ) || exit;
 
-const AGENTS_GET_CHAT_RUN_ABILITY                  = 'agents/get-chat-run';
-const AGENTS_CANCEL_CHAT_RUN_ABILITY               = 'agents/cancel-chat-run';
-const AGENTS_QUEUE_CHAT_MESSAGE_ABILITY            = 'agents/queue-chat-message';
-const AGENTS_CHAT_RUN_CONTROL_CAPABILITIES_ABILITY = 'agents/chat-run-control-capabilities';
+const AGENTS_GET_CHAT_RUN_ABILITY       = 'agents/get-chat-run';
+const AGENTS_CANCEL_CHAT_RUN_ABILITY    = 'agents/cancel-chat-run';
+const AGENTS_QUEUE_CHAT_MESSAGE_ABILITY = 'agents/queue-chat-message';
 
 add_action(
 	'wp_abilities_api_init',
 	static function (): void {
 		$abilities = array(
-			AGENTS_CHAT_RUN_CONTROL_CAPABILITIES_ABILITY => array(
-				'label'            => 'Get Chat Run-Control Capabilities',
-				'description'      => 'Detect run-control support for a selected agent and runtime.',
-				'input_schema'     => agents_chat_run_control_capabilities_input_schema(),
-				'output_schema'    => agents_chat_run_control_capabilities_output_schema(),
-				'execute_callback' => __NAMESPACE__ . '\agents_chat_run_control_capabilities',
-				'annotations'      => array( 'idempotent' => true ),
-			),
 			AGENTS_GET_CHAT_RUN_ABILITY       => array(
 				'label'            => 'Get Chat Run',
 				'description'      => 'Read the canonical status for an addressable chat run.',
@@ -85,83 +76,40 @@ add_action(
 	}
 );
 
-/**
- * Detect contextual chat run-control support for the selected runtime.
- *
- * The canonical run-control abilities are registered globally, but support is
- * runtime and agent specific. This probe lets adapters ask Agents API whether
- * a selected agent can actually honor status, cancel, and queued-message
- * controls before exposing UI for them.
- *
- * @param array<string,mixed> $input Capability probe input.
- * @return array{chat_run_status:bool,chat_run_cancel:bool,chat_message_queue:bool}
- */
-function agents_chat_run_control_capabilities( array $input ): array {
-	return array(
-		'chat_run_status'   => agents_chat_run_control_capability_supported(
-			$input,
-			AGENTS_GET_CHAT_RUN_ABILITY,
-			'wp_agent_chat_run_status_handler'
-		),
-		'chat_run_cancel'   => agents_chat_run_control_capability_supported(
-			$input,
-			AGENTS_CANCEL_CHAT_RUN_ABILITY,
-			'wp_agent_chat_run_cancel_handler'
-		),
-		'chat_message_queue' => agents_chat_run_control_capability_supported(
-			$input,
-			AGENTS_QUEUE_CHAT_MESSAGE_ABILITY,
-			'wp_agent_chat_message_queue_handler'
-		),
-	);
-}
-
-/**
- * Check one run-control capability for ability, permission, and runtime handler.
- *
- * @param array<string,mixed> $input          Capability probe input.
- * @param string              $ability        Canonical run-control ability name.
- * @param string              $handler_filter Runtime handler filter name.
- * @return bool Whether the selected runtime supports the capability.
- */
-function agents_chat_run_control_capability_supported( array $input, string $ability, string $handler_filter ): bool {
-	$agent = sanitize_title( (string) ( $input['agent'] ?? '' ) );
-	if ( '' === $agent ) {
-		return false;
-	}
-
-	if ( function_exists( 'wp_has_ability' ) && ! wp_has_ability( $ability ) ) {
-		return false;
-	}
-
-	$probe_input          = $input;
-	$probe_input['agent'] = $agent;
-
-	if ( ! agents_chat_run_control_permission( $probe_input ) ) {
-		return false;
-	}
-
-	return is_callable( apply_filters( $handler_filter, null, $probe_input ) );
-}
-
 /** @return array<string,mixed>|\WP_Error */
 function agents_get_chat_run( array $input ) {
 	$handler = apply_filters( 'wp_agent_chat_run_status_handler', null, $input );
-	if ( ! is_callable( $handler ) ) {
-		return agents_chat_run_control_no_handler( 'agents_chat_run_status_unsupported', 'No chat run status handler is registered.' );
+	if ( is_callable( $handler ) ) {
+		return agents_chat_run_control_normalize_result( call_user_func( $handler, $input ), 'agents_chat_run_invalid_status' );
 	}
 
-	return agents_chat_run_control_normalize_result( call_user_func( $handler, $input ), 'agents_chat_run_invalid_status' );
+	$run = WP_Agent_Chat_Run_Control::get_run( (string) ( $input['run_id'] ?? '' ) );
+	if ( $run && (string) $run['session_id'] !== (string) ( $input['session_id'] ?? '' ) ) {
+		return agents_chat_run_control_no_handler( 'agents_chat_run_not_found', 'No chat run was found for the requested session_id and run_id.' );
+	}
+	return $run ?: agents_chat_run_control_no_handler( 'agents_chat_run_not_found', 'No chat run was found for the requested run_id.' );
 }
 
 /** @return array<string,mixed>|\WP_Error */
 function agents_cancel_chat_run( array $input ) {
 	$handler = apply_filters( 'wp_agent_chat_run_cancel_handler', null, $input );
-	if ( ! is_callable( $handler ) ) {
-		return agents_chat_run_control_no_handler( 'agents_chat_run_cancel_unsupported', 'No chat run cancellation handler is registered.' );
+	if ( is_callable( $handler ) ) {
+		$result = agents_chat_run_control_normalize_result( call_user_func( $handler, $input ), 'agents_chat_run_invalid_cancel_result' );
+	} else {
+		$run = WP_Agent_Chat_Run_Control::get_run( (string) ( $input['run_id'] ?? '' ) );
+		if ( null === $run ) {
+			return agents_chat_run_control_no_handler( 'agents_chat_run_not_found', 'No chat run was found for the requested run_id.' );
+		}
+		if ( (string) $run['session_id'] !== (string) ( $input['session_id'] ?? '' ) ) {
+			return agents_chat_run_control_no_handler( 'agents_chat_run_not_found', 'No chat run was found for the requested session_id and run_id.' );
+		}
+
+		$result = WP_Agent_Chat_Run_Control::request_cancel( (string) ( $input['run_id'] ?? '' ) );
+		if ( null === $result ) {
+			return agents_chat_run_control_no_handler( 'agents_chat_run_not_found', 'No chat run was found for the requested run_id.' );
+		}
 	}
 
-	$result = agents_chat_run_control_normalize_result( call_user_func( $handler, $input ), 'agents_chat_run_invalid_cancel_result' );
 	if ( is_wp_error( $result ) ) {
 		return $result;
 	}
@@ -181,11 +129,16 @@ function agents_cancel_chat_run( array $input ) {
 /** @return array<string,mixed>|\WP_Error */
 function agents_queue_chat_message( array $input ) {
 	$handler = apply_filters( 'wp_agent_chat_message_queue_handler', null, $input );
-	if ( ! is_callable( $handler ) ) {
-		return agents_chat_run_control_no_handler( 'agents_chat_message_queue_unsupported', 'No chat message queue handler is registered.' );
+	if ( is_callable( $handler ) ) {
+		$result = agents_chat_run_control_normalize_result( call_user_func( $handler, $input ), 'agents_chat_message_queue_invalid_result' );
+	} else {
+		try {
+			$result = WP_Agent_Chat_Run_Control::queue_message( $input );
+		} catch ( \InvalidArgumentException $error ) {
+			return new \WP_Error( 'agents_chat_message_queue_invalid_result', $error->getMessage() );
+		}
 	}
 
-	$result = agents_chat_run_control_normalize_result( call_user_func( $handler, $input ), 'agents_chat_message_queue_invalid_result' );
 	if ( is_wp_error( $result ) ) {
 		return $result;
 	}
@@ -201,8 +154,35 @@ function agents_queue_chat_message( array $input ) {
 }
 
 function agents_chat_run_control_permission( array $input ): bool {
-	$allowed = function_exists( 'current_user_can' ) ? current_user_can( 'read' ) : false;
+	$agent = sanitize_title( (string) ( $input['agent'] ?? '' ) );
+	if ( '' !== $agent && class_exists( '\WP_Agent_Access' ) && class_exists( '\WP_Agent_Access_Grant' ) ) {
+		$allowed = \WP_Agent_Access::can_current_principal_access_agent(
+			$agent,
+			\WP_Agent_Access_Grant::ROLE_VIEWER,
+			agents_chat_run_control_request_scope( $input )
+		);
+	} else {
+		$allowed = function_exists( 'current_user_can' ) ? current_user_can( 'read' ) : false;
+	}
+
 	return (bool) apply_filters( 'agents_chat_run_control_permission', $allowed, $input );
+}
+
+/**
+ * Extract request-scope fields for run-control access checks.
+ *
+ * @param array<string,mixed> $input Ability input.
+ * @return array<string,mixed> Access request scope.
+ */
+function agents_chat_run_control_request_scope( array $input ): array {
+	$scope = array();
+	foreach ( array( 'workspace_id', 'workspace_type', 'request_context', 'client_id', 'audience_id' ) as $key ) {
+		if ( isset( $input[ $key ] ) && is_scalar( $input[ $key ] ) ) {
+			$scope[ $key ] = (string) $input[ $key ];
+		}
+	}
+
+	return $scope;
 }
 
 /** @return array<string,mixed>|\WP_Error */
@@ -234,32 +214,6 @@ function agents_chat_run_id_input_schema(): array {
 			'session_id'    => array( 'type' => 'string' ),
 			'run_id'        => array( 'type' => 'string' ),
 			'session_owner' => agents_chat_session_owner_schema(),
-		),
-	);
-}
-
-function agents_chat_run_control_capabilities_input_schema(): array {
-	return array(
-		'type'       => 'object',
-		'required'   => array( 'agent' ),
-		'properties' => array(
-			'agent'         => array(
-				'type'        => 'string',
-				'description' => 'Slug or ID of the selected agent/runtime to probe.',
-			),
-			'session_owner' => agents_chat_session_owner_schema(),
-		),
-	);
-}
-
-function agents_chat_run_control_capabilities_output_schema(): array {
-	return array(
-		'type'       => 'object',
-		'required'   => array( 'chat_run_status', 'chat_run_cancel', 'chat_message_queue' ),
-		'properties' => array(
-			'chat_run_status'    => array( 'type' => 'boolean' ),
-			'chat_run_cancel'    => array( 'type' => 'boolean' ),
-			'chat_message_queue' => array( 'type' => 'boolean' ),
 		),
 	);
 }

--- a/src/Channels/register-agents-chat-run-control-abilities.php
+++ b/src/Channels/register-agents-chat-run-control-abilities.php
@@ -11,14 +11,23 @@ use AgentsAPI\AI\WP_Agent_Chat_Run_Control;
 
 defined( 'ABSPATH' ) || exit;
 
-const AGENTS_GET_CHAT_RUN_ABILITY       = 'agents/get-chat-run';
-const AGENTS_CANCEL_CHAT_RUN_ABILITY    = 'agents/cancel-chat-run';
-const AGENTS_QUEUE_CHAT_MESSAGE_ABILITY = 'agents/queue-chat-message';
+const AGENTS_GET_CHAT_RUN_ABILITY                  = 'agents/get-chat-run';
+const AGENTS_CANCEL_CHAT_RUN_ABILITY               = 'agents/cancel-chat-run';
+const AGENTS_QUEUE_CHAT_MESSAGE_ABILITY            = 'agents/queue-chat-message';
+const AGENTS_CHAT_RUN_CONTROL_CAPABILITIES_ABILITY = 'agents/chat-run-control-capabilities';
 
 add_action(
 	'wp_abilities_api_init',
 	static function (): void {
 		$abilities = array(
+			AGENTS_CHAT_RUN_CONTROL_CAPABILITIES_ABILITY => array(
+				'label'            => 'Get Chat Run-Control Capabilities',
+				'description'      => 'Detect run-control support for a selected agent and runtime.',
+				'input_schema'     => agents_chat_run_control_capabilities_input_schema(),
+				'output_schema'    => agents_chat_run_control_capabilities_output_schema(),
+				'execute_callback' => __NAMESPACE__ . '\agents_chat_run_control_capabilities',
+				'annotations'      => array( 'idempotent' => true ),
+			),
 			AGENTS_GET_CHAT_RUN_ABILITY       => array(
 				'label'            => 'Get Chat Run',
 				'description'      => 'Read the canonical status for an addressable chat run.',
@@ -75,6 +84,65 @@ add_action(
 		}
 	}
 );
+
+/**
+ * Detect contextual chat run-control support for the selected runtime.
+ *
+ * The canonical run-control abilities are registered globally, but support is
+ * runtime and agent specific. This probe lets adapters ask Agents API whether
+ * a selected agent can actually honor status, cancel, and queued-message
+ * controls before exposing UI for them.
+ *
+ * @param array<string,mixed> $input Capability probe input.
+ * @return array{chat_run_status:bool,chat_run_cancel:bool,chat_message_queue:bool}
+ */
+function agents_chat_run_control_capabilities( array $input ): array {
+	return array(
+		'chat_run_status'   => agents_chat_run_control_capability_supported(
+			$input,
+			AGENTS_GET_CHAT_RUN_ABILITY,
+			'wp_agent_chat_run_status_handler'
+		),
+		'chat_run_cancel'   => agents_chat_run_control_capability_supported(
+			$input,
+			AGENTS_CANCEL_CHAT_RUN_ABILITY,
+			'wp_agent_chat_run_cancel_handler'
+		),
+		'chat_message_queue' => agents_chat_run_control_capability_supported(
+			$input,
+			AGENTS_QUEUE_CHAT_MESSAGE_ABILITY,
+			'wp_agent_chat_message_queue_handler'
+		),
+	);
+}
+
+/**
+ * Check one run-control capability for ability, permission, and runtime handler.
+ *
+ * @param array<string,mixed> $input          Capability probe input.
+ * @param string              $ability        Canonical run-control ability name.
+ * @param string              $handler_filter Runtime handler filter name.
+ * @return bool Whether the selected runtime supports the capability.
+ */
+function agents_chat_run_control_capability_supported( array $input, string $ability, string $handler_filter ): bool {
+	$agent = sanitize_title( (string) ( $input['agent'] ?? '' ) );
+	if ( '' === $agent ) {
+		return false;
+	}
+
+	if ( function_exists( 'wp_has_ability' ) && ! wp_has_ability( $ability ) ) {
+		return false;
+	}
+
+	$probe_input          = $input;
+	$probe_input['agent'] = $agent;
+
+	if ( ! agents_chat_run_control_permission( $probe_input ) ) {
+		return false;
+	}
+
+	return is_callable( apply_filters( $handler_filter, null, $probe_input ) );
+}
 
 /** @return array<string,mixed>|\WP_Error */
 function agents_get_chat_run( array $input ) {
@@ -166,6 +234,32 @@ function agents_chat_run_id_input_schema(): array {
 			'session_id'    => array( 'type' => 'string' ),
 			'run_id'        => array( 'type' => 'string' ),
 			'session_owner' => agents_chat_session_owner_schema(),
+		),
+	);
+}
+
+function agents_chat_run_control_capabilities_input_schema(): array {
+	return array(
+		'type'       => 'object',
+		'required'   => array( 'agent' ),
+		'properties' => array(
+			'agent'         => array(
+				'type'        => 'string',
+				'description' => 'Slug or ID of the selected agent/runtime to probe.',
+			),
+			'session_owner' => agents_chat_session_owner_schema(),
+		),
+	);
+}
+
+function agents_chat_run_control_capabilities_output_schema(): array {
+	return array(
+		'type'       => 'object',
+		'required'   => array( 'chat_run_status', 'chat_run_cancel', 'chat_message_queue' ),
+		'properties' => array(
+			'chat_run_status'    => array( 'type' => 'boolean' ),
+			'chat_run_cancel'    => array( 'type' => 'boolean' ),
+			'chat_message_queue' => array( 'type' => 'boolean' ),
 		),
 	);
 }

--- a/src/Channels/register-agents-chat-run-control-abilities.php
+++ b/src/Channels/register-agents-chat-run-control-abilities.php
@@ -83,11 +83,16 @@ function agents_get_chat_run( array $input ) {
 		return agents_chat_run_control_normalize_result( call_user_func( $handler, $input ), 'agents_chat_run_invalid_status' );
 	}
 
-	$run = WP_Agent_Chat_Run_Control::get_run( (string) ( $input['run_id'] ?? '' ) );
-	if ( $run && (string) $run['session_id'] !== (string) ( $input['session_id'] ?? '' ) ) {
+	$run                  = WP_Agent_Chat_Run_Control::get_run( (string) ( $input['run_id'] ?? '' ) );
+	$requested_session_id = (string) ( $input['session_id'] ?? '' );
+	if ( null !== $run && $requested_session_id !== (string) $run['session_id'] ) {
 		return agents_chat_run_control_no_handler( 'agents_chat_run_not_found', 'No chat run was found for the requested session_id and run_id.' );
 	}
-	return $run ?: agents_chat_run_control_no_handler( 'agents_chat_run_not_found', 'No chat run was found for the requested run_id.' );
+	if ( null !== $run ) {
+		return $run;
+	}
+
+	return agents_chat_run_control_no_handler( 'agents_chat_run_not_found', 'No chat run was found for the requested run_id.' );
 }
 
 /** @return array<string,mixed>|\WP_Error */
@@ -96,11 +101,12 @@ function agents_cancel_chat_run( array $input ) {
 	if ( is_callable( $handler ) ) {
 		$result = agents_chat_run_control_normalize_result( call_user_func( $handler, $input ), 'agents_chat_run_invalid_cancel_result' );
 	} else {
-		$run = WP_Agent_Chat_Run_Control::get_run( (string) ( $input['run_id'] ?? '' ) );
+		$run                  = WP_Agent_Chat_Run_Control::get_run( (string) ( $input['run_id'] ?? '' ) );
+		$requested_session_id = (string) ( $input['session_id'] ?? '' );
 		if ( null === $run ) {
 			return agents_chat_run_control_no_handler( 'agents_chat_run_not_found', 'No chat run was found for the requested run_id.' );
 		}
-		if ( (string) $run['session_id'] !== (string) ( $input['session_id'] ?? '' ) ) {
+		if ( $requested_session_id !== (string) $run['session_id'] ) {
 			return agents_chat_run_control_no_handler( 'agents_chat_run_not_found', 'No chat run was found for the requested session_id and run_id.' );
 		}
 

--- a/src/Runtime/class-wp-agent-chat-run-control.php
+++ b/src/Runtime/class-wp-agent-chat-run-control.php
@@ -20,6 +20,7 @@ class WP_Agent_Chat_Run_Control {
 	public const STATUS_CANCELLED  = 'cancelled';
 	public const STATUS_COMPLETED  = 'completed';
 	public const STATUS_FAILED     = 'failed';
+	private const OPTION_KEY       = 'agents_api_chat_run_control';
 
 	/** @return string[] */
 	public static function statuses(): array {
@@ -101,6 +102,165 @@ class WP_Agent_Chat_Run_Control {
 	}
 
 	/**
+	 * Start or update an addressable chat run in the default store.
+	 *
+	 * @param string              $run_id     Run ID.
+	 * @param string              $session_id Session ID.
+	 * @param array<string,mixed> $metadata   Run metadata.
+	 * @return array<string,mixed> Normalized run.
+	 */
+	public static function start_run( string $run_id, string $session_id, array $metadata = array() ): array {
+		$now = self::now();
+		$run = array(
+			'run_id'     => $run_id,
+			'session_id' => $session_id,
+			'status'     => self::STATUS_RUNNING,
+			'started_at' => $metadata['started_at'] ?? $now,
+			'updated_at' => $now,
+			'metadata'   => $metadata,
+		);
+
+		$state                  = self::state();
+		$state['runs'][ $run_id ] = $run;
+		self::save_state( $state );
+
+		return self::normalize_run( $run );
+	}
+
+	/**
+	 * Complete a stored chat run.
+	 *
+	 * @param string $run_id Run ID.
+	 * @param string $status Terminal status.
+	 * @return array<string,mixed>|null Normalized run, or null when absent.
+	 */
+	public static function finish_run( string $run_id, string $status = self::STATUS_COMPLETED ): ?array {
+		$state = self::state();
+		if ( empty( $state['runs'][ $run_id ] ) || ! is_array( $state['runs'][ $run_id ] ) ) {
+			return null;
+		}
+
+		$run               = $state['runs'][ $run_id ];
+		$run['status']     = self::normalize_status( $status );
+		$run['updated_at'] = self::now();
+		if ( self::STATUS_CANCELLED === $run['status'] ) {
+			$run['cancelled'] = true;
+		}
+
+		$state['runs'][ $run_id ] = $run;
+		self::save_state( $state );
+
+		return self::normalize_run( $run );
+	}
+
+	/**
+	 * Read a stored chat run.
+	 *
+	 * @param string $run_id Run ID.
+	 * @return array<string,mixed>|null Normalized run, or null when absent.
+	 */
+	public static function get_run( string $run_id ): ?array {
+		$state = self::state();
+		$run   = $state['runs'][ $run_id ] ?? null;
+		return is_array( $run ) ? self::normalize_run( $run ) : null;
+	}
+
+	/**
+	 * Request cancellation of a stored chat run.
+	 *
+	 * @param string $run_id Run ID.
+	 * @return array<string,mixed>|null Normalized run, or null when absent.
+	 */
+	public static function request_cancel( string $run_id ): ?array {
+		$state = self::state();
+		if ( empty( $state['runs'][ $run_id ] ) || ! is_array( $state['runs'][ $run_id ] ) ) {
+			return null;
+		}
+
+		$run           = $state['runs'][ $run_id ];
+		$terminal      = in_array( self::normalize_status( $run['status'] ?? '' ), array( self::STATUS_COMPLETED, self::STATUS_FAILED, self::STATUS_CANCELLED ), true );
+		$run['status'] = $terminal ? self::normalize_status( $run['status'] ?? '' ) : self::STATUS_CANCELLING;
+		$run['cancelled']  = ! $terminal;
+		$run['updated_at'] = self::now();
+
+		$state['runs'][ $run_id ] = $run;
+		self::save_state( $state );
+
+		return self::normalize_run( $run );
+	}
+
+	/**
+	 * Return a cancellation interrupt when one was requested for the run.
+	 *
+	 * @param string $run_id     Run ID.
+	 * @param string $session_id Session ID.
+	 * @return array<string,mixed>|null Interrupt message or null.
+	 */
+	public static function cancellation_interrupt_for_run( string $run_id, string $session_id = '' ): ?array {
+		$run = self::get_run( $run_id );
+		if ( ! $run || self::STATUS_CANCELLING !== $run['status'] ) {
+			return null;
+		}
+
+		return self::cancellation_interrupt_message( $run_id, $session_id ?: (string) $run['session_id'] );
+	}
+
+	/**
+	 * Queue a follow-up message for a chat session.
+	 *
+	 * @param array<string,mixed> $input Canonical queue input.
+	 * @return array<string,mixed> Queue result.
+	 */
+	public static function queue_message( array $input ): array {
+		$session_id = trim( (string) ( $input['session_id'] ?? '' ) );
+		$run_id     = trim( (string) ( $input['run_id'] ?? '' ) );
+		if ( '' === $session_id ) {
+			throw new \InvalidArgumentException( 'session_id must be a non-empty string' );
+		}
+
+		$queued_id = 'queued_' . str_replace( 'run_', '', self::generate_run_id() );
+		$item      = array(
+			'queued_message_id' => $queued_id,
+			'session_id'        => $session_id,
+			'run_id'            => $run_id,
+			'agent'             => sanitize_title( (string) ( $input['agent'] ?? '' ) ),
+			'message'           => (string) ( $input['message'] ?? '' ),
+			'attachments'       => is_array( $input['attachments'] ?? null ) ? $input['attachments'] : array(),
+			'client_context'    => is_array( $input['client_context'] ?? null ) ? $input['client_context'] : array(),
+			'created_at'        => self::now(),
+		);
+
+		$state                         = self::state();
+		$state['queues'][ $session_id ] = array_values( $state['queues'][ $session_id ] ?? array() );
+		$state['queues'][ $session_id ][] = $item;
+		$position                      = count( $state['queues'][ $session_id ] );
+		self::save_state( $state );
+
+		return self::normalize_run( array(
+			'run_id'            => '' !== $run_id ? $run_id : self::generate_run_id(),
+			'session_id'        => $session_id,
+			'status'            => self::STATUS_QUEUED,
+			'updated_at'        => self::now(),
+			'queued_message_id' => $queued_id,
+			'position'          => $position,
+		) );
+	}
+
+	/**
+	 * Claim queued messages for a session.
+	 *
+	 * @param string $session_id Session ID.
+	 * @return array<int,array<string,mixed>> Queued items.
+	 */
+	public static function claim_queued_messages( string $session_id ): array {
+		$state = self::state();
+		$items = array_values( $state['queues'][ $session_id ] ?? array() );
+		unset( $state['queues'][ $session_id ] );
+		self::save_state( $state );
+		return array_filter( $items, 'is_array' );
+	}
+
+	/**
 	 * Build the interrupt message shape consumed by WP_Agent_Conversation_Loop.
 	 *
 	 * Runtimes that cannot abort an in-flight provider request immediately can
@@ -129,5 +289,25 @@ class WP_Agent_Chat_Run_Control {
 				)
 			)
 		);
+	}
+
+	/** @return array{runs:array<string,array<string,mixed>>,queues:array<string,array<int,array<string,mixed>>>} */
+	private static function state(): array {
+		$state = function_exists( 'get_option' ) ? get_option( self::OPTION_KEY, array() ) : array();
+		return array(
+			'runs'   => is_array( $state['runs'] ?? null ) ? $state['runs'] : array(),
+			'queues' => is_array( $state['queues'] ?? null ) ? $state['queues'] : array(),
+		);
+	}
+
+	/** @param array<string,mixed> $state State to persist. */
+	private static function save_state( array $state ): void {
+		if ( function_exists( 'update_option' ) ) {
+			update_option( self::OPTION_KEY, $state, false );
+		}
+	}
+
+	private static function now(): string {
+		return function_exists( 'gmdate' ) ? gmdate( 'c' ) : date( 'c' );
 	}
 }

--- a/src/Runtime/class-wp-agent-chat-run-control.php
+++ b/src/Runtime/class-wp-agent-chat-run-control.php
@@ -120,7 +120,7 @@ class WP_Agent_Chat_Run_Control {
 			'metadata'   => $metadata,
 		);
 
-		$state                  = self::state();
+		$state                    = self::state();
 		$state['runs'][ $run_id ] = $run;
 		self::save_state( $state );
 
@@ -136,7 +136,7 @@ class WP_Agent_Chat_Run_Control {
 	 */
 	public static function finish_run( string $run_id, string $status = self::STATUS_COMPLETED ): ?array {
 		$state = self::state();
-		if ( empty( $state['runs'][ $run_id ] ) || ! is_array( $state['runs'][ $run_id ] ) ) {
+		if ( ! isset( $state['runs'][ $run_id ] ) ) {
 			return null;
 		}
 
@@ -173,13 +173,13 @@ class WP_Agent_Chat_Run_Control {
 	 */
 	public static function request_cancel( string $run_id ): ?array {
 		$state = self::state();
-		if ( empty( $state['runs'][ $run_id ] ) || ! is_array( $state['runs'][ $run_id ] ) ) {
+		if ( ! isset( $state['runs'][ $run_id ] ) ) {
 			return null;
 		}
 
-		$run           = $state['runs'][ $run_id ];
-		$terminal      = in_array( self::normalize_status( $run['status'] ?? '' ), array( self::STATUS_COMPLETED, self::STATUS_FAILED, self::STATUS_CANCELLED ), true );
-		$run['status'] = $terminal ? self::normalize_status( $run['status'] ?? '' ) : self::STATUS_CANCELLING;
+		$run               = $state['runs'][ $run_id ];
+		$terminal          = in_array( self::normalize_status( $run['status'] ?? '' ), array( self::STATUS_COMPLETED, self::STATUS_FAILED, self::STATUS_CANCELLED ), true );
+		$run['status']     = $terminal ? self::normalize_status( $run['status'] ?? '' ) : self::STATUS_CANCELLING;
 		$run['cancelled']  = ! $terminal;
 		$run['updated_at'] = self::now();
 
@@ -198,11 +198,13 @@ class WP_Agent_Chat_Run_Control {
 	 */
 	public static function cancellation_interrupt_for_run( string $run_id, string $session_id = '' ): ?array {
 		$run = self::get_run( $run_id );
-		if ( ! $run || self::STATUS_CANCELLING !== $run['status'] ) {
+		if ( null === $run || self::STATUS_CANCELLING !== $run['status'] ) {
 			return null;
 		}
 
-		return self::cancellation_interrupt_message( $run_id, $session_id ?: (string) $run['session_id'] );
+		$resolved_session_id = '' !== $session_id ? $session_id : (string) $run['session_id'];
+
+		return self::cancellation_interrupt_message( $run_id, $resolved_session_id );
 	}
 
 	/**
@@ -230,10 +232,10 @@ class WP_Agent_Chat_Run_Control {
 			'created_at'        => self::now(),
 		);
 
-		$state                         = self::state();
-		$state['queues'][ $session_id ] = array_values( $state['queues'][ $session_id ] ?? array() );
+		$state                            = self::state();
+		$state['queues'][ $session_id ]   = array_values( $state['queues'][ $session_id ] ?? array() );
 		$state['queues'][ $session_id ][] = $item;
-		$position                      = count( $state['queues'][ $session_id ] );
+		$position                         = count( $state['queues'][ $session_id ] );
 		self::save_state( $state );
 
 		return self::normalize_run( array(
@@ -308,6 +310,6 @@ class WP_Agent_Chat_Run_Control {
 	}
 
 	private static function now(): string {
-		return function_exists( 'gmdate' ) ? gmdate( 'c' ) : date( 'c' );
+		return gmdate( 'c' );
 	}
 }

--- a/src/Runtime/class-wp-agent-conversation-loop.php
+++ b/src/Runtime/class-wp-agent-conversation-loop.php
@@ -89,6 +89,7 @@ class WP_Agent_Conversation_Loop {
 		$interrupt_source      = self::resolve_interrupt_source( $options );
 		$request               = self::resolve_request( $messages, $options );
 		$lock_session_id       = self::resolve_lock_session_id( $options, $request );
+		$run_id                = self::resolve_run_id( $options, $request );
 		$lock_ttl              = self::resolve_lock_ttl( $options );
 		$lock_token            = null;
 		$budget_resolution     = self::resolve_budgets( $options, $max_turns );
@@ -98,6 +99,9 @@ class WP_Agent_Conversation_Loop {
 		$wall_clock_initial    = isset( $budgets['wall_clock_seconds'] ) ? $budgets['wall_clock_seconds']->current() : 0;
 		$mediation_enabled     = null !== $tool_executor && ! empty( $tool_declarations );
 		$messages              = WP_Agent_Message::normalize_many( $messages );
+		if ( '' !== $run_id && '' !== $lock_session_id ) {
+			WP_Agent_Chat_Run_Control::start_run( $run_id, $lock_session_id, array( 'source' => 'conversation_loop' ) );
+		}
 		$events                = array();
 		$tool_results          = array();
 		$tool_audit_events     = array();
@@ -278,6 +282,12 @@ class WP_Agent_Conversation_Loop {
 				}
 
 				$interrupt = self::check_interrupt_source( $interrupt_source, $messages, $options, $turn_context, $on_event );
+				if ( null === $interrupt && '' !== $run_id ) {
+					$interrupt_message = WP_Agent_Chat_Run_Control::cancellation_interrupt_for_run( $run_id, $lock_session_id );
+					if ( null !== $interrupt_message ) {
+						$interrupt = self::normalize_interrupt_message( $interrupt_message, $turn_context, $on_event );
+					}
+				}
 				if ( null !== $interrupt ) {
 					$messages[] = $interrupt['message'];
 					$events[]   = array(
@@ -345,6 +355,13 @@ class WP_Agent_Conversation_Loop {
 			}
 
 			$final_result = WP_Agent_Conversation_Result::normalize( $final_result_data );
+
+			if ( '' !== $run_id && '' !== $lock_session_id ) {
+				WP_Agent_Chat_Run_Control::finish_run(
+					$run_id,
+					null !== $interrupted ? WP_Agent_Chat_Run_Control::STATUS_CANCELLED : WP_Agent_Chat_Run_Control::STATUS_COMPLETED
+				);
+			}
 
 			self::persist_transcript( $transcript_persister, $messages, $options, $final_result );
 
@@ -677,6 +694,18 @@ class WP_Agent_Conversation_Loop {
 			return null;
 		}
 
+		return self::normalize_interrupt_message( $message, $context, $on_event );
+	}
+
+	/**
+	 * Normalize and emit a received interrupt message.
+	 *
+	 * @param array<string,mixed>  $message  Interrupt message.
+	 * @param array<string,mixed>  $context  Current turn context.
+	 * @param callable|null        $on_event Event sink.
+	 * @return array{message: array<string, mixed>, metadata: array<string, mixed>, action: string}
+	 */
+	private static function normalize_interrupt_message( array $message, array $context, ?callable $on_event ): array {
 		$normalized         = WP_Agent_Message::normalize( $message );
 		$message_metadata   = isset( $normalized['metadata'] ) && is_array( $normalized['metadata'] ) ? $normalized['metadata'] : array();
 		$action             = self::normalize_interrupt_action( $message_metadata['interrupt_action'] ?? ( $message_metadata['action'] ?? 'message' ) );
@@ -1308,6 +1337,32 @@ class WP_Agent_Conversation_Loop {
 
 		$metadata = $request->metadata();
 		foreach ( array( 'transcript_session_id', 'session_id', 'transcript_id' ) as $key ) {
+			$value = $metadata[ $key ] ?? null;
+			if ( is_string( $value ) && '' !== trim( $value ) ) {
+				return trim( $value );
+			}
+		}
+
+		return '';
+	}
+
+	/**
+	 * Resolve the chat run ID used by generic run-control.
+	 *
+	 * @param array                         $options Loop options.
+	 * @param WP_Agent_Conversation_Request $request Request object.
+	 * @return string
+	 */
+	private static function resolve_run_id( array $options, WP_Agent_Conversation_Request $request ): string {
+		foreach ( array( 'run_id', 'chat_run_id' ) as $key ) {
+			$value = $options[ $key ] ?? null;
+			if ( is_string( $value ) && '' !== trim( $value ) ) {
+				return trim( $value );
+			}
+		}
+
+		$metadata = $request->metadata();
+		foreach ( array( 'run_id', 'chat_run_id' ) as $key ) {
 			$value = $metadata[ $key ] ?? null;
 			if ( is_string( $value ) && '' !== trim( $value ) ) {
 				return trim( $value );

--- a/tests/chat-run-control-smoke.php
+++ b/tests/chat-run-control-smoke.php
@@ -57,6 +57,7 @@ do_action( 'wp_abilities_api_init' );
 agents_api_smoke_assert_equals( true, isset( $GLOBALS['__agents_api_smoke_abilities'][ AgentsAPI\AI\Channels\AGENTS_GET_CHAT_RUN_ABILITY ] ), 'get-run ability registers', $failures, $passes );
 agents_api_smoke_assert_equals( true, isset( $GLOBALS['__agents_api_smoke_abilities'][ AgentsAPI\AI\Channels\AGENTS_CANCEL_CHAT_RUN_ABILITY ] ), 'cancel-run ability registers', $failures, $passes );
 agents_api_smoke_assert_equals( true, isset( $GLOBALS['__agents_api_smoke_abilities'][ AgentsAPI\AI\Channels\AGENTS_QUEUE_CHAT_MESSAGE_ABILITY ] ), 'queue-message ability registers', $failures, $passes );
+agents_api_smoke_assert_equals( true, isset( $GLOBALS['__agents_api_smoke_abilities'][ AgentsAPI\AI\Channels\AGENTS_CHAT_RUN_CONTROL_CAPABILITIES_ABILITY ] ), 'run-control capabilities ability registers', $failures, $passes );
 agents_api_smoke_assert_equals( true, in_array( 'run_id', AgentsAPI\AI\Channels\agents_chat_output_schema()['required'] ?? array(), true ) || isset( AgentsAPI\AI\Channels\agents_chat_output_schema()['properties']['run_id'] ), 'chat output schema exposes run_id', $failures, $passes );
 
 $captured_chat_input = array();
@@ -88,6 +89,11 @@ agents_api_smoke_assert_equals( true, is_array( $chat ), 'chat dispatch succeeds
 agents_api_smoke_assert_equals( true, isset( $captured_chat_input['run_id'] ) && '' !== $captured_chat_input['run_id'], 'chat dispatch passes generated run_id to runtime', $failures, $passes );
 agents_api_smoke_assert_equals( $captured_chat_input['run_id'], $chat['run_id'] ?? null, 'chat dispatch returns generated run_id', $failures, $passes );
 
+$capabilities = AgentsAPI\AI\Channels\agents_chat_run_control_capabilities( array( 'agent' => 'demo-agent' ) );
+agents_api_smoke_assert_equals( false, $capabilities['chat_run_status'] ?? null, 'status capability false without runtime handler', $failures, $passes );
+agents_api_smoke_assert_equals( false, $capabilities['chat_run_cancel'] ?? null, 'cancel capability false without runtime handler', $failures, $passes );
+agents_api_smoke_assert_equals( false, $capabilities['chat_message_queue'] ?? null, 'queue capability false without runtime handler', $failures, $passes );
+
 add_filter(
 	'wp_agent_chat_run_status_handler',
 	static fn() => static fn( array $input ): array => array(
@@ -101,6 +107,11 @@ add_filter(
 	10,
 	2
 );
+
+$capabilities = AgentsAPI\AI\Channels\agents_chat_run_control_capabilities( array( 'agent' => 'demo-agent' ) );
+agents_api_smoke_assert_equals( true, $capabilities['chat_run_status'] ?? null, 'status capability true with runtime handler', $failures, $passes );
+agents_api_smoke_assert_equals( false, $capabilities['chat_run_cancel'] ?? null, 'cancel capability remains false without runtime handler', $failures, $passes );
+agents_api_smoke_assert_equals( false, $capabilities['chat_message_queue'] ?? null, 'queue capability remains false without runtime handler', $failures, $passes );
 
 $status = AgentsAPI\AI\Channels\agents_get_chat_run( array( 'session_id' => 'session-1', 'run_id' => 'run-1' ) );
 agents_api_smoke_assert_equals( 'running', $status['status'] ?? null, 'get-run normalizes status payload', $failures, $passes );
@@ -117,6 +128,11 @@ add_filter(
 	2
 );
 
+$capabilities = AgentsAPI\AI\Channels\agents_chat_run_control_capabilities( array( 'agent' => 'demo-agent' ) );
+agents_api_smoke_assert_equals( true, $capabilities['chat_run_status'] ?? null, 'status capability stays true with runtime handler', $failures, $passes );
+agents_api_smoke_assert_equals( true, $capabilities['chat_run_cancel'] ?? null, 'cancel capability true with runtime handler', $failures, $passes );
+agents_api_smoke_assert_equals( false, $capabilities['chat_message_queue'] ?? null, 'queue capability remains false until handler exists', $failures, $passes );
+
 $cancelled = AgentsAPI\AI\Channels\agents_cancel_chat_run( array( 'session_id' => 'session-1', 'run_id' => 'run-1' ) );
 agents_api_smoke_assert_equals( true, $cancelled['cancelled'] ?? null, 'cancel-run marks cancelling as cancelled request accepted', $failures, $passes );
 
@@ -132,6 +148,11 @@ add_filter(
 	10,
 	2
 );
+
+$capabilities = AgentsAPI\AI\Channels\agents_chat_run_control_capabilities( array( 'agent' => 'demo-agent' ) );
+agents_api_smoke_assert_equals( true, $capabilities['chat_run_status'] ?? null, 'status capability true in full runtime', $failures, $passes );
+agents_api_smoke_assert_equals( true, $capabilities['chat_run_cancel'] ?? null, 'cancel capability true in full runtime', $failures, $passes );
+agents_api_smoke_assert_equals( true, $capabilities['chat_message_queue'] ?? null, 'queue capability true with runtime handler', $failures, $passes );
 
 $queued = AgentsAPI\AI\Channels\agents_queue_chat_message(
 	array(

--- a/tests/chat-run-control-smoke.php
+++ b/tests/chat-run-control-smoke.php
@@ -20,6 +20,7 @@ require_once __DIR__ . '/agents-api-smoke-helpers.php';
 
 $GLOBALS['__agents_api_smoke_abilities']  = array();
 $GLOBALS['__agents_api_smoke_categories'] = array();
+$GLOBALS['__agents_api_smoke_options']    = array();
 
 class WP_Error {
 	public function __construct( private string $code = '', private string $message = '', private array $data = array() ) {}
@@ -49,6 +50,16 @@ function wp_register_ability( string $ability, array $args ): void {
 	$GLOBALS['__agents_api_smoke_abilities'][ $ability ] = $args;
 }
 
+function get_option( string $option, $default = false ) {
+	return $GLOBALS['__agents_api_smoke_options'][ $option ] ?? $default;
+}
+
+function update_option( string $option, $value, $autoload = null ): bool {
+	unset( $autoload );
+	$GLOBALS['__agents_api_smoke_options'][ $option ] = $value;
+	return true;
+}
+
 agents_api_smoke_require_module();
 
 do_action( 'wp_abilities_api_categories_init' );
@@ -57,7 +68,6 @@ do_action( 'wp_abilities_api_init' );
 agents_api_smoke_assert_equals( true, isset( $GLOBALS['__agents_api_smoke_abilities'][ AgentsAPI\AI\Channels\AGENTS_GET_CHAT_RUN_ABILITY ] ), 'get-run ability registers', $failures, $passes );
 agents_api_smoke_assert_equals( true, isset( $GLOBALS['__agents_api_smoke_abilities'][ AgentsAPI\AI\Channels\AGENTS_CANCEL_CHAT_RUN_ABILITY ] ), 'cancel-run ability registers', $failures, $passes );
 agents_api_smoke_assert_equals( true, isset( $GLOBALS['__agents_api_smoke_abilities'][ AgentsAPI\AI\Channels\AGENTS_QUEUE_CHAT_MESSAGE_ABILITY ] ), 'queue-message ability registers', $failures, $passes );
-agents_api_smoke_assert_equals( true, isset( $GLOBALS['__agents_api_smoke_abilities'][ AgentsAPI\AI\Channels\AGENTS_CHAT_RUN_CONTROL_CAPABILITIES_ABILITY ] ), 'run-control capabilities ability registers', $failures, $passes );
 agents_api_smoke_assert_equals( true, in_array( 'run_id', AgentsAPI\AI\Channels\agents_chat_output_schema()['required'] ?? array(), true ) || isset( AgentsAPI\AI\Channels\agents_chat_output_schema()['properties']['run_id'] ), 'chat output schema exposes run_id', $failures, $passes );
 
 $captured_chat_input = array();
@@ -80,19 +90,30 @@ add_filter(
 
 $chat = AgentsAPI\AI\Channels\agents_chat_dispatch(
 	array(
-		'agent'   => 'demo-agent',
-		'message' => 'Hello',
+		'agent'      => 'demo-agent',
+		'message'    => 'Hello',
+		'session_id' => 'session-1',
 	)
 );
 
 agents_api_smoke_assert_equals( true, is_array( $chat ), 'chat dispatch succeeds', $failures, $passes );
 agents_api_smoke_assert_equals( true, isset( $captured_chat_input['run_id'] ) && '' !== $captured_chat_input['run_id'], 'chat dispatch passes generated run_id to runtime', $failures, $passes );
 agents_api_smoke_assert_equals( $captured_chat_input['run_id'], $chat['run_id'] ?? null, 'chat dispatch returns generated run_id', $failures, $passes );
+$stored = AgentsAPI\AI\Channels\agents_get_chat_run( array( 'session_id' => 'session-1', 'run_id' => $chat['run_id'] ) );
+agents_api_smoke_assert_equals( 'completed', $stored['status'] ?? null, 'chat dispatch records completed run by default', $failures, $passes );
 
-$capabilities = AgentsAPI\AI\Channels\agents_chat_run_control_capabilities( array( 'agent' => 'demo-agent' ) );
-agents_api_smoke_assert_equals( false, $capabilities['chat_run_status'] ?? null, 'status capability false without runtime handler', $failures, $passes );
-agents_api_smoke_assert_equals( false, $capabilities['chat_run_cancel'] ?? null, 'cancel capability false without runtime handler', $failures, $passes );
-agents_api_smoke_assert_equals( false, $capabilities['chat_message_queue'] ?? null, 'queue capability false without runtime handler', $failures, $passes );
+AgentsAPI\AI\WP_Agent_Chat_Run_Control::start_run( 'run-default-cancel', 'session-1' );
+$default_cancelled = AgentsAPI\AI\Channels\agents_cancel_chat_run( array( 'session_id' => 'session-1', 'run_id' => 'run-default-cancel' ) );
+agents_api_smoke_assert_equals( 'cancelling', $default_cancelled['status'] ?? null, 'default cancel marks running runs as cancelling', $failures, $passes );
+
+$default_queued = AgentsAPI\AI\Channels\agents_queue_chat_message(
+	array(
+		'agent'      => 'demo-agent',
+		'session_id' => 'session-default',
+		'message'    => 'Default queue',
+	)
+);
+agents_api_smoke_assert_equals( 'queued', $default_queued['status'] ?? null, 'default queue handler accepts messages', $failures, $passes );
 
 add_filter(
 	'wp_agent_chat_run_status_handler',
@@ -107,11 +128,6 @@ add_filter(
 	10,
 	2
 );
-
-$capabilities = AgentsAPI\AI\Channels\agents_chat_run_control_capabilities( array( 'agent' => 'demo-agent' ) );
-agents_api_smoke_assert_equals( true, $capabilities['chat_run_status'] ?? null, 'status capability true with runtime handler', $failures, $passes );
-agents_api_smoke_assert_equals( false, $capabilities['chat_run_cancel'] ?? null, 'cancel capability remains false without runtime handler', $failures, $passes );
-agents_api_smoke_assert_equals( false, $capabilities['chat_message_queue'] ?? null, 'queue capability remains false without runtime handler', $failures, $passes );
 
 $status = AgentsAPI\AI\Channels\agents_get_chat_run( array( 'session_id' => 'session-1', 'run_id' => 'run-1' ) );
 agents_api_smoke_assert_equals( 'running', $status['status'] ?? null, 'get-run normalizes status payload', $failures, $passes );
@@ -128,11 +144,6 @@ add_filter(
 	2
 );
 
-$capabilities = AgentsAPI\AI\Channels\agents_chat_run_control_capabilities( array( 'agent' => 'demo-agent' ) );
-agents_api_smoke_assert_equals( true, $capabilities['chat_run_status'] ?? null, 'status capability stays true with runtime handler', $failures, $passes );
-agents_api_smoke_assert_equals( true, $capabilities['chat_run_cancel'] ?? null, 'cancel capability true with runtime handler', $failures, $passes );
-agents_api_smoke_assert_equals( false, $capabilities['chat_message_queue'] ?? null, 'queue capability remains false until handler exists', $failures, $passes );
-
 $cancelled = AgentsAPI\AI\Channels\agents_cancel_chat_run( array( 'session_id' => 'session-1', 'run_id' => 'run-1' ) );
 agents_api_smoke_assert_equals( true, $cancelled['cancelled'] ?? null, 'cancel-run marks cancelling as cancelled request accepted', $failures, $passes );
 
@@ -148,11 +159,6 @@ add_filter(
 	10,
 	2
 );
-
-$capabilities = AgentsAPI\AI\Channels\agents_chat_run_control_capabilities( array( 'agent' => 'demo-agent' ) );
-agents_api_smoke_assert_equals( true, $capabilities['chat_run_status'] ?? null, 'status capability true in full runtime', $failures, $passes );
-agents_api_smoke_assert_equals( true, $capabilities['chat_run_cancel'] ?? null, 'cancel capability true in full runtime', $failures, $passes );
-agents_api_smoke_assert_equals( true, $capabilities['chat_message_queue'] ?? null, 'queue capability true with runtime handler', $failures, $passes );
 
 $queued = AgentsAPI\AI\Channels\agents_queue_chat_message(
 	array(


### PR DESCRIPTION
## Summary
- Makes chat run control default in Agents API instead of a separate capability probe.
- Stores generic run status for `agents/chat`, supports best-effort cancellation, and accepts queued follow-up messages when no runtime-specific handler is registered.
- Lets runtimes override status/cancel/queue hooks only when they can provide stronger behavior, while clients can rely on the canonical abilities by default.

## Verification
- `git diff --check`
- `php tests/chat-run-control-smoke.php`
- `php -l src/Runtime/class-wp-agent-chat-run-control.php && php -l src/Channels/register-agents-chat-run-control-abilities.php && php -l src/Channels/register-agents-chat-ability.php && php -l src/Runtime/class-wp-agent-conversation-loop.php && php -l tests/chat-run-control-smoke.php`
- `composer test`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Revised the run-control implementation from a capability-probe model to default generic support, updated docs/tests, and ran validation. Chris remains responsible for review and merge.