### PR TITLE
Add neutral runtime authority contracts

### DIFF
--- a/docs/runtime-and-tools.md
+++ b/docs/runtime-and-tools.md
@@ -197,8 +197,14 @@ Canonical keys:
 | --- | --- | --- |
 | `duplicate_policy` | `repeatable` | The same tool may be called repeatedly with the same parameters when the host considers that safe. |
 | `completion_signal` | `progress` | A successful tool result is progress toward completion and may be used by caller-owned completion policy. |
+| `capability_scope` | `sandbox_safe` or `parent_only` | Whether a host may expose the tool inside a disposable sandbox or should keep it in the parent/control-plane runtime. |
+| `environment` | `disposable_sandbox` or `parent_control` | The intended execution environment for a declaration or result. |
 
 The substrate treats `runtime` as a JSON-friendly associative array. It preserves scalar and nested array values with string keys, drops unsupported values, and leaves product-specific interpretation to callers.
+
+Disposable sandbox consumers should advertise runtime-local tools with `capability_scope: sandbox_safe` and `environment: disposable_sandbox`. Parent-only tools such as repository mutation, deployment, approval, or product control-plane actions should use `capability_scope: parent_only` and stay out of sandbox-visible declarations. Agents API records and propagates this vocabulary; hosts still own the concrete allow/deny policy and execution adapter.
+
+Disposable runtimes can also resolve an execution principal with `WP_Agent_Execution_Principal::disposable_sandbox()`. The helper produces a non-user runtime principal with `auth_source: runtime`, `request_context: sandbox`, a host-owned sandbox `audience_id`, and an isolated runtime conversation owner key. Hosts remain responsible for attesting the sandbox, choosing the owner key, and enforcing authorization policy.
 
 When the conversation loop mediates tool calls, declaration runtime metadata is propagated into the normalized tool result and exposed on the corresponding `tool_execution_results[]` entry:
 

--- a/docs/runtime-and-tools.md
+++ b/docs/runtime-and-tools.md
@@ -197,14 +197,14 @@ Canonical keys:
 | --- | --- | --- |
 | `duplicate_policy` | `repeatable` | The same tool may be called repeatedly with the same parameters when the host considers that safe. |
 | `completion_signal` | `progress` | A successful tool result is progress toward completion and may be used by caller-owned completion policy. |
-| `capability_scope` | `sandbox_safe` or `parent_only` | Whether a host may expose the tool inside a disposable sandbox or should keep it in the parent/control-plane runtime. |
-| `environment` | `disposable_sandbox` or `parent_control` | The intended execution environment for a declaration or result. |
+| `capability_scope` | `runtime_local` or `control_plane` | Whether a host may expose the tool to a delegated runtime or should keep it in the parent/control-plane runtime. |
+| `environment` | `runtime_local` or `control_plane` | The intended execution environment for a declaration or result. |
 
 The substrate treats `runtime` as a JSON-friendly associative array. It preserves scalar and nested array values with string keys, drops unsupported values, and leaves product-specific interpretation to callers.
 
-Disposable sandbox consumers should advertise runtime-local tools with `capability_scope: sandbox_safe` and `environment: disposable_sandbox`. Parent-only tools such as repository mutation, deployment, approval, or product control-plane actions should use `capability_scope: parent_only` and stay out of sandbox-visible declarations. Agents API records and propagates this vocabulary; hosts still own the concrete allow/deny policy and execution adapter.
+Delegated runtime consumers should advertise runtime-local tools with `capability_scope: runtime_local` and `environment: runtime_local`. Control-plane tools such as repository mutation, deployment, approval, or parent orchestration actions should use `capability_scope: control_plane` and stay out of runtime-local declarations. Agents API records and propagates this vocabulary; hosts still own the concrete allow/deny policy and execution adapter.
 
-Disposable runtimes can also resolve an execution principal with `WP_Agent_Execution_Principal::disposable_sandbox()`. The helper produces a non-user runtime principal with `auth_source: runtime`, `request_context: sandbox`, a host-owned sandbox `audience_id`, and an isolated runtime conversation owner key. Hosts remain responsible for attesting the sandbox, choosing the owner key, and enforcing authorization policy.
+Delegated runtimes can also resolve an execution principal with `WP_Agent_Execution_Principal::runtime()`. The helper produces a non-user runtime principal with `auth_source: runtime`, `request_context: runtime`, a host-owned runtime `audience_id`, and an isolated runtime conversation owner key. Hosts remain responsible for attesting the runtime, choosing the owner key, supplying any `runtime_type` claim, and enforcing authorization policy.
 
 When the conversation loop mediates tool calls, declaration runtime metadata is propagated into the normalized tool result and exposed on the corresponding `tool_execution_results[]` entry:
 

