### PR TITLE
Add runtime agent bundle imports

### DIFF
--- a/agents-api.php
+++ b/agents-api.php
@@ -80,6 +80,7 @@ require_once AGENTS_API_PATH . 'src/Context/class-wp-agent-composable-context.ph
 require_once AGENTS_API_PATH . 'src/Context/class-wp-agent-context-section-registry.php';
 require_once AGENTS_API_PATH . 'src/Registry/class-wp-agents-registry.php';
 require_once AGENTS_API_PATH . 'src/Registry/register-agents.php';
+require_once AGENTS_API_PATH . 'src/Registry/register-agent-runtime-bundle-importer.php';
 require_once AGENTS_API_PATH . 'src/Packages/register-agent-package-artifacts.php';
 require_once AGENTS_API_PATH . 'src/Workspace/class-wp-agent-workspace-scope.php';
 require_once AGENTS_API_PATH . 'src/Identity/class-wp-agent-identity-scope.php';

--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
       "php tests/registry-smoke.php",
       "php tests/installed-agent-materialization-smoke.php",
       "php tests/registered-agent-materialization-adapter-smoke.php",
+      "php tests/runtime-agent-bundle-importer-smoke.php",
       "php tests/package-lifecycle-smoke.php",
       "php tests/package-capability-contract-smoke.php",
       "php tests/package-adoption-orchestration-smoke.php",

--- a/src/Channels/register-agents-chat-ability.php
+++ b/src/Channels/register-agents-chat-ability.php
@@ -286,6 +286,36 @@ function agents_chat_input_schema(): array {
 				'default'     => array(),
 				'items'       => array( 'type' => 'object' ),
 			),
