### PR TITLE
Add installed agent materialization contracts

### DIFF
--- a/agents-api.php
+++ b/agents-api.php
@@ -29,6 +29,11 @@ define( 'AGENTS_API_PLUGIN_FILE', __FILE__ );
 
 require_once AGENTS_API_PATH . 'src/Registry/class-wp-agent-runtime-overrides.php';
 require_once AGENTS_API_PATH . 'src/Registry/class-wp-agent.php';
+require_once AGENTS_API_PATH . 'src/Registry/class-wp-agent-installed-agent.php';
+require_once AGENTS_API_PATH . 'src/Registry/class-wp-agent-materialization-request.php';
+require_once AGENTS_API_PATH . 'src/Registry/class-wp-agent-materialization-result.php';
+require_once AGENTS_API_PATH . 'src/Registry/class-wp-agent-installed-agent-state-store.php';
+require_once AGENTS_API_PATH . 'src/Registry/class-wp-agent-installed-agent-projector.php';
 require_once AGENTS_API_PATH . 'src/Packages/class-wp-agent-package-artifact.php';
 require_once AGENTS_API_PATH . 'src/Packages/class-wp-agent-package-artifact-type.php';
 require_once AGENTS_API_PATH . 'src/Packages/class-wp-agent-package-artifacts-registry.php';

--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
       "php tests/message-envelope-smoke.php",
       "php tests/message-coalesce-smoke.php",
       "php tests/registry-smoke.php",
+      "php tests/installed-agent-materialization-smoke.php",
       "php tests/package-lifecycle-smoke.php",
       "php tests/package-capability-contract-smoke.php",
       "php tests/package-adoption-orchestration-smoke.php",

--- a/docs/registry-and-packages.md
+++ b/docs/registry-and-packages.md
@@ -76,6 +76,37 @@ Duplicate registration returns `null` and emits an invalid-usage notice that inc
 
 `WP_Agent_Package` models a portable package containing one agent definition plus generic artifacts. It is storage-neutral and runtime-neutral.
 
+## Durable installed agents
+
+Agents API defines the durable installed-agent contract without choosing a storage backend. Hosts that need plugin-shipped or user-installed agents to survive requests implement the state store and decide whether the backing store is tables, options, custom files, an external service, or something else. Agents API does not create installed-agent rows, directories, logs, memory files, access grants, tokens, admin UI, CLI commands, or REST routes for this contract.
+
+Core classes:
+
+| Class | Purpose |
+| --- | --- |
+| `WP_Agent_Installed_Agent` | Immutable installed-state value for a logical `(agent_slug, owner_user_id, instance_key)` instance. |
+| `WP_Agent_Materialization_Request` | Normalized install, upgrade, reconcile, project, uninstall, or dry-run request. It adopts `WP_Agent::get_default_config()` unless the caller opts out. |
+| `WP_Agent_Materialization_Result` | Result status plus optional installed state and projected request-local `WP_Agent`. |
+| `WP_Agent_Installed_Agent_State_Store` | Storage-neutral interface for resolving, materializing, and deleting installed state. |
+| `WP_Agent_Installed_Agent_Projector` | Helper for projecting durable installed state back into a request-local `WP_Agent` definition. |
+
+The intended lifecycle is:
+
+```text
+request-local WP_Agent or WP_Agent_Package agent
+  -> host resolves owner_user_id and instance_key
+  -> host materializes durable installed state through its store
+  -> package adoption may reconcile artifacts through package contracts
+  -> projector turns durable state back into a request-local WP_Agent
+  -> host registers/projected agents during its normal request bootstrap
+```
+
+Owner resolution remains host-owned. `WP_Agent` can declare an `owner_resolver` callback and default config, but Agents API does not call that resolver automatically or grant access. A host materializer should resolve an owner explicitly, pass it into `WP_Agent_Materialization_Request`, and persist only the host-approved installed state. This keeps sensitive owner/access semantics auditable instead of inferred from ambient runtime context.
+
+The installed-agent contract composes with package adoption but does not replace it. `WP_Agent_Package_Adoption_Orchestrator` handles artifact planning/application through artifact callbacks; the installed-agent state store handles the durable agent instance row or equivalent host record. Products such as Data Machine can implement both surfaces against their own storage and then project persisted agents into the request-local registry.
+
+This is the durable boundary decision for installed agents: Agents API owns neutral shapes and projection; products own persistence, feature flags, materializers, memory scaffolding, access grants, tokens, logs, and user-facing approval UX.
+
 Normalized package fields:
 
 | Field | Purpose |