--- a/src/Runtime/class-wp-agent-execution-principal.php
+++ b/src/Runtime/class-wp-agent-execution-principal.php
@@ -47,7 +47,7 @@ final class WP_Agent_Execution_Principal {
 	public const REQUEST_CONTEXT_CHAT    = 'chat';
 	public const REQUEST_CONTEXT_RUNTIME = 'runtime';
 
-	public const AUDIENCE_CLAIM_RUNTIME_TYPE     = 'runtime_type';
+	public const AUDIENCE_CLAIM_RUNTIME_TYPE = 'runtime_type';
 
 	/**
 	 * @param int         $acting_user_id    WordPress user ID on whose behalf the run executes. 0 = system/anonymous context.

--- a/src/Runtime/class-wp-agent-execution-principal.php
+++ b/src/Runtime/class-wp-agent-execution-principal.php
@@ -23,6 +23,7 @@ final class WP_Agent_Execution_Principal {
 	public const AUTH_SOURCE_APPLICATION_PASSWORD = 'application_password';
 	public const AUTH_SOURCE_AGENT_TOKEN          = 'agent_token';
 	public const AUTH_SOURCE_AUDIENCE             = 'audience';
+	public const AUTH_SOURCE_RUNTIME              = 'runtime';
 	public const AUTH_SOURCE_SYSTEM               = 'system';
 
 	public const KNOWN_AUTH_SOURCES = array(
@@ -30,18 +31,24 @@ final class WP_Agent_Execution_Principal {
 		self::AUTH_SOURCE_APPLICATION_PASSWORD,
 		self::AUTH_SOURCE_AGENT_TOKEN,
 		self::AUTH_SOURCE_AUDIENCE,
+		self::AUTH_SOURCE_RUNTIME,
 		self::AUTH_SOURCE_SYSTEM,
 	);
 
 	public const OWNER_TYPE_USER     = 'user';
 	public const OWNER_TYPE_AUDIENCE = 'audience';
+	public const OWNER_TYPE_RUNTIME  = 'runtime';
 	public const OWNER_TYPE_TOKEN    = 'token';
 	public const OWNER_TYPE_SYSTEM   = 'system';
 
-	public const REQUEST_CONTEXT_REST = 'rest';
-	public const REQUEST_CONTEXT_CLI  = 'cli';
-	public const REQUEST_CONTEXT_CRON = 'cron';
-	public const REQUEST_CONTEXT_CHAT = 'chat';
+	public const REQUEST_CONTEXT_REST    = 'rest';
+	public const REQUEST_CONTEXT_CLI     = 'cli';
+	public const REQUEST_CONTEXT_CRON    = 'cron';
+	public const REQUEST_CONTEXT_CHAT    = 'chat';
+	public const REQUEST_CONTEXT_SANDBOX = 'sandbox';
+
+	public const AUDIENCE_CLAIM_RUNTIME_TYPE     = 'runtime_type';
+	public const RUNTIME_TYPE_DISPOSABLE_SANDBOX = 'disposable_sandbox';
 
 	/**
 	 * @param int         $acting_user_id    WordPress user ID on whose behalf the run executes. 0 = system/anonymous context.
@@ -215,6 +222,46 @@ final class WP_Agent_Execution_Principal {
 	 */
 	public static function audience( string $audience_id, string $effective_agent_id, string $request_context = self::REQUEST_CONTEXT_REST, array $request_metadata = array(), ?string $workspace_id = null, ?string $client_id = null, array $audience_claims = array(), ?string $owner_key = null ): self {
 		return new self( 0, $effective_agent_id, self::AUTH_SOURCE_AUDIENCE, $request_context, null, $request_metadata, $workspace_id, $client_id, null, null, $audience_id, $audience_claims, null !== $owner_key ? self::OWNER_TYPE_AUDIENCE : null, $owner_key );
+	}
+
+	/**
+	 * Build a principal for a host-attested disposable runtime sandbox.
+	 *
+	 * Disposable sandbox principals are non-user principals with an opaque runtime
+	 * owner key so transcripts and policy decisions do not bleed into the parent
+	 * control plane or another sandbox session.
+	 *
+	 * @param string              $sandbox_id        Host-owned sandbox/session identifier.
+	 * @param string              $effective_agent_id Registered agent ID/slug effective for the run.
+	 * @param array<string,mixed> $request_metadata  Request metadata.
+	 * @param string|null         $workspace_id      Optional host workspace/scope identifier.
+	 * @param string|null         $client_id         Optional client/runtime identifier.
+	 * @param array<string,mixed> $audience_claims   Additional host-owned sandbox claims.
+	 * @param string|null         $owner_key         Optional opaque transcript owner key. Defaults to the sandbox id.
+	 * @return self
+	 */
+	public static function disposable_sandbox( string $sandbox_id, string $effective_agent_id, array $request_metadata = array(), ?string $workspace_id = null, ?string $client_id = null, array $audience_claims = array(), ?string $owner_key = null ): self {
+		$audience_claims = array_merge(
+			array( self::AUDIENCE_CLAIM_RUNTIME_TYPE => self::RUNTIME_TYPE_DISPOSABLE_SANDBOX ),
+			$audience_claims
+		);
+
+		return new self(
+			0,
+			$effective_agent_id,
+			self::AUTH_SOURCE_RUNTIME,
+			self::REQUEST_CONTEXT_SANDBOX,
+			null,
+			$request_metadata,
+			$workspace_id,
+			$client_id,
+			null,
+			null,
+			$sandbox_id,
+			$audience_claims,
+			self::OWNER_TYPE_RUNTIME,
+			$owner_key ?? $sandbox_id
+		);
 	}
 
 	/**

--- a/src/Runtime/class-wp-agent-execution-principal.php
+++ b/src/Runtime/class-wp-agent-execution-principal.php
@@ -45,10 +45,9 @@ final class WP_Agent_Execution_Principal {
 	public const REQUEST_CONTEXT_CLI     = 'cli';
 	public const REQUEST_CONTEXT_CRON    = 'cron';
 	public const REQUEST_CONTEXT_CHAT    = 'chat';
-	public const REQUEST_CONTEXT_SANDBOX = 'sandbox';
+	public const REQUEST_CONTEXT_RUNTIME = 'runtime';
 
 	public const AUDIENCE_CLAIM_RUNTIME_TYPE     = 'runtime_type';
-	public const RUNTIME_TYPE_DISPOSABLE_SANDBOX = 'disposable_sandbox';
 
 	/**
 	 * @param int         $acting_user_id    WordPress user ID on whose behalf the run executes. 0 = system/anonymous context.
@@ -225,42 +224,37 @@ final class WP_Agent_Execution_Principal {
 	}
 
 	/**
-	 * Build a principal for a host-attested disposable runtime sandbox.
+	 * Build a principal for a host-attested delegated runtime.
 	 *
-	 * Disposable sandbox principals are non-user principals with an opaque runtime
+	 * Delegated runtime principals are non-user principals with an opaque runtime
 	 * owner key so transcripts and policy decisions do not bleed into the parent
-	 * control plane or another sandbox session.
+	 * control plane or another runtime session.
 	 *
-	 * @param string              $sandbox_id        Host-owned sandbox/session identifier.
+	 * @param string              $runtime_id        Host-owned runtime/session identifier.
 	 * @param string              $effective_agent_id Registered agent ID/slug effective for the run.
 	 * @param array<string,mixed> $request_metadata  Request metadata.
 	 * @param string|null         $workspace_id      Optional host workspace/scope identifier.
 	 * @param string|null         $client_id         Optional client/runtime identifier.
-	 * @param array<string,mixed> $audience_claims   Additional host-owned sandbox claims.
-	 * @param string|null         $owner_key         Optional opaque transcript owner key. Defaults to the sandbox id.
+	 * @param array<string,mixed> $audience_claims   Additional host-owned runtime claims.
+	 * @param string|null         $owner_key         Optional opaque transcript owner key. Defaults to the runtime id.
 	 * @return self
 	 */
-	public static function disposable_sandbox( string $sandbox_id, string $effective_agent_id, array $request_metadata = array(), ?string $workspace_id = null, ?string $client_id = null, array $audience_claims = array(), ?string $owner_key = null ): self {
-		$audience_claims = array_merge(
-			array( self::AUDIENCE_CLAIM_RUNTIME_TYPE => self::RUNTIME_TYPE_DISPOSABLE_SANDBOX ),
-			$audience_claims
-		);
-
+	public static function runtime( string $runtime_id, string $effective_agent_id, array $request_metadata = array(), ?string $workspace_id = null, ?string $client_id = null, array $audience_claims = array(), ?string $owner_key = null ): self {
 		return new self(
 			0,
 			$effective_agent_id,
 			self::AUTH_SOURCE_RUNTIME,
-			self::REQUEST_CONTEXT_SANDBOX,
+			self::REQUEST_CONTEXT_RUNTIME,
 			null,
 			$request_metadata,
 			$workspace_id,
 			$client_id,
 			null,
 			null,
-			$sandbox_id,
+			$runtime_id,
 			$audience_claims,
 			self::OWNER_TYPE_RUNTIME,
-			$owner_key ?? $sandbox_id
+			$owner_key ?? $runtime_id
 		);
 	}
 

--- a/src/Tools/class-wp-agent-tool-declaration.php
+++ b/src/Tools/class-wp-agent-tool-declaration.php
@@ -35,6 +35,36 @@ class WP_Agent_Tool_Declaration {
 	public const RUNTIME_COMPLETION_SIGNAL = 'completion_signal';
 
 	/**
+	 * Generic runtime metadata key for where a tool may be exposed.
+	 */
+	public const RUNTIME_CAPABILITY_SCOPE = 'capability_scope';
+
+	/**
+	 * Tool may be exposed inside a disposable runtime sandbox.
+	 */
+	public const CAPABILITY_SCOPE_SANDBOX_SAFE = 'sandbox_safe';
+
+	/**
+	 * Tool belongs to the parent/control-plane runtime and should stay out of sandboxes.
+	 */
+	public const CAPABILITY_SCOPE_PARENT_ONLY = 'parent_only';
+
+	/**
+	 * Generic runtime metadata key for the target execution environment.
+	 */
+	public const RUNTIME_ENVIRONMENT = 'environment';
+
+	/**
+	 * Tool declaration targets a disposable sandbox runtime.
+	 */
+	public const ENVIRONMENT_DISPOSABLE_SANDBOX = 'disposable_sandbox';
+
+	/**
+	 * Tool declaration targets a parent/control-plane runtime.
+	 */
+	public const ENVIRONMENT_PARENT_CONTROL = 'parent_control';
+
+	/**
 	 * Normalize a runtime tool declaration or throw a field-scoped error.
 	 *
 	 * @param array<mixed> $declaration Raw runtime tool declaration.

--- a/src/Tools/class-wp-agent-tool-declaration.php
+++ b/src/Tools/class-wp-agent-tool-declaration.php
@@ -40,14 +40,14 @@ class WP_Agent_Tool_Declaration {
 	public const RUNTIME_CAPABILITY_SCOPE = 'capability_scope';
 
 	/**
-	 * Tool may be exposed inside a disposable runtime sandbox.
+	 * Tool may be exposed inside a delegated runtime.
 	 */
-	public const CAPABILITY_SCOPE_SANDBOX_SAFE = 'sandbox_safe';
+	public const CAPABILITY_SCOPE_RUNTIME_LOCAL = 'runtime_local';
 
 	/**
-	 * Tool belongs to the parent/control-plane runtime and should stay out of sandboxes.
+	 * Tool belongs to the parent/control-plane runtime.
 	 */
-	public const CAPABILITY_SCOPE_PARENT_ONLY = 'parent_only';
+	public const CAPABILITY_SCOPE_CONTROL_PLANE = 'control_plane';
 
 	/**
 	 * Generic runtime metadata key for the target execution environment.
@@ -55,14 +55,14 @@ class WP_Agent_Tool_Declaration {
 	public const RUNTIME_ENVIRONMENT = 'environment';
 
 	/**
-	 * Tool declaration targets a disposable sandbox runtime.
+	 * Tool declaration targets a delegated runtime.
 	 */
-	public const ENVIRONMENT_DISPOSABLE_SANDBOX = 'disposable_sandbox';
+	public const ENVIRONMENT_RUNTIME_LOCAL = 'runtime_local';
 
 	/**
 	 * Tool declaration targets a parent/control-plane runtime.
 	 */
-	public const ENVIRONMENT_PARENT_CONTROL = 'parent_control';
+	public const ENVIRONMENT_CONTROL_PLANE = 'control_plane';
 
 	/**
 	 * Normalize a runtime tool declaration or throw a field-scoped error.

--- a/tests/execution-principal-smoke.php
+++ b/tests/execution-principal-smoke.php
@@ -184,20 +184,20 @@ agents_api_smoke_assert_equals( 'audience:docs-readers', $audience_from_array->a
 agents_api_smoke_assert_equals( array( 'tier' => 'viewer' ), $audience_from_array->audience_claims, 'from_array restores audience claims', $failures, $passes );
 agents_api_smoke_assert_equals( array( 'type' => AgentsAPI\AI\WP_Agent_Execution_Principal::OWNER_TYPE_AUDIENCE, 'key' => 'browser-session:opaque-456' ), $audience_from_array->conversation_owner(), 'from_array restores explicit conversation owner', $failures, $passes );
 
-$sandbox_principal = AgentsAPI\AI\WP_Agent_Execution_Principal::disposable_sandbox(
-	'codebox-browser-session-123',
-	'wp-codebox-sandbox',
-	array( 'route' => '/wp-codebox/browser-runner' ),
+$runtime_principal = AgentsAPI\AI\WP_Agent_Execution_Principal::runtime(
+	'runtime-session-123',
+	'delegated-runtime-agent',
+	array( 'route' => '/agents/runtime' ),
 	'workspace:demo',
-	'wp-codebox',
-	array( 'wp' => 'trunk' )
+	'example-runtime',
+	array( AgentsAPI\AI\WP_Agent_Execution_Principal::AUDIENCE_CLAIM_RUNTIME_TYPE => 'ephemeral' )
 );
-agents_api_smoke_assert_equals( 0, $sandbox_principal->acting_user_id, 'disposable sandbox principal has no WordPress user', $failures, $passes );
-agents_api_smoke_assert_equals( AgentsAPI\AI\WP_Agent_Execution_Principal::AUTH_SOURCE_RUNTIME, $sandbox_principal->auth_source, 'disposable sandbox principal records runtime auth source', $failures, $passes );
-agents_api_smoke_assert_equals( AgentsAPI\AI\WP_Agent_Execution_Principal::REQUEST_CONTEXT_SANDBOX, $sandbox_principal->request_context, 'disposable sandbox principal records sandbox request context', $failures, $passes );
-agents_api_smoke_assert_equals( 'codebox-browser-session-123', $sandbox_principal->audience_id, 'disposable sandbox principal records sandbox id as audience id', $failures, $passes );
-agents_api_smoke_assert_equals( AgentsAPI\AI\WP_Agent_Execution_Principal::RUNTIME_TYPE_DISPOSABLE_SANDBOX, $sandbox_principal->audience_claims[ AgentsAPI\AI\WP_Agent_Execution_Principal::AUDIENCE_CLAIM_RUNTIME_TYPE ] ?? null, 'disposable sandbox principal stamps runtime type claim', $failures, $passes );
-agents_api_smoke_assert_equals( array( 'type' => AgentsAPI\AI\WP_Agent_Execution_Principal::OWNER_TYPE_RUNTIME, 'key' => 'codebox-browser-session-123' ), $sandbox_principal->conversation_owner(), 'disposable sandbox principal derives isolated runtime conversation owner', $failures, $passes );
+agents_api_smoke_assert_equals( 0, $runtime_principal->acting_user_id, 'runtime principal has no WordPress user', $failures, $passes );
+agents_api_smoke_assert_equals( AgentsAPI\AI\WP_Agent_Execution_Principal::AUTH_SOURCE_RUNTIME, $runtime_principal->auth_source, 'runtime principal records runtime auth source', $failures, $passes );
+agents_api_smoke_assert_equals( AgentsAPI\AI\WP_Agent_Execution_Principal::REQUEST_CONTEXT_RUNTIME, $runtime_principal->request_context, 'runtime principal records runtime request context', $failures, $passes );
+agents_api_smoke_assert_equals( 'runtime-session-123', $runtime_principal->audience_id, 'runtime principal records runtime id as audience id', $failures, $passes );
+agents_api_smoke_assert_equals( 'ephemeral', $runtime_principal->audience_claims[ AgentsAPI\AI\WP_Agent_Execution_Principal::AUDIENCE_CLAIM_RUNTIME_TYPE ] ?? null, 'runtime principal preserves host-supplied runtime type claim', $failures, $passes );
+agents_api_smoke_assert_equals( array( 'type' => AgentsAPI\AI\WP_Agent_Execution_Principal::OWNER_TYPE_RUNTIME, 'key' => 'runtime-session-123' ), $runtime_principal->conversation_owner(), 'runtime principal derives isolated runtime conversation owner', $failures, $passes );
 
 try {
 	new AgentsAPI\AI\WP_Agent_Execution_Principal( -1, 'agent', AgentsAPI\AI\WP_Agent_Execution_Principal::AUTH_SOURCE_USER, AgentsAPI\AI\WP_Agent_Execution_Principal::REQUEST_CONTEXT_REST );

--- a/tests/execution-principal-smoke.php
+++ b/tests/execution-principal-smoke.php
@@ -184,6 +184,21 @@ agents_api_smoke_assert_equals( 'audience:docs-readers', $audience_from_array->a
 agents_api_smoke_assert_equals( array( 'tier' => 'viewer' ), $audience_from_array->audience_claims, 'from_array restores audience claims', $failures, $passes );
 agents_api_smoke_assert_equals( array( 'type' => AgentsAPI\AI\WP_Agent_Execution_Principal::OWNER_TYPE_AUDIENCE, 'key' => 'browser-session:opaque-456' ), $audience_from_array->conversation_owner(), 'from_array restores explicit conversation owner', $failures, $passes );
 
+$sandbox_principal = AgentsAPI\AI\WP_Agent_Execution_Principal::disposable_sandbox(
+	'codebox-browser-session-123',
+	'wp-codebox-sandbox',
+	array( 'route' => '/wp-codebox/browser-runner' ),
+	'workspace:demo',
+	'wp-codebox',
+	array( 'wp' => 'trunk' )
+);
+agents_api_smoke_assert_equals( 0, $sandbox_principal->acting_user_id, 'disposable sandbox principal has no WordPress user', $failures, $passes );
+agents_api_smoke_assert_equals( AgentsAPI\AI\WP_Agent_Execution_Principal::AUTH_SOURCE_RUNTIME, $sandbox_principal->auth_source, 'disposable sandbox principal records runtime auth source', $failures, $passes );
+agents_api_smoke_assert_equals( AgentsAPI\AI\WP_Agent_Execution_Principal::REQUEST_CONTEXT_SANDBOX, $sandbox_principal->request_context, 'disposable sandbox principal records sandbox request context', $failures, $passes );
+agents_api_smoke_assert_equals( 'codebox-browser-session-123', $sandbox_principal->audience_id, 'disposable sandbox principal records sandbox id as audience id', $failures, $passes );
+agents_api_smoke_assert_equals( AgentsAPI\AI\WP_Agent_Execution_Principal::RUNTIME_TYPE_DISPOSABLE_SANDBOX, $sandbox_principal->audience_claims[ AgentsAPI\AI\WP_Agent_Execution_Principal::AUDIENCE_CLAIM_RUNTIME_TYPE ] ?? null, 'disposable sandbox principal stamps runtime type claim', $failures, $passes );
+agents_api_smoke_assert_equals( array( 'type' => AgentsAPI\AI\WP_Agent_Execution_Principal::OWNER_TYPE_RUNTIME, 'key' => 'codebox-browser-session-123' ), $sandbox_principal->conversation_owner(), 'disposable sandbox principal derives isolated runtime conversation owner', $failures, $passes );
+
 try {
 	new AgentsAPI\AI\WP_Agent_Execution_Principal( -1, 'agent', AgentsAPI\AI\WP_Agent_Execution_Principal::AUTH_SOURCE_USER, AgentsAPI\AI\WP_Agent_Execution_Principal::REQUEST_CONTEXT_REST );
 	agents_api_smoke_assert_equals( true, false, 'negative user id is rejected', $failures, $passes );

--- a/tests/tool-runtime-smoke.php
+++ b/tests/tool-runtime-smoke.php
@@ -34,8 +34,10 @@ $declaration = AgentsAPI\AI\Tools\WP_Agent_Tool_Declaration::normalize(
 		'executor'    => 'client',
 		'scope'       => 'run',
 		'runtime'     => array(
-			'duplicate_policy' => 'repeatable',
-			'completion_signal' => 'progress',
+			AgentsAPI\AI\Tools\WP_Agent_Tool_Declaration::RUNTIME_DUPLICATE_POLICY  => 'repeatable',
+			AgentsAPI\AI\Tools\WP_Agent_Tool_Declaration::RUNTIME_COMPLETION_SIGNAL => 'progress',
+			AgentsAPI\AI\Tools\WP_Agent_Tool_Declaration::RUNTIME_CAPABILITY_SCOPE  => AgentsAPI\AI\Tools\WP_Agent_Tool_Declaration::CAPABILITY_SCOPE_SANDBOX_SAFE,
+			AgentsAPI\AI\Tools\WP_Agent_Tool_Declaration::RUNTIME_ENVIRONMENT       => AgentsAPI\AI\Tools\WP_Agent_Tool_Declaration::ENVIRONMENT_DISPOSABLE_SANDBOX,
 			'unsupported'       => new stdClass(),
 		),
 	)
@@ -45,6 +47,8 @@ agents_api_smoke_assert_equals( 'client', $declaration['source'], 'runtime decla
 agents_api_smoke_assert_equals( 'run', $declaration['scope'], 'runtime declaration records run scope', $failures, $passes );
 agents_api_smoke_assert_equals( 'repeatable', $declaration['runtime']['duplicate_policy'] ?? '', 'runtime declaration preserves duplicate policy metadata', $failures, $passes );
 agents_api_smoke_assert_equals( 'progress', $declaration['runtime']['completion_signal'] ?? '', 'runtime declaration preserves completion signal metadata', $failures, $passes );
+agents_api_smoke_assert_equals( 'sandbox_safe', $declaration['runtime']['capability_scope'] ?? '', 'runtime declaration preserves sandbox-safe capability scope metadata', $failures, $passes );
+agents_api_smoke_assert_equals( 'disposable_sandbox', $declaration['runtime']['environment'] ?? '', 'runtime declaration preserves disposable sandbox environment metadata', $failures, $passes );
 agents_api_smoke_assert_equals( false, array_key_exists( 'unsupported', $declaration['runtime'] ?? array() ), 'runtime declaration drops unsupported metadata values', $failures, $passes );
 
 $host_declaration = AgentsAPI\AI\Tools\WP_Agent_Tool_Declaration::normalizeForConversationRequest(

--- a/tests/tool-runtime-smoke.php
+++ b/tests/tool-runtime-smoke.php
@@ -36,8 +36,8 @@ $declaration = AgentsAPI\AI\Tools\WP_Agent_Tool_Declaration::normalize(
 		'runtime'     => array(
 			AgentsAPI\AI\Tools\WP_Agent_Tool_Declaration::RUNTIME_DUPLICATE_POLICY  => 'repeatable',
 			AgentsAPI\AI\Tools\WP_Agent_Tool_Declaration::RUNTIME_COMPLETION_SIGNAL => 'progress',
-			AgentsAPI\AI\Tools\WP_Agent_Tool_Declaration::RUNTIME_CAPABILITY_SCOPE  => AgentsAPI\AI\Tools\WP_Agent_Tool_Declaration::CAPABILITY_SCOPE_SANDBOX_SAFE,
-			AgentsAPI\AI\Tools\WP_Agent_Tool_Declaration::RUNTIME_ENVIRONMENT       => AgentsAPI\AI\Tools\WP_Agent_Tool_Declaration::ENVIRONMENT_DISPOSABLE_SANDBOX,
+			AgentsAPI\AI\Tools\WP_Agent_Tool_Declaration::RUNTIME_CAPABILITY_SCOPE  => AgentsAPI\AI\Tools\WP_Agent_Tool_Declaration::CAPABILITY_SCOPE_RUNTIME_LOCAL,
+			AgentsAPI\AI\Tools\WP_Agent_Tool_Declaration::RUNTIME_ENVIRONMENT       => AgentsAPI\AI\Tools\WP_Agent_Tool_Declaration::ENVIRONMENT_RUNTIME_LOCAL,
 			'unsupported'       => new stdClass(),
 		),
 	)
@@ -47,8 +47,8 @@ agents_api_smoke_assert_equals( 'client', $declaration['source'], 'runtime decla
 agents_api_smoke_assert_equals( 'run', $declaration['scope'], 'runtime declaration records run scope', $failures, $passes );
 agents_api_smoke_assert_equals( 'repeatable', $declaration['runtime']['duplicate_policy'] ?? '', 'runtime declaration preserves duplicate policy metadata', $failures, $passes );
 agents_api_smoke_assert_equals( 'progress', $declaration['runtime']['completion_signal'] ?? '', 'runtime declaration preserves completion signal metadata', $failures, $passes );
-agents_api_smoke_assert_equals( 'sandbox_safe', $declaration['runtime']['capability_scope'] ?? '', 'runtime declaration preserves sandbox-safe capability scope metadata', $failures, $passes );
-agents_api_smoke_assert_equals( 'disposable_sandbox', $declaration['runtime']['environment'] ?? '', 'runtime declaration preserves disposable sandbox environment metadata', $failures, $passes );
+agents_api_smoke_assert_equals( 'runtime_local', $declaration['runtime']['capability_scope'] ?? '', 'runtime declaration preserves runtime-local capability scope metadata', $failures, $passes );
+agents_api_smoke_assert_equals( 'runtime_local', $declaration['runtime']['environment'] ?? '', 'runtime declaration preserves runtime-local environment metadata', $failures, $passes );
 agents_api_smoke_assert_equals( false, array_key_exists( 'unsupported', $declaration['runtime'] ?? array() ), 'runtime declaration drops unsupported metadata values', $failures, $passes );
 
 $host_declaration = AgentsAPI\AI\Tools\WP_Agent_Tool_Declaration::normalizeForConversationRequest(


### PR DESCRIPTION
## Summary
- Adds neutral execution-principal vocabulary for host-attested delegated runtimes.
- Adds neutral runtime tool metadata constants for runtime-local vs control-plane exposure and target execution environment.
- Documents how consumers can use these storage-neutral seams without moving product-specific runtime policy, UI, apply behavior, or tool execution into Agents API.

## Existing contract map
- Principals/authorization: `WP_Agent_Execution_Principal`, `agents_api_execution_principal`, `WP_Agent_Authorization_Policy`, `WP_Agent_Capability_Ceiling`, and principal conversation owner support already cover host-resolved non-user execution scopes.
- Runtime tools/tool mediation: `WP_Agent_Tool_Source_Registry`, `WP_Agent_Tool_Declaration`, `WP_Agent_Tool_Policy`, `WP_Agent_Tool_Execution_Core`, and conversation-loop tool audit/result envelopes already cover per-run tools and policy-filtered declarations.
- Package artifacts/import planning: `WP_Agent_Package`, package artifact types, capability reports, update plans, and adoption orchestration already cover portable agent/package manifests and reviewable artifact materialization.
- Pending actions: `WP_Agent_Pending_Action`, pending-action store/resolver contracts, and canonical pending-action abilities already cover generic approval mediation.
- Workflows/conversation runtime: workflow specs/runners and `WP_Agent_Conversation_Loop` already provide storage-neutral run sequencing and replay envelopes.

## Missing contract proposal
- Neutral delegated runtime principal vocabulary: cooked here as `auth_source: runtime`, `request_context: runtime`, runtime owner type, host-supplied `runtime_type` claim key, and `WP_Agent_Execution_Principal::runtime()`.
- Neutral runtime tool exposure vocabulary: cooked here as `runtime.capability_scope` values `runtime_local` / `control_plane` and `runtime.environment` values `runtime_local` / `control_plane`.
- Remaining consumer contracts stay outside Agents API: sandboxing primitives, browser sessions, materializer envelopes, artifact capture/persistence, concrete allow/deny policy, and apply-back target behavior.

## Cookable first PR
This PR is the first substrate PR for Automattic/agents-api#277. It gives consumers canonical runtime/control-plane vocabulary without making Agents API own WP Codebox sandbox semantics.

## Verification
- `php tests/execution-principal-smoke.php`
- `php tests/tool-runtime-smoke.php`
- `composer run smoke`

## Follow-up order
1. WP Codebox: map its disposable Playground sandbox principal to `WP_Agent_Execution_Principal::runtime()` while keeping Codebox-owned sandbox semantics in WP Codebox. Tracker: Automattic/wp-codebox#547.
2. WP Codebox: map sandbox-visible tools onto `runtime.capability_scope: runtime_local` and parent/control-plane tools onto `control_plane`; keep concrete sandbox allow/deny enforcement in Codebox. Tracker: Automattic/wp-codebox#547.
3. WP Codebox: keep reusable browser-session/materializer APIs in Codebox, using Agents API package/pending-action/conversation contracts where applicable. Tracker: Automattic/wp-codebox#546.
4. Optional later Agents API issue only if needed: package artifact type(s) for importable agent definitions, but current package/adoption contracts may already be enough once Codebox migrates.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Inspecting existing contracts, drafting the minimal contract addition, revising product-specific vocabulary into neutral runtime/control-plane terms, updating tests/docs, and running verification. Chris remains responsible for review and merge.