### PR TITLE
Add registered agent materialization adapter

### DIFF
--- a/agents-api.php
+++ b/agents-api.php
@@ -42,6 +42,7 @@ require_once AGENTS_API_PATH . 'src/Registry/class-wp-agent-materialization-requ
 require_once AGENTS_API_PATH . 'src/Registry/class-wp-agent-materialization-result.php';
 require_once AGENTS_API_PATH . 'src/Registry/class-wp-agent-installed-agent-state-store.php';
 require_once AGENTS_API_PATH . 'src/Registry/class-wp-agent-installed-agent-projector.php';
+require_once AGENTS_API_PATH . 'src/Registry/class-wp-agent-registered-agent-materialization-adapter.php';
 require_once AGENTS_API_PATH . 'src/Packages/class-wp-agent-package-artifact.php';
 require_once AGENTS_API_PATH . 'src/Packages/class-wp-agent-package-artifact-type.php';
 require_once AGENTS_API_PATH . 'src/Packages/class-wp-agent-package-artifacts-registry.php';

--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
       "php tests/message-coalesce-smoke.php",
       "php tests/registry-smoke.php",
       "php tests/installed-agent-materialization-smoke.php",
+      "php tests/registered-agent-materialization-adapter-smoke.php",
       "php tests/package-lifecycle-smoke.php",
       "php tests/package-capability-contract-smoke.php",
       "php tests/package-adoption-orchestration-smoke.php",

--- a/docs/registry-and-packages.md
+++ b/docs/registry-and-packages.md
@@ -89,19 +89,33 @@ Core classes:
 | `WP_Agent_Materialization_Result` | Result status plus optional installed state and projected request-local `WP_Agent`. |
 | `WP_Agent_Installed_Agent_State_Store` | Storage-neutral interface for resolving, materializing, and deleting installed state. |
 | `WP_Agent_Installed_Agent_Projector` | Helper for projecting durable installed state back into a request-local `WP_Agent` definition. |
+| `WP_Agent_Registered_Agent_Materialization_Adapter` | Storage-neutral adapter interface for reconciling the current registered-agent snapshot into host-owned runtime or persisted agents. |
+
+`wp_materialize_registered_agents()` is the generic registry materialization entry point. Pass an adapter directly, or provide one through `wp_agent_registered_agent_materialization_adapter`. Agents API returns an empty result set when no adapter is available; it never creates a default table, option, post type, runtime process, access grant, token, or queue.
 
 The intended lifecycle is:
 
 ```text
 request-local WP_Agent or WP_Agent_Package agent
   -> host resolves owner_user_id and instance_key
-  -> host materializes durable installed state through its store
+  -> host materializes the registered snapshot through its adapter
+  -> adapter materializes durable installed state through its store when needed
   -> package adoption may reconcile artifacts through package contracts
   -> projector turns durable state back into a request-local WP_Agent
   -> host registers/projected agents during its normal request bootstrap
 ```
 
 Owner resolution remains host-owned. `WP_Agent` can declare an `owner_resolver` callback and default config, but Agents API does not call that resolver automatically or grant access. A host materializer should resolve an owner explicitly, pass it into `WP_Agent_Materialization_Request`, and persist only the host-approved installed state. This keeps sensitive owner/access semantics auditable instead of inferred from ambient runtime context.
+
+Registered-agent materialization timing is explicit. Product plugins register definitions during `wp_agents_api_init`; host runtimes call `wp_materialize_registered_agents()` later in their own bootstrap, CLI, admin, package-install, or reconcile flow. The helper passes the current registry snapshot to the adapter and does not schedule recurring reconciliation by itself.
+
+Adapter identity and duplicate rules:
+
+- The registry rejects duplicate request-local slugs before the adapter sees them; the first registered definition wins and the duplicate attempt emits an invalid-usage notice with source provenance when available.
+- Adapter implementations should key durable/runtime state by the normalized `(agent_slug, owner_user_id, instance_key)` tuple. Repeating materialization for the same tuple is idempotent and should return `updated`, `skipped`, `projected`, or another accurate `WP_Agent_Materialization_Result` status instead of creating a second logical agent.
+- Registered definition updates for an existing slug reconcile the existing durable/runtime identity. The adapter decides which fields are mutable, how package provenance is compared, and whether user-modified runtime artifacts require approval.
+- Removed definitions are represented by absence from the registered snapshot. Adapters that keep prior installed state may mark missing identities as `removed`, `disabled`, or `skipped` according to host policy; Agents API does not delete host state automatically.
+- Source/provenance metadata remains generic. Producers should place JSON-friendly provenance in `WP_Agent::get_meta()` using keys such as `source_plugin`, `source_type`, `source_package`, and `source_version`; adapters may persist or report those values without interpreting them as a Data Machine concept.
 
 The installed-agent contract composes with package adoption but does not replace it. `WP_Agent_Package_Adoption_Orchestrator` handles artifact planning/application through artifact callbacks; the installed-agent state store handles the durable agent instance row or equivalent host record. Products such as Data Machine can implement both surfaces against their own storage and then project persisted agents into the request-local registry.
 

