### PR TITLE
Define host-owned tool declarations for conversation requests

### DIFF
--- a/docs/runtime-and-tools.md
+++ b/docs/runtime-and-tools.md
@@ -141,7 +141,7 @@ $result = AgentsAPI\AI\WP_Agent_Conversation_Loop::run(
 
 ## Runtime tool declarations
 
-`AgentsAPI\AI\Tools\WP_Agent_Tool_Declaration` validates per-run tool declarations. The current substrate shape is intentionally narrow:
+`AgentsAPI\AI\Tools\WP_Agent_Tool_Declaration::normalize()` validates per-run client tool declarations. The runtime-client shape is intentionally narrow:
 
 - tool names must be namespaced as `client/tool_slug`;
 - `source` must match the name prefix and currently resolves to `client`;
@@ -169,6 +169,23 @@ $tool = AgentsAPI\AI\Tools\WP_Agent_Tool_Declaration::normalize(
 ```
 
 Invalid declarations produce machine-readable invalid field names through `validate()` or an `InvalidArgumentException` from `normalize()`.
+
+Conversation requests use `normalizeForConversationRequest()` so replay/audit records can carry the full model-facing tool catalog without weakening the client runtime contract. Client tools still pass through strict `normalize()`. Host-owned tools use `executor => 'host'`, `scope => 'run'`, a namespaced stable name, matching source metadata, description, parameters schema, and optional runtime metadata:
+
+```php
+$tool = AgentsAPI\AI\Tools\WP_Agent_Tool_Declaration::normalizeForConversationRequest(
+	array(
+		'name'        => 'ability/search_posts',
+		'source'      => 'ability',
+		'description' => 'Search host-owned posts.',
+		'parameters'  => array(
+			'required' => array( 'query' ),
+		),
+		'executor'    => 'host',
+		'scope'       => 'run',
+	)
+);
+```
 
 ### Tool runtime metadata
 

--- a/src/Runtime/class-wp-agent-conversation-request.php
+++ b/src/Runtime/class-wp-agent-conversation-request.php
@@ -176,7 +176,7 @@ class WP_Agent_Conversation_Request {
 			}
 
 			try {
-				$normalized[] = self::string_keyed_array( WP_Agent_Tool_Declaration::normalize( self::string_keyed_array( $tool ) ) );
+				$normalized[] = self::string_keyed_array( WP_Agent_Tool_Declaration::normalizeForConversationRequest( self::string_keyed_array( $tool ) ) );
 			} catch ( \InvalidArgumentException $error ) {
 				throw self::invalid( 'tools[' . $index . ']', $error->getMessage() );
 			}

--- a/src/Tools/class-wp-agent-tool-declaration.php
+++ b/src/Tools/class-wp-agent-tool-declaration.php
@@ -21,6 +21,7 @@ class WP_Agent_Tool_Declaration {
 
 	public const SOURCE_CLIENT   = 'client';
 	public const EXECUTOR_CLIENT = 'client';
+	public const EXECUTOR_HOST   = 'host';
 	public const SCOPE_RUN       = 'run';
 
 	/**
@@ -62,6 +63,56 @@ class WP_Agent_Tool_Declaration {
 			'description' => is_string( $description ) ? trim( $description ) : '',
 			'parameters'  => $declaration['parameters'] ?? array(),
 			'executor'    => self::EXECUTOR_CLIENT,
+			'scope'       => self::SCOPE_RUN,
+		);
+
+		$runtime = self::normalizeRuntimeMetadata( $declaration['runtime'] ?? array() );
+		if ( ! empty( $runtime ) ) {
+			$normalized['runtime'] = $runtime;
+		}
+
+		return $normalized;
+	}
+
+	/**
+	 * Normalize a conversation-request tool declaration.
+	 *
+	 * Client runtime tools keep the strict `normalize()` contract. Host-owned
+	 * declarations are request/replay catalog entries for tools executed by the
+	 * host runtime rather than the client transport.
+	 *
+	 * @param array<mixed> $declaration Raw request tool declaration.
+	 * @return array<mixed> Normalized declaration.
+	 */
+	public static function normalizeForConversationRequest( array $declaration ): array {
+		$name     = is_string( $declaration['name'] ?? null ) ? $declaration['name'] : '';
+		$executor = $declaration['executor'] ?? null;
+
+		if ( self::EXECUTOR_CLIENT === $executor || self::SOURCE_CLIENT === self::sourceFromName( $name ) ) {
+			return self::normalize( $declaration );
+		}
+
+		$errors = self::validateHostDeclaration( $declaration );
+		if ( ! empty( $errors ) ) {
+			$message = sprintf(
+				'invalid_conversation_tool_declaration: %s',
+				implode( ', ', self::sanitizeErrorKeys( $errors ) )
+			);
+
+			throw new \InvalidArgumentException(
+				$message
+			);
+		}
+
+		$source      = self::sourceFromName( $name );
+		$description = $declaration['description'] ?? '';
+
+		$normalized = array(
+			'name'        => $name,
+			'source'      => $source,
+			'description' => is_string( $description ) ? trim( $description ) : '',
+			'parameters'  => $declaration['parameters'] ?? array(),
+			'executor'    => self::EXECUTOR_HOST,
 			'scope'       => self::SCOPE_RUN,
 		);
 
@@ -116,6 +167,63 @@ class WP_Agent_Tool_Declaration {
 		}
 
 		if ( ( $declaration['executor'] ?? null ) !== self::EXECUTOR_CLIENT ) {
+			$errors[] = 'executor';
+		}
+
+		if ( ( $declaration['scope'] ?? null ) !== self::SCOPE_RUN ) {
+			$errors[] = 'scope';
+		}
+
+		if ( isset( $declaration['runtime'] ) && ! is_array( $declaration['runtime'] ) ) {
+			$errors[] = 'runtime';
+		}
+
+		return array_values( array_unique( $errors ) );
+	}
+
+	/**
+	 * Validate a host-owned request/replay tool declaration without throwing.
+	 *
+	 * @param array<mixed> $declaration Raw host declaration.
+	 * @return string[] Machine-readable invalid field names.
+	 */
+	private static function validateHostDeclaration( array $declaration ): array {
+		$errors = array();
+
+		$name = $declaration['name'] ?? null;
+		if (
+			! is_string( $name )
+			|| '' === $name
+			|| ! preg_match( '/^[a-z][a-z0-9_-]*\/[a-z][a-z0-9_-]*$/', $name )
+		) {
+			$errors[] = 'name';
+		}
+
+		$source = is_string( $name ) ? self::sourceFromName( $name ) : '';
+		if ( '' === $source || self::SOURCE_CLIENT === $source ) {
+			$errors[] = 'source';
+		}
+
+		if (
+			isset( $declaration['source'] )
+			&& $declaration['source'] !== $source
+		) {
+			$errors[] = 'source';
+		}
+
+		$description = $declaration['description'] ?? null;
+		if ( ! is_string( $description ) || '' === trim( $description ) ) {
+			$errors[] = 'description';
+		}
+
+		if (
+			isset( $declaration['parameters'] )
+			&& ! is_array( $declaration['parameters'] )
+		) {
+			$errors[] = 'parameters';
+		}
+
+		if ( ( $declaration['executor'] ?? null ) !== self::EXECUTOR_HOST ) {
 			$errors[] = 'executor';
 		}
 

--- a/tests/conversation-runner-contracts-smoke.php
+++ b/tests/conversation-runner-contracts-smoke.php
@@ -40,6 +40,22 @@ $request           = new AgentsAPI\AI\WP_Agent_Conversation_Request(
 			'executor'    => AgentsAPI\AI\Tools\WP_Agent_Tool_Declaration::EXECUTOR_CLIENT,
 			'scope'       => AgentsAPI\AI\Tools\WP_Agent_Tool_Declaration::SCOPE_RUN,
 		),
+		array(
+			'name'        => 'ability/search_posts',
+			'description' => 'Search host-owned posts.',
+			'parameters'  => array(
+				'type'       => 'object',
+				'required'   => array( 'query' ),
+				'properties' => array(
+					'query' => array( 'type' => 'string' ),
+				),
+			),
+			'executor'    => AgentsAPI\AI\Tools\WP_Agent_Tool_Declaration::EXECUTOR_HOST,
+			'scope'       => AgentsAPI\AI\Tools\WP_Agent_Tool_Declaration::SCOPE_RUN,
+			'runtime'     => array(
+				'duplicate_policy' => 'repeatable',
+			),
+		),
 	),
 	$principal,
 	array( 'request_kind' => 'interactive' ),
@@ -60,6 +76,8 @@ agents_api_smoke_assert_equals( 'gpt-5.5', $request->runtimeContext()['model_id'
 agents_api_smoke_assert_equals( 0.3, $request->runtimeContext()['temperature'], 'request carries temperature override to runtime context', $failures, $passes );
 agents_api_smoke_assert_equals( 'abc123', $request->metadata()['trace_id'], 'request preserves caller metadata', $failures, $passes );
 agents_api_smoke_assert_equals( 'client/lookup', $request->tools()[0]['name'], 'request preserves normalized tool list', $failures, $passes );
+agents_api_smoke_assert_equals( 'ability/search_posts', $request->tools()[1]['name'], 'request preserves host-owned tool declarations', $failures, $passes );
+agents_api_smoke_assert_equals( 'host', $request->to_array()['tools'][1]['executor'], 'request array exposes host tool executor for replay', $failures, $passes );
 agents_api_smoke_assert_equals(
 	array( 'messages', 'tools', 'principal', 'runtime_context', 'metadata', 'max_turns', 'single_turn', 'workspace', 'runtime_overrides' ),
 	array_keys( $request->to_array() ),

--- a/tests/tool-runtime-smoke.php
+++ b/tests/tool-runtime-smoke.php
@@ -47,6 +47,65 @@ agents_api_smoke_assert_equals( 'repeatable', $declaration['runtime']['duplicate
 agents_api_smoke_assert_equals( 'progress', $declaration['runtime']['completion_signal'] ?? '', 'runtime declaration preserves completion signal metadata', $failures, $passes );
 agents_api_smoke_assert_equals( false, array_key_exists( 'unsupported', $declaration['runtime'] ?? array() ), 'runtime declaration drops unsupported metadata values', $failures, $passes );
 
+$host_declaration = AgentsAPI\AI\Tools\WP_Agent_Tool_Declaration::normalizeForConversationRequest(
+	array(
+		'name'        => 'ability/search_posts',
+		'source'      => 'ability',
+		'description' => 'Search host-owned posts.',
+		'parameters'  => array(
+			'type'       => 'object',
+			'required'   => array( 'query' ),
+			'properties' => array(
+				'query' => array( 'type' => 'string' ),
+			),
+		),
+		'executor'    => AgentsAPI\AI\Tools\WP_Agent_Tool_Declaration::EXECUTOR_HOST,
+		'scope'       => AgentsAPI\AI\Tools\WP_Agent_Tool_Declaration::SCOPE_RUN,
+		'runtime'     => array(
+			'duplicate_policy' => 'repeatable',
+			'unsupported'      => new stdClass(),
+		),
+	)
+);
+agents_api_smoke_assert_equals( 'ability/search_posts', $host_declaration['name'], 'request declaration accepts host-owned namespaced tools', $failures, $passes );
+agents_api_smoke_assert_equals( 'ability', $host_declaration['source'], 'request declaration records host-owned source', $failures, $passes );
+agents_api_smoke_assert_equals( 'host', $host_declaration['executor'], 'request declaration records host executor', $failures, $passes );
+agents_api_smoke_assert_equals( 'run', $host_declaration['scope'], 'request declaration records run scope for host tools', $failures, $passes );
+agents_api_smoke_assert_equals( 'repeatable', $host_declaration['runtime']['duplicate_policy'] ?? '', 'request declaration preserves host runtime metadata', $failures, $passes );
+agents_api_smoke_assert_equals( false, array_key_exists( 'unsupported', $host_declaration['runtime'] ?? array() ), 'request declaration drops unsupported host metadata values', $failures, $passes );
+
+$strict_rejected_host = false;
+try {
+	AgentsAPI\AI\Tools\WP_Agent_Tool_Declaration::normalize(
+		array(
+			'name'        => 'ability/search_posts',
+			'description' => 'Search host-owned posts.',
+			'executor'    => AgentsAPI\AI\Tools\WP_Agent_Tool_Declaration::EXECUTOR_HOST,
+			'scope'       => AgentsAPI\AI\Tools\WP_Agent_Tool_Declaration::SCOPE_RUN,
+		)
+	);
+} catch ( InvalidArgumentException $error ) {
+	$strict_rejected_host = str_starts_with( $error->getMessage(), 'invalid_runtime_tool_declaration:' );
+}
+agents_api_smoke_assert_equals( true, $strict_rejected_host, 'strict runtime declaration still rejects host-owned tools', $failures, $passes );
+
+$invalid_host = false;
+try {
+	AgentsAPI\AI\Tools\WP_Agent_Tool_Declaration::normalizeForConversationRequest(
+		array(
+			'name'        => 'ability/search_posts',
+			'source'      => 'wrong',
+			'description' => 'Search host-owned posts.',
+			'parameters'  => 'bad-parameters',
+			'executor'    => AgentsAPI\AI\Tools\WP_Agent_Tool_Declaration::EXECUTOR_HOST,
+			'scope'       => AgentsAPI\AI\Tools\WP_Agent_Tool_Declaration::SCOPE_RUN,
+		)
+	);
+} catch ( InvalidArgumentException $error ) {
+	$invalid_host = str_starts_with( $error->getMessage(), 'invalid_conversation_tool_declaration:' );
+}
+agents_api_smoke_assert_equals( true, $invalid_host, 'request declaration rejects invalid host-owned tool shapes', $failures, $passes );
+
 $registry = new AgentsAPI\AI\Tools\WP_Agent_Tool_Source_Registry();
 $registry->registerSource(
 	'local',


### PR DESCRIPTION
## Summary
- Allow `WP_Agent_Conversation_Request` to normalize host-owned `executor=host`, `scope=run` tool declarations for canonical request/replay catalogs.
- Keep `WP_Agent_Tool_Declaration::normalize()` strict for existing `client/*`, `executor=client`, `scope=run` runtime tools.
- Document the split between strict client runtime declarations and broader conversation request declarations.

Fixes https://github.com/Automattic/agents-api/issues/275

## Testing
- `php tests/tool-runtime-smoke.php`
- `php tests/conversation-runner-contracts-smoke.php`
- `composer test`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Investigated the existing request/tool declaration contracts, implemented the host-tool request normalization path, added smoke coverage, and drafted this PR summary for Chris to review.