### PR TITLE
chore: pin third-party GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/docs-agent.yml
+++ b/.github/workflows/docs-agent.yml
@@ -93,7 +93,7 @@ jobs:
   docs-agent:
     name: Run Docs Agent
     needs: prepare
-    uses: Extra-Chill/homeboy-extensions/.github/workflows/datamachine-agent-ci.yml@main
+    uses: Extra-Chill/homeboy-extensions/.github/workflows/datamachine-agent-ci.yml@179eedbeb1da7a0b7dfacd10a6010019fd62a68b # main
     with:
       bundle_path: bundles/docs-agent
       bundle_repo: https://github.com/Automattic/docs-agent.git


### PR DESCRIPTION
Pins third-party GitHub Actions in this repo to immutable commit SHAs.

This PR was prepared with agent assistance and manually verified.

Tracking: DEVPROD-1072

Repo-level summary:
- Pinned distinct third-party action refs in this PR: 1
- Repo-level unpinned usage count from the trunk recheck: 1
- Dependabot GitHub Actions coverage: already_present (.github/dependabot.yml)


Verification commands:

```bash
# Extra-Chill/homeboy-extensions/.github/workflows/datamachine-agent-ci.yml # main -> 179eedbeb1da7a0b7dfacd10a6010019fd62a68b
gh api repos/Extra-Chill/homeboy-extensions/commits/main --jq '.sha'
# expected: 179eedbeb1da7a0b7dfacd10a6010019fd62a68b
```