--- a/src/Registry/class-wp-agent-registered-agent-materialization-adapter.php
+++ b/src/Registry/class-wp-agent-registered-agent-materialization-adapter.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * WP_Agent_Registered_Agent_Materialization_Adapter contract.
+ *
+ * @package AgentsAPI
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+if ( ! interface_exists( 'WP_Agent_Registered_Agent_Materialization_Adapter' ) ) {
+	/**
+	 * Storage-neutral adapter for materializing registered agent definitions.
+	 */
+	interface WP_Agent_Registered_Agent_Materialization_Adapter {
+
+		/**
+		 * Materializes the current request-local registered-agent snapshot.
+		 *
+		 * The adapter owns storage, runtime activation, owner resolution, and any
+		 * comparison against previously materialized agents. Implementations must
+		 * treat the same normalized `(agent_slug, owner_user_id, instance_key)`
+		 * identity as idempotent: repeat calls update or reconcile the existing
+		 * materialized agent instead of creating duplicates.
+		 *
+		 * Duplicate registered slugs are rejected by `WP_Agents_Registry` before the
+		 * adapter runs. Removed definitions are represented by their absence from
+		 * `$registered_agents`; adapters that track prior state may report removed
+		 * or disabled instances in the returned result set according to host policy.
+		 *
+		 * @param array<string,WP_Agent> $registered_agents Current registered-agent snapshot keyed by slug.
+		 * @param array<string,mixed>    $args              Host-owned materialization options and context.
+		 * @return array<string,WP_Agent_Materialization_Result> Results keyed by registered slug or adapter-owned removed-state key.
+		 */
+		public function materialize_registered_agents( array $registered_agents, array $args = array() ): array;
+	}
+}

--- a/src/Registry/register-agents.php
+++ b/src/Registry/register-agents.php
@@ -110,3 +110,47 @@ if ( ! function_exists( 'wp_unregister_agent' ) ) {
 		return $registry->unregister( $slug );
 	}
 }
+
+if ( ! function_exists( 'wp_materialize_registered_agents' ) ) {
+	/**
+	 * Materializes registered agents through a host-provided adapter.
+	 *
+	 * Agents API collects declarative definitions only. This helper exposes the
+	 * generic lifecycle seam for products that want to reconcile those definitions
+	 * into runtime or persisted agents without making Agents API choose storage.
+	 *
+	 * Callers may pass an adapter directly or provide one with the
+	 * `wp_agent_registered_agent_materialization_adapter` filter. No adapter means
+	 * no materialization and an empty result set.
+	 *
+	 * @param WP_Agent_Registered_Agent_Materialization_Adapter|null $adapter Adapter, or null to use the filter.
+	 * @param array<string,mixed>                                    $args    Host-owned materialization options and context.
+	 * @return array<string,WP_Agent_Materialization_Result> Results keyed by registered slug or adapter-owned removed-state key.
+	 */
+	function wp_materialize_registered_agents( ?WP_Agent_Registered_Agent_Materialization_Adapter $adapter = null, array $args = array() ): array {
+		$registry = WP_Agents_Registry::get_instance();
+		if ( null === $registry ) {
+			return array();
+		}
+
+		/**
+		 * Filters the adapter used to materialize registered agents.
+		 *
+		 * The adapter decides storage, runtime activation, owner resolution,
+		 * duplicate-update behavior for durable identities, and removed-definition
+		 * reconciliation. Agents API passes only the current registered definition
+		 * snapshot plus caller-provided options.
+		 *
+		 * @param WP_Agent_Registered_Agent_Materialization_Adapter|null $adapter Adapter.
+		 * @param WP_Agents_Registry                                      $registry Registry snapshot source.
+		 * @param array<string,mixed>                                     $args     Host-owned materialization options and context.
+		 */
+		$adapter = apply_filters( 'wp_agent_registered_agent_materialization_adapter', $adapter, $registry, $args );
+
+		if ( ! $adapter instanceof WP_Agent_Registered_Agent_Materialization_Adapter ) {
+			return array();
+		}
+
+		return $adapter->materialize_registered_agents( $registry->get_all_registered(), $args );
+	}
+}