--- a/src/Registry/class-wp-agent-installed-agent-projector.php
+++ b/src/Registry/class-wp-agent-installed-agent-projector.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * WP_Agent_Installed_Agent_Projector service.
+ *
+ * @package AgentsAPI
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+if ( ! class_exists( 'WP_Agent_Installed_Agent_Projector' ) ) {
+	/**
+	 * Projects durable installed-agent state into request-local WP_Agent objects.
+	 */
+	final class WP_Agent_Installed_Agent_Projector {
+
+		/**
+		 * Projects installed state back into a declarative agent definition.
+		 *
+		 * @param WP_Agent_Installed_Agent $installed_agent Installed state.
+		 * @param WP_Agent|null            $source_agent     Optional package/registry source definition.
+		 * @return WP_Agent
+		 */
+		public static function project( WP_Agent_Installed_Agent $installed_agent, ?WP_Agent $source_agent = null ): WP_Agent {
+			$args = null === $source_agent ? array() : $source_agent->to_array();
+			unset( $args['slug'] );
+
+			$args['default_config'] = $installed_agent->get_config();
+			$args['meta']           = array_merge(
+				is_array( $args['meta'] ?? null ) ? $args['meta'] : array(),
+				$installed_agent->get_meta(),
+				array(
+					'installed_agent_id'       => $installed_agent->get_id(),
+					'installed_agent_status'   => $installed_agent->get_status(),
+					'installed_agent_owner_id' => $installed_agent->get_owner_user_id(),
+					'installed_agent_instance' => $installed_agent->get_instance_key(),
+				)
+			);
+
+			if ( null !== $installed_agent->get_package_slug() ) {
+				$args['meta']['source_package'] = $installed_agent->get_package_slug();
+			}
+
+			if ( null !== $installed_agent->get_package_version() ) {
+				$args['meta']['source_version'] = $installed_agent->get_package_version();
+			}
+
+			return new WP_Agent( $installed_agent->get_agent_slug(), $args );
+		}
+	}
+}

--- a/src/Registry/class-wp-agent-installed-agent-state-store.php
+++ b/src/Registry/class-wp-agent-installed-agent-state-store.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * WP_Agent_Installed_Agent_State_Store contract.
+ *
+ * @package AgentsAPI
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+if ( ! interface_exists( 'WP_Agent_Installed_Agent_State_Store' ) ) {
+	/**
+	 * Storage-neutral installed-agent state store contract.
+	 */
+	interface WP_Agent_Installed_Agent_State_Store {
+
+		/**
+		 * Resolves installed state for a logical agent instance.
+		 *
+		 * @param string              $agent_slug    Agent slug.
+		 * @param int|null            $owner_user_id Optional owner user ID.
+		 * @param string              $instance_key  Product-owned instance key.
+		 * @param array<string,mixed> $context       Host context.
+		 * @return WP_Agent_Installed_Agent|null Installed state, or null when absent.
+		 */
+		public function resolve( string $agent_slug, ?int $owner_user_id = null, string $instance_key = 'default', array $context = array() ): ?WP_Agent_Installed_Agent;
+
+		/**
+		 * Materializes or reconciles installed state.
+		 *
+		 * Implementations own persistence and must keep the same normalized
+		 * `(agent_slug, owner_user_id, instance_key)` tuple idempotent.
+		 *
+		 * @param WP_Agent_Materialization_Request $request Request.
+		 * @return WP_Agent_Materialization_Result Result.
+		 */
+		public function materialize( WP_Agent_Materialization_Request $request ): WP_Agent_Materialization_Result;
+
+		/**
+		 * Deletes or disables installed state according to host policy.
+		 *
+		 * @param WP_Agent_Installed_Agent $installed_agent Installed state.
+		 * @param array<string,mixed>      $context         Host context.
+		 * @return bool Whether the operation succeeded.
+		 */
+		public function delete( WP_Agent_Installed_Agent $installed_agent, array $context = array() ): bool;
+	}
+}

