### PR TITLE
Clarify conversation session store contract

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,7 @@
       "php tests/authorization-smoke.php",
       "php tests/agents-access-ability-smoke.php",
       "php tests/agents-conversation-session-abilities-smoke.php",
+      "php tests/conversation-session-store-contract-smoke.php",
       "php tests/action-policy-values-smoke.php",
       "php tests/consent-policy-smoke.php",
       "php tests/tool-policy-contracts-smoke.php",

--- a/docs/channels-workflows-operations.md
+++ b/docs/channels-workflows-operations.md
@@ -205,6 +205,26 @@ Transcript contracts live in `src/Transcripts/` and runtime persister contracts 
 - `WP_Agent_Conversation_Lock` and `WP_Agent_Null_Conversation_Lock`: lock contracts used by the conversation loop to avoid concurrent session mutation.
 - `WP_Agent_Transcript_Persister` and `WP_Agent_Null_Transcript_Persister`: loop-level persistence adapters.
 
+### Canonical conversation sessions
+
+Agents API owns the canonical conversation-session ability surface for agent chat channels:
+
+| Ability | Purpose |
+| --- | --- |
+| `agents/list-conversation-sessions` | List sessions for the resolved `(workspace, owner)` tuple. |
+| `agents/get-conversation-session` | Read one session owned by the current principal. |
+| `agents/create-conversation-session` | Create an empty session for the current principal. |
+| `agents/update-conversation-session-title` | Update the stored display title. |
+| `agents/delete-conversation-session` | Idempotently delete the session. |
+
+The backing store is resolved through `WP_Agent_Conversation_Sessions::get_store()`, which accepts a direct `conversation_store` context value or the `wp_agent_conversation_store` filter. This keeps the contract storage-neutral: runtimes can use posts, custom tables, remote stores, files, or in-memory fakes as long as they implement the interface.
+
+Canonical session rows should expose stable generic fields when available: `session_id`, `workspace_type`, `workspace_id`, `owner_type`, `owner_key`, `user_id`, `agent_slug`, `title`, `messages`, `metadata`, `provider`, `model`, `provider_response_id`, `context`, `created_at`, `updated_at`, `last_read_at`, and `expires_at`. `list_sessions()` should omit `messages` when `include_messages` is false. `update_session()` replaces the complete transcript and metadata, and the provider fields link the transcript to provider-side continuation state without making the session store own run-status storage.
+
+Principal-aware stores should implement `WP_Agent_Principal_Conversation_Store` for non-user owners such as browser sessions, external channels, tokens, or system principals. Stores that hash or hide owner keys should also implement `WP_Agent_Principal_Conversation_Session_Reader` so `get`, `update-title`, and `delete` can verify ownership without exposing raw owner keys in generic rows.
+
+Product-specific state belongs in `metadata` under namespaced keys. For example, Data Machine can keep read/progress/reporting fields under `metadata['data_machine']` while exposing the canonical Agents API fields to channel clients. Data Machine `datamachine/*chat-session*` abilities, REST routes, and CLI commands can then become compatibility/product aliases over its adapter instead of a parallel generic contract.
+
 Approval primitives live in `src/Approvals/`:
 
 - `WP_Agent_Pending_Action`: JSON-friendly proposal and audit value object.

--- a/src/Transcripts/class-wp-agent-conversation-store.php
+++ b/src/Transcripts/class-wp-agent-conversation-store.php
@@ -8,6 +8,27 @@
  * to a transcript row. It deliberately does not include chat UI listing,
  * read-state, retention scheduling, or reporting/metrics responsibilities.
  *