+			'tool_policy'    => array(
+				'type'        => array( 'object', 'null' ),
+				'description' => 'Optional caller-owned tool policy for this turn. Runtimes may use this to narrow tool visibility for peer-agent or sandbox invocations.',
+				'properties'  => array(
+					'mode'  => array(
+						'type' => 'string',
+						'enum' => array( 'allow', 'deny' ),
+					),
+					'tools' => array(
+						'type'  => 'array',
+						'items' => array( 'type' => 'string' ),
+					),
+				),
+			),
+			'allow_only'     => array(
+				'type'        => 'array',
+				'description' => 'Optional per-turn allow-list of tool names. Runtimes may intersect this with agent policy and available tool declarations.',
+				'default'     => array(),
+				'items'       => array( 'type' => 'string' ),
+			),
+			'completion_assertions' => array(
+				'type'        => array( 'object', 'null' ),
+				'description' => 'Optional runtime-defined completion assertions for this turn, such as required tool names before natural completion is accepted.',
+				'properties'  => array(
+					'required_tool_names' => array(
+						'type'  => 'array',
+						'items' => array( 'type' => 'string' ),
+					),
+				),
+			),
 			'client_context' => array(
 				'type'        => 'object',
 				'description' => 'Transport-level context describing where this turn originated.',

--- a/src/Registry/register-agent-runtime-bundle-importer.php
+++ b/src/Registry/register-agent-runtime-bundle-importer.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * Runtime agent bundle importer.
+ *
+ * @package AgentsAPI
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+add_filter(
+	'wp_agent_runtime_import_bundle',
+	static function ( $result, array $spec, array $input = array(), int $index = 0 ) {
+		if ( null !== $result ) {
+			return $result;
+		}
+
+		$string_value = static function ( mixed ...$values ): string {
+			foreach ( $values as $value ) {
+				if ( is_scalar( $value ) && '' !== trim( (string) $value ) ) {
+					return trim( (string) $value );
+				}
+			}
+
+			return '';
+		};
+
+		$bundle = is_array( $spec['bundle'] ?? null ) ? $spec['bundle'] : array();
+		$agent  = is_array( $bundle['agent'] ?? null ) ? $bundle['agent'] : array();
+		if ( empty( $agent ) ) {
+			return null;
+		}
+
+		$slug = sanitize_title( $string_value( $input['slug'] ?? null, $spec['slug'] ?? null, $agent['agent_slug'] ?? null, $bundle['bundle_slug'] ?? null ) );
+		if ( '' === $slug ) {
+			return new WP_Error(
+				'wp_agent_runtime_bundle_missing_agent_slug',
+				'Runtime agent bundle imports require an agent slug.',
+				array( 'index' => $index )
+			);
+		}
+
+		$registry = WP_Agents_Registry::get_instance();
+		if ( ! $registry instanceof WP_Agents_Registry ) {
+			return new WP_Error(
+				'wp_agent_runtime_bundle_registry_unavailable',
+				'The Agents API registry is unavailable for runtime bundle import.',
+				array( 'index' => $index )
+			);
+		}
+
+		$on_conflict = $string_value( $input['on_conflict'] ?? null, $spec['on_conflict'] ?? null, 'upgrade' );
+		if ( ! in_array( $on_conflict, array( 'error', 'skip', 'upgrade' ), true ) ) {
+			$on_conflict = 'upgrade';
+		}
+
+		if ( $registry->is_registered( $slug ) ) {
+			if ( 'skip' === $on_conflict ) {
+				return array(
+					'success'    => true,
+					'status'     => 'skipped',
+					'agent_slug' => $slug,
+				);
+			}
+
+			if ( 'error' === $on_conflict ) {
+				return new WP_Error(
+					'wp_agent_runtime_bundle_agent_exists',
+					'Runtime agent bundle import would replace an existing agent.',
+					array(
+						'index'      => $index,
+						'agent_slug' => $slug,
+					)
+				);
+			}
+
+			$registry->unregister( $slug );
+		}
+
+		$config = is_array( $agent['agent_config'] ?? null ) ? $agent['agent_config'] : array();
+		$meta   = is_array( $agent['meta'] ?? null ) ? $agent['meta'] : array();
+		if ( is_array( $config['datamachine_bundle'] ?? null ) ) {
+			$meta = array_merge(
+				array(
+					'source_type'    => 'runtime-agent-bundle',
+					'source_package' => $string_value( $config['datamachine_bundle']['bundle_slug'] ?? null, $bundle['bundle_slug'] ?? null ),
+					'source_version' => $string_value( $config['datamachine_bundle']['bundle_version'] ?? null, $bundle['bundle_version'] ?? null ),
+				),
+				$meta
+			);
+		}
+
+		$registered = $registry->register(
+			$slug,
+			array(
+				'label'          => $string_value( $agent['agent_name'] ?? null, $agent['label'] ?? null, $slug ),
+				'description'    => $string_value( $agent['description'] ?? null ),
+				'default_config' => $config,
+				'meta'           => $meta,
+			)
+		);
+
+		if ( ! $registered instanceof WP_Agent ) {
+			return new WP_Error(
+				'wp_agent_runtime_bundle_register_failed',
+				'Runtime agent bundle import failed to register the agent.',
+				array(
+					'index'      => $index,
+					'agent_slug' => $slug,
+				)
+			);
+		}
+
+		return array(
+			'success'    => true,
+			'status'     => 'registered',
+			'agent_slug' => $slug,
+		);
+	},
+	10,
+	4
+);

--- a/src/Transcripts/register-agents-conversation-session-abilities.php
+++ b/src/Transcripts/register-agents-conversation-session-abilities.php
@@ -539,6 +539,12 @@ function agents_conversation_session_full( array $session ): array {
 		$session['metadata'] = array();
 	}
 
+	foreach ( array( 'session_id', 'workspace_type', 'workspace_id', 'owner_type', 'owner_key', 'agent_slug', 'title', 'provider', 'model', 'context' ) as $field ) {
+		$session[ $field ] = isset( $session[ $field ] ) && is_scalar( $session[ $field ] ) ? (string) $session[ $field ] : '';
+	}
+
+	$session['user_id'] = isset( $session['user_id'] ) && is_numeric( $session['user_id'] ) ? (int) $session['user_id'] : 0;
+
 	return $session;
 }
 