--- a/src/Registry/class-wp-agent-installed-agent.php
+++ b/src/Registry/class-wp-agent-installed-agent.php
@@ -35,7 +35,7 @@ if ( ! class_exists( 'WP_Agent_Installed_Agent' ) ) {
 		public function __construct( array $args ) {
 			$this->id              = self::prepare_required_string( $args['id'] ?? '', 'Installed agent id cannot be empty.' );
 			$this->agent_slug      = self::prepare_slug( $args['agent_slug'] ?? '', 'Installed agent slug cannot be empty.' );
-			$this->owner_user_id   = isset( $args['owner_user_id'] ) && null !== $args['owner_user_id'] ? max( 0, (int) $args['owner_user_id'] ) : null;
+			$this->owner_user_id   = array_key_exists( 'owner_user_id', $args ) && null !== $args['owner_user_id'] ? max( 0, (int) $args['owner_user_id'] ) : null;
 			$this->instance_key    = self::prepare_instance_key( $args['instance_key'] ?? 'default' );
 			$this->config          = is_array( $args['config'] ?? null ) ? $args['config'] : array();
 			$this->meta            = is_array( $args['meta'] ?? null ) ? $args['meta'] : array();
@@ -117,7 +117,7 @@ if ( ! class_exists( 'WP_Agent_Installed_Agent' ) ) {
 		private static function prepare_required_string( $value, string $message ): string {
 			$value = trim( (string) $value );
 			if ( '' === $value ) {
-				throw new InvalidArgumentException( $message );
+				throw new InvalidArgumentException( esc_html( $message ) );
 			}
 
 			return $value;
@@ -126,7 +126,7 @@ if ( ! class_exists( 'WP_Agent_Installed_Agent' ) ) {
 		private static function prepare_slug( $value, string $message ): string {
 			$value = sanitize_title( (string) $value );
 			if ( '' === $value ) {
-				throw new InvalidArgumentException( $message );
+				throw new InvalidArgumentException( esc_html( $message ) );
 			}
 
 			return $value;

--- a/src/Registry/class-wp-agent-installed-agent.php
+++ b/src/Registry/class-wp-agent-installed-agent.php
@@ -1,0 +1,152 @@
+<?php
+/**
+ * WP_Agent_Installed_Agent value object.
+ *
+ * @package AgentsAPI
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+if ( ! class_exists( 'WP_Agent_Installed_Agent' ) ) {
+	/**
+	 * Describes durable installed agent state without defining storage.
+	 */
+	final class WP_Agent_Installed_Agent {
+
+		private string $id;
+		private string $agent_slug;
+		private ?int $owner_user_id;
+		private string $instance_key;
+		/** @var array<string,mixed> */
+		private array $config;
+		/** @var array<string,mixed> */
+		private array $meta;
+		private string $status;
+		private ?string $package_slug;
+		private ?string $package_version;
+		private ?string $created_at;
+		private ?string $updated_at;
+
+		/**
+		 * Constructor.
+		 *
+		 * @param array<string,mixed> $args Installed agent state.
+		 */
+		public function __construct( array $args ) {
+			$this->id              = self::prepare_required_string( $args['id'] ?? '', 'Installed agent id cannot be empty.' );
+			$this->agent_slug      = self::prepare_slug( $args['agent_slug'] ?? '', 'Installed agent slug cannot be empty.' );
+			$this->owner_user_id   = isset( $args['owner_user_id'] ) && null !== $args['owner_user_id'] ? max( 0, (int) $args['owner_user_id'] ) : null;
+			$this->instance_key    = self::prepare_instance_key( $args['instance_key'] ?? 'default' );
+			$this->config          = is_array( $args['config'] ?? null ) ? $args['config'] : array();
+			$this->meta            = is_array( $args['meta'] ?? null ) ? $args['meta'] : array();
+			$this->status          = self::prepare_status( $args['status'] ?? 'installed' );
+			$this->package_slug    = isset( $args['package_slug'] ) && '' !== trim( (string) $args['package_slug'] ) ? self::prepare_slug( $args['package_slug'], 'Installed agent package slug cannot be empty.' ) : null;
+			$this->package_version = isset( $args['package_version'] ) && '' !== trim( (string) $args['package_version'] ) ? trim( (string) $args['package_version'] ) : null;
+			$this->created_at      = isset( $args['created_at'] ) && '' !== trim( (string) $args['created_at'] ) ? trim( (string) $args['created_at'] ) : null;
+			$this->updated_at      = isset( $args['updated_at'] ) && '' !== trim( (string) $args['updated_at'] ) ? trim( (string) $args['updated_at'] ) : null;
+		}
+
+		public function get_id(): string {
+			return $this->id;
+		}
+
+		public function get_agent_slug(): string {
+			return $this->agent_slug;
+		}
+
+		public function get_owner_user_id(): ?int {
+			return $this->owner_user_id;
+		}
+
+		public function get_instance_key(): string {
+			return $this->instance_key;
+		}
+
+		/** @return array<string,mixed> */
+		public function get_config(): array {
+			return $this->config;
+		}
+
+		/** @return array<string,mixed> */
+		public function get_meta(): array {
+			return $this->meta;
+		}
+
+		public function get_status(): string {
+			return $this->status;
+		}
+
+		public function get_package_slug(): ?string {
+			return $this->package_slug;
+		}
+
+		public function get_package_version(): ?string {
+			return $this->package_version;
+		}
+
+		public function get_created_at(): ?string {
+			return $this->created_at;
+		}
+
+		public function get_updated_at(): ?string {
+			return $this->updated_at;
+		}
+
+		public function key(): string {
+			$owner = null === $this->owner_user_id ? 'none' : (string) $this->owner_user_id;
+			return $this->agent_slug . ':' . $owner . ':' . $this->instance_key;
+		}
+
+		/** @return array<string,mixed> */
+		public function to_array(): array {
+			return array(
+				'id'              => $this->id,
+				'agent_slug'      => $this->agent_slug,
+				'owner_user_id'   => $this->owner_user_id,
+				'instance_key'    => $this->instance_key,
+				'config'          => $this->config,
+				'meta'            => $this->meta,
+				'status'          => $this->status,
+				'package_slug'    => $this->package_slug,
+				'package_version' => $this->package_version,
+				'created_at'      => $this->created_at,
+				'updated_at'      => $this->updated_at,
+			);
+		}
+
+		private static function prepare_required_string( $value, string $message ): string {
+			$value = trim( (string) $value );
+			if ( '' === $value ) {
+				throw new InvalidArgumentException( $message );
+			}
+
+			return $value;
+		}
+
+		private static function prepare_slug( $value, string $message ): string {
+			$value = sanitize_title( (string) $value );
+			if ( '' === $value ) {
+				throw new InvalidArgumentException( $message );
+			}
+
+			return $value;
+		}
+
+		private static function prepare_instance_key( $value ): string {
+			$value = trim( strtolower( str_replace( '\\', '/', (string) $value ) ) );
+			$value = preg_replace( '#\s*/\s*#', '/', $value );
+			$value = preg_replace( '#/+#', '/', $value );
+			return '' === $value ? 'default' : $value;
+		}
+
+		private static function prepare_status( $status ): string {
+			$status  = sanitize_title( (string) $status );
+			$allowed = array( 'installed', 'updated', 'disabled', 'removed', 'projected' );
+			if ( ! in_array( $status, $allowed, true ) ) {
+				throw new InvalidArgumentException( 'Installed agent status is invalid.' );
+			}
+
+			return $status;
+		}
+	}
+}

--- a/src/Registry/class-wp-agent-materialization-request.php
+++ b/src/Registry/class-wp-agent-materialization-request.php
@@ -31,22 +31,25 @@ if ( ! class_exists( 'WP_Agent_Materialization_Request' ) ) {
 		 * @param array<string,mixed> $args  Request args.
 		 */
 		public function __construct( WP_Agent $agent, array $args = array() ) {
-			$this->agent          = $agent;
-			$this->operation      = self::prepare_operation( $args['operation'] ?? 'install' );
-			$this->owner_user_id  = isset( $args['owner_user_id'] ) && null !== $args['owner_user_id'] ? max( 0, (int) $args['owner_user_id'] ) : null;
-			$this->instance_key   = self::prepare_instance_key( $args['instance_key'] ?? 'default' );
-			$this->config         = self::prepare_config( $agent, $args['config'] ?? array(), (bool) ( $args['adopt_default_config'] ?? true ) );
-			$this->context        = is_array( $args['context'] ?? null ) ? $args['context'] : array();
-			$this->package        = $args['package'] ?? null;
-			$this->package_result = $args['package_result'] ?? null;
+			$this->agent         = $agent;
+			$this->operation     = self::prepare_operation( $args['operation'] ?? 'install' );
+			$this->owner_user_id = array_key_exists( 'owner_user_id', $args ) && null !== $args['owner_user_id'] ? max( 0, (int) $args['owner_user_id'] ) : null;
+			$this->instance_key  = self::prepare_instance_key( $args['instance_key'] ?? 'default' );
+			$this->config        = self::prepare_config( $agent, $args['config'] ?? array(), (bool) ( $args['adopt_default_config'] ?? true ) );
+			$this->context       = is_array( $args['context'] ?? null ) ? $args['context'] : array();
+			$package             = $args['package'] ?? null;
+			$package_result      = $args['package_result'] ?? null;
 
-			if ( null !== $this->package && ! $this->package instanceof WP_Agent_Package ) {
+			if ( null !== $package && ! $package instanceof WP_Agent_Package ) {
 				throw new InvalidArgumentException( 'Materialization package must be a WP_Agent_Package.' );
 			}
 
-			if ( null !== $this->package_result && ! $this->package_result instanceof WP_Agent_Package_Adoption_Result ) {
+			if ( null !== $package_result && ! $package_result instanceof WP_Agent_Package_Adoption_Result ) {
 				throw new InvalidArgumentException( 'Materialization package_result must be a WP_Agent_Package_Adoption_Result.' );
 			}
+
+			$this->package        = $package;
+			$this->package_result = $package_result;
 		}
 
 		public function get_agent(): WP_Agent {

--- a/src/Registry/class-wp-agent-materialization-request.php
+++ b/src/Registry/class-wp-agent-materialization-request.php
@@ -1,0 +1,129 @@
+<?php
+/**
+ * WP_Agent_Materialization_Request value object.
+ *
+ * @package AgentsAPI
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+if ( ! class_exists( 'WP_Agent_Materialization_Request' ) ) {
+	/**
+	 * Describes a storage-neutral installed-agent materialization request.
+	 */
+	final class WP_Agent_Materialization_Request {
+
+		private WP_Agent $agent;
+		private string $operation;
+		private ?int $owner_user_id;
+		private string $instance_key;
+		/** @var array<string,mixed> */
+		private array $config;
+		/** @var array<string,mixed> */
+		private array $context;
+		private ?WP_Agent_Package $package;
+		private ?WP_Agent_Package_Adoption_Result $package_result;
+
+		/**
+		 * Constructor.
+		 *
+		 * @param WP_Agent            $agent Agent definition to materialize.
+		 * @param array<string,mixed> $args  Request args.
+		 */
+		public function __construct( WP_Agent $agent, array $args = array() ) {
+			$this->agent          = $agent;
+			$this->operation      = self::prepare_operation( $args['operation'] ?? 'install' );
+			$this->owner_user_id  = isset( $args['owner_user_id'] ) && null !== $args['owner_user_id'] ? max( 0, (int) $args['owner_user_id'] ) : null;
+			$this->instance_key   = self::prepare_instance_key( $args['instance_key'] ?? 'default' );
+			$this->config         = self::prepare_config( $agent, $args['config'] ?? array(), (bool) ( $args['adopt_default_config'] ?? true ) );
+			$this->context        = is_array( $args['context'] ?? null ) ? $args['context'] : array();
+			$this->package        = $args['package'] ?? null;
+			$this->package_result = $args['package_result'] ?? null;
+
+			if ( null !== $this->package && ! $this->package instanceof WP_Agent_Package ) {
+				throw new InvalidArgumentException( 'Materialization package must be a WP_Agent_Package.' );
+			}
+
+			if ( null !== $this->package_result && ! $this->package_result instanceof WP_Agent_Package_Adoption_Result ) {
+				throw new InvalidArgumentException( 'Materialization package_result must be a WP_Agent_Package_Adoption_Result.' );
+			}
+		}
+
+		public function get_agent(): WP_Agent {
+			return $this->agent;
+		}
+
+		public function get_operation(): string {
+			return $this->operation;
+		}
+
+		public function get_owner_user_id(): ?int {
+			return $this->owner_user_id;
+		}
+
+		public function get_instance_key(): string {
+			return $this->instance_key;
+		}
+
+		/** @return array<string,mixed> */
+		public function get_config(): array {
+			return $this->config;
+		}
+
+		/** @return array<string,mixed> */
+		public function get_context(): array {
+			return $this->context;
+		}
+
+		public function get_package(): ?WP_Agent_Package {
+			return $this->package;
+		}
+
+		public function get_package_result(): ?WP_Agent_Package_Adoption_Result {
+			return $this->package_result;
+		}
+
+		/** @return array<string,mixed> */
+		public function to_array(): array {
+			return array(
+				'agent'          => $this->agent->to_array(),
+				'operation'      => $this->operation,
+				'owner_user_id'  => $this->owner_user_id,
+				'instance_key'   => $this->instance_key,
+				'config'         => $this->config,
+				'context'        => $this->context,
+				'package'        => null === $this->package ? null : $this->package->to_array(),
+				'package_result' => null === $this->package_result ? null : $this->package_result->to_array(),
+			);
+		}
+
+		private static function prepare_operation( $operation ): string {
+			$operation = sanitize_title( (string) $operation );
+			$allowed   = array( 'install', 'upgrade', 'reconcile', 'project', 'uninstall', 'dry-run' );
+			if ( ! in_array( $operation, $allowed, true ) ) {
+				throw new InvalidArgumentException( 'Agent materialization operation must be install, upgrade, reconcile, project, uninstall, or dry-run.' );
+			}
+
+			return $operation;
+		}
+
+		private static function prepare_instance_key( $value ): string {
+			$value = trim( strtolower( str_replace( '\\', '/', (string) $value ) ) );
+			$value = preg_replace( '#\s*/\s*#', '/', $value );
+			$value = preg_replace( '#/+#', '/', $value );
+			return '' === $value ? 'default' : $value;
+		}
+
+		/**
+		 * @param mixed $config Raw config.
+		 * @return array<string,mixed>
+		 */
+		private static function prepare_config( WP_Agent $agent, $config, bool $adopt_default_config ): array {
+			if ( ! is_array( $config ) ) {
+				throw new InvalidArgumentException( 'Agent materialization config must be an array.' );
+			}
+
+			return $adopt_default_config ? array_replace_recursive( $agent->get_default_config(), $config ) : $config;
+		}
+	}
+}

--- a/src/Registry/class-wp-agent-materialization-result.php
+++ b/src/Registry/class-wp-agent-materialization-result.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * WP_Agent_Materialization_Result value object.
+ *
+ * @package AgentsAPI
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+if ( ! class_exists( 'WP_Agent_Materialization_Result' ) ) {
+	/**
+	 * Reports storage-neutral installed-agent materialization outcomes.
+	 */
+	final class WP_Agent_Materialization_Result {
+
+		private string $status;
+		private ?WP_Agent_Installed_Agent $installed_agent;
+		private ?WP_Agent $projected_agent;
+		/** @var array<int,string> */
+		private array $messages;
+		/** @var array<string,mixed> */
+		private array $meta;
+
+		/**
+		 * Constructor.
+		 *
+		 * @param string                        $status          Result status.
+		 * @param WP_Agent_Installed_Agent|null $installed_agent Installed state.
+		 * @param WP_Agent|null                 $projected_agent  Projected request-local definition.
+		 * @param array<int,string>             $messages         Messages.
+		 * @param array<string,mixed>           $meta             Metadata.
+		 */
+		public function __construct( string $status, ?WP_Agent_Installed_Agent $installed_agent = null, ?WP_Agent $projected_agent = null, array $messages = array(), array $meta = array() ) {
+			$this->status          = self::prepare_status( $status );
+			$this->installed_agent = $installed_agent;
+			$this->projected_agent = $projected_agent;
+			$this->messages        = self::prepare_messages( $messages );
+			$this->meta            = $meta;
+		}
+
+		public function get_status(): string {
+			return $this->status;
+		}
+
+		public function get_installed_agent(): ?WP_Agent_Installed_Agent {
+			return $this->installed_agent;
+		}
+
+		public function get_projected_agent(): ?WP_Agent {
+			return $this->projected_agent;
+		}
+
+		/** @return array<int,string> */
+		public function get_messages(): array {
+			return $this->messages;
+		}
+
+		/** @return array<string,mixed> */
+		public function get_meta(): array {
+			return $this->meta;
+		}
+
+		/** @return array<string,mixed> */
+		public function to_array(): array {
+			return array(
+				'status'          => $this->status,
+				'installed_agent' => null === $this->installed_agent ? null : $this->installed_agent->to_array(),
+				'projected_agent' => null === $this->projected_agent ? null : $this->projected_agent->to_array(),
+				'messages'        => $this->messages,
+				'meta'            => $this->meta,
+			);
+		}
+
+		private static function prepare_status( string $status ): string {
+			$status  = sanitize_title( $status );
+			$allowed = array( 'installed', 'updated', 'projected', 'skipped', 'failed', 'planned', 'removed' );
+			if ( ! in_array( $status, $allowed, true ) ) {
+				throw new InvalidArgumentException( 'Agent materialization result status is invalid.' );
+			}
+
+			return $status;
+		}
+
+		/** @param array<int,string> $messages */
+		private static function prepare_messages( array $messages ): array {
+			$prepared = array();
+			foreach ( $messages as $message ) {
+				$message = trim( (string) $message );
+				if ( '' !== $message ) {
+					$prepared[] = $message;
+				}
+			}
+
+			return $prepared;
+		}
+	}
+}

--- a/src/Transcripts/class-wp-agent-cpt-conversation-store.php
+++ b/src/Transcripts/class-wp-agent-cpt-conversation-store.php
@@ -125,6 +125,10 @@ final class WP_Agent_Cpt_Conversation_Store implements WP_Agent_Principal_Conver
 		if ( null === $post ) {
 			return false;
 		}
+		$messages_json = wp_json_encode( array_values( $messages ) );
+		if ( false === $messages_json ) {
+			$messages_json = '[]';
+		}
 
 		$updated = wp_update_post(
 			array(
@@ -132,12 +136,12 @@ final class WP_Agent_Cpt_Conversation_Store implements WP_Agent_Principal_Conver
 				// wp_update_post unslashes post_content; wp_slash preserves the
 				// JSON's escaped quotes (notably tool_result payloads that nest
 				// JSON in their content field).
-				'post_content' => wp_slash( wp_json_encode( array_values( $messages ) ) ),
+				'post_content' => (string) wp_slash( $messages_json ),
 			),
 			true
 		);
 
-		if ( is_wp_error( $updated ) || ! $updated ) {
+		if ( is_wp_error( $updated ) ) {
 			return false;
 		}
 
@@ -178,7 +182,7 @@ final class WP_Agent_Cpt_Conversation_Store implements WP_Agent_Principal_Conver
 			true
 		);
 
-		return ! is_wp_error( $updated ) && (bool) $updated;
+		return ! is_wp_error( $updated );
 	}
 
 	/* ---------------- Principal conversation store contract --------------- */
@@ -186,6 +190,10 @@ final class WP_Agent_Cpt_Conversation_Store implements WP_Agent_Principal_Conver
 	public function create_session_for_owner( WP_Agent_Workspace_Scope $workspace, array $owner, string $agent_slug = '', array $metadata = array(), string $context = 'chat' ): string {
 		$owner      = $this->normalize_owner( $owner );
 		$session_id = self::uuid4();
+		$empty_json = wp_json_encode( array() );
+		if ( false === $empty_json ) {
+			$empty_json = '[]';
+		}
 
 		$post_id = wp_insert_post(
 			array(
@@ -195,12 +203,12 @@ final class WP_Agent_Cpt_Conversation_Store implements WP_Agent_Principal_Conver
 				'post_title'   => '',
 				// wp_insert_post unslashes post_content; wp_slash compensates so
 				// JSON-escaped characters survive the round-trip.
-				'post_content' => wp_slash( wp_json_encode( array() ) ),
+				'post_content' => (string) wp_slash( $empty_json ),
 			),
 			true
 		);
 
-		if ( is_wp_error( $post_id ) || ! $post_id ) {
+		if ( is_wp_error( $post_id ) ) {
 			return '';
 		}
 
@@ -259,6 +267,9 @@ final class WP_Agent_Cpt_Conversation_Store implements WP_Agent_Principal_Conver
 
 		$sessions = array();
 		foreach ( $query->posts as $post ) {
+			if ( ! $post instanceof \WP_Post ) {
+				continue;
+			}
 			$session = $this->session_array( $post );
 			if ( ! $include_messages ) {
 				unset( $session['messages'] );
@@ -313,7 +324,11 @@ final class WP_Agent_Cpt_Conversation_Store implements WP_Agent_Principal_Conver
 			return null;
 		}
 
-		$post     = $query->posts[0];
+		$post = $query->posts[0];
+		if ( ! $post instanceof \WP_Post ) {
+			return null;
+		}
+
 		$messages = $this->decode_messages( $post->post_content );
 
 		// "Pending" = empty transcript or actively-locked session.
@@ -342,9 +357,12 @@ final class WP_Agent_Cpt_Conversation_Store implements WP_Agent_Principal_Conver
 				'expires' => $expires,
 			)
 		);
+		if ( false === $value ) {
+			$value = '{}';
+		}
 
 		// Fast path: no lock present. add_post_meta with $unique=true is atomic.
-		$added = add_post_meta( $post->ID, self::META_LOCK, $value, true );
+		$added = $this->add_unique_post_meta( $post->ID, self::META_LOCK, $value );
 		if ( $added ) {
 			return $token;
 		}
@@ -353,8 +371,7 @@ final class WP_Agent_Cpt_Conversation_Store implements WP_Agent_Principal_Conver
 		$existing_raw = get_post_meta( $post->ID, self::META_LOCK, true );
 		if ( ! is_string( $existing_raw ) || '' === $existing_raw ) {
 			// Race: meta disappeared between calls. Retry once.
-			$retry = add_post_meta( $post->ID, self::META_LOCK, $value, true );
-			return $retry ? $token : null;
+			return $this->add_unique_post_meta( $post->ID, self::META_LOCK, $value ) ? $token : null;
 		}
 
 		$existing = json_decode( $existing_raw, true );
@@ -442,11 +459,12 @@ final class WP_Agent_Cpt_Conversation_Store implements WP_Agent_Principal_Conver
 	/**
 	 * Coerce a caller-supplied owner into the canonical shape.
 	 *
-	 * @param array{type?:string,key?:string} $owner Raw owner.
+	 * @param array<string,mixed> $owner Raw owner.
 	 * @return array{type:string,key:string}
 	 */
 	private function normalize_owner( array $owner ): array {
-		$type = isset( $owner['type'] ) && is_string( $owner['type'] ) && '' !== $owner['type'] ? $owner['type'] : self::OWNER_TYPE_USER;
+		$type = isset( $owner['type'] ) ? (string) $owner['type'] : '';
+		$type = '' !== $type ? $type : self::OWNER_TYPE_USER;
 		$key  = isset( $owner['key'] ) ? (string) $owner['key'] : '0';
 		return array(
 			'type' => $type,
@@ -472,7 +490,11 @@ final class WP_Agent_Cpt_Conversation_Store implements WP_Agent_Principal_Conver
 			)
 		);
 
-		return ! empty( $query->posts ) ? $query->posts[0] : null;
+		if ( empty( $query->posts ) || ! $query->posts[0] instanceof \WP_Post ) {
+			return null;
+		}
+
+		return $query->posts[0];
 	}
 
 	private function session_array( \WP_Post $post ): array {
@@ -536,6 +558,10 @@ final class WP_Agent_Cpt_Conversation_Store implements WP_Agent_Principal_Conver
 		}
 		$decoded = json_decode( $raw, true );
 		return is_array( $decoded ) ? $decoded : null;
+	}
+
+	private function add_unique_post_meta( int $post_id, string $key, string $value ): bool {
+		return (bool) add_post_meta( $post_id, $key, $value, true );
 	}
 
 	private function lock_active( int $post_id ): bool {

--- a/tests/agents-api-smoke-helpers.php
+++ b/tests/agents-api-smoke-helpers.php
@@ -186,12 +186,12 @@ function is_wp_error( $value ): bool {
 function agents_api_smoke_assert_equals( $expected, $actual, string $name, array &$failures, int &$passes ): void {
 	if ( $expected === $actual ) {
 		++$passes;
-		echo "  PASS {$name}\n";
+		echo '  PASS ' . esc_html( $name ) . "\n";
 		return;
 	}
 
 	$failures[] = $name;
-	echo "  FAIL {$name}\n";
+	echo '  FAIL ' . esc_html( $name ) . "\n";
 	echo '    expected: ' . var_export( $expected, true ) . "\n";
 	echo '    actual:   ' . var_export( $actual, true ) . "\n";
 }

--- a/tests/installed-agent-materialization-smoke.php
+++ b/tests/installed-agent-materialization-smoke.php
@@ -1,0 +1,138 @@
+<?php
+/**
+ * Pure-PHP smoke test for installed-agent materialization contracts.
+ *
+ * Run with: php tests/installed-agent-materialization-smoke.php
+ *
+ * @package AgentsAPI\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+$failures = array();
+$passes   = 0;
+
+echo "agents-api-installed-agent-materialization-smoke\n";
+
+require_once __DIR__ . '/agents-api-smoke-helpers.php';
+agents_api_smoke_require_module();
+
+final class Agents_API_Test_Installed_Agent_State_Store implements WP_Agent_Installed_Agent_State_Store {
+	/** @var array<string,WP_Agent_Installed_Agent> */
+	private array $installed = array();
+
+	public function resolve( string $agent_slug, ?int $owner_user_id = null, string $instance_key = 'default', array $context = array() ): ?WP_Agent_Installed_Agent {
+		unset( $context );
+		$probe = new WP_Agent_Installed_Agent(
+			array(
+				'id'            => 'probe',
+				'agent_slug'    => $agent_slug,
+				'owner_user_id' => $owner_user_id,
+				'instance_key'  => $instance_key,
+			)
+		);
+
+		return $this->installed[ $probe->key() ] ?? null;
+	}
+
+	public function materialize( WP_Agent_Materialization_Request $request ): WP_Agent_Materialization_Result {
+		$package = $request->get_package();
+		$agent   = $request->get_agent();
+		$state   = new WP_Agent_Installed_Agent(
+			array(
+				'id'              => 'store:' . $agent->get_slug() . ':1',
+				'agent_slug'      => $agent->get_slug(),
+				'owner_user_id'   => $request->get_owner_user_id(),
+				'instance_key'    => $request->get_instance_key(),
+				'config'          => $request->get_config(),
+				'meta'            => array( 'store' => 'smoke' ),
+				'package_slug'    => null === $package ? null : $package->get_slug(),
+				'package_version' => null === $package ? null : $package->get_version(),
+				'created_at'      => '2026-06-01T00:00:00Z',
+				'updated_at'      => '2026-06-01T00:00:00Z',
+			)
+		);
+
+		$this->installed[ $state->key() ] = $state;
+
+		return new WP_Agent_Materialization_Result(
+			'installed',
+			$state,
+			WP_Agent_Installed_Agent_Projector::project( $state, $agent ),
+			array( 'Installed by smoke store.' ),
+			array( 'operation' => $request->get_operation() )
+		);
+	}
+
+	public function delete( WP_Agent_Installed_Agent $installed_agent, array $context = array() ): bool {
+		unset( $context );
+		unset( $this->installed[ $installed_agent->key() ] );
+		return true;
+	}
+}
+
+$agent = new WP_Agent(
+	'Demo Agent',
+	array(
+		'label'          => 'Demo Agent',
+		'description'    => 'A package-shipped agent.',
+		'default_config' => array(
+			'model'       => 'gpt-test',
+			'temperature' => 0.2,
+		),
+		'meta'           => array( 'source_type' => 'package' ),
+	)
+);
+
+$package = WP_Agent_Package::from_array(
+	array(
+		'slug'    => 'demo-package',
+		'version' => '1.2.3',
+		'agent'   => $agent->to_array(),
+	)
+);
+
+echo "\n[1] Materialization request adopts default config without storage coupling:\n";
+$request = new WP_Agent_Materialization_Request(
+	$agent,
+	array(
+		'operation'     => 'install',
+		'owner_user_id' => 42,
+		'instance_key'  => ' Site:99 / Primary ',
+		'config'        => array( 'temperature' => 0.7 ),
+		'package'       => $package,
+		'context'       => array( 'actor' => 'smoke' ),
+	)
+);
+
+agents_api_smoke_assert_equals( 'install', $request->get_operation(), 'operation is normalized', $failures, $passes );
+agents_api_smoke_assert_equals( 'site:99/primary', $request->get_instance_key(), 'instance key is normalized but host-owned', $failures, $passes );
+agents_api_smoke_assert_equals( array( 'model' => 'gpt-test', 'temperature' => 0.7 ), $request->get_config(), 'default config is adopted and caller overrides win', $failures, $passes );
+
+echo "\n[2] Installed state store contract materializes and resolves durable state:\n";
+$store  = new Agents_API_Test_Installed_Agent_State_Store();
+$result = $store->materialize( $request );
+$state  = $result->get_installed_agent();
+
+agents_api_smoke_assert_equals( 'installed', $result->get_status(), 'materialization result reports installed', $failures, $passes );
+agents_api_smoke_assert_equals( true, $state instanceof WP_Agent_Installed_Agent, 'result contains installed state value', $failures, $passes );
+agents_api_smoke_assert_equals( 'demo-agent:42:site:99/primary', $state->key(), 'installed state key is stable', $failures, $passes );
+agents_api_smoke_assert_equals( 'demo-package', $state->get_package_slug(), 'installed state carries package provenance', $failures, $passes );
+agents_api_smoke_assert_equals( true, $store->resolve( 'demo-agent', 42, 'site:99/primary' ) instanceof WP_Agent_Installed_Agent, 'store resolves by logical tuple', $failures, $passes );
+
+echo "\n[3] Projector returns request-local WP_Agent definition from durable state:\n";
+$projected = $result->get_projected_agent();
+agents_api_smoke_assert_equals( true, $projected instanceof WP_Agent, 'result contains projected WP_Agent', $failures, $passes );
+agents_api_smoke_assert_equals( 'demo-agent', $projected->get_slug(), 'projected agent keeps installed slug', $failures, $passes );
+agents_api_smoke_assert_equals( array( 'model' => 'gpt-test', 'temperature' => 0.7 ), $projected->get_default_config(), 'projected agent uses installed config', $failures, $passes );
+agents_api_smoke_assert_equals( 'store:demo-agent:1', $projected->get_meta()['installed_agent_id'] ?? null, 'projected metadata includes installed identity', $failures, $passes );
+agents_api_smoke_assert_equals( '1.2.3', $projected->get_meta()['source_version'] ?? null, 'projected metadata includes package version', $failures, $passes );
+
+echo "\n[4] Contract stays storage-neutral:\n";
+agents_api_smoke_assert_equals( true, interface_exists( 'WP_Agent_Installed_Agent_State_Store' ), 'installed-agent store interface is available', $failures, $passes );
+agents_api_smoke_assert_equals( false, class_exists( 'WP_Agent_Option_Installed_Agent_State_Store', false ), 'no option-backed installed-agent store is loaded', $failures, $passes );
+agents_api_smoke_assert_equals( false, class_exists( 'WP_Agent_Log_Installed_Agent_State_Store', false ), 'no log-backed installed-agent store is loaded', $failures, $passes );
+
+agents_api_smoke_finish( 'Agents API installed-agent materialization', $failures, $passes );


### PR DESCRIPTION
## Summary
- Adds storage-neutral installed-agent materialization contracts for durable host-owned agent state.
- Documents the boundary between request-local `WP_Agent` declarations, package adoption, host-owned persistence, owner resolution, and projection.
- Adds smoke coverage proving default config adoption, stable installed state resolution, request-local projection, and the absence of concrete storage implementations.

Closes #255.

## Verification
- `php tests/installed-agent-materialization-smoke.php`
- `php tests/package-adoption-orchestration-smoke.php`
- `composer test`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** implementation draft, tests, and verification.