+ * The canonical session row is storage-neutral and runtime-neutral. Stores can
+ * back it with posts, custom tables, external services, files, or memory, but
+ * callers should be able to rely on these generic keys when available:
+ *
+ * - `session_id` (string): stable opaque session identifier.
+ * - `workspace_type` / `workspace_id` (string): workspace scope.
+ * - `owner_type` / `owner_key` (string): canonical principal owner. Legacy
+ *   user-only stores may expose only `user_id`; principal-aware stores should
+ *   expose owner keys or implement `WP_Agent_Principal_Conversation_Session_Reader`.
+ * - `user_id` (int): WordPress user id for user-owned sessions, otherwise 0.
+ * - `agent_slug` (string): registered agent slug, not a product storage id.
+ * - `title` (string), `messages` (array), `metadata` (array), `context` (string).
+ * - `provider`, `model`, `provider_response_id` (string|null): provider
+ *   continuity for transcript/run resumption.
+ * - `created_at`, `updated_at`, `last_read_at`, `expires_at` (string|null):
+ *   timestamps in an implementation-documented format, preferably ISO-8601.
+ *
+ * Product-specific metadata belongs in `metadata` under a namespaced key (for
+ * example `metadata['data_machine']`). Generic clients must treat unknown
+ * metadata and extra top-level fields as optional extensions.
+ *
  * @package AgentsAPI
  */
 
