### PR TITLE
Add runtime tool loop contracts

### DIFF
--- a/agents-api.php
+++ b/agents-api.php
@@ -129,6 +129,9 @@ require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-identical-failure-tra
 require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-consecutive-identical-failure-tracker.php';
 require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-tool-result-truncator.php';
 require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-byte-limit-tool-result-truncator.php';
+require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-runtime-tool-request.php';
+require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-runtime-tool-result.php';
+require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-runtime-tool-request-store.php';
 require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-conversation-result.php';
 require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-chat-run-control.php';
 require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-conversation-loop.php';

--- a/src/Runtime/class-wp-agent-conversation-loop.php
+++ b/src/Runtime/class-wp-agent-conversation-loop.php
@@ -519,9 +519,10 @@ class WP_Agent_Conversation_Loop {
 
 			$pending_request = self::runtime_tool_pending_request( $exec_result, $tool_name, $tool_call_id, is_array( $parameters ) ? $parameters : array(), $turn_context );
 			if ( null !== $pending_request ) {
+				$pending_request_json = self::json_encode_safe( $pending_request );
 				$runtime_tool_pending = $pending_request;
 				$messages[]           = WP_Agent_Message::toolResult(
-					self::json_encode_safe( $pending_request ),
+					false !== $pending_request_json ? $pending_request_json : '',
 					$tool_name,
 					array(
 						'success' => false,
@@ -547,7 +548,7 @@ class WP_Agent_Conversation_Loop {
 						'request_id' => $pending_request['request_id'],
 					)
 				);
-				$complete = true;
+				$complete      = true;
 				break;
 			}
 
@@ -755,7 +756,7 @@ class WP_Agent_Conversation_Loop {
 			'failure'                => array(
 				'type'       => get_class( $error ),
 				'message'    => $error->getMessage(),
-				'code'       => is_scalar( $error->getCode() ) ? (string) $error->getCode() : '',
+				'code'       => (string) $error->getCode(),
 				'turn_count' => $turn,
 			),
 		) );

--- a/src/Runtime/class-wp-agent-conversation-loop.php
+++ b/src/Runtime/class-wp-agent-conversation-loop.php
@@ -104,11 +104,13 @@ class WP_Agent_Conversation_Loop {
 		}
 		$events                = array();
 		$tool_results          = array();
+		$tool_events           = array();
 		$tool_audit_events     = array();
 		$conversation_complete = false;
 		$exceeded_budget       = null;
 		$stalled               = null;
 		$approval_required     = null;
+		$runtime_tool_pending  = null;
 		$interrupted           = null;
 
 		// Universal observability accumulators. Turn runners may report
@@ -170,14 +172,24 @@ class WP_Agent_Conversation_Loop {
 						'error' => $error->getMessage(),
 					) );
 
-					$failure_result = WP_Agent_Conversation_Result::normalize( array(
-						'messages'               => $messages,
-						'tool_execution_results' => $tool_results,
-						'events'                 => $events,
-					) );
+					$failure_result = self::failure_result(
+						$messages,
+						$tool_results,
+						$tool_events,
+						$tool_audit_events,
+						$events,
+						$error,
+						$turn,
+						$total_usage,
+						$request_metadata
+					);
+
+					if ( '' !== $run_id && '' !== $lock_session_id ) {
+						WP_Agent_Chat_Run_Control::finish_run( $run_id, WP_Agent_Chat_Run_Control::STATUS_FAILED );
+					}
 
 					self::persist_transcript( $transcript_persister, $messages, $options, $failure_result );