--- a/tests/agents-chat-ability-smoke.php
+++ b/tests/agents-chat-ability-smoke.php
@@ -170,6 +170,9 @@ smoke_assert( true, isset( $in['properties']['session_owner'] ), 'input_schema_h
 smoke_assert( true, isset( $in['properties']['session_owner']['properties']['type'] ), 'session_owner_schema_has_type', $failures, $passes );
 smoke_assert( true, isset( $in['properties']['session_owner']['properties']['key'] ), 'session_owner_schema_has_key', $failures, $passes );
 smoke_assert( true, isset( $in['properties']['attachments'] ), 'input_schema_has_attachments', $failures, $passes );
+smoke_assert( true, isset( $in['properties']['tool_policy']['properties']['mode'] ), 'input_schema_has_tool_policy', $failures, $passes );
+smoke_assert( true, isset( $in['properties']['allow_only']['items'] ), 'input_schema_has_allow_only', $failures, $passes );
+smoke_assert( true, isset( $in['properties']['completion_assertions']['properties']['required_tool_names'] ), 'input_schema_has_completion_assertions', $failures, $passes );
 smoke_assert( true, isset( $in['properties']['client_context']['properties']['sender_id'] ), 'client_context_schema_has_sender_id', $failures, $passes );
 smoke_assert( true, in_array( 'peer-agent', $in['properties']['client_context']['properties']['source']['enum'] ?? array(), true ), 'client_context_source_allows_peer_agent', $failures, $passes );
 smoke_assert( true, isset( $in['properties']['client_context']['properties']['caller_agent'] ), 'client_context_schema_has_caller_agent', $failures, $passes );

--- a/tests/agents-conversation-session-abilities-smoke.php
+++ b/tests/agents-conversation-session-abilities-smoke.php
@@ -210,6 +210,8 @@ $input     = array(
 $created = agents_create_conversation_session( $input );
 smoke_assert( 's-1', $created['session']['session_id'] ?? null, 'create returns stored session', $failures, $passes );
 smoke_assert( 'frontend', $created['session']['metadata']['client'] ?? null, 'create passes metadata to store', $failures, $passes );
+smoke_assert( true, is_string( $created['session']['title'] ?? null ), 'create normalizes session title to string', $failures, $passes );
+smoke_assert( true, is_string( $created['session']['provider'] ?? null ) && is_string( $created['session']['model'] ?? null ), 'create normalizes nullable provider fields to strings', $failures, $passes );
 
 $store->update_session( 's-1', array( array( 'role' => 'user', 'content' => 'hello' ) ) );
 $got = agents_get_conversation_session( array( 'principal' => $principal, 'session_id' => 's-1' ) );

--- a/tests/runtime-agent-bundle-importer-smoke.php
+++ b/tests/runtime-agent-bundle-importer-smoke.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * Pure-PHP smoke test for runtime agent bundle imports.
+ *
+ * Run with: php tests/runtime-agent-bundle-importer-smoke.php
+ *
+ * @package AgentsAPI\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+if ( ! class_exists( 'WP_Error' ) ) {
+	class WP_Error {
+		private string $code;
+		private string $message;
+		private mixed $data;
+
+		public function __construct( string $code = '', string $message = '', mixed $data = null ) {
+			$this->code    = $code;
+			$this->message = $message;
+			$this->data    = $data;
+		}
+
+		public function get_error_code(): string {
+			return $this->code;
+		}
+
+		public function get_error_message(): string {
+			return $this->message;
+		}
+
+		public function get_error_data(): mixed {
+			return $this->data;
+		}
+	}
+}
+
+$failures = array();
+$passes   = 0;
+
+echo "agents-api-runtime-agent-bundle-importer-smoke\n";
+
+require_once __DIR__ . '/agents-api-smoke-helpers.php';
+agents_api_smoke_require_module();
+
+do_action( 'init' );
+
+$bundle = array(
+	'bundle_version' => '1.2.3',
+	'bundle_slug'    => 'studio-web-static-site-generator',
+	'agent'          => array(
+		'agent_slug'   => 'studio-web-static-site-generator',
+		'agent_name'   => 'Static Site Generator',
+		'agent_config' => array(
+			'studio_web'         => array( 'prompt' => 'Cook a site.' ),
+			'datamachine_bundle' => array(
+				'bundle_slug'    => 'studio-web-static-site-generator',
+				'bundle_version' => '1.2.3',
+			),
+		),
+	),
+);
+
+echo "\n[1] Inline bundle registers a runtime agent:\n";
+$result = apply_filters(
+	'wp_agent_runtime_import_bundle',
+	null,
+	array( 'bundle' => $bundle ),
+	array( 'on_conflict' => 'upgrade' ),
+	0
+);
+
+agents_api_smoke_assert_equals( true, is_array( $result ) && true === ( $result['success'] ?? false ), 'inline bundle import succeeds', $failures, $passes );
+agents_api_smoke_assert_equals( 'registered', $result['status'] ?? '', 'inline bundle reports registered status', $failures, $passes );
+agents_api_smoke_assert_equals( true, wp_has_agent( 'studio-web-static-site-generator' ), 'runtime agent is registered', $failures, $passes );
+agents_api_smoke_assert_equals( 'Cook a site.', wp_get_agent( 'studio-web-static-site-generator' )->get_default_config()['studio_web']['prompt'] ?? null, 'agent default config is preserved', $failures, $passes );
+agents_api_smoke_assert_equals( 'runtime-agent-bundle', wp_get_agent( 'studio-web-static-site-generator' )->get_meta()['source_type'] ?? null, 'bundle provenance is recorded', $failures, $passes );
+
+echo "\n[2] Conflict policy is enforced:\n";
+$skipped = apply_filters( 'wp_agent_runtime_import_bundle', null, array( 'bundle' => $bundle ), array( 'on_conflict' => 'skip' ), 1 );
+agents_api_smoke_assert_equals( 'skipped', $skipped['status'] ?? '', 'skip policy leaves existing agent registered', $failures, $passes );
+
+$error = apply_filters( 'wp_agent_runtime_import_bundle', null, array( 'bundle' => $bundle ), array( 'on_conflict' => 'error' ), 2 );
+agents_api_smoke_assert_equals( true, is_wp_error( $error ), 'error policy fails when agent exists', $failures, $passes );
+agents_api_smoke_assert_equals( 'wp_agent_runtime_bundle_agent_exists', $error instanceof WP_Error ? $error->get_error_code() : '', 'error policy returns stable code', $failures, $passes );
+
+echo "\n[3] Non-agent bundles remain available for other importers:\n";
+$unclaimed = apply_filters( 'wp_agent_runtime_import_bundle', null, array( 'bundle' => array( 'not_agent' => true ) ), array(), 3 );
+agents_api_smoke_assert_equals( null, $unclaimed, 'non-agent bundle is not claimed', $failures, $passes );
+
+agents_api_smoke_finish( 'Agents API runtime agent bundle importer', $failures, $passes );


### PR DESCRIPTION
## Summary
- Add a generic runtime bundle importer so browser/runtime callers can register request-local agent bundles through Agents API.
- Extend `agents/chat` with generic per-turn tool controls for peer-agent and sandbox callers.
- Normalize nullable conversation session fields before output validation.

## Verification
- `php -l src/Channels/register-agents-chat-ability.php`
- `php -l src/Transcripts/register-agents-conversation-session-abilities.php`
- `php -l src/Registry/register-agent-runtime-bundle-importer.php`
- `php tests/agents-chat-ability-smoke.php`
- `php tests/agents-conversation-session-abilities-smoke.php`
- `php tests/runtime-agent-bundle-importer-smoke.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5 / openai/gpt-5.5)
- **Used for:** Drafted the implementation and smoke coverage; Chris remains responsible for review and merge decisions.