### PR TITLE
Add workflow run evidence references

### DIFF
--- a/src/Workflows/class-wp-agent-workflow-run-recorder.php
+++ b/src/Workflows/class-wp-agent-workflow-run-recorder.php
@@ -10,6 +10,11 @@
  * recorder. Consumers wire one against whatever storage they already
  * use for jobs / runs — a custom post type, a custom table, an external
  * observability system. Persistence detail stays a consumer concern.
+ * When results include evidence references, recorders should preserve the
+ * first-class `evidence_refs` array as-is instead of burying artifact or log
+ * pointers under implementation metadata. The referenced storage remains
+ * host-owned and may point at CPTs, feature-flagged request logs, external
+ * artifacts, or any other JSON-serializable reference envelope.
  *
  * Implementations should be best-effort safe — losing a run record
  * must not break a workflow's user-facing outcome. The runner tolerates

--- a/src/Workflows/class-wp-agent-workflow-run-result.php
+++ b/src/Workflows/class-wp-agent-workflow-run-result.php
@@ -2,9 +2,9 @@
 /**
  * Immutable execution outcome of a single workflow run.
  *
- * Captures the per-step record (status, output, error) plus the overall
- * status and the final output map. Run recorders persist this; callers
- * inspect it to act on the result.
+ * Captures the per-step record (status, output, error), the overall
+ * status, the final output map, and neutral evidence references. Run
+ * recorders persist this; callers inspect it to act on the result.
  *
  * Statuses:
  *   `pending`   — recorded but not yet executed (used by recorders that
@@ -48,6 +48,7 @@ final class WP_Agent_Workflow_Run_Result {
 	 * @param int    $started_at  Unix timestamp.
 	 * @param int    $ended_at    Unix timestamp; 0 while running.
 	 * @param array  $metadata    Free-form metadata for recorders / tracers (Langfuse trace ids, etc.).
+	 * @param array  $evidence_refs Neutral JSON-serializable artifact/log references owned by the host.
 	 */
 	public function __construct(
 		private string $run_id,
@@ -59,11 +60,36 @@ final class WP_Agent_Workflow_Run_Result {
 		private array $error,
 		private int $started_at,
 		private int $ended_at,
-		private array $metadata
+		private array $metadata,
+		private array $evidence_refs = array()
 	) {}
 
 	public static function pending( string $run_id, string $workflow_id, array $inputs, int $started_at ): self {
-		return new self( $run_id, $workflow_id, self::STATUS_PENDING, $inputs, array(), array(), array(), $started_at, 0, array() );
+		return new self( $run_id, $workflow_id, self::STATUS_PENDING, $inputs, array(), array(), array(), $started_at, 0, array(), array() );
+	}
+
+	/**
+	 * Rebuild a run result from its serialized array shape.
+	 *
+	 * @since 0.108.0
+	 *
+	 * @param array $value Serialized run result.
+	 * @return self
+	 */
+	public static function from_array( array $value ): self {
+		return new self(
+			(string) ( $value['run_id'] ?? '' ),
+			(string) ( $value['workflow_id'] ?? '' ),
+			(string) ( $value['status'] ?? self::STATUS_PENDING ),
+			(array) ( $value['inputs'] ?? array() ),
+			(array) ( $value['output'] ?? array() ),
+			(array) ( $value['steps'] ?? array() ),
+			(array) ( $value['error'] ?? array() ),
+			(int) ( $value['started_at'] ?? 0 ),
+			(int) ( $value['ended_at'] ?? 0 ),
+			(array) ( $value['metadata'] ?? array() ),
+			(array) ( $value['evidence_refs'] ?? array() )
+		);
 	}
 
 	public function get_run_id(): string {
@@ -106,6 +132,10 @@ final class WP_Agent_Workflow_Run_Result {
 		return $this->metadata;
 	}
 
+	public function get_evidence_refs(): array {
+		return $this->evidence_refs;
+	}
+
 	public function is_succeeded(): bool {
 		return self::STATUS_SUCCEEDED === $this->status;
 	}
@@ -135,6 +165,7 @@ final class WP_Agent_Workflow_Run_Result {
 			(int) ( $patch['started_at'] ?? $this->started_at ),
 			(int) ( $patch['ended_at'] ?? $this->ended_at ),
 			(array) ( $patch['metadata'] ?? $this->metadata ),
+			(array) ( $patch['evidence_refs'] ?? $this->evidence_refs ),
 		);
 	}
 
@@ -148,16 +179,17 @@ final class WP_Agent_Workflow_Run_Result {
 	 */
 	public function to_array(): array {
 		return array(
-			'run_id'      => $this->run_id,
-			'workflow_id' => $this->workflow_id,
-			'status'      => $this->status,
-			'inputs'      => $this->inputs,
-			'output'      => $this->output,
-			'steps'       => $this->steps,
-			'error'       => $this->error,
-			'started_at'  => $this->started_at,
-			'ended_at'    => $this->ended_at,
-			'metadata'    => $this->metadata,
+			'run_id'        => $this->run_id,
+			'workflow_id'   => $this->workflow_id,
+			'status'        => $this->status,
+			'inputs'        => $this->inputs,
+			'output'        => $this->output,
+			'steps'         => $this->steps,
+			'error'         => $this->error,
+			'started_at'    => $this->started_at,
+			'ended_at'      => $this->ended_at,
+			'metadata'      => $this->metadata,
+			'evidence_refs' => $this->evidence_refs,
 		);
 	}
 }

--- a/src/Workflows/class-wp-agent-workflow-runner.php
+++ b/src/Workflows/class-wp-agent-workflow-runner.php
@@ -94,12 +94,14 @@ class WP_Agent_Workflow_Runner {
 	 *                                        - `run_id` (string, optional): caller-suggested run id.
 	 *                                        - `continue_on_error` (bool): keep running after a failed step. Default false.
 	 *                                        - `metadata` (array): forwarded to the run result.
+	 *                                        - `evidence_refs` (array): neutral artifact/log references forwarded to the run result.
 	 * @return WP_Agent_Workflow_Run_Result
 	 */
 	public function run( WP_Agent_Workflow_Spec $spec, array $inputs = array(), array $options = array() ): WP_Agent_Workflow_Run_Result {
-		$started_at = time();
-		$run_id     = (string) ( $options['run_id'] ?? self::generate_run_id() );
-		$metadata   = (array) ( $options['metadata'] ?? array() );
+		$started_at    = time();
+		$run_id        = (string) ( $options['run_id'] ?? self::generate_run_id() );
+		$metadata      = (array) ( $options['metadata'] ?? array() );
+		$evidence_refs = (array) ( $options['evidence_refs'] ?? array() );
 
 		// Build the initial RUNNING result and persist via recorder->start()
 		// before doing anything else. Even if input validation fails on the
@@ -115,7 +117,8 @@ class WP_Agent_Workflow_Runner {
 			array(),
 			$started_at,
 			0,
-			$metadata
+			$metadata,
+			$evidence_refs
 		);
 
 		if ( $this->recorder ) {

--- a/tests/workflow-runner-smoke.php
+++ b/tests/workflow-runner-smoke.php
@@ -96,11 +96,21 @@ use AgentsAPI\AI\Workflows\WP_Agent_Workflow_Spec;
 class Capture_Recorder implements WP_Agent_Workflow_Run_Recorder {
 	public array $writes = array();
 	public function start( WP_Agent_Workflow_Run_Result $result ) {
-		$this->writes[] = array( 'op' => 'start', 'status' => $result->get_status(), 'steps' => count( $result->get_steps() ) );
+		$this->writes[] = array(
+			'op'     => 'start',
+			'status' => $result->get_status(),
+			'steps'  => count( $result->get_steps() ),
+			'result' => $result->to_array(),
+		);
 		return $result->get_run_id();
 	}
 	public function update( WP_Agent_Workflow_Run_Result $result ) {
-		$this->writes[] = array( 'op' => 'update', 'status' => $result->get_status(), 'steps' => count( $result->get_steps() ) );
+		$this->writes[] = array(
+			'op'     => 'update',
+			'status' => $result->get_status(),
+			'steps'  => count( $result->get_steps() ),
+			'result' => $result->to_array(),
+		);
 		return true;
 	}
 	public function find( string $run_id ): ?WP_Agent_Workflow_Run_Result { return null; }
@@ -160,6 +170,42 @@ smoke_assert( '<<HELLO>>', $result->get_steps()[1]['output']['wrapped'], 'step 2
 smoke_assert( '<<HELLO>>', $result->get_output()['last']['wrapped'], 'final output exposes last step', $failures, $passes );
 smoke_assert( true, count( $recorder->writes ) >= 3, 'recorder hit at least 3 times (start + per-step updates + final)', $failures, $passes );
 smoke_assert( 'start', $recorder->writes[0]['op'], 'recorder start fires first', $failures, $passes );
+
+// ─── Evidence refs stay first-class through results and recorders ─────
+
+$evidence_refs     = array(
+	'artifact_refs' => array(
+		array(
+			'type'  => 'wp_guideline_artifact',
+			'id'    => 'guideline-artifact:123',
+			'url'   => 'https://example.com/artifacts/123',
+			'label' => 'Generated guideline artifact',
+		),
+	),
+	'log_refs'      => array(
+		array(
+			'type' => 'wpai_request_log',
+			'id'   => 'wpai_request_logs:42',
+			'url'  => 'https://example.com/logs/42',
+		),
+	),
+);
+$evidence_recorder = new Capture_Recorder();
+$evidence_result   = ( new WP_Agent_Workflow_Runner( $evidence_recorder ) )->run(
+	$spec,
+	array( 'text' => 'evidence' ),
+	array(
+		'run_id'        => 'evidence-run-1',
+		'evidence_refs' => $evidence_refs,
+	)
+);
+$roundtrip         = WP_Agent_Workflow_Run_Result::from_array( $evidence_result->to_array() );
+$last_write        = end( $evidence_recorder->writes );
+
+smoke_assert( $evidence_refs, $evidence_result->get_evidence_refs(), 'result exposes first-class evidence refs', $failures, $passes );
+smoke_assert( $evidence_result->to_array(), $roundtrip->to_array(), 'run result round-trips through to_array/from_array', $failures, $passes );
+smoke_assert( $evidence_refs, $last_write['result']['evidence_refs'] ?? array(), 'recorder update preserves evidence refs', $failures, $passes );
+smoke_assert( true, is_string( json_encode( $evidence_result->get_evidence_refs() ) ), 'evidence refs are JSON-serializable', $failures, $passes );
 
 // ─── Failed step short-circuits ───────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Adds first-class `evidence_refs` to `WP_Agent_Workflow_Run_Result` so workflow runs can carry neutral artifact/log references outside generic metadata.
- Preserves evidence refs through runner options, immutable result updates, `to_array()` / `from_array()`, and recorder update expectations.
- Keeps Agents API storage-neutral: no artifact storage, log storage, or request-log tables are added. Hosts can point refs at existing surfaces such as Gutenberg `wp_guideline` artifact/content posts or feature-flagged WordPress/ai `wpai_request_logs`.

## Testing
- `php tests/workflow-runner-smoke.php`
- `composer test`

Closes #253

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** implementation draft, tests, and verification