### PR TITLE
Define provider-turn adapter contract

### DIFF
--- a/agents-api.php
+++ b/agents-api.php
@@ -126,6 +126,9 @@ require_once AGENTS_API_PATH . 'src/Tools/class-wp-agent-default-tool-tier-resol
 require_once AGENTS_API_PATH . 'src/Tools/register-agent-ability-meta-abilities.php';
 require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-conversation-request.php';
 require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-conversation-runner.php';
+require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-provider-turn-request.php';
+require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-provider-turn-result.php';
+require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-provider-turn-adapter.php';
 require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-conversation-completion-decision.php';
 require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-conversation-completion-policy.php';
 require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-transcript-persister.php';

--- a/composer.json
+++ b/composer.json
@@ -67,6 +67,7 @@
       "php tests/tool-result-truncator-smoke.php",
       "php tests/context-registry-smoke.php",
       "php tests/conversation-loop-smoke.php",
+      "php tests/provider-turn-adapter-smoke.php",
       "php tests/conversation-loop-tool-execution-smoke.php",
       "php tests/conversation-loop-completion-policy-smoke.php",
       "php tests/conversation-loop-transcript-persister-smoke.php",

--- a/src/Runtime/class-wp-agent-conversation-loop.php
+++ b/src/Runtime/class-wp-agent-conversation-loop.php
@@ -32,10 +32,14 @@ class WP_Agent_Conversation_Loop {
 	 * Run a conversation loop.
 	 *
 	 * The turn runner receives `(array $messages, array $context)` and must return
-	 * an array. When tool mediation is enabled (`tool_executor` + `tool_declarations`),
-	 * the turn runner can return a `tool_calls` key (array of `{name, parameters}`)
-	 * and the loop handles execution internally. Otherwise the turn runner must
-	 * return an `WP_Agent_Conversation_Result`-compatible array as before.
+	 * an array. Callers may also pass `provider_turn_adapter` in options; that
+	 * adapter receives `WP_Agent_Provider_Turn_Request` and returns a normalized
+	 * `WP_Agent_Provider_Turn_Result` shape while the loop keeps ownership of
+	 * continuation and mediated tool execution. When tool mediation is enabled
+	 * (`tool_executor` + `tool_declarations`), the turn runner or provider-turn
+	 * adapter can return a `tool_calls` key (array of `{name, parameters}`) and
+	 * the loop handles execution internally. Otherwise the turn runner must return
+	 * an `WP_Agent_Conversation_Result`-compatible array as before.
 	 *
 	 * Supported options:
 	 *
@@ -53,6 +57,7 @@ class WP_Agent_Conversation_Loop {
 	 *   opt into the historical continue-always behavior.
 	 * - `compaction_policy` (array|null): Optional compaction policy.
 	 * - `summarizer` (callable|null): Optional compaction summarizer.
+	 * - `provider_turn_adapter` (WP_Agent_Provider_Turn_Adapter|callable|null): Provider dispatch adapter.
 	 * - `tool_executor` (WP_Agent_Tool_Executor|null): Tool execution adapter.
 	 * - `tool_declarations` (array|null): Tool declarations keyed by name.
 	 * - `completion_policy` (WP_Agent_Conversation_Completion_Policy|null): Typed completion policy.
@@ -67,11 +72,11 @@ class WP_Agent_Conversation_Loop {
 	 * - `on_event` (callable|null): Caller-owned lifecycle event sink `fn(string $event, array $payload)`.
 	 *
 	 * @param array<int, array<string, mixed>> $messages    Initial transcript messages.
-	 * @param callable                         $turn_runner Caller-owned turn adapter.
+	 * @param callable|null                    $turn_runner Caller-owned turn adapter.
 	 * @param array<string, mixed>             $options     Loop options.
 	 * @return array<string, mixed> Normalized conversation result.
 	 */
-	public static function run( array $messages, callable $turn_runner, array $options = array() ): array {
+	public static function run( array $messages, ?callable $turn_runner = null, array $options = array() ): array {
 		$runtime_overrides     = self::resolve_runtime_overrides( $options );
 		$options               = self::apply_runtime_overrides_to_options( $options, $runtime_overrides );
 		$max_turns             = self::max_turns( $options['max_turns'] ?? 1 );
@@ -95,6 +100,7 @@ class WP_Agent_Conversation_Loop {
 		$budget_resolution     = self::resolve_budgets( $options, $max_turns );
 		$budgets               = $budget_resolution['budgets'];
 		$has_explicit_turns    = $budget_resolution['has_explicit_turns'];
+		$turn_runner           = self::resolve_turn_runner( $turn_runner, $options, $tool_declarations, $run_id, $lock_session_id, $request, $budgets );
 		$wall_clock_started_at = microtime( true );
 		$wall_clock_initial    = isset( $budgets['wall_clock_seconds'] ) ? $budgets['wall_clock_seconds']->current() : 0;
 		$mediation_enabled     = null !== $tool_executor && ! empty( $tool_declarations );
@@ -125,6 +131,7 @@ class WP_Agent_Conversation_Loop {
 			'total_tokens'      => 0,
 		);
 		$request_metadata = array();
+		$provider_diagnostics = array();
 
 		if ( null !== $transcript_lock && '' !== $lock_session_id ) {
 			$lock_token = $transcript_lock->acquire_session_lock( $lock_session_id, $lock_ttl );
@@ -209,6 +216,41 @@ class WP_Agent_Conversation_Loop {
 					) );
 
 					throw $error;
+				}
+
+				if ( isset( $result['provider_diagnostics'] ) && is_array( $result['provider_diagnostics'] ) ) {
+					$provider_diagnostics[] = self::normalize_assoc_array( $result['provider_diagnostics'] );
+				}
+
+				if ( isset( $result['failure'] ) && is_array( $result['failure'] ) ) {
+					$failure = self::normalize_provider_turn_failure( $result['failure'], $turn );
+					self::emit_event( $on_event, 'failed', array(
+						'turn'  => $turn,
+						'error' => $failure['message'],
+					) );
+
+					$failure_result = self::normalize_conversation_result( array(
+						'messages'               => $messages,
+						'tool_execution_results' => self::normalize_array_list( $tool_results ),
+						'tool_events'            => self::normalize_array_list( $tool_events ),
+						'tool_audit_events'      => self::normalize_array_list( $tool_audit_events ),
+						'events'                 => self::normalize_array_list( $events ),
+						'status'                 => 'failed',
+						'completed'              => false,
+						'turn_count'             => $turn,
+						'final_content'          => self::extract_final_content( $messages ),
+						'usage'                  => $total_usage,
+						'request_metadata'       => $request_metadata,
+						'provider_diagnostics'   => $provider_diagnostics,
+						'failure'                => $failure,
+					) );
+
+					if ( '' !== $run_id && '' !== $lock_session_id ) {
+						WP_Agent_Chat_Run_Control::finish_run( $run_id, WP_Agent_Chat_Run_Control::STATUS_FAILED );
+					}
+
+					self::persist_transcript( $transcript_persister, $messages, $options, $failure_result );
+					return $failure_result;
 				}
 
 				// Accumulate optional observability fields from the turn runner.
@@ -354,6 +396,7 @@ class WP_Agent_Conversation_Loop {
 				'final_content'          => self::extract_final_content( $messages ),
 				'usage'                  => $total_usage,
 				'request_metadata'       => $request_metadata,
+				'provider_diagnostics'   => $provider_diagnostics,
 				'completed'              => true,
 			);
 
@@ -1208,6 +1251,134 @@ class WP_Agent_Conversation_Loop {
 	}
 
 	/**
+	 * Resolve the caller turn runner or wrap a provider-turn adapter.
+	 *
+	 * @param callable|null                         $turn_runner       Caller-owned turn runner.
+	 * @param array<string, mixed>                  $options           Loop options.
+	 * @param array<string, array<string, mixed>>   $tool_declarations Tool declarations keyed by name.
+	 * @param string                                $run_id            Run identifier.
+	 * @param string                                $session_id        Session identifier.
+	 * @param WP_Agent_Conversation_Request         $request           Conversation request.
+	 * @param array<string, WP_Agent_Iteration_Budget> $budgets        Resolved budgets.
+	 * @return callable
+	 */
+	private static function resolve_turn_runner( ?callable $turn_runner, array $options, array $tool_declarations, string $run_id, string $session_id, WP_Agent_Conversation_Request $request, array $budgets ): callable {
+		$provider_turn_adapter = $options['provider_turn_adapter'] ?? null;
+		if ( null === $provider_turn_adapter ) {
+			if ( null === $turn_runner ) {
+				throw new \InvalidArgumentException( 'invalid_agent_conversation_loop: a turn runner or provider_turn_adapter is required' );
+			}
+
+			return $turn_runner;
+		}
+
+		if ( $provider_turn_adapter instanceof WP_Agent_Provider_Turn_Adapter ) {
+			$adapter = array( $provider_turn_adapter, 'run_turn' );
+		} elseif ( is_callable( $provider_turn_adapter ) ) {
+			$adapter = $provider_turn_adapter;
+		} else {
+			throw new \InvalidArgumentException( 'invalid_agent_conversation_loop: provider_turn_adapter must implement WP_Agent_Provider_Turn_Adapter or be callable' );
+		}
+		$mediation_enabled = self::resolve_tool_executor( $options ) instanceof WP_Agent_Tool_Executor && ! empty( $tool_declarations );
+
+		return static function ( array $messages, array $context ) use ( $adapter, $options, $tool_declarations, $run_id, $session_id, $request, $budgets, $mediation_enabled ): array {
+			$context = self::normalize_assoc_array( $context );
+			$provider_request = new WP_Agent_Provider_Turn_Request(
+				$messages,
+				$tool_declarations,
+				self::provider_turn_model_metadata( $context, $options ),
+				self::provider_turn_runtime_metadata( $context, $options ),
+				$context,
+				self::provider_turn_budget_metadata( $budgets ),
+				$run_id,
+				$session_id,
+				$request->metadata()
+			);
+
+			$raw_result = call_user_func( $adapter, $provider_request );
+			if ( ! is_array( $raw_result ) ) {
+				throw new \InvalidArgumentException( 'invalid_agent_provider_turn_result: adapter must return an array' );
+			}
+
+			$result = WP_Agent_Provider_Turn_Result::normalize( $raw_result );
+			if ( isset( $result['message'] ) && is_array( $result['message'] ) && '' === $result['content'] ) {
+				$result['content'] = is_string( $result['message']['content'] ?? null ) ? $result['message']['content'] : '';
+			}
+
+			if ( ! $mediation_enabled ) {
+				if ( isset( $result['message'] ) && is_array( $result['message'] ) ) {
+					$messages[] = $result['message'];
+				} else {
+					$content = is_string( $result['content'] ?? null ) ? $result['content'] : '';
+					if ( '' !== $content ) {
+						$messages[] = WP_Agent_Message::text( 'assistant', $content );
+					}
+				}
+
+				$result['tool_execution_results'] = array();
+				$result['events']                 = array();
+			}
+
+			$result['messages'] = $messages;
+			return $result;
+		};
+	}
+
+	/**
+	 * Extract provider/model metadata for provider-turn adapters.
+	 *
+	 * @param array<string, mixed> $context Turn context.
+	 * @param array<string, mixed> $options Loop options.
+	 * @return array<string, mixed>
+	 */
+	private static function provider_turn_model_metadata( array $context, array $options ): array {
+		$model = self::normalize_assoc_array( $options['model'] ?? array() );
+		foreach ( array( 'provider_id', 'model_id', 'temperature' ) as $key ) {
+			if ( array_key_exists( $key, $context ) && ! array_key_exists( $key, $model ) ) {
+				$model[ $key ] = $context[ $key ];
+			}
+		}
+
+		return $model;
+	}
+
+	/**
+	 * Extract runtime metadata for provider-turn adapters.
+	 *
+	 * @param array<string, mixed> $context Turn context.
+	 * @param array<string, mixed> $options Loop options.
+	 * @return array<string, mixed>
+	 */
+	private static function provider_turn_runtime_metadata( array $context, array $options ): array {
+		$runtime = self::normalize_assoc_array( $options['runtime'] ?? array() );
+		foreach ( array( 'runtime_id', 'runtime_context', 'request_kind' ) as $key ) {
+			if ( array_key_exists( $key, $context ) && ! array_key_exists( $key, $runtime ) ) {
+				$runtime[ $key ] = $context[ $key ];
+			}
+		}
+
+		return $runtime;
+	}
+
+	/**
+	 * Snapshot budget counters for provider-turn adapters.
+	 *
+	 * @param array<string, WP_Agent_Iteration_Budget> $budgets Resolved budgets.
+	 * @return array<string, mixed>
+	 */
+	private static function provider_turn_budget_metadata( array $budgets ): array {
+		$metadata = array();
+		foreach ( $budgets as $name => $budget ) {
+			$metadata[ $name ] = array(
+				'current' => $budget->current(),
+				'limit'   => $budget->ceiling(),
+			);
+		}
+
+		return $metadata;
+	}
+
+	/**
 	 * Emit a lifecycle event through the caller sink and WordPress observers.
 	 *
 	 * The caller-owned `on_event` sink and the `agents_api_loop_event` action are
@@ -1895,6 +2066,25 @@ class WP_Agent_Conversation_Loop {
 	 */
 	private static function normalize_conversation_result( array $result ): array {
 		return self::normalize_assoc_array( WP_Agent_Conversation_Result::normalize( $result ) );
+	}
+
+	/**
+	 * Normalize provider-turn typed failure information.
+	 *
+	 * @param array<mixed> $failure Raw failure.
+	 * @param int          $turn    Current turn.
+	 * @return array<string, mixed>
+	 */
+	private static function normalize_provider_turn_failure( array $failure, int $turn ): array {
+		$normalized = self::normalize_assoc_array( $failure );
+		$type       = is_string( $normalized['type'] ?? null ) && '' !== $normalized['type'] ? $normalized['type'] : 'provider_turn_failure';
+		$message    = is_string( $normalized['message'] ?? null ) && '' !== $normalized['message'] ? $normalized['message'] : 'Provider turn failed.';
+
+		$normalized['type']       = $type;
+		$normalized['message']    = $message;
+		$normalized['turn_count'] = isset( $normalized['turn_count'] ) && is_int( $normalized['turn_count'] ) ? $normalized['turn_count'] : $turn;
+
+		return $normalized;
 	}
 
 	/**

--- a/src/Runtime/class-wp-agent-conversation-loop.php
+++ b/src/Runtime/class-wp-agent-conversation-loop.php
@@ -124,13 +124,13 @@ class WP_Agent_Conversation_Loop {
 		// descriptor) in their per-turn return value; the loop accumulates
 		// these and exposes them in the final result so consumers don't have
 		// to track them out-of-band via mutable state.
-		$turns_run        = 0;
-		$total_usage      = array(
+		$turns_run            = 0;
+		$total_usage          = array(
 			'prompt_tokens'     => 0,
 			'completion_tokens' => 0,
 			'total_tokens'      => 0,
 		);
-		$request_metadata = array();
+		$request_metadata     = array();
 		$provider_diagnostics = array();
 
 		if ( null !== $transcript_lock && '' !== $lock_session_id ) {
@@ -1282,7 +1282,7 @@ class WP_Agent_Conversation_Loop {
 		$mediation_enabled = self::resolve_tool_executor( $options ) instanceof WP_Agent_Tool_Executor && ! empty( $tool_declarations );
 
 		return static function ( array $messages, array $context ) use ( $adapter, $options, $tool_declarations, $run_id, $session_id, $request, $budgets, $mediation_enabled ): array {
-			$context = self::normalize_assoc_array( $context );
+			$context          = self::normalize_assoc_array( $context );
 			$provider_request = new WP_Agent_Provider_Turn_Request(
 				$messages,
 				$tool_declarations,

--- a/src/Runtime/class-wp-agent-conversation-result.php
+++ b/src/Runtime/class-wp-agent-conversation-result.php
@@ -209,6 +209,10 @@ class WP_Agent_Conversation_Result {
 			throw self::invalid( 'request_metadata', 'must be an array when present' );
 		}
 
+		if ( array_key_exists( 'provider_diagnostics', $result ) && ! is_array( $result['provider_diagnostics'] ) ) {
+			throw self::invalid( 'provider_diagnostics', 'must be an array when present' );
+		}
+
 		if ( array_key_exists( 'completed', $result ) && ! is_bool( $result['completed'] ) ) {
 			throw self::invalid( 'completed', 'must be a boolean when present' );
 		}

--- a/src/Runtime/class-wp-agent-provider-turn-adapter.php
+++ b/src/Runtime/class-wp-agent-provider-turn-adapter.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Provider-turn adapter interface.
+ *
+ * @package AgentsAPI
+ */
+
+namespace AgentsAPI\AI;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Provider-neutral adapter boundary for one model turn.
+ *
+ * Implementations own provider request construction and dispatch. The
+ * conversation loop owns continuation, mediated tool execution, transcript
+ * events, result normalization, and stop conditions.
+ */
+interface WP_Agent_Provider_Turn_Adapter {
+
+	/**
+	 * Run one provider turn.
+	 *
+	 * @param WP_Agent_Provider_Turn_Request $request Provider-turn request.
+	 * @return array<string, mixed> Raw provider-turn result.
+	 */
+	public function run_turn( WP_Agent_Provider_Turn_Request $request ): array;
+}

--- a/src/Runtime/class-wp-agent-provider-turn-request.php
+++ b/src/Runtime/class-wp-agent-provider-turn-request.php
@@ -1,0 +1,198 @@
+<?php
+/**
+ * Provider-turn request contract.
+ *
+ * @package AgentsAPI
+ */
+
+namespace AgentsAPI\AI;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Storage-neutral request object passed to provider-turn adapters.
+ */
+// phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Validation exceptions are not rendered output.
+class WP_Agent_Provider_Turn_Request {
+
+	/** @var array<int, array<string, mixed>> Canonical transcript messages. */
+	private array $messages;
+
+	/** @var array<string, array<string, mixed>> Tool declarations keyed by name. */
+	private array $tool_declarations;
+
+	/** @var array<string, mixed> Provider/model metadata. */
+	private array $model;
+
+	/** @var array<string, mixed> Runtime-owned metadata. */
+	private array $runtime;
+
+	/** @var array<string, mixed> Turn context. */
+	private array $context;
+
+	/** @var array<string, mixed> Budget state. */
+	private array $budgets;
+
+	/** @var string Run identifier. */
+	private string $run_id;
+
+	/** @var string Session identifier. */
+	private string $session_id;
+
+	/** @var array<string, mixed> Caller-owned metadata. */
+	private array $metadata;
+
+	/**
+	 * @param array<mixed>         $messages          Canonical transcript messages.
+	 * @param array<mixed>         $tool_declarations Tool declarations keyed by name.
+	 * @param array<string, mixed> $model             Provider/model metadata.
+	 * @param array<string, mixed> $runtime           Runtime-owned metadata.
+	 * @param array<string, mixed> $context           Turn context.
+	 * @param array<string, mixed> $budgets           Budget state.
+	 * @param string               $run_id            Run identifier.
+	 * @param string               $session_id        Session identifier.
+	 * @param array<string, mixed> $metadata          Caller-owned metadata.
+	 */
+	public function __construct( array $messages, array $tool_declarations = array(), array $model = array(), array $runtime = array(), array $context = array(), array $budgets = array(), string $run_id = '', string $session_id = '', array $metadata = array() ) {
+		$this->messages          = WP_Agent_Message::normalize_many( $messages );
+		$this->tool_declarations = self::normalize_tool_declarations( $tool_declarations );
+		$this->model             = self::normalize_json_array( $model, 'model' );
+		$this->runtime           = self::normalize_json_array( $runtime, 'runtime' );
+		$this->context           = self::normalize_json_array( $context, 'context' );
+		$this->budgets           = self::normalize_json_array( $budgets, 'budgets' );
+		$this->run_id            = $run_id;
+		$this->session_id        = $session_id;
+		$this->metadata          = self::normalize_json_array( $metadata, 'metadata' );
+	}
+
+	/** @return array<int, array<string, mixed>> Canonical transcript messages. */
+	public function messages(): array {
+		return $this->messages;
+	}
+
+	/** @return array<string, array<string, mixed>> Tool declarations keyed by name. */
+	public function toolDeclarations(): array {
+		return $this->tool_declarations;
+	}
+
+	/** @return array<string, mixed> Provider/model metadata. */
+	public function model(): array {
+		return $this->model;
+	}
+
+	/** @return array<string, mixed> Runtime-owned metadata. */
+	public function runtime(): array {
+		return $this->runtime;
+	}
+
+	/** @return array<string, mixed> Turn context. */
+	public function context(): array {
+		return $this->context;
+	}
+
+	/** @return array<string, mixed> Budget state. */
+	public function budgets(): array {
+		return $this->budgets;
+	}
+
+	/** @return string Run identifier. */
+	public function runId(): string {
+		return $this->run_id;
+	}
+
+	/** @return string Session identifier. */
+	public function sessionId(): string {
+		return $this->session_id;
+	}
+
+	/** @return array<string, mixed> Caller-owned metadata. */
+	public function metadata(): array {
+		return $this->metadata;
+	}
+
+	/**
+	 * Return a normalized array representation.
+	 *
+	 * @return array<string, mixed>
+	 */
+	public function to_array(): array {
+		return array(
+			'messages'          => $this->messages,
+			'tool_declarations' => $this->tool_declarations,
+			'model'             => $this->model,
+			'runtime'           => $this->runtime,
+			'context'           => $this->context,
+			'budgets'           => $this->budgets,
+			'run_id'            => $this->run_id,
+			'session_id'        => $this->session_id,
+			'metadata'          => $this->metadata,
+		);
+	}
+
+	/**
+	 * Normalize tool declarations keyed by tool name.
+	 *
+	 * @param array<mixed> $tool_declarations Tool declarations.
+	 * @return array<string, array<string, mixed>>
+	 */
+	private static function normalize_tool_declarations( array $tool_declarations ): array {
+		$normalized = array();
+		foreach ( $tool_declarations as $key => $declaration ) {
+			if ( ! is_array( $declaration ) ) {
+				throw self::invalid( 'tool_declarations.' . (string) $key, 'must be an array' );
+			}
+
+			$name = is_string( $key ) ? $key : ( $declaration['name'] ?? '' );
+			if ( ! is_string( $name ) || '' === $name ) {
+				throw self::invalid( 'tool_declarations.' . (string) $key . '.name', 'must be a non-empty string' );
+			}
+
+			$normalized[ $name ] = self::string_keyed_array( $declaration );
+		}
+
+		return $normalized;
+	}
+
+	/**
+	 * Validate that an associative array is JSON serializable.
+	 *
+	 * @param array<mixed> $value Raw value.
+	 * @param string       $path  Field path.
+	 * @return array<string, mixed>
+	 */
+	private static function normalize_json_array( array $value, string $path ): array {
+		if ( false === wp_json_encode( $value, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ) ) {
+			throw self::invalid( $path, 'must be JSON serializable' );
+		}
+
+		return self::string_keyed_array( $value );
+	}
+
+	/**
+	 * Normalize an associative array to string keys.
+	 *
+	 * @param array<mixed> $value Raw array.
+	 * @return array<string, mixed>
+	 */
+	private static function string_keyed_array( array $value ): array {
+		$normalized = array();
+		foreach ( $value as $key => $item ) {
+			if ( is_string( $key ) ) {
+				$normalized[ $key ] = $item;
+			}
+		}
+
+		return $normalized;
+	}
+
+	/**
+	 * Build a machine-readable validation exception.
+	 *
+	 * @param string $path Field path.
+	 * @param string $reason Failure reason.
+	 * @return \InvalidArgumentException Validation exception.
+	 */
+	private static function invalid( string $path, string $reason ): \InvalidArgumentException {
+		return new \InvalidArgumentException( 'invalid_agent_provider_turn_request: ' . $path . ' ' . $reason );
+	}
+}

--- a/src/Runtime/class-wp-agent-provider-turn-result.php
+++ b/src/Runtime/class-wp-agent-provider-turn-result.php
@@ -1,0 +1,157 @@
+<?php
+/**
+ * Provider-turn result contract.
+ *
+ * @package AgentsAPI
+ */
+
+namespace AgentsAPI\AI;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Validates and normalizes provider-turn adapter results.
+ */
+// phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Validation exceptions are not rendered output.
+class WP_Agent_Provider_Turn_Result {
+
+	/**
+	 * Normalize provider-turn adapter output.
+	 *
+	 * The adapter reports one assistant turn only. The conversation loop owns
+	 * continuation, mediated tool execution, transcript events, and final result
+	 * assembly.
+	 *
+	 * @param array<mixed> $result Raw provider-turn adapter result.
+	 * @return array<string, mixed> Normalized provider-turn result.
+	 */
+	public static function normalize( array $result ): array {
+		$normalized = array(
+			'content'              => self::string_value( $result['content'] ?? '' ),
+			'message'              => null,
+			'tool_calls'           => array(),
+			'usage'                => self::assoc_array( $result['usage'] ?? array(), 'usage' ),
+			'request_metadata'     => self::assoc_array( $result['request_metadata'] ?? array(), 'request_metadata' ),
+			'provider_diagnostics' => self::assoc_array( $result['provider_diagnostics'] ?? array(), 'provider_diagnostics' ),
+		);
+
+		if ( isset( $result['message'] ) ) {
+			if ( ! is_array( $result['message'] ) ) {
+				throw self::invalid( 'message', 'must be an array when present' );
+			}
+			$normalized['message'] = WP_Agent_Message::normalize( $result['message'] );
+		}
+
+		if ( isset( $result['tool_calls'] ) ) {
+			if ( ! is_array( $result['tool_calls'] ) ) {
+				throw self::invalid( 'tool_calls', 'must be an array when present' );
+			}
+			$normalized['tool_calls'] = self::normalize_tool_calls( $result['tool_calls'] );
+		}
+
+		if ( isset( $result['failure'] ) ) {
+			if ( ! is_array( $result['failure'] ) ) {
+				throw self::invalid( 'failure', 'must be an array when present' );
+			}
+			$failure = self::assoc_array( $result['failure'], 'failure' );
+			foreach ( array( 'type', 'message' ) as $field ) {
+				if ( ! isset( $failure[ $field ] ) || ! is_string( $failure[ $field ] ) || '' === $failure[ $field ] ) {
+					throw self::invalid( 'failure.' . $field, 'must be a non-empty string' );
+				}
+			}
+			$normalized['failure'] = $failure;
+		}
+
+		return $normalized;
+	}
+
+	/**
+	 * Normalize provider tool calls.
+	 *
+	 * @param array<mixed> $tool_calls Raw tool calls.
+	 * @return array<int, array<string, mixed>>
+	 */
+	private static function normalize_tool_calls( array $tool_calls ): array {
+		$normalized = array();
+		foreach ( $tool_calls as $index => $tool_call ) {
+			if ( ! is_array( $tool_call ) ) {
+				throw self::invalid( 'tool_calls[' . $index . ']', 'must be an array' );
+			}
+
+			$tool_call = self::assoc_array( $tool_call, 'tool_calls[' . $index . ']' );
+			$name      = $tool_call['name'] ?? $tool_call['tool_name'] ?? '';
+			if ( ! is_string( $name ) || '' === $name ) {
+				throw self::invalid( 'tool_calls[' . $index . '].name', 'must be a non-empty string' );
+			}
+
+			$parameters = $tool_call['parameters'] ?? array();
+			if ( ! is_array( $parameters ) ) {
+				throw self::invalid( 'tool_calls[' . $index . '].parameters', 'must be an array when present' );
+			}
+
+			$normalized_call = array(
+				'name'       => $name,
+				'parameters' => self::assoc_array( $parameters, 'tool_calls[' . $index . '].parameters' ),
+			);
+
+			if ( isset( $tool_call['id'] ) && is_string( $tool_call['id'] ) && '' !== $tool_call['id'] ) {
+				$normalized_call['id'] = $tool_call['id'];
+			}
+
+			if ( isset( $tool_call['metadata'] ) && is_array( $tool_call['metadata'] ) ) {
+				$normalized_call['metadata'] = self::assoc_array( $tool_call['metadata'], 'tool_calls[' . $index . '].metadata' );
+			}
+
+			$normalized[] = $normalized_call;
+		}
+
+		return $normalized;
+	}
+
+	/**
+	 * Normalize an associative array.
+	 *
+	 * @param mixed  $value Raw value.
+	 * @param string $path  Field path.
+	 * @return array<string, mixed>
+	 */
+	private static function assoc_array( $value, string $path ): array {
+		if ( ! is_array( $value ) ) {
+			throw self::invalid( $path, 'must be an array' );
+		}
+
+		$normalized = array();
+		foreach ( $value as $key => $item ) {
+			if ( is_string( $key ) ) {
+				$normalized[ $key ] = $item;
+			}
+		}
+
+		if ( false === wp_json_encode( $normalized, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ) ) {
+			throw self::invalid( $path, 'must be JSON serializable' );
+		}
+
+		return $normalized;
+	}
+
+	/**
+	 * Return a string value or an empty string.
+	 *
+	 * @param mixed $value Raw value.
+	 * @return string
+	 */
+	private static function string_value( $value ): string {
+		return is_string( $value ) ? $value : '';
+	}
+
+	/**
+	 * Build a machine-readable validation exception.
+	 *
+	 * @param string $path Field path.
+	 * @param string $reason Failure reason.
+	 * @return \InvalidArgumentException Validation exception.
+	 */
+	private static function invalid( string $path, string $reason ): \InvalidArgumentException {
+		return new \InvalidArgumentException( 'invalid_agent_provider_turn_result: ' . $path . ' ' . $reason );
+	}
+}

--- a/tests/provider-turn-adapter-smoke.php
+++ b/tests/provider-turn-adapter-smoke.php
@@ -1,0 +1,212 @@
+<?php
+/**
+ * Pure-PHP smoke test for provider-turn adapter contracts.
+ *
+ * Run with: php tests/provider-turn-adapter-smoke.php
+ *
+ * @package AgentsAPI\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+$failures = array();
+$passes   = 0;
+
+echo "agents-api-provider-turn-adapter-smoke\n";
+
+require_once __DIR__ . '/agents-api-smoke-helpers.php';
+agents_api_smoke_require_module();
+
+$tools = array(
+	'client/lookup' => array(
+		'name'        => 'client/lookup',
+		'source'      => 'client',
+		'description' => 'Look up one value.',
+		'parameters'  => array(
+			'type'       => 'object',
+			'required'   => array( 'query' ),
+			'properties' => array(
+				'query' => array( 'type' => 'string' ),
+			),
+		),
+		'executor'    => 'client',
+		'scope'       => 'run',
+	),
+);
+
+$executor = new class() implements AgentsAPI\AI\Tools\WP_Agent_Tool_Executor {
+	/** @var array<int, array<string, mixed>> Executed tool calls. */
+	public array $executed = array();
+
+	public function executeWP_Agent_Tool_Call( array $tool_call, array $tool_definition, array $context = array() ): array {
+		unset( $tool_definition, $context );
+		$this->executed[] = $tool_call;
+
+		return array(
+			'success'   => true,
+			'tool_name' => $tool_call['tool_name'],
+			'result'    => array( 'value' => 'lookup:' . (string) ( $tool_call['parameters']['query'] ?? '' ) ),
+		);
+	}
+};
+
+echo "\n[1] Provider-turn request and result contracts normalize neutral fields:\n";
+$request = new AgentsAPI\AI\WP_Agent_Provider_Turn_Request(
+	array( array( 'role' => 'user', 'content' => 'hello' ) ),
+	$tools,
+	array( 'provider_id' => 'fake-provider', 'model_id' => 'fake-model' ),
+	array( 'runtime_id' => 'fake-runtime' ),
+	array( 'turn' => 1 ),
+	array( 'turns' => array( 'current' => 0, 'limit' => 3 ) ),
+	'run-123',
+	'session-456',
+	array( 'trace_id' => 'trace-789' )
+);
+
+agents_api_smoke_assert_equals( AgentsAPI\AI\WP_Agent_Message::SCHEMA, $request->messages()[0]['schema'], 'provider request messages normalize to canonical envelopes', $failures, $passes );
+agents_api_smoke_assert_equals( 'client/lookup', array_key_first( $request->toolDeclarations() ), 'provider request carries keyed tool declarations', $failures, $passes );
+agents_api_smoke_assert_equals( 'fake-provider', $request->model()['provider_id'], 'provider request carries provider metadata', $failures, $passes );
+agents_api_smoke_assert_equals( 'fake-runtime', $request->runtime()['runtime_id'], 'provider request carries runtime metadata', $failures, $passes );
+agents_api_smoke_assert_equals( 'run-123', $request->runId(), 'provider request carries run id', $failures, $passes );
+agents_api_smoke_assert_equals( 'session-456', $request->sessionId(), 'provider request carries session id', $failures, $passes );
+
+$normalized_turn = AgentsAPI\AI\WP_Agent_Provider_Turn_Result::normalize(
+	array(
+		'content'              => 'Using a tool.',
+		'tool_calls'           => array(
+			array(
+				'id'         => 'call-1',
+				'name'       => 'client/lookup',
+				'parameters' => array( 'query' => 'alpha' ),
+			),
+		),
+		'usage'                => array( 'prompt_tokens' => 1, 'completion_tokens' => 2, 'total_tokens' => 3 ),
+		'request_metadata'     => array( 'provider_request_id' => 'req-1' ),
+		'provider_diagnostics' => array( 'latency_ms' => 12 ),
+	)
+);
+agents_api_smoke_assert_equals( 'client/lookup', $normalized_turn['tool_calls'][0]['name'], 'provider result normalizes tool call names', $failures, $passes );
+agents_api_smoke_assert_equals( 3, $normalized_turn['usage']['total_tokens'], 'provider result preserves usage', $failures, $passes );
+
+echo "\n[2] Conversation loop can run through a fake provider-turn adapter without Data Machine:\n";
+$adapter_calls = array();
+$adapter       = new class( $adapter_calls ) implements AgentsAPI\AI\WP_Agent_Provider_Turn_Adapter {
+	/** @var array<int, array<string, mixed>> Captured requests. */
+	public array $requests = array();
+
+	/**
+	 * @param array<int, array<string, mixed>> $unused Unused initial calls.
+	 */
+	public function __construct( array $unused ) {
+		unset( $unused );
+	}
+
+	public function run_turn( AgentsAPI\AI\WP_Agent_Provider_Turn_Request $request ): array {
+		$this->requests[] = $request->to_array();
+		$turn             = (int) ( $request->context()['turn'] ?? 0 );
+
+		if ( 1 === $turn ) {
+			return array(
+				'content'              => 'I need one lookup.',
+				'tool_calls'           => array(
+					array(
+						'id'         => 'call-provider-1',
+						'name'       => 'client/lookup',
+						'parameters' => array( 'query' => 'alpha' ),
+					),
+				),
+				'usage'                => array( 'prompt_tokens' => 5, 'completion_tokens' => 7, 'total_tokens' => 12 ),
+				'request_metadata'     => array( 'provider_request_id' => 'provider-req-1' ),
+				'provider_diagnostics' => array( 'turn' => 1, 'transport' => 'fake' ),
+			);
+		}
+
+		return array(
+			'content'              => 'Final answer from fake adapter.',
+			'tool_calls'           => array(),
+			'usage'                => array( 'prompt_tokens' => 3, 'completion_tokens' => 4, 'total_tokens' => 7 ),
+			'request_metadata'     => array( 'provider_request_id' => 'provider-req-2' ),
+			'provider_diagnostics' => array( 'turn' => 2, 'transport' => 'fake' ),
+		);
+	}
+};
+
+$result = AgentsAPI\AI\WP_Agent_Conversation_Loop::run(
+	array( array( 'role' => 'user', 'content' => 'look up alpha' ) ),
+	null,
+	array(
+		'provider_turn_adapter' => $adapter,
+		'tool_executor'         => $executor,
+		'tool_declarations'     => $tools,
+		'max_turns'             => 3,
+		'run_id'                => 'run-loop-1',
+		'session_id'            => 'session-loop-1',
+		'context'               => array(
+			'provider_id'  => 'fake-provider',
+			'model_id'     => 'fake-model',
+			'request_kind' => 'smoke',
+		),
+	)
+);
+
+agents_api_smoke_assert_equals( 2, count( $adapter->requests ), 'loop called provider adapter for tool and final turns', $failures, $passes );
+agents_api_smoke_assert_equals( 'fake-provider', $adapter->requests[0]['model']['provider_id'], 'provider adapter receives model metadata', $failures, $passes );
+agents_api_smoke_assert_equals( 'smoke', $adapter->requests[0]['runtime']['request_kind'], 'provider adapter receives runtime metadata', $failures, $passes );
+agents_api_smoke_assert_equals( 'run-loop-1', $adapter->requests[0]['run_id'], 'provider adapter receives run id', $failures, $passes );
+agents_api_smoke_assert_equals( 'session-loop-1', $adapter->requests[0]['session_id'], 'provider adapter receives session id', $failures, $passes );
+agents_api_smoke_assert_equals( 1, count( $executor->executed ), 'loop mediated adapter tool call through executor', $failures, $passes );
+agents_api_smoke_assert_equals( 'call-provider-1', $executor->executed[0]['id'] ?? '', 'loop preserved provider tool call id', $failures, $passes );
+agents_api_smoke_assert_equals( 'Final answer from fake adapter.', $result['final_content'], 'loop surfaces adapter final assistant content', $failures, $passes );
+agents_api_smoke_assert_equals( 19, $result['usage']['total_tokens'], 'loop accumulates adapter usage', $failures, $passes );
+agents_api_smoke_assert_equals( 'provider-req-2', $result['request_metadata']['provider_request_id'], 'loop surfaces latest provider request metadata', $failures, $passes );
+agents_api_smoke_assert_equals( 2, count( $result['provider_diagnostics'] ), 'loop accumulates provider diagnostics per turn', $failures, $passes );
+
+echo "\n[3] Content-only provider-turn adapters work without tool mediation:\n";
+$content_only_result = AgentsAPI\AI\WP_Agent_Conversation_Loop::run(
+	array( array( 'role' => 'user', 'content' => 'answer only' ) ),
+	null,
+	array(
+		'provider_turn_adapter' => static function ( AgentsAPI\AI\WP_Agent_Provider_Turn_Request $unused ): array {
+			unset( $unused );
+			return array(
+				'content'          => 'Plain assistant answer.',
+				'request_metadata' => array( 'provider_request_id' => 'content-only-1' ),
+			);
+		},
+	)
+);
+
+agents_api_smoke_assert_equals( 'Plain assistant answer.', $content_only_result['final_content'], 'content-only adapter result becomes final assistant content', $failures, $passes );
+agents_api_smoke_assert_equals( 2, count( $content_only_result['messages'] ), 'content-only adapter appends one assistant message', $failures, $passes );
+agents_api_smoke_assert_equals( 'content-only-1', $content_only_result['request_metadata']['provider_request_id'], 'content-only adapter preserves request metadata', $failures, $passes );
+
+echo "\n[4] Provider-turn typed failures become canonical failed loop results:\n";
+$failing_adapter = static function ( AgentsAPI\AI\WP_Agent_Provider_Turn_Request $unused ): array {
+	unset( $unused );
+	return array(
+		'failure'              => array(
+			'type'    => 'rate_limit',
+			'message' => 'Provider rate limit exceeded.',
+		),
+		'provider_diagnostics' => array( 'retry_after_seconds' => 30 ),
+	);
+};
+
+$failure_result = AgentsAPI\AI\WP_Agent_Conversation_Loop::run(
+	array( array( 'role' => 'user', 'content' => 'fail' ) ),
+	null,
+	array(
+		'provider_turn_adapter' => $failing_adapter,
+		'tool_executor'         => $executor,
+		'tool_declarations'     => $tools,
+	)
+);
+
+agents_api_smoke_assert_equals( 'failed', $failure_result['status'] ?? '', 'typed provider failure sets failed status', $failures, $passes );
+agents_api_smoke_assert_equals( false, $failure_result['completed'] ?? true, 'typed provider failure is incomplete', $failures, $passes );
+agents_api_smoke_assert_equals( 'rate_limit', $failure_result['failure']['type'] ?? '', 'typed provider failure preserves type', $failures, $passes );
+agents_api_smoke_assert_equals( 30, $failure_result['provider_diagnostics'][0]['retry_after_seconds'] ?? 0, 'typed provider failure preserves diagnostics', $failures, $passes );
+
+agents_api_smoke_finish( 'Agents API provider-turn adapter', $failures, $passes );


### PR DESCRIPTION
## Summary
- Adds a provider-neutral `WP_Agent_Provider_Turn_Adapter` contract with request/result value shapes for one model turn.
- Wires `WP_Agent_Conversation_Loop` to consume `provider_turn_adapter` while retaining loop-owned continuation, mediated tool execution, usage/request metadata aggregation, diagnostics, and typed failures.
- Adds pure-PHP smoke coverage proving fake provider-turn adapters drive the loop with and without tool mediation, without Data Machine loaded.

Closes #268.

## Tests
- `php tests/provider-turn-adapter-smoke.php`
- `php tests/conversation-loop-smoke.php`
- `php tests/conversation-loop-tool-execution-smoke.php`
- `php tests/conversation-runner-contracts-smoke.php`
- `composer phpstan`
- `composer test`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the provider-turn adapter contract implementation and smoke coverage; Chris remains responsible for review and acceptance.