### PR TITLE
Add JSON-RPC chat adapter (message/send + message/stream)

### DIFF
--- a/agents-api.php
+++ b/agents-api.php
@@ -195,6 +195,7 @@ require_once AGENTS_API_PATH . 'src/Channels/class-wp-agent-channel.php';
 require_once AGENTS_API_PATH . 'src/Channels/register-agents-chat-ability.php';
 require_once AGENTS_API_PATH . 'src/Channels/register-agents-chat-run-control-abilities.php';
 require_once AGENTS_API_PATH . 'src/Channels/register-frontend-chat-rest-route.php';
+require_once AGENTS_API_PATH . 'src/Channels/register-agents-chat-jsonrpc-route.php';
 require_once AGENTS_API_PATH . 'src/Channels/register-agents-dispatch-message-ability.php';
 require_once AGENTS_API_PATH . 'src/Workflows/class-wp-agent-workflow-bindings.php';
 require_once AGENTS_API_PATH . 'src/Workflows/class-wp-agent-workflow-spec-validator.php';

--- a/composer.json
+++ b/composer.json
@@ -80,6 +80,7 @@
       "php tests/channels-smoke.php",
       "php tests/chat-run-control-smoke.php",
       "php tests/frontend-chat-rest-smoke.php",
+      "php tests/agents-chat-jsonrpc-route-smoke.php",
       "php tests/agents-dispatch-message-ability-smoke.php",
       "php tests/webhook-safety-smoke.php",
       "php tests/remote-bridge-smoke.php",

--- a/docs/external-clients.md
+++ b/docs/external-clients.md
@@ -88,6 +88,102 @@ external daemon / mobile client / message relay
 Agents API owns the generic bridge registration, queue-first delivery, pending
 polling, and ack logic so runtimes do not copy product-specific bridge code.
 
+### JSON-RPC Protocol Endpoint
+
+A protocol client is a browser or app component that speaks a generic JSON-RPC
+chat wire, rather than a WordPress plugin (direct channel) or a bridge daemon.
+This is the shape consumed by JSON-RPC chat UIs that send `message/send` and
+`message/stream` over HTTP/SSE.
+
+```text
+JSON-RPC chat client
+-> POST agents-api/v1/agent/{agent_id}   (JSON-RPC 2.0)
+-> agents/chat ability  (message/send)   or
+-> streaming runtime    (message/stream, Server-Sent Events)
+-> Task / message/delta frames
+```
+
+`register-agents-chat-jsonrpc-route.php` registers this endpoint. It is a thin
+envelope over the same `agents/chat` ability the direct channels use, so it
+inherits the same handler, session store, run-control, and permissions.
+
+**Wire (mapped onto the canonical chat contract):**
+
+| Method | Transport | Request | Response |
+| --- | --- | --- | --- |
+| `message/send` | JSON | `{jsonrpc, id, method, params}` | `{jsonrpc, id, result: Task}` |
+| `message/stream` | SSE | same, `Accept: text/event-stream` | `data: {…}` frames |
+
+`params` is `MessageSendParams` (`{id?, sessionId?, message, metadata?}`); the
+user's text is the concatenation of the message's `text` parts (parts with
+`contentType: "context"` are excluded from the visible message). The response
+`Task` is derived from the canonical `agents/chat` output:
+
+```text
+agents/chat output   JSON-RPC Task
+------------------   -------------
+run_id            -> id
+session_id        -> sessionId
+reply             -> status.message.parts[0].text
+completed===false -> status.state: "input-required" (else "completed")
+```
+
+**Streaming (`message/stream`).** The endpoint emits two SSE frame types:
+per-token `message/delta` notifications, then a terminal `result: Task` frame.
+
+Token streaming requires a streaming runtime registered via the
+`wp_agent_chat_stream_handler` filter (or the `register_chat_stream_handler()`
+helper). The streaming handler is the token-by-token sibling of the synchronous
+`wp_agent_chat_handler`:
+
+```php
+use function AgentsAPI\AI\Channels\register_chat_stream_handler;
+
+register_chat_stream_handler(
+	function ( array $input, callable $emit ): array {
+		// Emit canonical deltas as tokens arrive.
+		$emit( array( 'type' => 'content', 'text' => 'Hel' ) );
+		$emit( array( 'type' => 'content', 'text' => 'lo' ) );
+		// Tool deltas are also supported:
+		// array( 'type' => 'tool_call',     'tool_call_id' => 't1', 'tool_name' => 'search', 'index' => 0 )
+		// array( 'type' => 'tool_argument', 'tool_call_id' => 't1', 'text' => '{"q":"…"}', 'index' => 0 )
+
+		// Return the canonical agents/chat output once complete.
+		return array(
+			'session_id' => $input['session_id'] ?? '',
+			'reply'      => 'Hello',
+			'run_id'     => $input['run_id'] ?? '',
+			'completed'  => true,
+		);
+	}
+);
+```
+
+When no streaming runtime is registered, `message/stream` degrades gracefully:
+it runs the synchronous `agents/chat` handler and emits a single terminal Task
+frame. The endpoint therefore works with any sync handler, just without
+token-level granularity.
+
+The provider/turn-runner itself stays out of Agents API — both the sync and
+streaming handlers are consumer territory (the same boundary as `agents/chat`).
+
+**End-to-end wiring.** A runnable endpoint composes three pieces:
+
+```php
+// 1. Durable sessions: opt into the default WordPress-native conversation store.
+add_filter( 'agents_api_enable_default_conversation_store', '__return_true' );
+
+// 2. A runtime: register a chat handler (sync) and/or a stream handler (tokens).
+AgentsAPI\AI\Channels\register_chat_handler( $my_sync_handler );
+AgentsAPI\AI\Channels\register_chat_stream_handler( $my_stream_handler );
+
+// 3. Point the client at agents-api/v1/agent/{agent_id}.
+```
+
+Pieces 1 (the conversation store) and 3 (the endpoint) ship in Agents API; the
+store is the persistence example, and the endpoint is the transport. Piece 2 —
+the runtime that calls a provider — is supplied by a consumer plugin.
+
 ## Connectors API Boundary
 
 WordPress Connectors API is the default registry and settings layer for

--- a/src/Channels/register-agents-chat-jsonrpc-route.php
+++ b/src/Channels/register-agents-chat-jsonrpc-route.php
@@ -30,18 +30,18 @@ use AgentsAPI\AI\WP_Agent_Chat_Run_Control;
 
 defined( 'ABSPATH' ) || exit;
 
