### PR TITLE
Add completion policy stop event coverage

### DIFF
--- a/tests/conversation-loop-completion-policy-smoke.php
+++ b/tests/conversation-loop-completion-policy-smoke.php
@@ -118,6 +118,19 @@ agents_api_smoke_assert_equals( 3, $turn_count, 'loop stopped at turn 3 when pol
 agents_api_smoke_assert_equals( 3, count( $policy_log ), 'policy was consulted for each tool execution', $failures, $passes );
 agents_api_smoke_assert_equals( 'client/finish', $policy_log[2]['tool_name'], 'policy received the finish tool name', $failures, $passes );
 
+$stop_events = array_values(
+	array_filter(
+		$result['events'],
+		static function ( array $event ): bool {
+			return 'completion_policy_stop' === ( $event['type'] ?? '' );
+		}
+	)
+);
+
+agents_api_smoke_assert_equals( 1, count( $stop_events ), 'complete decision records one stop event', $failures, $passes );
+agents_api_smoke_assert_equals( 'finish tool called', $stop_events[0]['metadata']['message'] ?? '', 'stop event carries decision message', $failures, $passes );
+agents_api_smoke_assert_equals( array( 'tool_name' => 'client/finish', 'turn' => 3 ), $stop_events[0]['metadata']['context'] ?? array(), 'stop event carries decision context', $failures, $passes );
+
 echo "\n[2] Completion policy coexists with should_continue — policy takes precedence:\n";
 $policy_log       = array();
 $continue_called  = 0;


### PR DESCRIPTION
## Summary
- Adds smoke coverage for the `completion_policy_stop` event emitted when a mediated completion policy returns a complete decision.
- Complements the existing incomplete-with-message and incomplete-without-message continuation coverage so issue #261 has explicit assertions for all requested decision paths.

Closes #261.

## Tests
- `php tests/conversation-loop-completion-policy-smoke.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Inspected the existing mediated completion-policy implementation, identified the remaining complete-path smoke assertion gap, drafted the test update, and ran focused verification.