### PR TITLE
Add runtime tool policy opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,8 +357,11 @@ Tool visibility is resolved by `WP_Agent_Tool_Policy` over an already-gathered t
 - Registered agent or runtime `tool_policy` config with `allow` / `deny`, `tools`, and `categories`.
 - Host-provided `WP_Agent_Tool_Access_Policy` policy fragments.
 - Runtime `categories`, `allow_only`, and explicit `deny` lists.
+- Caller-provided runtime tool opt-in via `runtime_tools`, `runtime_categories`, allow-mode `tools` / `categories`, `allow_only`, or mandatory policy.
 
-Mandatory tools are not hardcoded by Agents API. A consumer that needs mandatory runtime plumbing can return `mandatory_tools` or `mandatory_categories` from a policy provider, and explicit deny still wins.
+Caller-provided runtime tools are declarations with neutral metadata such as `runtime_tool: true`, `executor: client`, or `scope: run`. They are excluded by default so transport-provided tools are not exposed to the model ambiently. A caller, agent config, or policy provider must opt them in explicitly by name or category. Mandatory tools are not hardcoded by Agents API; a consumer that needs mandatory runtime plumbing can return `mandatory_tools` or `mandatory_categories` from a policy provider, and explicit deny still wins.
+
+This visibility policy is separate from parameter sourcing. Required tool parameters are filled from model/caller parameters first, then from `client_context_bindings` only when the tool declaration explicitly maps a context key. Ambient runtime context keys, including sensitive names such as `api_key`, `token`, and `authorization`, do not satisfy required parameters just because their names match.
 
 ```php
 $visible_tools = ( new WP_Agent_Tool_Policy() )->resolve(
@@ -369,6 +372,7 @@ $visible_tools = ( new WP_Agent_Tool_Policy() )->resolve(
 			'tool_policy' => array(
 				'mode'       => 'allow',
 				'categories' => array( 'read' ),
+				'runtime_tools' => array( 'client/choose_post' ),
 			),
 		),
 		'tool_policy_providers' => array( $consumer_policy_provider ),

--- a/docs/runtime-and-tools.md
+++ b/docs/runtime-and-tools.md
@@ -276,6 +276,20 @@ The tool policy layer resolves which tools are visible and how each tool may exe
 - `WP_Agent_Action_Policy_Provider`
 - `AgentsAPI\AI\Tools\WP_Agent_Action_Policy`
 
+Caller-provided runtime tools are opt-in. Declarations marked with neutral
+runtime metadata such as `runtime_tool: true`, `executor: client`, or
+`scope: run` are excluded from the visible tool set unless policy explicitly
+allows them by name or category. Explicit opt-in can come from `runtime_tools`,
+`runtime_categories`, allow-mode `tools` / `categories`, `allow_only`, or
+mandatory policy returned by a `WP_Agent_Tool_Access_Policy` provider. The final
+explicit `deny` list still wins after opt-in.
+
+This policy only decides model visibility. Required argument sourcing remains
+auditable through each tool declaration: runtime context keys fill required
+parameters only when listed in `client_context_bindings`. Sensitive ambient keys
+such as `api_key`, `token`, or `authorization` never satisfy required
+parameters by name alone.
+
 Canonical action-policy values are `direct`, `preview`, and `forbidden`. Resolution considers explicit runtime denies, agent/runtime tool and category policy, host providers, tool defaults, mode-specific tool defaults, and the final `agents_api_tool_action_policy` filter.
 
 ## Ability lifecycle bridge

--- a/src/Tools/class-wp-agent-tool-access-policy.php
+++ b/src/Tools/class-wp-agent-tool-access-policy.php
@@ -17,7 +17,8 @@ if ( ! interface_exists( 'WP_Agent_Tool_Access_Policy' ) ) {
 		 * Return a tool visibility policy for the current runtime context.
 		 *
 		 * Supported keys are: mode, tools, categories, allow_only, deny,
-		 * mandatory_tools, and mandatory_categories.
+		 * runtime_tools, runtime_categories, mandatory_tools, and
+		 * mandatory_categories.
 		 *
 		 * @param array<string, mixed> $context Runtime context.
 		 * @return array<string, mixed>|null Policy fragment, or null for no opinion.

--- a/src/Tools/class-wp-agent-tool-policy-filter.php
+++ b/src/Tools/class-wp-agent-tool-policy-filter.php
@@ -143,6 +143,60 @@ if ( ! class_exists( 'WP_Agent_Tool_Policy_Filter' ) ) {
 		}
 
 		/**
+		 * Exclude caller-provided runtime tools unless policy explicitly opts them in.
+		 *
+		 * Non-runtime tools are never affected by this guard. Runtime tools match neutral
+		 * declaration metadata (`runtime_tool`, `executor=client`, or `scope=run`) and
+		 * must be explicitly named, category-matched, or preserved by host policy.
+		 *
+		 * @param array<string, array> $tools              Tool definitions keyed by tool name.
+		 * @param string[]            $allowed_tools      Runtime tool names explicitly allowed.
+		 * @param string[]            $allowed_categories Runtime tool categories explicitly allowed.
+		 * @param callable|null       $preserve_tool      Optional callback for mandatory tools.
+		 * @return array<string, array> Filtered tools.
+		 */
+		public function filter_runtime_tools_by_policy_opt_in( array $tools, array $allowed_tools, array $allowed_categories = array(), ?callable $preserve_tool = null ): array {
+			$allowed_tools      = $this->string_list( $allowed_tools );
+			$allowed_categories = $this->string_list( $allowed_categories );
+			$filtered           = array();
+
+			foreach ( $tools as $name => $tool ) {
+				if ( ! $this->is_runtime_tool( $tool ) ) {
+					$filtered[ $name ] = $tool;
+					continue;
+				}
+
+				if ( in_array( $name, $allowed_tools, true ) ) {
+					$filtered[ $name ] = $tool;
+					continue;
+				}
+
+				if ( $this->tool_matches_categories( $tool, $allowed_categories ) ) {
+					$filtered[ $name ] = $tool;
+					continue;
+				}
+
+				if ( $preserve_tool && $preserve_tool( $tool, $name ) ) {
+					$filtered[ $name ] = $tool;
+				}
+			}
+
+			return $filtered;
+		}
+
+		/**
+		 * Whether a declaration represents a caller-provided runtime tool.
+		 *
+		 * @param array<string, mixed> $tool Tool definition.
+		 * @return bool Whether the tool is a runtime/client tool.
+		 */
+		public function is_runtime_tool( array $tool ): bool {
+			return true === ( $tool['runtime_tool'] ?? false )
+				|| 'client' === ( $tool['executor'] ?? null )
+				|| 'run' === ( $tool['scope'] ?? null );
+		}
+
+		/**
 		 * Whether a tool matches any category in a policy.
 		 *
 		 * @param array<string, mixed> $tool       Tool definition.

--- a/src/Tools/class-wp-agent-tool-policy.php
+++ b/src/Tools/class-wp-agent-tool-policy.php
@@ -83,6 +83,14 @@ if ( ! class_exists( 'WP_Agent_Tool_Policy' ) ) {
 				$tools = $this->filter->filter_by_allow_only( $tools, array_values( array_unique( $allow_only ) ), $preserve_tool );
 			}
 
+			$runtime_opt_in = $this->collect_runtime_tool_opt_in( $policies, $context, $allow_only, $mandatory_tools, $mandatory_cats );
+			$tools          = $this->filter->filter_runtime_tools_by_policy_opt_in(
+				$tools,
+				$runtime_opt_in['tools'],
+				$runtime_opt_in['categories'],
+				$preserve_tool
+			);
+
 			$deny = $this->filter->string_list( $context['deny'] ?? array() );
 			foreach ( $policies as $policy ) {
 				$deny = array_merge( $deny, $this->filter->string_list( $policy['deny'] ?? array() ) );
@@ -211,6 +219,45 @@ if ( ! class_exists( 'WP_Agent_Tool_Policy' ) ) {
 			}
 
 			return array_values( array_unique( $values ) );
+		}
+
+		/**
+		 * Collect explicit opt-ins for caller-provided runtime tools.
+		 *
+		 * @param array<int, array<string, mixed>> $policies        Policy fragments.
+		 * @param array<string, mixed>             $context         Runtime context.
+		 * @param string[]                         $allow_only      Effective allow-only names.
+		 * @param string[]                         $mandatory_tools Mandatory tool names.
+		 * @param string[]                         $mandatory_cats  Mandatory category slugs.
+		 * @return array{tools: string[], categories: string[]} Runtime opt-in names/categories.
+		 */
+		private function collect_runtime_tool_opt_in( array $policies, array $context, array $allow_only, array $mandatory_tools, array $mandatory_cats ): array {
+			$allowed_tools      = array_merge(
+				$allow_only,
+				$mandatory_tools,
+				$this->filter->string_list( $context['runtime_tools'] ?? array() )
+			);
+			$allowed_categories = array_merge(
+				$mandatory_cats,
+				$this->filter->string_list( $context['runtime_categories'] ?? array() )
+			);
+
+			foreach ( $policies as $policy ) {
+				$allowed_tools      = array_merge( $allowed_tools, $this->filter->string_list( $policy['runtime_tools'] ?? array() ) );
+				$allowed_categories = array_merge( $allowed_categories, $this->filter->string_list( $policy['runtime_categories'] ?? array() ) );
+
+				if ( self::MODE_ALLOW !== (string) ( $policy['mode'] ?? self::MODE_DENY ) ) {
+					continue;
+				}
+
+				$allowed_tools      = array_merge( $allowed_tools, $this->filter->string_list( $policy['tools'] ?? array() ) );
+				$allowed_categories = array_merge( $allowed_categories, $this->filter->string_list( $policy['categories'] ?? array() ) );
+			}
+
+			return array(
+				'tools'      => array_values( array_unique( $allowed_tools ) ),
+				'categories' => array_values( array_unique( $allowed_categories ) ),
+			);
 		}
 	}
 }

--- a/tests/tool-policy-contracts-smoke.php
+++ b/tests/tool-policy-contracts-smoke.php
@@ -45,6 +45,29 @@ $tools = array(
 		'categories' => array( 'system' ),
 		'modes'      => array( 'system' ),
 	),
+	'client/runtime'   => array(
+		'name'         => 'client/runtime',
+		'categories'   => array( 'read' ),
+		'modes'        => array( 'chat' ),
+		'executor'     => 'client',
+		'scope'        => 'run',
+		'parameters'   => array(
+			'type'       => 'object',
+			'required'   => array( 'api_key' ),
+			'properties' => array(
+				'api_key' => array( 'type' => 'string' ),
+			),
+		),
+		'runtime_tool' => true,
+	),
+	'client/ambient'   => array(
+		'name'         => 'client/ambient',
+		'categories'   => array( 'read' ),
+		'modes'        => array( 'chat' ),
+		'executor'     => 'client',
+		'scope'        => 'run',
+		'runtime_tool' => true,
+	),
 );
 
 $resolver = new WP_Agent_Tool_Policy();
@@ -109,5 +132,90 @@ $resolved = $resolver->resolve(
 	)
 );
 agents_api_smoke_assert_equals( array( 'client/read' ), array_keys( $resolved ), 'explicit deny removes mandatory provider tool', $failures, $passes );
+
+echo "\n[5] Runtime/client tools require explicit opt-in while non-runtime tools remain visible:\n";
+$resolved = $resolver->resolve(
+	$tools,
+	array(
+		'mode' => 'chat',
+	)
+);
+$resolved_names = array_keys( $resolved );
+sort( $resolved_names );
+agents_api_smoke_assert_equals( array( 'client/mandatory', 'client/read', 'client/write' ), $resolved_names, 'runtime tools are excluded by default without hiding ordinary tools', $failures, $passes );
+
+$resolved = $resolver->resolve(
+	$tools,
+	array(
+		'mode'         => 'chat',
+		'agent_config' => array(
+			'tool_policy' => array(
+				'mode'  => 'allow',
+				'tools' => array( 'client/read', 'client/runtime' ),
+			),
+		),
+	)
+);
+$resolved_names = array_keys( $resolved );
+sort( $resolved_names );
+agents_api_smoke_assert_equals( array( 'client/read', 'client/runtime' ), $resolved_names, 'allow policy can explicitly opt in a runtime tool by name', $failures, $passes );
+
+$resolved = $resolver->resolve(
+	$tools,
+	array(
+		'mode'        => 'chat',
+		'tool_policy' => array(
+			'mode'          => 'deny',
+			'tools'         => array( 'client/write' ),
+			'runtime_tools' => array( 'client/runtime' ),
+		),
+	)
+);
+$resolved_names = array_keys( $resolved );
+sort( $resolved_names );
+agents_api_smoke_assert_equals( array( 'client/mandatory', 'client/read', 'client/runtime' ), $resolved_names, 'deny policy still requires runtime_tools opt-in for runtime tools', $failures, $passes );
+
+$resolved = $resolver->resolve(
+	$tools,
+	array(
+		'mode'       => 'chat',
+		'allow_only' => array( 'client/read', 'client/runtime' ),
+	)
+);
+$resolved_names = array_keys( $resolved );
+sort( $resolved_names );
+agents_api_smoke_assert_equals( array( 'client/read', 'client/runtime' ), $resolved_names, 'allow_only explicitly opts in a named runtime tool', $failures, $passes );
+
+$resolved = $resolver->resolve(
+	$tools,
+	array(
+		'mode'        => 'chat',
+		'tool_policy' => array(
+			'mode'               => 'deny',
+			'runtime_categories' => array( 'read' ),
+		),
+		'deny'        => array( 'client/runtime' ),
+	)
+);
+$resolved_names = array_keys( $resolved );
+sort( $resolved_names );
+agents_api_smoke_assert_equals( array( 'client/ambient', 'client/mandatory', 'client/read', 'client/write' ), $resolved_names, 'runtime category opt-in composes with final explicit deny', $failures, $passes );
+
+echo "\n[6] Sensitive required parameters stay auditable and intentional:\n";
+$parameters = AgentsAPI\AI\Tools\WP_Agent_Tool_Parameters::buildParameters(
+	array(),
+	array( 'api_key' => 'ambient-secret' ),
+	$tools['client/runtime']
+);
+agents_api_smoke_assert_equals( array(), $parameters, 'ambient sensitive context does not satisfy runtime tool required parameters', $failures, $passes );
+
+$bound_runtime_tool                            = $tools['client/runtime'];
+$bound_runtime_tool['client_context_bindings'] = array( 'api_key' );
+$parameters                                    = AgentsAPI\AI\Tools\WP_Agent_Tool_Parameters::buildParameters(
+	array(),
+	array( 'api_key' => 'declared-secret' ),
+	$bound_runtime_tool
+);
+agents_api_smoke_assert_equals( array( 'api_key' => 'declared-secret' ), $parameters, 'declared context binding makes sensitive required parameter sourcing explicit', $failures, $passes );
 
 agents_api_smoke_finish( 'Tool policy contracts', $failures, $passes );


### PR DESCRIPTION
## Summary
- Adds a generic policy/filter primitive that excludes caller-provided runtime tools by default unless explicitly opted in by name/category, allow-mode policy, allow_only, or mandatory policy.
- Documents the runtime-tool visibility boundary separately from parameter sourcing so sensitive required parameters remain auditable through explicit `client_context_bindings`.
- Expands smoke coverage for allow mode, deny mode, allow_only, explicit deny composition, non-runtime tools, and sensitive ambient context handling.

## Verification
- `php tests/tool-policy-contracts-smoke.php`
- `php tests/tool-runtime-smoke.php`
- `composer test`

Closes #254.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** implementation draft, tests, and verification