-const AGENTS_CHAT_JSONRPC_NAMESPACE   = 'agents-api/v1';
-const AGENTS_CHAT_JSONRPC_ROUTE       = '/agent/(?P<agent_id>[A-Za-z0-9._-]+)';
-const AGENTS_CHAT_JSONRPC_VERSION     = '2.0';
-const AGENTS_CHAT_JSONRPC_METHOD_SEND = 'message/send';
+const AGENTS_CHAT_JSONRPC_NAMESPACE     = 'agents-api/v1';
+const AGENTS_CHAT_JSONRPC_ROUTE         = '/agent/(?P<agent_id>[A-Za-z0-9._-]+)';
+const AGENTS_CHAT_JSONRPC_VERSION       = '2.0';
+const AGENTS_CHAT_JSONRPC_METHOD_SEND   = 'message/send';
 const AGENTS_CHAT_JSONRPC_METHOD_STREAM = 'message/stream';
 
 // JSON-RPC 2.0 reserved error codes (see the spec + agenttic-client ErrorCodes).
-const AGENTS_CHAT_JSONRPC_ERR_PARSE          = -32700;
-const AGENTS_CHAT_JSONRPC_ERR_INVALID_REQUEST = -32600;
+const AGENTS_CHAT_JSONRPC_ERR_PARSE            = -32700;
+const AGENTS_CHAT_JSONRPC_ERR_INVALID_REQUEST  = -32600;
 const AGENTS_CHAT_JSONRPC_ERR_METHOD_NOT_FOUND = -32601;