-					throw $error;
+					return $failure_result;
 				}
 
 				if ( ! is_array( $result ) ) {
@@ -191,6 +203,8 @@ class WP_Agent_Conversation_Loop {
 					self::persist_transcript( $transcript_persister, $messages, $options, array(
 						'messages'               => $messages,
 						'tool_execution_results' => $tool_results,
+						'tool_events'            => $tool_events,
+						'tool_audit_events'      => $tool_audit_events,
 						'events'                 => $events,
 					) );
 
@@ -228,11 +242,13 @@ class WP_Agent_Conversation_Loop {
 
 					$messages              = $mediation_result['messages'];
 					$tool_results          = array_merge( $tool_results, $mediation_result['tool_execution_results'] );
+					$tool_events           = array_merge( $tool_events, $mediation_result['tool_events'] );
 					$tool_audit_events     = array_merge( $tool_audit_events, $mediation_result['tool_audit_events'] );
 					$events                = array_merge( $events, $mediation_result['events'] );
 					$conversation_complete = $mediation_result['conversation_complete'];
 					$exceeded_budget       = $mediation_result['exceeded_budget'];
 					$approval_required     = $mediation_result['approval_required'] ?? null;
+					$runtime_tool_pending  = $mediation_result['runtime_tool_pending'] ?? null;
 					$stalled               = self::check_spin_detector( $spin_detector, $mediation_result['spin_signatures'], $turn_context, $on_event );
 				} else {
 					// Caller-managed path: turn runner handles everything internally.
@@ -241,6 +257,9 @@ class WP_Agent_Conversation_Loop {
 					$tool_results = array_merge( $tool_results, $result['tool_execution_results'] );
 					if ( isset( $result['tool_audit_events'] ) && is_array( $result['tool_audit_events'] ) ) {
 						$tool_audit_events = array_merge( $tool_audit_events, $result['tool_audit_events'] );
+					}
+					if ( isset( $result['tool_events'] ) && is_array( $result['tool_events'] ) ) {
+						$tool_events = array_merge( $tool_events, $result['tool_events'] );
 					}
 					$events = array_merge( $events, self::normalize_events( $result['events'] ?? array() ) );
 					if ( isset( $result['request_metadata'] ) && is_array( $result['request_metadata'] ) ) {
@@ -274,6 +293,10 @@ class WP_Agent_Conversation_Loop {
 				}
 
 				if ( null !== $stalled ) {
+					break;
+				}
+
+				if ( null !== $runtime_tool_pending ) {
 					break;
 				}
 
@@ -321,6 +344,7 @@ class WP_Agent_Conversation_Loop {
 			$final_result_data = array(
 				'messages'               => $messages,
 				'tool_execution_results' => $tool_results,
+				'tool_events'            => $tool_events,
 				'tool_audit_events'      => $tool_audit_events,
 				'events'                 => $events,
 				'turn_count'             => $turns_run,
@@ -346,6 +370,12 @@ class WP_Agent_Conversation_Loop {
 				$final_result_data['status']            = 'approval_required';
 				$final_result_data['approval_required'] = $approval_required;
 				$final_result_data['completed']         = false;
+			}
+
+			if ( null !== $runtime_tool_pending ) {
+				$final_result_data['status']               = WP_Agent_Runtime_Tool_Request::STATUS_PENDING;
+				$final_result_data['runtime_tool_pending'] = $runtime_tool_pending;
+				$final_result_data['completed']            = false;
 			}
 
 			if ( null !== $interrupted ) {
@@ -399,7 +429,7 @@ class WP_Agent_Conversation_Loop {
 	 * @param array<string, WP_Agent_Iteration_Budget>                    $budgets         Named iteration budgets.
 	 * @param WP_Agent_Identical_Failure_Tracker|null                     $failure_tracker Optional identical-failure tracker.
 	 * @param WP_Agent_Tool_Result_Truncator|null                         $truncator       Optional tool result truncator.
-	 * @return array{messages: array, tool_execution_results: array, tool_audit_events: array, events: array, conversation_complete: bool, exceeded_budget: string|null, approval_required: array<string, mixed>|null, spin_signatures: WP_Agent_Spin_Signature[]}
+	 * @return array{messages: array, tool_execution_results: array, tool_events: array, tool_audit_events: array, events: array, conversation_complete: bool, exceeded_budget: string|null, approval_required: array<string, mixed>|null, runtime_tool_pending: array<string, mixed>|null, spin_signatures: WP_Agent_Spin_Signature[]}
 	 */
 	private static function mediate_tool_calls(
 		array $result,
@@ -424,12 +454,14 @@ class WP_Agent_Conversation_Loop {
 			: $prior_messages;
 		$tool_calls             = $result['tool_calls'];
 		$tool_execution_results = array();
+		$tool_events            = array();
 		$tool_audit_events      = array();
 		$events                 = array();
 		$spin_signatures        = array();
 		$complete               = false;
 		$exceeded_budget        = null;
 		$approval_required      = null;
+		$runtime_tool_pending   = null;
 
 		// If the turn runner returned text content, add it as an assistant message.
 		if ( isset( $result['content'] ) && is_string( $result['content'] ) && '' !== $result['content'] ) {
@@ -453,6 +485,7 @@ class WP_Agent_Conversation_Loop {
 				'tool_call_id' => $tool_call_id,
 				'parameters'   => $parameters,
 			) );
+			$tool_events[] = self::tool_event( 'tool_call', $tool_name, $tool_call_id, $turn, array( 'status' => 'called' ) );
 
 			// Add tool-call message to transcript. The structured info
 			// (tool_name + parameters) lives in metadata; `content` is
@@ -483,6 +516,40 @@ class WP_Agent_Conversation_Loop {
 				$executor,
 				$tool_context
 			);
+
+			$pending_request = self::runtime_tool_pending_request( $exec_result, $tool_name, $tool_call_id, is_array( $parameters ) ? $parameters : array(), $turn_context );
+			if ( null !== $pending_request ) {
+				$runtime_tool_pending = $pending_request;
+				$messages[]           = WP_Agent_Message::toolResult(
+					self::json_encode_safe( $pending_request ),
+					$tool_name,
+					array(
+						'success' => false,
+						'status'  => WP_Agent_Runtime_Tool_Request::STATUS_PENDING,
+						'result'  => $pending_request,
+					),
+					array( 'tool_call_id' => $tool_call_id )
+				);
+
+				self::emit_event( $on_event, WP_Agent_Runtime_Tool_Request::STATUS_PENDING, array(
+					'turn'         => $turn,
+					'tool_name'    => $tool_name,
+					'tool_call_id' => $tool_call_id,
+					'request_id'   => $pending_request['request_id'],
+				) );
+				$tool_events[] = self::tool_event(
+					WP_Agent_Runtime_Tool_Request::STATUS_PENDING,
+					$tool_name,
+					$tool_call_id,
+					$turn,
+					array(
+						'status'     => WP_Agent_Runtime_Tool_Request::STATUS_PENDING,
+						'request_id' => $pending_request['request_id'],
+					)
+				);
+				$complete = true;
+				break;
+			}
 
 			// Detect an approval_required envelope returned by an ability via the
 			// wp_pre_execute_ability bridge handler. The envelope replaces the
@@ -534,6 +601,16 @@ class WP_Agent_Conversation_Loop {
 				'tool_call_id' => $tool_call_id,
 				'success'      => (bool) ( $exec_result['success'] ?? false ),
 			) );
+			$tool_events[] = self::tool_event(
+				'tool_result',
+				$tool_name,
+				$tool_call_id,
+				$turn,
+				array(
+					'status'  => ! empty( $exec_result['success'] ) ? 'success' : 'error',
+					'success' => (bool) ( $exec_result['success'] ?? false ),
+				)
+			);
 
 			// Build the tool_execution_results entry.
 			$execution_result = array(
@@ -637,13 +714,115 @@ class WP_Agent_Conversation_Loop {
 		return array(
 			'messages'               => $messages,
 			'tool_execution_results' => $tool_execution_results,
+			'tool_events'            => $tool_events,
 			'tool_audit_events'      => $tool_audit_events,
 			'events'                 => $events,
 			'conversation_complete'  => $complete,
 			'exceeded_budget'        => $exceeded_budget,
 			'approval_required'      => $approval_required,
+			'runtime_tool_pending'   => $runtime_tool_pending,
 			'spin_signatures'        => $spin_signatures,
 		);
+	}
+
+	/**
+	 * Build a structured runtime failure result without forcing callers to rebuild loop state.
+	 *
+	 * @param array      $messages          Current transcript messages.
+	 * @param array      $tool_results      Accumulated tool execution results.
+	 * @param array      $tool_events       Accumulated canonical tool events.
+	 * @param array      $tool_audit_events Accumulated audit events.
+	 * @param array      $events            Accumulated loop events.
+	 * @param \Throwable $error             Runtime/provider error.
+	 * @param int        $turn              Current turn.
+	 * @param array      $usage             Accumulated usage.
+	 * @param array      $request_metadata  Latest request metadata.
+	 * @return array<string, mixed> Normalized conversation result.
+	 */
+	private static function failure_result( array $messages, array $tool_results, array $tool_events, array $tool_audit_events, array $events, \Throwable $error, int $turn, array $usage, array $request_metadata ): array {
+		return WP_Agent_Conversation_Result::normalize( array(
+			'messages'               => $messages,
+			'tool_execution_results' => $tool_results,
+			'tool_events'            => $tool_events,
+			'tool_audit_events'      => $tool_audit_events,
+			'events'                 => $events,
+			'status'                 => 'failed',
+			'completed'              => false,
+			'turn_count'             => $turn,
+			'final_content'          => self::extract_final_content( $messages ),
+			'usage'                  => $usage,
+			'request_metadata'       => $request_metadata,
+			'failure'                => array(
+				'type'       => get_class( $error ),
+				'message'    => $error->getMessage(),
+				'code'       => is_scalar( $error->getCode() ) ? (string) $error->getCode() : '',
+				'turn_count' => $turn,
+			),
+		) );
+	}
+
+	/**
+	 * Normalize a pending runtime-tool request embedded in a tool execution result.
+	 *
+	 * @param array<string, mixed> $exec_result  Normalized tool execution result.
+	 * @param string               $tool_name    Tool name.
+	 * @param string               $tool_call_id Tool call id.
+	 * @param array<string, mixed> $parameters   Tool parameters.
+	 * @param array<string, mixed> $context      Turn context.
+	 * @return array<string, mixed>|null Pending request or null.
+	 */
+	private static function runtime_tool_pending_request( array $exec_result, string $tool_name, string $tool_call_id, array $parameters, array $context ): ?array {
+		$status = $exec_result['status'] ?? ( $exec_result['metadata']['status'] ?? '' );
+		if ( WP_Agent_Runtime_Tool_Request::STATUS_PENDING !== $status ) {
+			return null;
+		}
+
+		$request = $exec_result['runtime_tool_request'] ?? ( $exec_result['result'] ?? array() );
+		if ( ! is_array( $request ) ) {
+			$request = array();
+		}
+
+		$runtime  = isset( $exec_result['runtime'] ) && is_array( $exec_result['runtime'] ) ? $exec_result['runtime'] : array();
+		$metadata = isset( $exec_result['metadata'] ) && is_array( $exec_result['metadata'] ) ? $exec_result['metadata'] : array();
+
+		return WP_Agent_Runtime_Tool_Request::normalize( array_merge(
+			$request,
+			array(
+				'tool_name'    => $request['tool_name'] ?? $tool_name,
+				'tool_call_id' => $request['tool_call_id'] ?? $tool_call_id,
+				'parameters'   => $request['parameters'] ?? $parameters,
+				'run_id'       => $request['run_id'] ?? ( is_string( $context['run_id'] ?? null ) ? $context['run_id'] : '' ),
+				'timeout_at'   => $request['timeout_at'] ?? ( is_string( $context['runtime_tool_timeout_at'] ?? null ) ? $context['runtime_tool_timeout_at'] : '' ),
+				'runtime'      => $request['runtime'] ?? $runtime,
+				'metadata'     => $request['metadata'] ?? $metadata,
+			)
+		) );
+	}
+
+	/**
+	 * Build one canonical tool history event.
+	 *
+	 * @param string               $type         Event type.
+	 * @param string               $tool_name    Tool name.
+	 * @param string               $tool_call_id Tool call id.
+	 * @param int                  $turn         Turn number.
+	 * @param array<string, mixed> $metadata     Event metadata.
+	 * @return array<string, mixed> Tool event.
+	 */
+	private static function tool_event( string $type, string $tool_name, string $tool_call_id, int $turn, array $metadata = array() ): array {
+		$event = array(
+			'type'         => $type,
+			'tool_name'    => $tool_name,
+			'tool_call_id' => $tool_call_id,
+			'turn_count'   => $turn,
+			'metadata'     => $metadata,
+		);
+
+		if ( isset( $metadata['status'] ) && is_string( $metadata['status'] ) ) {
+			$event['status'] = $metadata['status'];
+		}
+
+		return $event;
 	}
 
 	/**

--- a/src/Runtime/class-wp-agent-conversation-result.php
+++ b/src/Runtime/class-wp-agent-conversation-result.php
@@ -79,12 +79,20 @@ class WP_Agent_Conversation_Result {
 			$result['tool_audit_events'] = array();
 		}
 
+		if ( ! array_key_exists( 'tool_events', $result ) ) {
+			$result['tool_events'] = array();
+		}
+
 		if ( ! is_array( $result['tool_execution_results'] ) ) {
 			throw self::invalid( 'tool_execution_results', 'must be an array' );
 		}
 
 		if ( ! is_array( $result['tool_audit_events'] ) ) {
 			throw self::invalid( 'tool_audit_events', 'must be an array' );
+		}
+
+		if ( ! is_array( $result['tool_events'] ) ) {
+			throw self::invalid( 'tool_events', 'must be an array' );
 		}
 
 		foreach ( $result['tool_execution_results'] as $index => $tool_result ) {
@@ -149,6 +157,32 @@ class WP_Agent_Conversation_Result {
 			}
 		}
 
+		foreach ( $result['tool_events'] as $index => $tool_event ) {
+			$path = 'tool_events[' . $index . ']';
+
+			if ( ! is_array( $tool_event ) ) {
+				throw self::invalid( $path, 'must be an array' );
+			}
+
+			foreach ( array( 'type', 'tool_name', 'tool_call_id' ) as $field ) {
+				if ( ! array_key_exists( $field, $tool_event ) || ! is_string( $tool_event[ $field ] ) || '' === $tool_event[ $field ] ) {
+					throw self::invalid( $path . '.' . $field, 'must be a non-empty string' );
+				}
+			}
+
+			if ( ! array_key_exists( 'turn_count', $tool_event ) || ! is_int( $tool_event['turn_count'] ) ) {
+				throw self::invalid( $path . '.turn_count', 'must be an integer' );
+			}
+
+			if ( array_key_exists( 'status', $tool_event ) && ! is_string( $tool_event['status'] ) ) {
+				throw self::invalid( $path . '.status', 'must be a string when present' );
+			}
+
+			if ( array_key_exists( 'metadata', $tool_event ) && ! is_array( $tool_event['metadata'] ) ) {
+				throw self::invalid( $path . '.metadata', 'must be an array when present' );
+			}
+		}
+
 		// Validate optional budget-exceeded status fields.
 		if ( array_key_exists( 'status', $result ) && ! is_string( $result['status'] ) ) {
 			throw self::invalid( 'status', 'must be a string when present' );
@@ -173,6 +207,30 @@ class WP_Agent_Conversation_Result {
 
 		if ( array_key_exists( 'request_metadata', $result ) && ! is_array( $result['request_metadata'] ) ) {
 			throw self::invalid( 'request_metadata', 'must be an array when present' );
+		}
+
+		if ( array_key_exists( 'completed', $result ) && ! is_bool( $result['completed'] ) ) {
+			throw self::invalid( 'completed', 'must be a boolean when present' );
+		}
+
+		if ( array_key_exists( 'failure', $result ) ) {
+			if ( ! is_array( $result['failure'] ) ) {
+				throw self::invalid( 'failure', 'must be an array when present' );
+			}
+
+			foreach ( array( 'type', 'message' ) as $field ) {
+				if ( ! array_key_exists( $field, $result['failure'] ) || ! is_string( $result['failure'][ $field ] ) || '' === $result['failure'][ $field ] ) {
+					throw self::invalid( 'failure.' . $field, 'must be a non-empty string' );
+				}
+			}
+
+			if ( array_key_exists( 'turn_count', $result['failure'] ) && ! is_int( $result['failure']['turn_count'] ) ) {
+				throw self::invalid( 'failure.turn_count', 'must be an integer when present' );
+			}
+		}
+
+		if ( array_key_exists( 'runtime_tool_pending', $result ) && ! is_array( $result['runtime_tool_pending'] ) ) {
+			throw self::invalid( 'runtime_tool_pending', 'must be an array when present' );
 		}
 
 		return $result;

--- a/src/Runtime/class-wp-agent-runtime-tool-request-store.php
+++ b/src/Runtime/class-wp-agent-runtime-tool-request-store.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * External runtime tool request store interface.
+ *
+ * @package AgentsAPI
+ */
+
+namespace AgentsAPI\AI;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Host-provided persistence boundary for pending runtime tool requests.
+ */
+interface WP_Agent_Runtime_Tool_Request_Store {
+
+	/**
+	 * Create or replace a pending runtime tool request.
+	 *
+	 * @param array<string, mixed> $request Normalized runtime tool request.
+	 */
+	public function create( array $request ): void;
+
+	/**
+	 * Read a pending runtime tool request by id.
+	 *
+	 * @param string $request_id Runtime tool request id.
+	 * @return array<string, mixed>|null Normalized request or null when absent.
+	 */
+	public function get( string $request_id ): ?array;
+
+	/**
+	 * Mark a pending request complete with a client-submitted result.
+	 *
+	 * @param string               $request_id Runtime tool request id.
+	 * @param array<string, mixed> $result Normalized runtime tool result.
+	 */
+	public function complete( string $request_id, array $result ): void;
+
+	/**
+	 * Mark a pending request timed out.
+	 *
+	 * @param string $request_id Runtime tool request id.
+	 */
+	public function timeout( string $request_id ): void;
+}

--- a/src/Runtime/class-wp-agent-runtime-tool-request.php
+++ b/src/Runtime/class-wp-agent-runtime-tool-request.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * External runtime tool pending request contract.
+ *
+ * @package AgentsAPI
+ */
+
+namespace AgentsAPI\AI;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Normalizes pending external/client tool requests.
+ */
+class WP_Agent_Runtime_Tool_Request {
+
+	public const STATUS_PENDING = 'runtime_tool_pending';
+	public const STATUS_TIMEOUT = 'runtime_tool_timeout';
+
+	/**
+	 * Normalize a pending runtime tool request.
+	 *
+	 * @param array<string, mixed> $request Raw request payload.
+	 * @return array<string, mixed> Normalized request payload.
+	 */
+	public static function normalize( array $request ): array {
+		$tool_name = $request['tool_name'] ?? '';
+		if ( ! is_string( $tool_name ) || '' === trim( $tool_name ) ) {
+			throw new \InvalidArgumentException( 'invalid_runtime_tool_request: tool_name must be a non-empty string' );
+		}
+
+		$tool_call_id = $request['tool_call_id'] ?? '';
+		if ( ! is_string( $tool_call_id ) || '' === trim( $tool_call_id ) ) {
+			throw new \InvalidArgumentException( 'invalid_runtime_tool_request: tool_call_id must be a non-empty string' );
+		}
+
+		$request_id = $request['request_id'] ?? '';
+		if ( ! is_string( $request_id ) || '' === trim( $request_id ) ) {
+			$request_id = self::request_id( $tool_name, $tool_call_id, $request['run_id'] ?? '' );
+		}
+
+		$parameters = $request['parameters'] ?? array();
+		$runtime    = $request['runtime'] ?? array();
+		$metadata   = $request['metadata'] ?? array();
+
+		return array(
+			'status'       => self::STATUS_PENDING,
+			'request_id'   => $request_id,
+			'tool_name'    => trim( $tool_name ),
+			'tool_call_id' => trim( $tool_call_id ),
+			'parameters'   => is_array( $parameters ) ? $parameters : array(),
+			'run_id'       => is_string( $request['run_id'] ?? null ) ? $request['run_id'] : '',
+			'timeout_at'   => is_string( $request['timeout_at'] ?? null ) ? $request['timeout_at'] : '',
+			'runtime'      => is_array( $runtime ) ? $runtime : array(),
+			'metadata'     => is_array( $metadata ) ? $metadata : array(),
+		);
+	}
+
+	/**
+	 * Build a pending request from a loop-mediated tool call.
+	 *
+	 * @param string               $tool_name    Tool identifier.
+	 * @param string               $tool_call_id Tool call identifier.
+	 * @param array<string, mixed> $parameters   Tool parameters.
+	 * @param array<string, mixed> $context      Turn context.
+	 * @param array<string, mixed> $runtime      Runtime metadata.
+	 * @param array<string, mixed> $metadata     Host metadata.
+	 * @return array<string, mixed> Normalized request payload.
+	 */
+	public static function from_tool_call( string $tool_name, string $tool_call_id, array $parameters, array $context = array(), array $runtime = array(), array $metadata = array() ): array {
+		return self::normalize( array(
+			'tool_name'    => $tool_name,
+			'tool_call_id' => $tool_call_id,
+			'parameters'   => $parameters,
+			'run_id'       => is_string( $context['run_id'] ?? null ) ? $context['run_id'] : '',
+			'timeout_at'   => is_string( $context['runtime_tool_timeout_at'] ?? null ) ? $context['runtime_tool_timeout_at'] : '',
+			'runtime'      => $runtime,
+			'metadata'     => $metadata,
+		) );
+	}
+
+	/**
+	 * Build a stable request id when the host did not supply one.
+	 *
+	 * @param string $tool_name Tool name.
+	 * @param string $tool_call_id Tool call id.
+	 * @param mixed  $run_id Optional run id.
+	 * @return string Request id.
+	 */
+	private static function request_id( string $tool_name, string $tool_call_id, $run_id ): string {
+		$parts = array_filter( array( is_string( $run_id ) ? $run_id : '', $tool_name, $tool_call_id ) );
+		return 'runtime-tool-' . hash( 'sha256', implode( '|', $parts ) );
+	}
+}

--- a/src/Runtime/class-wp-agent-runtime-tool-result.php
+++ b/src/Runtime/class-wp-agent-runtime-tool-result.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * External runtime tool submitted result contract.
+ *
+ * @package AgentsAPI
+ */
+
+namespace AgentsAPI\AI;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Normalizes client/transport-submitted runtime tool results.
+ */
+class WP_Agent_Runtime_Tool_Result {
+
+	public const STATUS_SUBMITTED = 'runtime_tool_submitted';
+
+	/**
+	 * Normalize a submitted runtime tool result.
+	 *
+	 * @param array<string, mixed> $result Raw result payload.
+	 * @return array<string, mixed> Normalized result payload.
+	 */
+	public static function normalize( array $result ): array {
+		$request_id = $result['request_id'] ?? '';
+		if ( ! is_string( $request_id ) || '' === trim( $request_id ) ) {
+			throw new \InvalidArgumentException( 'invalid_runtime_tool_result: request_id must be a non-empty string' );
+		}
+
+		$tool_name = $result['tool_name'] ?? '';
+		if ( ! is_string( $tool_name ) || '' === trim( $tool_name ) ) {
+			throw new \InvalidArgumentException( 'invalid_runtime_tool_result: tool_name must be a non-empty string' );
+		}
+
+		$payload  = $result['result'] ?? array();
+		$metadata = $result['metadata'] ?? array();
+
+		$normalized = array(
+			'status'     => self::STATUS_SUBMITTED,
+			'request_id' => trim( $request_id ),
+			'tool_name'  => trim( $tool_name ),
+			'success'    => (bool) ( $result['success'] ?? true ),
+			'metadata'   => is_array( $metadata ) ? $metadata : array(),
+		);
+
+		if ( $normalized['success'] ) {
+			$normalized['result'] = is_array( $payload ) ? $payload : array( 'value' => $payload );
+			return $normalized;
+		}
+
+		$error               = $result['error'] ?? 'Runtime tool execution failed.';
+		$normalized['error'] = is_string( $error ) && '' !== trim( $error ) ? $error : 'Runtime tool execution failed.';
+
+		return $normalized;
+	}
+}

--- a/src/Tools/class-wp-agent-tool-result.php
+++ b/src/Tools/class-wp-agent-tool-result.php
@@ -84,6 +84,14 @@ class WP_Agent_Tool_Result {
 			$normalized['runtime'] = $runtime;
 		}
 
+		if ( isset( $result['status'] ) && is_string( $result['status'] ) && '' !== trim( $result['status'] ) ) {
+			$normalized['status'] = trim( $result['status'] );
+		}
+
+		if ( isset( $result['runtime_tool_request'] ) && is_array( $result['runtime_tool_request'] ) ) {
+			$normalized['runtime_tool_request'] = $result['runtime_tool_request'];
+		}
+
 		if ( $success ) {
 			$normalized['result'] = $result['result'] ?? array();
 			return $normalized;

--- a/tests/conversation-loop-events-smoke.php
+++ b/tests/conversation-loop-events-smoke.php
@@ -99,25 +99,22 @@ agents_api_smoke_assert_equals( 'client/work', $tool_call_event['payload']['tool
 echo "\n[2] Failed event emits on turn runner exception:\n";
 $event_log = array();
 
-$threw = false;
-try {
-	AgentsAPI\AI\WP_Agent_Conversation_Loop::run(
-		array( array( 'role' => 'user', 'content' => 'fail' ) ),
-		static function (): array {
-			throw new \RuntimeException( 'provider down' );
+$failure_result = AgentsAPI\AI\WP_Agent_Conversation_Loop::run(
+	array( array( 'role' => 'user', 'content' => 'fail' ) ),
+	static function (): array {
+		throw new \RuntimeException( 'provider down' );
+	},
+	array(
+		'max_turns' => 1,
+		'on_event'  => static function ( string $event, array $payload ) use ( &$event_log ): void {
+			$event_log[] = array( 'event' => $event, 'payload' => $payload );
 		},
-		array(
-			'max_turns' => 1,
-			'on_event'  => static function ( string $event, array $payload ) use ( &$event_log ): void {
-				$event_log[] = array( 'event' => $event, 'payload' => $payload );
-			},
-		)
-	);
-} catch ( \RuntimeException $e ) {
-	$threw = true;
-}
+	)
+);
 
-agents_api_smoke_assert_equals( true, $threw, 'exception was re-thrown', $failures, $passes );
+agents_api_smoke_assert_equals( 'failed', $failure_result['status'] ?? '', 'exception returns structured failed status', $failures, $passes );
+agents_api_smoke_assert_equals( false, $failure_result['completed'] ?? true, 'structured failure is not completed', $failures, $passes );
+agents_api_smoke_assert_equals( 'provider down', $failure_result['failure']['message'] ?? '', 'structured failure carries error message', $failures, $passes );
 $event_names = array_column( $event_log, 'event' );
 agents_api_smoke_assert_equals( true, in_array( 'failed', $event_names, true ), 'failed event was emitted on exception', $failures, $passes );
 

--- a/tests/conversation-loop-tool-execution-smoke.php
+++ b/tests/conversation-loop-tool-execution-smoke.php
@@ -105,6 +105,8 @@ agents_api_smoke_assert_equals( 'call_123', $result['tool_audit_events'][0]['too
 agents_api_smoke_assert_equals( true, $result['tool_audit_events'][0]['success'], 'tool audit event records success', $failures, $passes );
 agents_api_smoke_assert_equals( true, str_starts_with( $result['tool_audit_events'][0]['parameters_sha256'], 'sha256:' ), 'tool audit event hashes parameters', $failures, $passes );
 agents_api_smoke_assert_equals( true, ! array_key_exists( 'parameters', $result['tool_audit_events'][0] ), 'tool audit event omits raw parameters', $failures, $passes );
+agents_api_smoke_assert_equals( array( 'tool_call', 'tool_result' ), array_column( $result['tool_events'], 'type' ), 'result contains canonical tool call/result events', $failures, $passes );
+agents_api_smoke_assert_equals( 'success', $result['tool_events'][1]['status'] ?? '', 'tool result event records status', $failures, $passes );
 
 // Messages should contain: user, assistant text, tool_call, tool_result.
 $message_count = count( $result['messages'] );
@@ -444,5 +446,52 @@ agents_api_smoke_assert_equals( 2, $omit_turn, 'loop completes naturally even wh
 agents_api_smoke_assert_equals( true, count( $omit_result['messages'] ) >= 4, 'transcript retains user + tool_call + tool_result + final content despite omitted messages key', $failures, $passes );
 $omit_roles = array_map( static fn( array $m ): string => (string) ( $m['role'] ?? '' ), $omit_result['messages'] );
 agents_api_smoke_assert_equals( 'user', $omit_roles[0] ?? '', 'first transcript message is the original user turn (history preserved)', $failures, $passes );
+
+echo "\n[Runtime tools can pause the loop with a canonical pending request (#250):\n";
+$pending_executor = new class() implements AgentsAPI\AI\Tools\WP_Agent_Tool_Executor {
+	public function executeWP_Agent_Tool_Call( array $tool_call, array $tool_definition, array $context = array() ): array {
+		return array(
+			'success'              => false,
+			'tool_name'            => $tool_call['tool_name'],
+			'status'               => AgentsAPI\AI\WP_Agent_Runtime_Tool_Request::STATUS_PENDING,
+			'error'                => 'Waiting for client runtime tool result.',
+			'runtime_tool_request' => AgentsAPI\AI\WP_Agent_Runtime_Tool_Request::from_tool_call(
+				$tool_call['tool_name'],
+				$tool_call['id'] ?? 'pending-call',
+				$tool_call['parameters'],
+				$context,
+				array( 'completion_signal' => 'external_result' ),
+				array( 'transport' => 'browser' )
+			),
+		);
+	}
+};
+
+$pending_result = AgentsAPI\AI\WP_Agent_Conversation_Loop::run(
+	array( array( 'role' => 'user', 'content' => 'choose' ) ),
+	static function ( array $messages ): array {
+		return array(
+			'messages'   => $messages,
+			'tool_calls' => array(
+				array(
+					'id'         => 'client-call-1',
+					'name'       => 'client/summarize',
+					'parameters' => array( 'text' => 'needs browser' ),
+				),
+			),
+		);
+	},
+	array(
+		'max_turns'         => 3,
+		'tool_executor'     => $pending_executor,
+		'tool_declarations' => $tools,
+	)
+);
+
+agents_api_smoke_assert_equals( AgentsAPI\AI\WP_Agent_Runtime_Tool_Request::STATUS_PENDING, $pending_result['status'] ?? '', 'pending runtime tool sets canonical loop status', $failures, $passes );
+agents_api_smoke_assert_equals( false, $pending_result['completed'] ?? true, 'pending runtime tool result is incomplete', $failures, $passes );
+agents_api_smoke_assert_equals( 'client/summarize', $pending_result['runtime_tool_pending']['tool_name'] ?? '', 'pending request carries tool name', $failures, $passes );
+agents_api_smoke_assert_equals( 'client-call-1', $pending_result['runtime_tool_pending']['tool_call_id'] ?? '', 'pending request carries tool call id', $failures, $passes );
+agents_api_smoke_assert_equals( array( 'tool_call', AgentsAPI\AI\WP_Agent_Runtime_Tool_Request::STATUS_PENDING ), array_column( $pending_result['tool_events'], 'type' ), 'pending request is recorded in canonical tool events', $failures, $passes );
 
 agents_api_smoke_finish( 'Agents API conversation loop tool execution', $failures, $passes );

--- a/tests/conversation-loop-transcript-persister-smoke.php
+++ b/tests/conversation-loop-transcript-persister-smoke.php
@@ -35,6 +35,7 @@ $persister     = new class( $persister_log ) implements AgentsAPI\AI\WP_Agent_Tr
 			'request_turns'    => $request->maxTurns(),
 			'workspace'        => $request->workspace() ? $request->workspace()->to_array() : null,
 			'result_keys'      => array_keys( $result ),
+			'result_status'    => $result['status'] ?? '',
 			'completed'        => $result['completed'] ?? null,
 			'request_metadata' => $result['request_metadata'] ?? null,
 		);
@@ -83,24 +84,21 @@ agents_api_smoke_assert_equals( 'SITE.md', $persister_log[0]['request_metadata']
 echo "\n[2] Persister fires on the failure path (turn runner throws):\n";
 $persister_log = array();
 
-$threw = false;
-try {
-	AgentsAPI\AI\WP_Agent_Conversation_Loop::run(
-		array( array( 'role' => 'user', 'content' => 'fail' ) ),
-		static function (): array {
-			throw new \RuntimeException( 'provider error' );
-		},
-		array(
-			'max_turns'            => 1,
-			'transcript_persister' => $persister,
-		)
-	);
-} catch ( \RuntimeException $e ) {
-	$threw = 'provider error' === $e->getMessage();
-}
+$failure_result = AgentsAPI\AI\WP_Agent_Conversation_Loop::run(
+	array( array( 'role' => 'user', 'content' => 'fail' ) ),
+	static function (): array {
+		throw new \RuntimeException( 'provider error' );
+	},
+	array(
+		'max_turns'            => 1,
+		'transcript_persister' => $persister,
+	)
+);
 
-agents_api_smoke_assert_equals( true, $threw, 'turn runner exception was re-thrown', $failures, $passes );
+agents_api_smoke_assert_equals( 'failed', $failure_result['status'] ?? '', 'turn runner exception returns structured failure status', $failures, $passes );
+agents_api_smoke_assert_equals( 'provider error', $failure_result['failure']['message'] ?? '', 'structured failure preserves provider error', $failures, $passes );
 agents_api_smoke_assert_equals( 1, count( $persister_log ), 'persister was called on failure path', $failures, $passes );
+agents_api_smoke_assert_equals( 'failed', $persister_log[0]['result_status'] ?? '', 'persister receives structured failure result', $failures, $passes );
 
 echo "\n[3] No persister = no persistence calls (backwards compatible):\n";
 $persister_log = array();

--- a/tests/tool-runtime-smoke.php
+++ b/tests/tool-runtime-smoke.php
@@ -239,4 +239,28 @@ $result_override = $executor->executeTool(
 agents_api_smoke_assert_equals( 'repeatable', $result_override['runtime']['duplicate_policy'] ?? '', 'result runtime keeps declaration metadata when executor adds runtime', $failures, $passes );
 agents_api_smoke_assert_equals( 'complete', $result_override['runtime']['completion_signal'] ?? '', 'executor runtime metadata can refine result runtime metadata', $failures, $passes );
 
+$pending_request = AgentsAPI\AI\WP_Agent_Runtime_Tool_Request::from_tool_call(
+	'client/choose_post',
+	'call_abc',
+	array( 'post_id' => 123 ),
+	array( 'run_id' => 'run-1', 'runtime_tool_timeout_at' => '2026-06-01T00:00:00Z' ),
+	array( 'completion_signal' => 'external_result' ),
+	array( 'transport' => 'browser' )
+);
+agents_api_smoke_assert_equals( AgentsAPI\AI\WP_Agent_Runtime_Tool_Request::STATUS_PENDING, $pending_request['status'], 'runtime tool request has canonical pending status', $failures, $passes );
+agents_api_smoke_assert_equals( 'client/choose_post', $pending_request['tool_name'], 'runtime tool request carries tool name', $failures, $passes );
+agents_api_smoke_assert_equals( 'call_abc', $pending_request['tool_call_id'], 'runtime tool request carries tool call id', $failures, $passes );
+agents_api_smoke_assert_equals( 'browser', $pending_request['metadata']['transport'] ?? '', 'runtime tool request preserves host metadata', $failures, $passes );
+
+$submitted_result = AgentsAPI\AI\WP_Agent_Runtime_Tool_Result::normalize(
+	array(
+		'request_id' => $pending_request['request_id'],
+		'tool_name'  => 'client/choose_post',
+		'success'    => true,
+		'result'     => array( 'post_id' => 123 ),
+	)
+);
+agents_api_smoke_assert_equals( AgentsAPI\AI\WP_Agent_Runtime_Tool_Result::STATUS_SUBMITTED, $submitted_result['status'], 'runtime tool result has canonical submitted status', $failures, $passes );
+agents_api_smoke_assert_equals( 123, $submitted_result['result']['post_id'] ?? null, 'runtime tool result preserves payload', $failures, $passes );
+
 agents_api_smoke_finish( 'Agents API tool runtime', $failures, $passes );


### PR DESCRIPTION
## Summary
- Adds generic runtime tool request/result/store contracts for external/client tool fulfillment lifecycle primitives.
- Surfaces `runtime_tool_pending` from mediated tool execution so hosts can pause and resume without product-specific result keys.
- Adds canonical `tool_events` and structured `failed` conversation results so consumers can avoid side-channel accumulators for generic loop state.

Fixes #250.
Fixes #251.

## Testing
- `for test_file in tests/*smoke.php; do php \"$test_file\" || exit 1; done`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implementing the runtime tool loop contracts, structured failure result handling, canonical tool event history, and focused smoke coverage. Chris remains responsible for review and validation.