@@ -26,6 +47,11 @@ interface WP_Agent_Conversation_Store {
 	 * `wp_get_agent()`, and related registry functions. Consumers that materialize
 	 * agents as posts may store post IDs in their concrete backend, but the generic
 	 * transcript contract keys runtime agent identity by slug.
+	 *
+	 * `$metadata` is caller/runtime metadata for the session row. Store adapters
+	 * should preserve JSON-serializable values and keep product-specific fields
+	 * namespaced inside the array rather than promoting them into the generic row
+	 * schema.
 	 *
 	 * @param WP_Agent_Workspace_Scope $workspace Workspace owning the session.
 	 * @param int                      $user_id   WordPress user ID owning the session.
@@ -67,6 +93,13 @@ interface WP_Agent_Conversation_Store {
 
 	/**
 	 * Replace a session's messages + metadata.
+	 *
+	 * The message array is the complete transcript, not a delta. `$provider`,
+	 * `$model`, and `$provider_response_id` link the transcript to the most recent
+	 * provider-side run/response state without requiring this store to own chat run
+	 * status. Active run status is handled by the runtime-neutral chat run-control
+	 * contract; adapters may also mirror run ids in namespaced metadata when their
+	 * product needs that linkage for listing or reporting.
 	 *
 	 * @param string      $session_id           Session UUID.
 	 * @param array<mixed>       $messages             Complete messages array (not a delta).

--- a/src/Transcripts/class-wp-agent-conversation-store.php
+++ b/src/Transcripts/class-wp-agent-conversation-store.php
@@ -25,9 +25,9 @@
  * - `created_at`, `updated_at`, `last_read_at`, `expires_at` (string|null):
  *   timestamps in an implementation-documented format, preferably ISO-8601.
  *
- * Product-specific metadata belongs in `metadata` under a namespaced key (for
- * example `metadata['data_machine']`). Generic clients must treat unknown
- * metadata and extra top-level fields as optional extensions.
+ * Product-specific metadata belongs in `metadata` under a namespaced key. Generic
+ * clients must treat unknown metadata and extra top-level fields as optional
+ * extensions.
  *
  * @package AgentsAPI
  */

--- a/src/Transcripts/class-wp-agent-principal-conversation-session-reader.php
+++ b/src/Transcripts/class-wp-agent-principal-conversation-session-reader.php
@@ -16,7 +16,9 @@ defined( 'ABSPATH' ) || exit;
  *
  * Stores that keep opaque owner keys hashed can implement this to verify a
  * session ID belongs to a principal without exposing the raw owner key in
- * generic session rows.
+ * generic session rows. Stores that expose `owner_type` and `owner_key` in their
+ * generic rows can skip this interface; the canonical abilities will verify
+ * ownership from those row fields.
  */
 interface WP_Agent_Principal_Conversation_Session_Reader extends WP_Agent_Principal_Conversation_Store {
 

--- a/src/Transcripts/class-wp-agent-principal-conversation-store.php
+++ b/src/Transcripts/class-wp-agent-principal-conversation-store.php
@@ -18,6 +18,9 @@ defined( 'ABSPATH' ) || exit;
  * persist sessions for non-user principals. `$owner` is the canonical shape
  * returned by WP_Agent_Execution_Principal::conversation_owner():
  * `array( 'type' => 'user|audience|token|system', 'key' => '<opaque stable key>' )`.
+ * The owner key is opaque to Agents API. Runtime adapters may hash or otherwise
+ * protect it at rest, but list/get/create/delete semantics must remain scoped to
+ * the `(workspace, owner_type, owner_key)` tuple.
  *
  * Legacy WP_Agent_Conversation_Store implementations remain valid for user-owned
  * sessions through the int user ID methods above.

--- a/src/Transcripts/register-agents-conversation-session-abilities.php
+++ b/src/Transcripts/register-agents-conversation-session-abilities.php
@@ -573,7 +573,7 @@ function agents_conversation_sessions_list_input_schema(): array {
 function agents_conversation_session_owner_schema(): array {
 	return array(
 		'type'        => array( 'object', 'null' ),
-		'description' => 'Opaque, isolating owner for persisted conversation sessions. Use for anonymous browser or external-channel chats when no logged-in user owns the transcript. Do not use a shared public audience as a session owner.',
+		'description' => 'Opaque, isolating owner for persisted conversation sessions. Use for anonymous browser or external-channel chats when no logged-in user owns the transcript. Do not use a shared public audience as a session owner. Runtime adapters may store this key hashed, but canonical abilities scope list/get/create/update-title/delete by the resolved owner tuple.',
 		'properties'  => array(
 			'type'  => array( 'type' => 'string' ),
 			'key'   => array( 'type' => 'string' ),
@@ -586,7 +586,11 @@ function agents_conversation_session_owner_schema(): array {
 function agents_conversation_sessions_create_input_schema(): array {
 	$schema = agents_conversation_sessions_list_input_schema();
 	if ( isset( $schema['properties'] ) && is_array( $schema['properties'] ) ) {
-		$schema['properties']['metadata'] = array( 'type' => 'object' );
+		$schema['properties']['metadata'] = array(
+			'type'                 => 'object',
+			'description'          => 'Optional JSON-serializable session metadata. Product-specific fields should live under namespaced keys, e.g. metadata.data_machine, so the generic session schema remains runtime-neutral.',
+			'additionalProperties' => true,
+		);
 	}
 	return $schema;
 }
@@ -634,7 +638,41 @@ function agents_conversation_session_output_schema(): array {
 	return array(
 		'type'       => 'object',
 		'required'   => array( 'session' ),
-		'properties' => array( 'session' => array( 'type' => 'object' ) ),
+		'properties' => array(
+			'session' => agents_conversation_session_row_schema(),
+		),
+	);
+}
+
+/** @return array<string,mixed> */
+function agents_conversation_session_row_schema(): array {
+	return array(
+		'type'                 => 'object',
+		'description'          => 'Canonical conversation session row. Unknown fields are optional runtime/product extensions; product-specific metadata should be namespaced inside metadata.',
+		'additionalProperties' => true,
+		'properties'           => array(
+			'session_id'           => array( 'type' => 'string' ),
+			'workspace_type'       => array( 'type' => 'string' ),
+			'workspace_id'         => array( 'type' => 'string' ),
+			'owner_type'           => array( 'type' => 'string' ),
+			'owner_key'            => array( 'type' => 'string' ),
+			'user_id'              => array( 'type' => 'integer' ),
+			'agent_slug'           => array( 'type' => 'string' ),
+			'title'                => array( 'type' => 'string' ),
+			'messages'             => array( 'type' => 'array' ),
+			'metadata'             => array(
+				'type'                 => 'object',
+				'additionalProperties' => true,
+			),
+			'provider'             => array( 'type' => 'string' ),
+			'model'                => array( 'type' => 'string' ),
+			'provider_response_id' => array( 'type' => array( 'string', 'null' ) ),
+			'context'              => array( 'type' => 'string' ),
+			'created_at'           => array( 'type' => array( 'string', 'null' ) ),
+			'updated_at'           => array( 'type' => array( 'string', 'null' ) ),
+			'last_read_at'         => array( 'type' => array( 'string', 'null' ) ),
+			'expires_at'           => array( 'type' => array( 'string', 'null' ) ),
+		),
 	);
 }
 

--- a/src/Transcripts/register-agents-conversation-session-abilities.php
+++ b/src/Transcripts/register-agents-conversation-session-abilities.php
@@ -588,7 +588,7 @@ function agents_conversation_sessions_create_input_schema(): array {
 	if ( isset( $schema['properties'] ) && is_array( $schema['properties'] ) ) {
 		$schema['properties']['metadata'] = array(
 			'type'                 => 'object',
-			'description'          => 'Optional JSON-serializable session metadata. Product-specific fields should live under namespaced keys, e.g. metadata.data_machine, so the generic session schema remains runtime-neutral.',
+			'description'          => 'Optional JSON-serializable session metadata. Product-specific fields should live under namespaced keys so the generic session schema remains runtime-neutral.',
 			'additionalProperties' => true,
 		);
 	}

--- a/tests/conversation-session-store-contract-smoke.php
+++ b/tests/conversation-session-store-contract-smoke.php
@@ -177,8 +177,8 @@ $store = new class() implements WP_Agent_Principal_Conversation_Session_Reader {
 
 $workspace = WP_Agent_Workspace_Scope::from_parts( 'site', '42' );
 $metadata  = array(
-	'run_id'       => 'run_123',
-	'data_machine' => array(
+	'run_id'          => 'run_123',
+	'example_product' => array(
 		'last_read_at' => '2026-06-03T00:00:30Z',
 	),
 );
@@ -194,7 +194,7 @@ smoke_assert( '7', $session['owner_key'] ?? null, 'user create stores canonical 
 smoke_assert( 7, $session['user_id'] ?? null, 'user_id mirrors user owner', $failures, $passes );
 smoke_assert( 'demo-agent', $session['agent_slug'] ?? null, 'agent slug is stored', $failures, $passes );
 smoke_assert( 'run_123', $session['metadata']['run_id'] ?? null, 'metadata can link caller run id', $failures, $passes );
-smoke_assert( '2026-06-03T00:00:30Z', $session['metadata']['data_machine']['last_read_at'] ?? null, 'product metadata remains namespaced', $failures, $passes );
+smoke_assert( '2026-06-03T00:00:30Z', $session['metadata']['example_product']['last_read_at'] ?? null, 'product metadata remains namespaced', $failures, $passes );
 
 $store->update_session(
 	$session_id,

--- a/tests/conversation-session-store-contract-smoke.php
+++ b/tests/conversation-session-store-contract-smoke.php
@@ -1,0 +1,245 @@
+<?php
+/**
+ * Pure-PHP smoke test for the canonical conversation session store contract.
+ *
+ * Run with: php tests/conversation-session-store-contract-smoke.php
+ *
+ * @package AgentsAPI\Tests
+ */
+
+defined( 'ABSPATH' ) || define( 'ABSPATH', __DIR__ . '/' );
+
+$failures = array();
+$passes   = 0;
+
+echo "conversation-session-store-contract-smoke\n";
+
+function smoke_assert( $expected, $actual, string $name, array &$failures, int &$passes ): void {
+	if ( $expected === $actual ) {
+		++$passes;
+		echo "  PASS {$name}\n";
+		return;
+	}
+
+	$failures[] = $name;
+	echo "  FAIL {$name}\n";
+	echo '    expected: ' . var_export( $expected, true ) . "\n";
+	echo '    actual:   ' . var_export( $actual, true ) . "\n";
+}
+
+require_once __DIR__ . '/../src/Workspace/class-wp-agent-workspace-scope.php';
+require_once __DIR__ . '/../src/Runtime/class-wp-agent-execution-principal.php';
+require_once __DIR__ . '/../src/Transcripts/class-wp-agent-conversation-store.php';
+require_once __DIR__ . '/../src/Transcripts/class-wp-agent-principal-conversation-store.php';
+require_once __DIR__ . '/../src/Transcripts/class-wp-agent-principal-conversation-session-reader.php';
+
+use AgentsAPI\AI\WP_Agent_Execution_Principal;
+use AgentsAPI\Core\Database\Chat\WP_Agent_Principal_Conversation_Session_Reader;
+use AgentsAPI\Core\Workspace\WP_Agent_Workspace_Scope;
+
+$store = new class() implements WP_Agent_Principal_Conversation_Session_Reader {
+	/** @var array<string,array<string,mixed>> */
+	private array $sessions = array();
+
+	public function create_session_for_owner( WP_Agent_Workspace_Scope $workspace, array $owner, string $agent_slug = '', array $metadata = array(), string $context = 'chat' ): string {
+		$session_id = 'fake-' . ( count( $this->sessions ) + 1 );
+		$now        = '2026-06-03T00:00:00Z';
+
+		$this->sessions[ $session_id ] = array(
+			'session_id'           => $session_id,
+			'workspace_type'       => $workspace->workspace_type,
+			'workspace_id'         => $workspace->workspace_id,
+			'owner_type'           => (string) ( $owner['type'] ?? '' ),
+			'owner_key'            => (string) ( $owner['key'] ?? '' ),
+			'user_id'              => WP_Agent_Execution_Principal::OWNER_TYPE_USER === ( $owner['type'] ?? '' ) ? (int) $owner['key'] : 0,
+			'agent_slug'           => $agent_slug,
+			'title'                => '',
+			'messages'             => array(),
+			'metadata'             => $metadata,
+			'provider'             => '',
+			'model'                => '',
+			'provider_response_id' => null,
+			'context'              => $context,
+			'created_at'           => $now,
+			'updated_at'           => $now,
+			'last_read_at'         => null,
+			'expires_at'           => null,
+		);
+
+		return $session_id;
+	}
+
+	public function create_session( WP_Agent_Workspace_Scope $workspace, int $user_id, string $agent_slug = '', array $metadata = array(), string $context = 'chat' ): string {
+		return $this->create_session_for_owner( $workspace, array( 'type' => WP_Agent_Execution_Principal::OWNER_TYPE_USER, 'key' => (string) $user_id ), $agent_slug, $metadata, $context );
+	}
+
+	/** @return array<int,array<string,mixed>> */
+	public function list_sessions_for_owner( WP_Agent_Workspace_Scope $workspace, array $owner, array $args = array() ): array {
+		$include_messages = ! empty( $args['include_messages'] );
+		$agent_slug       = (string) ( $args['agent_slug'] ?? '' );
+		$context          = (string) ( $args['context'] ?? '' );
+
+		$rows = array_values(
+			array_filter(
+				$this->sessions,
+				static function ( array $session ) use ( $workspace, $owner, $agent_slug, $context ): bool {
+					if ( $session['workspace_type'] !== $workspace->workspace_type || $session['workspace_id'] !== $workspace->workspace_id ) {
+						return false;
+					}
+					if ( $session['owner_type'] !== (string) ( $owner['type'] ?? '' ) || $session['owner_key'] !== (string) ( $owner['key'] ?? '' ) ) {
+						return false;
+					}
+					if ( '' !== $agent_slug && $session['agent_slug'] !== $agent_slug ) {
+						return false;
+					}
+					return '' === $context || $session['context'] === $context;
+				}
+			)
+		);
+
+		if ( ! $include_messages ) {
+			foreach ( $rows as &$row ) {
+				unset( $row['messages'] );
+			}
+			unset( $row );
+		}
+
+		$offset = max( 0, (int) ( $args['offset'] ?? 0 ) );
+		$limit  = max( 1, (int) ( $args['limit'] ?? count( $rows ) ?: 1 ) );
+		return array_slice( $rows, $offset, $limit );
+	}
+
+	/** @return array<int,array<string,mixed>> */
+	public function list_sessions( WP_Agent_Workspace_Scope $workspace, int $user_id, array $args = array() ): array {
+		return $this->list_sessions_for_owner( $workspace, array( 'type' => WP_Agent_Execution_Principal::OWNER_TYPE_USER, 'key' => (string) $user_id ), $args );
+	}
+
+	public function get_session_for_owner( WP_Agent_Workspace_Scope $workspace, array $owner, string $session_id ): ?array {
+		$session = $this->get_session( $session_id );
+		if ( null === $session ) {
+			return null;
+		}
+
+		return $session['workspace_type'] === $workspace->workspace_type
+			&& $session['workspace_id'] === $workspace->workspace_id
+			&& $session['owner_type'] === (string) ( $owner['type'] ?? '' )
+			&& $session['owner_key'] === (string) ( $owner['key'] ?? '' )
+			? $session
+			: null;
+	}
+
+	public function get_session( string $session_id ): ?array {
+		return $this->sessions[ $session_id ] ?? null;
+	}
+
+	public function update_session( string $session_id, array $messages, array $metadata = array(), string $provider = '', string $model = '', ?string $provider_response_id = null ): bool {
+		if ( ! isset( $this->sessions[ $session_id ] ) ) {
+			return false;
+		}
+
+		$this->sessions[ $session_id ]['messages']             = array_values( $messages );
+		$this->sessions[ $session_id ]['metadata']             = $metadata;
+		$this->sessions[ $session_id ]['provider']             = $provider;
+		$this->sessions[ $session_id ]['model']                = $model;
+		$this->sessions[ $session_id ]['provider_response_id'] = $provider_response_id;
+		$this->sessions[ $session_id ]['updated_at']           = '2026-06-03T00:01:00Z';
+		return true;
+	}
+
+	public function update_title( string $session_id, string $title ): bool {
+		if ( ! isset( $this->sessions[ $session_id ] ) ) {
+			return false;
+		}
+		$this->sessions[ $session_id ]['title']      = $title;
+		$this->sessions[ $session_id ]['updated_at'] = '2026-06-03T00:02:00Z';
+		return true;
+	}
+
+	public function delete_session( string $session_id ): bool {
+		unset( $this->sessions[ $session_id ] );
+		return true;
+	}
+
+	public function get_recent_pending_session_for_owner( WP_Agent_Workspace_Scope $workspace, array $owner, int $seconds = 600, string $context = 'chat', ?int $token_id = null ): ?array {
+		unset( $seconds, $token_id );
+		foreach ( array_reverse( $this->sessions ) as $session ) {
+			if ( $session['workspace_type'] === $workspace->workspace_type && $session['workspace_id'] === $workspace->workspace_id && $session['owner_type'] === (string) ( $owner['type'] ?? '' ) && $session['owner_key'] === (string) ( $owner['key'] ?? '' ) && $session['context'] === $context && array() === $session['messages'] ) {
+				return $session;
+			}
+		}
+		return null;
+	}
+
+	public function get_recent_pending_session( WP_Agent_Workspace_Scope $workspace, int $user_id, int $seconds = 600, string $context = 'chat', ?int $token_id = null ): ?array {
+		return $this->get_recent_pending_session_for_owner( $workspace, array( 'type' => WP_Agent_Execution_Principal::OWNER_TYPE_USER, 'key' => (string) $user_id ), $seconds, $context, $token_id );
+	}
+};
+
+$workspace = WP_Agent_Workspace_Scope::from_parts( 'site', '42' );
+$metadata  = array(
+	'run_id'       => 'run_123',
+	'data_machine' => array(
+		'last_read_at' => '2026-06-03T00:00:30Z',
+	),
+);
+
+$session_id = $store->create_session( $workspace, 7, 'demo-agent', $metadata, 'chat' );
+$session    = $store->get_session( $session_id );
+
+smoke_assert( 'fake-1', $session_id, 'create returns stable adapter session id', $failures, $passes );
+smoke_assert( 'site', $session['workspace_type'] ?? null, 'workspace_type is stored', $failures, $passes );
+smoke_assert( '42', $session['workspace_id'] ?? null, 'workspace_id is stored', $failures, $passes );
+smoke_assert( 'user', $session['owner_type'] ?? null, 'user create stores canonical owner_type', $failures, $passes );
+smoke_assert( '7', $session['owner_key'] ?? null, 'user create stores canonical owner_key', $failures, $passes );
+smoke_assert( 7, $session['user_id'] ?? null, 'user_id mirrors user owner', $failures, $passes );
+smoke_assert( 'demo-agent', $session['agent_slug'] ?? null, 'agent slug is stored', $failures, $passes );
+smoke_assert( 'run_123', $session['metadata']['run_id'] ?? null, 'metadata can link caller run id', $failures, $passes );
+smoke_assert( '2026-06-03T00:00:30Z', $session['metadata']['data_machine']['last_read_at'] ?? null, 'product metadata remains namespaced', $failures, $passes );
+
+$store->update_session(
+	$session_id,
+	array(
+		array( 'role' => 'user', 'content' => 'hello' ),
+		array( 'role' => 'assistant', 'content' => 'hi' ),
+	),
+	array( 'run_id' => 'run_124' ),
+	'openai',
+	'gpt-5.5',
+	'resp_abc'
+);
+$session = $store->get_session( $session_id );
+
+smoke_assert( 2, count( $session['messages'] ?? array() ), 'update_session replaces full transcript', $failures, $passes );
+smoke_assert( 'run_124', $session['metadata']['run_id'] ?? null, 'update_session replaces metadata', $failures, $passes );
+smoke_assert( 'openai', $session['provider'] ?? null, 'provider linkage is stored', $failures, $passes );
+smoke_assert( 'gpt-5.5', $session['model'] ?? null, 'model linkage is stored', $failures, $passes );
+smoke_assert( 'resp_abc', $session['provider_response_id'] ?? null, 'provider response linkage is stored', $failures, $passes );
+
+$store->update_title( $session_id, 'Renamed session' );
+smoke_assert( 'Renamed session', $store->get_session( $session_id )['title'] ?? null, 'update_title changes stored display title', $failures, $passes );
+
+$store->create_session( $workspace, 8, 'demo-agent', array(), 'chat' );
+$store->create_session( WP_Agent_Workspace_Scope::from_parts( 'site', '43' ), 7, 'demo-agent', array(), 'chat' );
+$listed = $store->list_sessions( $workspace, 7, array( 'include_messages' => false, 'agent_slug' => 'demo-agent', 'context' => 'chat' ) );
+
+smoke_assert( 1, count( $listed ), 'list_sessions scopes by workspace/user/agent/context', $failures, $passes );
+smoke_assert( false, isset( $listed[0]['messages'] ), 'list_sessions can omit transcript payloads', $failures, $passes );
+
+$browser_owner = array( 'type' => 'browser', 'key' => 'browser:opaque' );
+$browser_id    = $store->create_session_for_owner( $workspace, $browser_owner, 'demo-agent', array(), 'chat' );
+
+smoke_assert( 'browser:opaque', $store->get_session_for_owner( $workspace, $browser_owner, $browser_id )['owner_key'] ?? null, 'principal reader loads matching opaque owner', $failures, $passes );
+smoke_assert( null, $store->get_session_for_owner( $workspace, array( 'type' => 'browser', 'key' => 'browser:other' ), $browser_id ), 'principal reader blocks other opaque owners', $failures, $passes );
+smoke_assert( 'fake-2', $store->get_recent_pending_session( $workspace, 8, 600, 'chat' )['session_id'] ?? null, 'pending lookup scopes user sessions', $failures, $passes );
+smoke_assert( 'fake-4', $store->get_recent_pending_session_for_owner( $workspace, $browser_owner, 600, 'chat' )['session_id'] ?? null, 'pending lookup scopes principal sessions', $failures, $passes );
+
+smoke_assert( true, $store->delete_session( $session_id ), 'delete_session returns true', $failures, $passes );
+smoke_assert( null, $store->get_session( $session_id ), 'delete_session removes session', $failures, $passes );
+smoke_assert( true, $store->delete_session( $session_id ), 'delete_session is idempotent', $failures, $passes );
+
+if ( $failures ) {
+	echo "\nFAILED: " . count( $failures ) . " conversation session store contract assertions failed.\n";
+	exit( 1 );
+}
+
+echo "\nAll {$passes} conversation session store contract assertions passed.\n";


### PR DESCRIPTION
## Summary
- Tightens the canonical conversation session store contract around storage-neutral row fields, principal owner scoping, provider response continuity, and namespaced product metadata.
- Adds a typed session row output schema for the canonical conversation session abilities without requiring a concrete storage backend.
- Documents how runtime products such as Data Machine should adapt their existing chat/session stores as compatibility or product aliases over the Agents API surface.
- Adds a pure fake-store smoke test proving create/list/get/update-title/delete, transcript updates, provider response linkage, principal owners, and namespaced metadata work without Data Machine internals.

Closes https://github.com/Automattic/agents-api/issues/267

## Testing
- `php tests/conversation-session-store-contract-smoke.php`
- `php tests/agents-conversation-session-abilities-smoke.php`
- `php tests/cpt-conversation-store-smoke.php`
- `php tests/channels-smoke.php`
- `php tests/chat-run-control-smoke.php`
- `composer test`
- `composer phpstan`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the session contract documentation/schema hardening, drafted fake-store smoke coverage, and ran verification for Chris to review.