-const AGENTS_CHAT_JSONRPC_ERR_INVALID_PARAMS  = -32602;
-const AGENTS_CHAT_JSONRPC_ERR_INTERNAL        = -32603;
+const AGENTS_CHAT_JSONRPC_ERR_INVALID_PARAMS   = -32602;
+const AGENTS_CHAT_JSONRPC_ERR_INTERNAL         = -32603;
 
 add_action(
 	'rest_api_init',
@@ -155,11 +155,11 @@ function agents_chat_jsonrpc_permission( \WP_REST_Request $request ): bool|\WP_E
  * @return \WP_REST_Response
  */
 function agents_chat_jsonrpc_dispatch( \WP_REST_Request $request ): \WP_REST_Response {
-	$agent   = sanitize_title( agents_chat_jsonrpc_string( $request->get_param( 'agent_id' ) ) );
-	$body    = $request->get_json_params();
-	$rpc_id  = agents_chat_jsonrpc_request_id( $body );
-	$method  = isset( $body['method'] ) && is_string( $body['method'] ) ? $body['method'] : '';
-	$params  = isset( $body['params'] ) && is_array( $body['params'] ) ? $body['params'] : array();
+	$agent  = sanitize_title( agents_chat_jsonrpc_string( $request->get_param( 'agent_id' ) ) );
+	$body   = $request->get_json_params();
+	$rpc_id = agents_chat_jsonrpc_request_id( $body );
+	$method = isset( $body['method'] ) && is_string( $body['method'] ) ? $body['method'] : '';
+	$params = isset( $body['params'] ) && is_array( $body['params'] ) ? $body['params'] : array();
 
 	if ( AGENTS_CHAT_JSONRPC_VERSION !== ( $body['jsonrpc'] ?? null ) ) {
 		return rest_ensure_response(
@@ -509,7 +509,7 @@ function agents_chat_jsonrpc_attachments( array $message ): array {
 		if ( ! is_array( $part ) || 'file' !== ( $part['type'] ?? null ) ) {
 			continue;
 		}
-		$file = isset( $part['file'] ) && is_array( $part['file'] ) ? $part['file'] : array();
+		$file          = isset( $part['file'] ) && is_array( $part['file'] ) ? $part['file'] : array();
 		$attachments[] = agents_chat_jsonrpc_string_keyed_array( $file );
 	}
 

--- a/src/Channels/register-agents-chat-jsonrpc-route.php
+++ b/src/Channels/register-agents-chat-jsonrpc-route.php
@@ -1,0 +1,621 @@
+<?php
+/**
+ * JSON-RPC chat adapter (message/send + message/stream).
+ *
+ * Exposes the canonical agents/chat ability over a JSON-RPC 2.0 wire keyed by
+ * agent id, so protocol clients that speak `message/send` (request/response)
+ * and `message/stream` (Server-Sent Events) can drive a registered runtime.
+ *
+ * The route is intentionally a thin envelope: `message/send` is one synchronous
+ * agents/chat call wrapped in a Task; `message/stream` emits the same Task over
+ * SSE, plus per-token `message/delta` frames when a streaming runtime is
+ * registered via the `wp_agent_chat_stream_handler` filter. Without a streaming
+ * runtime, `message/stream` degrades gracefully to a single terminal Task frame
+ * produced by the synchronous agents/chat handler.
+ *
+ * Wire shape (mapped onto canonical agents/chat output):
+ *   agents/chat output   JSON-RPC Task
+ *   ------------------   -------------
+ *   run_id            -> id
+ *   session_id        -> sessionId
+ *   reply             -> status.message.parts[0].text
+ *   completed===false -> status.state: 'input-required' (else 'completed')
+ *
+ * @package AgentsAPI
+ */
+
+namespace AgentsAPI\AI\Channels;
+
+use AgentsAPI\AI\WP_Agent_Chat_Run_Control;
+
+defined( 'ABSPATH' ) || exit;
+
+const AGENTS_CHAT_JSONRPC_NAMESPACE   = 'agents-api/v1';
+const AGENTS_CHAT_JSONRPC_ROUTE       = '/agent/(?P<agent_id>[A-Za-z0-9._-]+)';
+const AGENTS_CHAT_JSONRPC_VERSION     = '2.0';
+const AGENTS_CHAT_JSONRPC_METHOD_SEND = 'message/send';
+const AGENTS_CHAT_JSONRPC_METHOD_STREAM = 'message/stream';
+
+// JSON-RPC 2.0 reserved error codes (see the spec + agenttic-client ErrorCodes).
+const AGENTS_CHAT_JSONRPC_ERR_PARSE          = -32700;
+const AGENTS_CHAT_JSONRPC_ERR_INVALID_REQUEST = -32600;
+const AGENTS_CHAT_JSONRPC_ERR_METHOD_NOT_FOUND = -32601;
+const AGENTS_CHAT_JSONRPC_ERR_INVALID_PARAMS  = -32602;
+const AGENTS_CHAT_JSONRPC_ERR_INTERNAL        = -32603;
+
+add_action(
+	'rest_api_init',
+	static function (): void {
+		register_rest_route(
+			AGENTS_CHAT_JSONRPC_NAMESPACE,
+			AGENTS_CHAT_JSONRPC_ROUTE,
+			array(
+				'methods'             => 'POST',
+				'callback'            => __NAMESPACE__ . '\\agents_chat_jsonrpc_dispatch',
+				'permission_callback' => __NAMESPACE__ . '\\agents_chat_jsonrpc_permission',
+				'args'                => array(
+					'agent_id' => array(
+						'type'        => 'string',
+						'required'    => true,
+						'description' => 'Agent slug this JSON-RPC endpoint is bound to.',
+					),
+				),
+			)
+		);
+	}
+);
+
+/**
+ * Register a streaming chat runtime.
+ *
+ * The streaming handler is the token-by-token sibling of the synchronous
+ * `wp_agent_chat_handler`. It receives the canonical agents/chat input plus an
+ * `$emit` callback and must:
+ *   - call `$emit( $delta )` for each chunk as it arrives, where `$delta` is a
+ *     canonical delta array (see agents_chat_jsonrpc_delta_to_wire for shapes):
+ *       array( 'type' => 'content',  'text' => '...' )
+ *       array( 'type' => 'tool_call', 'tool_call_id' => '', 'tool_name' => '', 'index' => 0 )
+ *       array( 'type' => 'tool_argument', 'tool_call_id' => '', 'text' => '<json fragment>', 'index' => 0 )
+ *   - return the canonical agents/chat output array (or WP_Error) once complete.
+ *
+ * Equivalent to `add_filter( 'wp_agent_chat_stream_handler', ... )` but reads
+ * more intentionally at the call site, mirroring register_chat_handler().
+ *
+ * @param callable $handler  Receives ( array $input, callable $emit ), returns
+ *                           canonical output array or WP_Error.
+ * @param int      $priority Filter priority. Default 10.
+ */
+function register_chat_stream_handler( callable $handler, int $priority = 10 ): void {
+	add_filter(
+		'wp_agent_chat_stream_handler',
+		static function ( $existing, array $input ) use ( $handler ) {
+			unset( $input );
+			if ( null !== $existing ) {
+				return $existing;
+			}
+			return $handler;
+		},
+		$priority,
+		2
+	);
+}
+
+/**
+ * Permission gate. Mirrors the synchronous frontend chat route, keyed on the
+ * agent slug carried in the URL.
+ *
+ * @param \WP_REST_Request $request REST request.
+ */
+function agents_chat_jsonrpc_permission( \WP_REST_Request $request ): bool|\WP_Error {
+	$agent = sanitize_title( agents_chat_jsonrpc_string( $request->get_param( 'agent_id' ) ) );
+	if ( '' === $agent ) {
+		return new \WP_Error(
+			'agents_chat_jsonrpc_forbidden',
+			'A non-empty agent id is required.',
+			array( 'status' => 403 )
+		);
+	}
+
+	$input   = array( 'agent' => $agent );
+	$allowed = agents_chat_permission( $input );
+
+	if ( ! $allowed ) {
+		$allowed = \WP_Agent_Access::can_current_principal_access_agent(
+			$agent,
+			\WP_Agent_Access_Grant::ROLE_OPERATOR,
+			agents_chat_jsonrpc_scope( $request )
+		);
+	}
+
+	/**
+	 * Filter the JSON-RPC chat permission decision.
+	 *
+	 * @param bool             $allowed Default access decision.
+	 * @param string           $agent   Agent slug from the URL.
+	 * @param \WP_REST_Request $request REST request.
+	 */
+	$allowed = (bool) apply_filters( 'agents_chat_jsonrpc_permission', $allowed, $agent, $request );
+
+	if ( $allowed ) {
+		return true;
+	}
+
+	return new \WP_Error(
+		'agents_chat_jsonrpc_forbidden',
+		'You are not allowed to chat with this agent.',
+		array( 'status' => 403 )
+	);
+}
+
+/**
+ * Dispatch a JSON-RPC chat request. Branches on the JSON-RPC method:
+ * `message/send` returns a JSON Task response; `message/stream` streams SSE.
+ *
+ * @param \WP_REST_Request $request REST request.
+ * @return \WP_REST_Response
+ */
+function agents_chat_jsonrpc_dispatch( \WP_REST_Request $request ): \WP_REST_Response {
+	$agent   = sanitize_title( agents_chat_jsonrpc_string( $request->get_param( 'agent_id' ) ) );
+	$body    = $request->get_json_params();
+	$rpc_id  = agents_chat_jsonrpc_request_id( $body );
+	$method  = isset( $body['method'] ) && is_string( $body['method'] ) ? $body['method'] : '';
+	$params  = isset( $body['params'] ) && is_array( $body['params'] ) ? $body['params'] : array();
+
+	if ( AGENTS_CHAT_JSONRPC_VERSION !== ( $body['jsonrpc'] ?? null ) ) {
+		return rest_ensure_response(
+			agents_chat_jsonrpc_error_frame( $rpc_id, AGENTS_CHAT_JSONRPC_ERR_INVALID_REQUEST, 'Request must be JSON-RPC 2.0.' )
+		);
+	}
+
+	$input = agents_chat_jsonrpc_input_from_params( $params, $agent );
+	if ( is_wp_error( $input ) ) {
+		return rest_ensure_response(
+			agents_chat_jsonrpc_error_frame( $rpc_id, AGENTS_CHAT_JSONRPC_ERR_INVALID_PARAMS, $input->get_error_message() )
+		);
+	}
+
+	if ( AGENTS_CHAT_JSONRPC_METHOD_STREAM === $method ) {
+		// Streams directly and exits; never returns to the REST server.
+		agents_chat_jsonrpc_stream( $rpc_id, $input );
+		exit;
+	}
+
+	if ( AGENTS_CHAT_JSONRPC_METHOD_SEND !== $method ) {
+		return rest_ensure_response(
+			agents_chat_jsonrpc_error_frame( $rpc_id, AGENTS_CHAT_JSONRPC_ERR_METHOD_NOT_FOUND, sprintf( 'Unknown JSON-RPC method "%s".', $method ) )
+		);
+	}
+
+	$output = agents_chat_jsonrpc_run_sync( $input );
+	if ( is_wp_error( $output ) ) {
+		return rest_ensure_response(
+			agents_chat_jsonrpc_error_frame( $rpc_id, AGENTS_CHAT_JSONRPC_ERR_INTERNAL, $output->get_error_message() )
+		);
+	}
+
+	return rest_ensure_response(
+		agents_chat_jsonrpc_result_frame( $rpc_id, agents_chat_jsonrpc_task_from_output( $output ) )
+	);
+}
+
+/**
+ * Run one synchronous agents/chat turn.
+ *
+ * @param array<string,mixed> $input Canonical agents/chat input.
+ * @return array<string,mixed>|\WP_Error
+ */
+function agents_chat_jsonrpc_run_sync( array $input ) {
+	$ability = function_exists( 'wp_get_ability' ) ? wp_get_ability( AGENTS_CHAT_ABILITY ) : null;
+	if ( ! $ability ) {
+		return new \WP_Error( 'agents_chat_jsonrpc_ability_unavailable', 'The agents/chat ability is not available.' );
+	}
+
+	$result = $ability->execute( $input );
+	if ( is_wp_error( $result ) ) {
+		return $result;
+	}
+
+	return agents_chat_jsonrpc_string_keyed_array( is_array( $result ) ? $result : array() );
+}
+
+/**
+ * Stream a chat turn as Server-Sent Events.
+ *
+ * Emits per-token `message/delta` frames when a streaming runtime is registered
+ * (wp_agent_chat_stream_handler), then a terminal `result: Task` frame. Without
+ * a streaming runtime it falls back to the synchronous handler and emits a
+ * single terminal frame. This function writes to the output buffer and is
+ * expected to be followed by `exit`.
+ *
+ * @param string|int|null     $rpc_id JSON-RPC request id to echo on the terminal frame.
+ * @param array<string,mixed> $input  Canonical agents/chat input.
+ * @return void
+ */
+function agents_chat_jsonrpc_stream( $rpc_id, array $input ): void {
+	agents_chat_jsonrpc_open_sse_stream();
+
+	$task_id = agents_chat_jsonrpc_string( $input['run_id'] ?? null );
+	if ( '' === $task_id ) {
+		$task_id         = WP_Agent_Chat_Run_Control::generate_run_id();
+		$input['run_id'] = $task_id;
+	}
+
+	$stream_handler = apply_filters( 'wp_agent_chat_stream_handler', null, $input );
+
+	if ( is_callable( $stream_handler ) ) {
+		/**
+		 * @param array<string,mixed> $delta Canonical delta emitted by the runtime.
+		 */
+		$emit = static function ( array $delta ) use ( $task_id ): void {
+			agents_chat_jsonrpc_send_sse_frame(
+				agents_chat_jsonrpc_delta_frame( $task_id, agents_chat_jsonrpc_string_keyed_array( $delta ) )
+			);
+		};
+
+		$output = call_user_func( $stream_handler, $input, $emit );
+	} else {
+		// Graceful degradation: no streaming runtime, run the sync handler.
+		$output = agents_chat_jsonrpc_run_sync( $input );
+	}
+
+	if ( is_wp_error( $output ) ) {
+		agents_chat_jsonrpc_send_sse_frame(
+			agents_chat_jsonrpc_error_frame( $rpc_id, AGENTS_CHAT_JSONRPC_ERR_INTERNAL, $output->get_error_message() )
+		);
+		return;
+	}
+
+	$output = agents_chat_jsonrpc_string_keyed_array( is_array( $output ) ? $output : array() );
+	if ( '' === agents_chat_jsonrpc_string( $output['run_id'] ?? null ) ) {
+		$output['run_id'] = $task_id;
+	}
+
+	agents_chat_jsonrpc_send_sse_frame(
+		agents_chat_jsonrpc_result_frame( $rpc_id, agents_chat_jsonrpc_task_from_output( $output ) )
+	);
+}
+
+/**
+ * Build canonical agents/chat input from JSON-RPC MessageSendParams.
+ *
+ * @param array<mixed> $params JSON-RPC params (MessageSendParams).
+ * @param string       $agent  Agent slug from the URL.
+ * @return array<string,mixed>|\WP_Error
+ */
+function agents_chat_jsonrpc_input_from_params( array $params, string $agent ) {
+	if ( '' === $agent ) {
+		return new \WP_Error( 'agents_chat_jsonrpc_invalid_params', 'A non-empty agent id is required.' );
+	}
+
+	$message = isset( $params['message'] ) && is_array( $params['message'] ) ? $params['message'] : array();
+	$text    = agents_chat_jsonrpc_extract_text( $message );
+	if ( '' === trim( $text ) ) {
+		return new \WP_Error( 'agents_chat_jsonrpc_invalid_params', 'params.message must contain non-empty text.' );
+	}
+
+	$session_id = agents_chat_jsonrpc_string( $params['sessionId'] ?? null );
+	$run_id     = agents_chat_jsonrpc_string( $params['id'] ?? null );
+
+	$client_context = array(
+		'source'      => 'jsonrpc',
+		'client_name' => 'jsonrpc-chat',
+	);
+	if ( isset( $params['metadata'] ) && is_array( $params['metadata'] ) ) {
+		$client_context['metadata'] = $params['metadata'];
+	}
+
+	$input = array(
+		'agent'          => $agent,
+		'message'        => $text,
+		'session_id'     => '' !== $session_id ? $session_id : null,
+		'run_id'         => '' !== $run_id ? $run_id : null,
+		'attachments'    => agents_chat_jsonrpc_attachments( $message ),
+		'client_context' => $client_context,
+	);
+
+	/**
+	 * Filter the canonical agents/chat input built by the JSON-RPC adapter.
+	 *
+	 * @param array<string,mixed> $input  Canonical agents/chat input.
+	 * @param array<mixed>        $params JSON-RPC params.
+	 * @param string              $agent  Agent slug.
+	 */
+	/** @var mixed $filtered Hosts may return invalid values from this filter. */
+	$filtered = apply_filters( 'agents_chat_jsonrpc_input', $input, $params, $agent );
+
+	return is_array( $filtered ) ? agents_chat_jsonrpc_string_keyed_array( $filtered ) : $input;
+}
+
+/**
+ * Map canonical agents/chat output onto a JSON-RPC Task.
+ *
+ * @param array<string,mixed> $output Canonical agents/chat output.
+ * @return array<string,mixed> Task.
+ */
+function agents_chat_jsonrpc_task_from_output( array $output ): array {
+	$run_id     = agents_chat_jsonrpc_string( $output['run_id'] ?? null );
+	$session_id = agents_chat_jsonrpc_string( $output['session_id'] ?? null );
+	$reply      = agents_chat_jsonrpc_string( $output['reply'] ?? null );
+
+	// `completed` defaults to true when absent (mirrors run-control in agents_chat_dispatch).
+	$completed = ! array_key_exists( 'completed', $output ) || ! empty( $output['completed'] );
+	$state     = $completed ? 'completed' : 'input-required';
+
+	$task = array(
+		'id'     => '' !== $run_id ? $run_id : ( '' !== $session_id ? $session_id : 'run' ),
+		'status' => array(
+			'state'   => $state,
+			'message' => agents_chat_jsonrpc_agent_message( $reply, $run_id ),
+		),
+	);
+
+	if ( '' !== $session_id ) {
+		$task['sessionId'] = $session_id;
+	}
+
+	return $task;
+}
+
+/**
+ * Build an agent Message object for a Task status.
+ *
+ * @param string $text   Assistant text.
+ * @param string $run_id Run id used to derive a stable message id.
+ * @return array<string,mixed>
+ */
+function agents_chat_jsonrpc_agent_message( string $text, string $run_id ): array {
+	$message_id = ( '' !== $run_id ? $run_id : 'run' ) . '-message';
+
+	return array(
+		'role'      => 'agent',
+		'parts'     => array(
+			array(
+				'type' => 'text',
+				'text' => $text,
+			),
+		),
+		'messageId' => $message_id,
+		'kind'      => 'message',
+	);
+}
+
+/**
+ * Wrap a Task in a JSON-RPC success frame.
+ *
+ * @param string|int|null     $rpc_id JSON-RPC request id.
+ * @param array<string,mixed> $task   Task object.
+ * @return array<string,mixed>
+ */
+function agents_chat_jsonrpc_result_frame( $rpc_id, array $task ): array {
+	return array(
+		'jsonrpc' => AGENTS_CHAT_JSONRPC_VERSION,
+		'id'      => $rpc_id,
+		'result'  => $task,
+	);
+}
+
+/**
+ * Build a JSON-RPC error frame.
+ *
+ * @param string|int|null $rpc_id  JSON-RPC request id.
+ * @param int             $code    JSON-RPC error code.
+ * @param string          $message Human-readable error message.
+ * @return array<string,mixed>
+ */
+function agents_chat_jsonrpc_error_frame( $rpc_id, int $code, string $message ): array {
+	return array(
+		'jsonrpc' => AGENTS_CHAT_JSONRPC_VERSION,
+		'id'      => $rpc_id,
+		'error'   => array(
+			'code'    => $code,
+			'message' => $message,
+		),
+	);
+}
+
+/**
+ * Build a `message/delta` notification frame from a canonical delta.
+ *
+ * @param string              $task_id Task id the delta belongs to.
+ * @param array<string,mixed> $delta   Canonical delta.
+ * @return array<string,mixed>
+ */
+function agents_chat_jsonrpc_delta_frame( string $task_id, array $delta ): array {
+	return array(
+		'jsonrpc' => AGENTS_CHAT_JSONRPC_VERSION,
+		'method'  => 'message/delta',
+		'params'  => array(
+			'id'    => $task_id,
+			'delta' => agents_chat_jsonrpc_delta_to_wire( $delta ),
+		),
+	);
+}
+
+/**
+ * Translate a canonical delta into the client's StreamDelta wire shape.
+ *
+ * Canonical -> wire:
+ *   content       { type:'content',       text }                          -> { deltaType:'content', content:text }
+ *   tool_call     { type:'tool_call',     tool_call_id, tool_name, index } -> { deltaType:'tool_name', content:tool_name, toolCallId, toolCallName, toolCallIndex }
+ *   tool_argument { type:'tool_argument', tool_call_id, text, index }      -> { deltaType:'tool_argument', content:text, toolCallId, toolCallIndex }
+ *
+ * @param array<string,mixed> $delta Canonical delta.
+ * @return array<string,mixed> Wire StreamDelta.
+ */
+function agents_chat_jsonrpc_delta_to_wire( array $delta ): array {
+	$type = agents_chat_jsonrpc_string( $delta['type'] ?? null );
+
+	if ( 'tool_call' === $type ) {
+		return array(
+			'deltaType'     => 'tool_name',
+			'content'       => agents_chat_jsonrpc_string( $delta['tool_name'] ?? null ),
+			'toolCallId'    => agents_chat_jsonrpc_string( $delta['tool_call_id'] ?? null ),
+			'toolCallName'  => agents_chat_jsonrpc_string( $delta['tool_name'] ?? null ),
+			'toolCallIndex' => agents_chat_jsonrpc_int( $delta['index'] ?? null ),
+		);
+	}
+
+	if ( 'tool_argument' === $type ) {
+		return array(
+			'deltaType'     => 'tool_argument',
+			'content'       => agents_chat_jsonrpc_string( $delta['text'] ?? null ),
+			'toolCallId'    => agents_chat_jsonrpc_string( $delta['tool_call_id'] ?? null ),
+			'toolCallIndex' => agents_chat_jsonrpc_int( $delta['index'] ?? null ),
+		);
+	}
+
+	// Default: content delta.
+	return array(
+		'deltaType' => 'content',
+		'content'   => agents_chat_jsonrpc_string( $delta['text'] ?? ( $delta['content'] ?? null ) ),
+	);
+}
+
+/**
+ * Extract concatenated user text from a JSON-RPC Message's text parts.
+ * Parts with contentType 'context' are excluded from the visible message.
+ *
+ * @param array<mixed> $message JSON-RPC Message.
+ * @return string
+ */
+function agents_chat_jsonrpc_extract_text( array $message ): string {
+	$parts = isset( $message['parts'] ) && is_array( $message['parts'] ) ? $message['parts'] : array();
+	$texts = array();
+
+	foreach ( $parts as $part ) {
+		if ( ! is_array( $part ) || 'text' !== ( $part['type'] ?? null ) ) {
+			continue;
+		}
+		if ( 'context' === ( $part['contentType'] ?? null ) ) {
+			continue;
+		}
+		$texts[] = agents_chat_jsonrpc_string( $part['text'] ?? null );
+	}
+
+	return trim( implode( '', $texts ) );
+}
+
+/**
+ * Extract file parts from a JSON-RPC Message into canonical attachments.
+ *
+ * @param array<mixed> $message JSON-RPC Message.
+ * @return array<int,array<string,mixed>>
+ */
+function agents_chat_jsonrpc_attachments( array $message ): array {
+	$parts       = isset( $message['parts'] ) && is_array( $message['parts'] ) ? $message['parts'] : array();
+	$attachments = array();
+
+	foreach ( $parts as $part ) {
+		if ( ! is_array( $part ) || 'file' !== ( $part['type'] ?? null ) ) {
+			continue;
+		}
+		$file = isset( $part['file'] ) && is_array( $part['file'] ) ? $part['file'] : array();
+		$attachments[] = agents_chat_jsonrpc_string_keyed_array( $file );
+	}
+
+	return $attachments;
+}
+
+/**
+ * Read the JSON-RPC request id, preserving string or int, defaulting to null.
+ *
+ * @param array<mixed> $body Decoded request body.
+ * @return string|int|null
+ */
+function agents_chat_jsonrpc_request_id( array $body ) {
+	$id = $body['id'] ?? null;
+	if ( is_string( $id ) || is_int( $id ) ) {
+		return $id;
+	}
+
+	return null;
+}
+
+/**
+ * Request context for principal/access helpers.
+ *
+ * @param \WP_REST_Request $request REST request.
+ * @return array<string,mixed>
+ */
+function agents_chat_jsonrpc_scope( \WP_REST_Request $request ): array {
+	$scope                     = \AgentsAPI\AI\Auth\agents_access_request_scope(
+		array(
+			'workspace_id' => $request->get_param( 'workspace_id' ),
+			'client_id'    => $request->get_param( 'client_id' ),
+		)
+	);
+	$scope['request_metadata'] = array(
+		'rest_route' => AGENTS_CHAT_JSONRPC_NAMESPACE . '/agent/' . sanitize_title( agents_chat_jsonrpc_string( $request->get_param( 'agent_id' ) ) ),
+	);
+
+	return $scope;
+}
+
+/**
+ * Open an SSE response: send headers and disable output buffering/compression.
+ *
+ * @return void
+ */
+function agents_chat_jsonrpc_open_sse_stream(): void {
+	if ( ! headers_sent() ) {
+		header( 'Content-Type: text/event-stream; charset=utf-8' );
+		header( 'Cache-Control: no-cache, no-store, must-revalidate' );
+		header( 'Connection: keep-alive' );
+		header( 'X-Accel-Buffering: no' ); // Disable nginx proxy buffering.
+	}
+
+	// Discard any output buffering so frames flush immediately.
+	while ( ob_get_level() > 0 ) {
+		ob_end_flush();
+	}
+}
+
+/**
+ * Write one SSE `data:` frame and flush.
+ *
+ * @param array<string,mixed> $frame JSON-RPC frame.
+ * @return void
+ */
+function agents_chat_jsonrpc_send_sse_frame( array $frame ): void {
+	echo 'data: ' . wp_json_encode( $frame ) . "\n\n"; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- SSE payload is JSON, not HTML.
+	flush();
+}
+
+/**
+ * Coerce a value to string only when it is safely representable as text.
+ *
+ * @param mixed $value Value to normalize.
+ */
+function agents_chat_jsonrpc_string( $value ): string {
+	if ( is_scalar( $value ) || $value instanceof \Stringable ) {
+		return (string) $value;
+	}
+
+	return '';
+}
+
+/**
+ * Coerce a value to int only when it is numeric, defaulting to 0.
+ *
+ * @param mixed $value Value to normalize.
+ */
+function agents_chat_jsonrpc_int( $value ): int {
+	return is_numeric( $value ) ? (int) $value : 0;
+}
+
+/**
+ * Keep only string-keyed entries for canonical associative arrays.
+ *
+ * @param array<mixed> $value Input array.
+ * @return array<string,mixed>
+ */
+function agents_chat_jsonrpc_string_keyed_array( array $value ): array {
+	$result = array();
+	foreach ( $value as $key => $item ) {
+		if ( is_string( $key ) ) {
+			$result[ $key ] = $item;
+		}
+	}
+
+	return $result;
+}

--- a/tests/agents-chat-jsonrpc-route-smoke.php
+++ b/tests/agents-chat-jsonrpc-route-smoke.php
@@ -1,0 +1,207 @@
+<?php
+/**
+ * Pure-PHP smoke test for the JSON-RPC chat adapter (message/send + message/stream).
+ *
+ * Run with: php tests/agents-chat-jsonrpc-route-smoke.php
+ *
+ * Covers the route registration, the request/response mappers, the StreamDelta
+ * wire translation, and the streaming-handler contract (input + emit -> deltas
+ * + final Task). The SSE I/O wrapper (headers/flush/exit) is thin glue and is
+ * exercised indirectly through the frame builders it calls.
+ *
+ * @package AgentsAPI\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+$failures = array();
+$passes   = 0;
+
+echo "agents-chat-jsonrpc-route-smoke\n";
+
+require_once __DIR__ . '/agents-api-smoke-helpers.php';
+
+$GLOBALS['__agents_api_smoke_current_user_id'] = 7;
+$GLOBALS['__agents_api_smoke_routes']          = array();
+$GLOBALS['__agents_api_smoke_abilities']       = array();
+$GLOBALS['__agents_api_smoke_categories']      = array();
+
+class WP_Error {
+	public function __construct( private string $code = '', private string $message = '', private array $data = array() ) {}
+	public function get_error_code(): string { return $this->code; }
+	public function get_error_message(): string { return $this->message; }
+	public function get_error_data(): array { return $this->data; }
+}
+
+class WP_REST_Request {
+	public function __construct( private array $params = array(), private array $json = array() ) {}
+	public function get_param( string $key ) {
+		return $this->params[ $key ] ?? null;
+	}
+	public function get_json_params(): array {
+		return $this->json;
+	}
+}
+
+class WP_REST_Response {
+	public function __construct( public mixed $data ) {}
+}
+
+function rest_ensure_response( $value ): WP_REST_Response {
+	return $value instanceof WP_REST_Response ? $value : new WP_REST_Response( $value );
+}
+
+function register_rest_route( string $namespace, string $route, array $args ): void {
+	$GLOBALS['__agents_api_smoke_routes'][ $namespace . $route ] = $args;
+}
+
+function get_current_user_id(): int {
+	return (int) $GLOBALS['__agents_api_smoke_current_user_id'];
+}
+
+function current_user_can( string $capability ): bool {
+	unset( $capability );
+	return (bool) ( $GLOBALS['__agents_api_smoke_can_manage'] ?? false );
+}
+
+function wp_has_ability_category( string $category ): bool {
+	return isset( $GLOBALS['__agents_api_smoke_categories'][ $category ] );
+}
+
+function wp_register_ability_category( string $category, array $args ): void {
+	$GLOBALS['__agents_api_smoke_categories'][ $category ] = $args;
+}
+
+function wp_has_ability( string $ability ): bool {
+	return isset( $GLOBALS['__agents_api_smoke_abilities'][ $ability ] );
+}
+
+function wp_register_ability( string $ability, array $args ): void {
+	$GLOBALS['__agents_api_smoke_abilities'][ $ability ] = $args;
+}
+
+function wp_get_ability( string $name ) {
+	return $GLOBALS['__agents_api_smoke_abilities'][ $name ] ?? null;
+}
+
+agents_api_smoke_require_module();
+
+use function AgentsAPI\AI\Channels\agents_chat_jsonrpc_input_from_params;
+use function AgentsAPI\AI\Channels\agents_chat_jsonrpc_task_from_output;
+use function AgentsAPI\AI\Channels\agents_chat_jsonrpc_delta_to_wire;
+use function AgentsAPI\AI\Channels\agents_chat_jsonrpc_delta_frame;
+use function AgentsAPI\AI\Channels\agents_chat_jsonrpc_result_frame;
+use function AgentsAPI\AI\Channels\agents_chat_jsonrpc_error_frame;
+use function AgentsAPI\AI\Channels\agents_chat_jsonrpc_extract_text;
+use function AgentsAPI\AI\Channels\register_chat_stream_handler;
+
+do_action( 'rest_api_init' );
+
+// --- Route registration -----------------------------------------------------
+$route_key = 'agents-api/v1/agent/(?P<agent_id>[A-Za-z0-9._-]+)';
+agents_api_smoke_assert_equals( true, isset( $GLOBALS['__agents_api_smoke_routes'][ $route_key ] ), 'JSON-RPC agent route registers', $failures, $passes );
+agents_api_smoke_assert_equals( 'POST', $GLOBALS['__agents_api_smoke_routes'][ $route_key ]['methods'] ?? null, 'JSON-RPC route uses POST', $failures, $passes );
+
+// --- Input mapping: MessageSendParams -> canonical agents/chat input --------
+$params = array(
+	'id'        => 'rpc-1',
+	'sessionId' => 'sess-9',
+	'message'   => array(
+		'role'      => 'user',
+		'kind'      => 'message',
+		'messageId' => 'm-1',
+		'parts'     => array(
+			array( 'type' => 'text', 'text' => 'Hello ' ),
+			array( 'type' => 'text', 'text' => 'world' ),
+			array( 'type' => 'text', 'text' => 'SECRET', 'contentType' => 'context' ),
+			array( 'type' => 'file', 'file' => array( 'name' => 'a.png', 'mimeType' => 'image/png' ) ),
+		),
+	),
+	'metadata'  => array( 'locale' => 'es' ),
+);
+
+$input = agents_chat_jsonrpc_input_from_params( $params, 'support-agent' );
+agents_api_smoke_assert_equals( false, $input instanceof WP_Error, 'input mapping succeeds', $failures, $passes );
+agents_api_smoke_assert_equals( 'support-agent', $input['agent'] ?? null, 'input carries agent slug from URL', $failures, $passes );
+agents_api_smoke_assert_equals( 'Hello world', $input['message'] ?? null, 'input concatenates text parts and skips context parts', $failures, $passes );
+agents_api_smoke_assert_equals( 'sess-9', $input['session_id'] ?? null, 'input carries sessionId', $failures, $passes );
+agents_api_smoke_assert_equals( 'rpc-1', $input['run_id'] ?? null, 'input maps JSON-RPC id to run_id', $failures, $passes );
+agents_api_smoke_assert_equals( 'jsonrpc', $input['client_context']['source'] ?? null, 'input marks jsonrpc source', $failures, $passes );
+agents_api_smoke_assert_equals( 'a.png', $input['attachments'][0]['name'] ?? null, 'input extracts file parts as attachments', $failures, $passes );
+
+$empty = agents_chat_jsonrpc_input_from_params( array( 'message' => array( 'parts' => array() ) ), 'support-agent' );
+agents_api_smoke_assert_equals( true, $empty instanceof WP_Error, 'input rejects empty message', $failures, $passes );
+
+// extract_text directly
+agents_api_smoke_assert_equals( 'ab', agents_chat_jsonrpc_extract_text( array( 'parts' => array( array( 'type' => 'text', 'text' => 'a' ), array( 'type' => 'text', 'text' => 'b' ) ) ) ), 'extract_text concatenates', $failures, $passes );
+
+// --- Output mapping: canonical agents/chat output -> Task --------------------
+$task = agents_chat_jsonrpc_task_from_output( array( 'session_id' => 'sess-9', 'reply' => 'hi there', 'run_id' => 'rpc-1' ) );
+agents_api_smoke_assert_equals( 'rpc-1', $task['id'] ?? null, 'task id derives from run_id', $failures, $passes );
+agents_api_smoke_assert_equals( 'sess-9', $task['sessionId'] ?? null, 'task carries sessionId', $failures, $passes );
+agents_api_smoke_assert_equals( 'completed', $task['status']['state'] ?? null, 'task state completed by default', $failures, $passes );
+agents_api_smoke_assert_equals( 'agent', $task['status']['message']['role'] ?? null, 'task message role is agent', $failures, $passes );
+agents_api_smoke_assert_equals( 'message', $task['status']['message']['kind'] ?? null, 'task message kind is message', $failures, $passes );
+agents_api_smoke_assert_equals( 'hi there', $task['status']['message']['parts'][0]['text'] ?? null, 'task message carries reply text', $failures, $passes );
+
+$pending = agents_chat_jsonrpc_task_from_output( array( 'session_id' => 's', 'reply' => 'r', 'run_id' => 'x', 'completed' => false ) );
+agents_api_smoke_assert_equals( 'input-required', $pending['status']['state'] ?? null, 'task state input-required when not completed', $failures, $passes );
+
+// --- StreamDelta wire translation ------------------------------------------
+$content_wire = agents_chat_jsonrpc_delta_to_wire( array( 'type' => 'content', 'text' => 'tok' ) );
+agents_api_smoke_assert_equals( 'content', $content_wire['deltaType'] ?? null, 'content delta -> deltaType content', $failures, $passes );
+agents_api_smoke_assert_equals( 'tok', $content_wire['content'] ?? null, 'content delta carries content', $failures, $passes );
+
+$tool_name_wire = agents_chat_jsonrpc_delta_to_wire( array( 'type' => 'tool_call', 'tool_call_id' => 'tc1', 'tool_name' => 'search', 'index' => 2 ) );
+agents_api_smoke_assert_equals( 'tool_name', $tool_name_wire['deltaType'] ?? null, 'tool_call -> deltaType tool_name', $failures, $passes );
+agents_api_smoke_assert_equals( 'tc1', $tool_name_wire['toolCallId'] ?? null, 'tool_call carries toolCallId', $failures, $passes );
+agents_api_smoke_assert_equals( 2, $tool_name_wire['toolCallIndex'] ?? null, 'tool_call carries toolCallIndex', $failures, $passes );
+
+$tool_arg_wire = agents_chat_jsonrpc_delta_to_wire( array( 'type' => 'tool_argument', 'tool_call_id' => 'tc1', 'text' => '{"q":', 'index' => 2 ) );
+agents_api_smoke_assert_equals( 'tool_argument', $tool_arg_wire['deltaType'] ?? null, 'tool_argument -> deltaType tool_argument', $failures, $passes );
+agents_api_smoke_assert_equals( '{"q":', $tool_arg_wire['content'] ?? null, 'tool_argument carries JSON fragment', $failures, $passes );
+
+// --- Frame builders ---------------------------------------------------------
+$delta_frame = agents_chat_jsonrpc_delta_frame( 'task-1', array( 'type' => 'content', 'text' => 'x' ) );
+agents_api_smoke_assert_equals( '2.0', $delta_frame['jsonrpc'] ?? null, 'delta frame is jsonrpc 2.0', $failures, $passes );
+agents_api_smoke_assert_equals( 'message/delta', $delta_frame['method'] ?? null, 'delta frame method is message/delta', $failures, $passes );
+agents_api_smoke_assert_equals( 'task-1', $delta_frame['params']['id'] ?? null, 'delta frame carries task id', $failures, $passes );
+
+$result_frame = agents_chat_jsonrpc_result_frame( 'rpc-1', $task );
+agents_api_smoke_assert_equals( 'rpc-1', $result_frame['id'] ?? null, 'result frame echoes rpc id', $failures, $passes );
+agents_api_smoke_assert_equals( true, isset( $result_frame['result']['status'] ), 'result frame wraps Task', $failures, $passes );
+
+$error_frame = agents_chat_jsonrpc_error_frame( 'rpc-1', -32601, 'nope' );
+agents_api_smoke_assert_equals( -32601, $error_frame['error']['code'] ?? null, 'error frame carries code', $failures, $passes );
+agents_api_smoke_assert_equals( 'nope', $error_frame['error']['message'] ?? null, 'error frame carries message', $failures, $passes );
+
+// --- Streaming-handler contract: input + emit -> deltas + final output ------
+$emitted = array();
+register_chat_stream_handler(
+	static function ( array $in, callable $emit ): array {
+		$emit( array( 'type' => 'content', 'text' => 'Hel' ) );
+		$emit( array( 'type' => 'content', 'text' => 'lo' ) );
+		return array( 'session_id' => $in['session_id'] ?? 's', 'reply' => 'Hello', 'run_id' => $in['run_id'] ?? 'r', 'completed' => true );
+	}
+);
+
+$stream_handler = apply_filters( 'wp_agent_chat_stream_handler', null, $input );
+agents_api_smoke_assert_equals( true, is_callable( $stream_handler ), 'stream handler registers via filter', $failures, $passes );
+
+// Drive the handler exactly as the SSE wrapper does: collect delta frames + final task.
+$collected_frames = array();
+$final_output     = call_user_func(
+	$stream_handler,
+	$input,
+	static function ( array $delta ) use ( &$collected_frames ): void {
+		$collected_frames[] = agents_chat_jsonrpc_delta_frame( 'rpc-1', $delta );
+	}
+);
+agents_api_smoke_assert_equals( 2, count( $collected_frames ), 'stream handler emits one frame per token', $failures, $passes );
+agents_api_smoke_assert_equals( 'Hel', $collected_frames[0]['params']['delta']['content'] ?? null, 'first delta frame carries first token', $failures, $passes );
+$final_task = agents_chat_jsonrpc_task_from_output( $final_output );
+agents_api_smoke_assert_equals( 'Hello', $final_task['status']['message']['parts'][0]['text'] ?? null, 'final task carries full reply', $failures, $passes );
+
+agents_api_smoke_finish( 'JSON-RPC chat adapter', $failures, $passes );


### PR DESCRIPTION
## What

A canonical JSON-RPC chat adapter that makes the existing `agents/chat` ability drivable by protocol chat clients (e.g. JSON-RPC/SSE chat UIs) — the third integration shape alongside Direct Channels and Remote Bridges.

**`POST agents-api/v1/agent/{agent_id}`**, JSON-RPC 2.0:

| Method | Transport | Request | Response |
| --- | --- | --- | --- |
| `message/send` | JSON | `{jsonrpc, id, method, params}` | `{jsonrpc, id, result: Task}` |
| `message/stream` | SSE | same, `Accept: text/event-stream` | `data: {…}` frames |

## How

It's a **thin envelope** over `agents/chat`: it reuses the existing handler, conversation store, run-control, and permission stack. The canonical output maps almost 1:1 onto a JSON-RPC `Task`:

```
agents/chat output   JSON-RPC Task
------------------   -------------
run_id            -> id
session_id        -> sessionId
reply             -> status.message.parts[0].text
completed===false -> status.state: "input-required" (else "completed")
```

**Token streaming** adds one new seam: the `wp_agent_chat_stream_handler` filter (and a `register_chat_stream_handler()` helper) — the token-by-token sibling of the synchronous `wp_agent_chat_handler`. It receives `($input, $emit)` and emits canonical deltas (`content` / `tool_call` / `tool_argument`), which the route translates into `message/delta` SSE frames followed by a terminal `result: Task` frame.

**Graceful degradation:** when no streaming runtime is registered, `message/stream` runs the synchronous handler and emits a single terminal frame — so the endpoint works with *any* existing handler, just without token-level granularity.

The provider/turn-runner stays **out of canonical** (consumer territory, the same boundary as `agents/chat`). End-to-end, the endpoint composes with the opt-in default conversation store (#242) for durable WordPress-native sessions; the store is the persistence example, the endpoint is the transport, and the runtime is supplied by a consumer plugin.

## Files

- `src/Channels/register-agents-chat-jsonrpc-route.php` — the adapter
- `tests/agents-chat-jsonrpc-route-smoke.php` — 36 assertions (request/response mappers, all three delta wire shapes, frame builders, streaming-handler contract via a mock handler + `$emit`)
- `docs/external-clients.md` — new *JSON-RPC Protocol Endpoint* section
- `agents-api.php`, `composer.json` — bootstrap require + smoke registration

## Verification

- New smoke: **36/36**
- Full smoke suite: **green**
- PHPStan **max**: `[OK] No errors`
- PHPCS via CI (Homeboy lint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)