--- a/tests/registered-agent-materialization-adapter-smoke.php
+++ b/tests/registered-agent-materialization-adapter-smoke.php
@@ -1,0 +1,190 @@
+<?php
+/**
+ * Pure-PHP smoke test for registered-agent materialization adapters.
+ *
+ * Run with: php tests/registered-agent-materialization-adapter-smoke.php
+ *
+ * @package AgentsAPI\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+$failures = array();
+$passes   = 0;
+
+echo "agents-api-registered-agent-materialization-adapter-smoke\n";
+
+require_once __DIR__ . '/agents-api-smoke-helpers.php';
+agents_api_smoke_require_module();
+
+final class Agents_API_Test_Registered_Agent_Materialization_Adapter implements WP_Agent_Registered_Agent_Materialization_Adapter {
+	/** @var array<string,WP_Agent_Installed_Agent> */
+	private array $installed = array();
+
+	/**
+	 * @param array<string,WP_Agent> $registered_agents Current registered-agent snapshot.
+	 * @param array<string,mixed>    $args              Adapter args.
+	 * @return array<string,WP_Agent_Materialization_Result>
+	 */
+	public function materialize_registered_agents( array $registered_agents, array $args = array() ): array {
+		$owner_user_id = isset( $args['owner_user_id'] ) ? (int) $args['owner_user_id'] : null;
+		$instance_key  = isset( $args['instance_key'] ) ? (string) $args['instance_key'] : 'default';
+		$seen          = array();
+		$results       = array();
+
+		foreach ( $registered_agents as $agent ) {
+			$request = new WP_Agent_Materialization_Request(
+				$agent,
+				array(
+					'operation'     => 'reconcile',
+					'owner_user_id' => $owner_user_id,
+					'instance_key'  => $instance_key,
+				)
+			);
+			$probe   = new WP_Agent_Installed_Agent(
+				array(
+					'id'            => 'probe',
+					'agent_slug'    => $agent->get_slug(),
+					'owner_user_id' => $request->get_owner_user_id(),
+					'instance_key'  => $request->get_instance_key(),
+				)
+			);
+			$key     = $probe->key();
+			$status  = isset( $this->installed[ $key ] ) ? 'updated' : 'installed';
+
+			$state = new WP_Agent_Installed_Agent(
+				array(
+					'id'            => 'fake:' . $key,
+					'agent_slug'    => $agent->get_slug(),
+					'owner_user_id' => $request->get_owner_user_id(),
+					'instance_key'  => $request->get_instance_key(),
+					'config'        => $request->get_config(),
+					'meta'          => array(
+						'source_plugin'  => $agent->get_meta()['source_plugin'] ?? null,
+						'source_type'    => $agent->get_meta()['source_type'] ?? null,
+						'source_package' => $agent->get_meta()['source_package'] ?? null,
+						'source_version' => $agent->get_meta()['source_version'] ?? null,
+					),
+					'status'        => $status,
+				)
+			);
+
+			$this->installed[ $key ]        = $state;
+			$seen[ $key ]                   = true;
+			$results[ $agent->get_slug() ]   = new WP_Agent_Materialization_Result(
+				$status,
+				$state,
+				WP_Agent_Installed_Agent_Projector::project( $state, $agent ),
+				array( 'Fake adapter reconciled ' . $agent->get_slug() . '.' ),
+				array( 'identity_key' => $key )
+			);
+		}
+
+		foreach ( $this->installed as $key => $state ) {
+			if ( isset( $seen[ $key ] ) ) {
+				continue;
+			}
+
+			$removed = new WP_Agent_Installed_Agent(
+				array_merge(
+					$state->to_array(),
+					array( 'status' => 'removed' )
+				)
+			);
+
+			$this->installed[ $key ] = $removed;
+			$results[ 'removed:' . $state->get_agent_slug() ] = new WP_Agent_Materialization_Result( 'removed', $removed );
+		}
+
+		return $results;
+	}
+}
+
+$adapter = new Agents_API_Test_Registered_Agent_Materialization_Adapter();
+
+add_action(
+	'wp_agents_api_init',
+	static function (): void {
+		wp_register_agent(
+			'kitchen-agent',
+			array(
+				'label'          => 'Kitchen Agent',
+				'default_config' => array( 'model' => 'gpt-test' ),
+				'meta'           => array(
+					'source_plugin'  => 'example/example.php',
+					'source_type'    => 'bundled-agent',
+					'source_package' => 'chef-pack',
+					'source_version' => '1.0.0',
+				),
+			)
+		);
+
+		wp_register_agent( 'kitchen-agent', array( 'label' => 'Duplicate Kitchen Agent' ) );
+		wp_register_agent( 'pantry-agent', array( 'label' => 'Pantry Agent' ) );
+	}
+);
+
+do_action( 'init' );
+
+echo "\n[1] Fake adapter materializes registered definitions without product storage:\n";
+$results = wp_materialize_registered_agents(
+	$adapter,
+	array(
+		'owner_user_id' => 7,
+		'instance_key'  => 'Site:42',
+	)
+);
+
+agents_api_smoke_assert_equals( true, interface_exists( 'WP_Agent_Registered_Agent_Materialization_Adapter' ), 'registered-agent adapter interface is available', $failures, $passes );
+agents_api_smoke_assert_equals( array( 'kitchen-agent', 'pantry-agent' ), array_keys( $results ), 'adapter receives only unique registered slugs', $failures, $passes );
+agents_api_smoke_assert_equals( 'installed', $results['kitchen-agent']->get_status(), 'first materialization installs the agent identity', $failures, $passes );
+agents_api_smoke_assert_equals( 'kitchen-agent:7:site:42', $results['kitchen-agent']->get_meta()['identity_key'] ?? null, 'identity tuple is stable and normalized', $failures, $passes );
+agents_api_smoke_assert_equals( 'example/example.php', $results['kitchen-agent']->get_installed_agent()->get_meta()['source_plugin'] ?? null, 'source provenance is available to the adapter', $failures, $passes );
+
+echo "\n[2] Repeat materialization is idempotent and updates existing identity:\n";
+$second_results = wp_materialize_registered_agents(
+	$adapter,
+	array(
+		'owner_user_id' => 7,
+		'instance_key'  => 'Site:42',
+	)
+);
+
+agents_api_smoke_assert_equals( 'updated', $second_results['kitchen-agent']->get_status(), 'second materialization updates instead of duplicating', $failures, $passes );
+agents_api_smoke_assert_equals( 'fake:kitchen-agent:7:site:42', $second_results['kitchen-agent']->get_installed_agent()->get_id(), 'same durable identity is reused', $failures, $passes );
+
+echo "\n[3] Removed definitions are adapter-owned reconciliation, not Agents API storage:\n";
+wp_unregister_agent( 'pantry-agent' );
+$removed_results = wp_materialize_registered_agents(
+	$adapter,
+	array(
+		'owner_user_id' => 7,
+		'instance_key'  => 'Site:42',
+	)
+);
+
+agents_api_smoke_assert_equals( true, isset( $removed_results['removed:pantry-agent'] ), 'adapter may report removed definitions absent from registry snapshot', $failures, $passes );
+agents_api_smoke_assert_equals( 'removed', $removed_results['removed:pantry-agent']->get_status(), 'removed definition result uses explicit status', $failures, $passes );
+
+echo "\n[4] Filter hook can provide the adapter lazily:\n";
+add_filter(
+	'wp_agent_registered_agent_materialization_adapter',
+	static function () use ( $adapter ): WP_Agent_Registered_Agent_Materialization_Adapter {
+		return $adapter;
+	}
+);
+
+$filtered_results = wp_materialize_registered_agents(
+	null,
+	array(
+		'owner_user_id' => 7,
+		'instance_key'  => 'Site:42',
+	)
+);
+
+agents_api_smoke_assert_equals( true, isset( $filtered_results['kitchen-agent'] ), 'filter-provided adapter is used when no adapter is passed', $failures, $passes );
+agents_api_smoke_assert_equals( false, class_exists( 'DataMachine_Agent_Store', false ), 'materialization contract does not load Data Machine classes', $failures, $passes );
+
+agents_api_smoke_finish( 'Agents API registered-agent materialization adapter', $failures, $passes );


### PR DESCRIPTION
## Summary
- Adds a storage-neutral `WP_Agent_Registered_Agent_Materialization_Adapter` contract plus `wp_materialize_registered_agents()` helper/filter entry point.
- Documents lifecycle timing, idempotent identity, duplicate/update semantics, removed-definition reconciliation, and generic source provenance.
- Adds pure-PHP smoke coverage with a fake in-memory adapter proving materialization works without Data Machine loaded.

Fixes #266.

## Testing
- `php tests/registered-agent-materialization-adapter-smoke.php`
- `php tests/installed-agent-materialization-smoke.php`
- `php tests/registry-smoke.php`
- `composer test`
- `composer phpstan`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the generic adapter contract, documentation, and smoke coverage; Chris remains responsible for review and merge.