### PR TITLE
Add runtime tool policy projection

### DIFF
--- a/agents-api.php
+++ b/agents-api.php
@@ -114,6 +114,7 @@ require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-effective-agent-resol
 require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-compaction-item.php';
 require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-compaction-conservation.php';
 require_once AGENTS_API_PATH . 'src/Tools/class-wp-agent-tool-declaration.php';
+require_once AGENTS_API_PATH . 'src/Tools/class-wp-agent-runtime-tool-policy.php';
 require_once AGENTS_API_PATH . 'src/Tools/class-wp-agent-action-policy.php';
 require_once AGENTS_API_PATH . 'src/Tools/class-wp-agent-tool-access-policy.php';
 require_once AGENTS_API_PATH . 'src/Tools/class-wp-agent-action-policy-provider.php';

--- a/composer.json
+++ b/composer.json
@@ -42,6 +42,7 @@
       "php tests/consent-policy-smoke.php",
       "php tests/tool-policy-contracts-smoke.php",
       "php tests/tool-source-registry-smoke.php",
+      "php tests/runtime-tool-policy-smoke.php",
       "php tests/tool-tier-resolver-smoke.php",
       "php tests/action-policy-resolver-smoke.php",
       "php tests/ability-meta-abilities-smoke.php",

--- a/src/Tools/class-wp-agent-runtime-tool-policy.php
+++ b/src/Tools/class-wp-agent-runtime-tool-policy.php
@@ -1,0 +1,164 @@
+<?php
+/**
+ * Runtime tool policy projection.
+ *
+ * @package AgentsAPI
+ */
+
+namespace AgentsAPI\AI\Tools;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Projects gathered tool declarations into a generic runtime-local policy.
+ */
+class WP_Agent_Runtime_Tool_Policy {
+
+	public const SCHEMA  = 'agents-api/runtime-tool-policy/v1';
+	public const VERSION = 1;
+
+	/**
+	 * Build a runtime-local tool policy from gathered tool declarations.
+	 *
+	 * Storage, UI, approval, and apply behavior remain host responsibilities; this
+	 * projection only carries the generic execution/scope contract consumers need
+	 * before invoking an ephemeral runtime.
+	 *
+	 * @param array<string,array<string,mixed>> $tools   Tool declarations keyed by tool id.
+	 * @param array<string,mixed>               $context Runtime context.
+	 * @return array<string,mixed> Runtime tool policy envelope.
+	 */
+	public static function fromTools( array $tools, array $context = array() ): array {
+		$policy_tools = array();
+
+		foreach ( $tools as $tool_id => $tool ) {
+			$id = self::toolId( $tool_id, $tool );
+			if ( '' === $id ) {
+				continue;
+			}
+
+			$runtime = self::runtimeMetadata( $tool );
+			$policy_tool = array(
+				'id'                   => $id,
+				'runtime_tool_id'      => self::runtimeToolId( $id, $tool ),
+				'allowed'              => self::isRuntimeLocal( $runtime ),
+				'runtime'              => $runtime,
+				'execution_location'   => self::legacyExecutionLocation( $runtime ),
+				'transport_visibility' => self::legacyTransportVisibility( $runtime ),
+			);
+			if ( is_string( $tool['source'] ?? null ) && '' !== $tool['source'] ) {
+				$policy_tool['source'] = $tool['source'];
+			}
+
+			$policy_tools[] = $policy_tool;
+		}
+
+		$policy = array(
+			'schema'  => self::SCHEMA,
+			'version' => self::VERSION,
+			'tools'   => $policy_tools,
+		);
+
+		if ( ! empty( $context ) ) {
+			$policy['context'] = self::scalarContext( $context );
+		}
+
+		if ( function_exists( 'apply_filters' ) ) {
+			$filtered = apply_filters( 'agents_api_runtime_tool_policy', $policy, $tools, $context );
+			if ( is_array( $filtered ) ) {
+				$policy = self::stringKeyedArray( $filtered );
+			}
+		}
+
+		return $policy;
+	}
+
+	/**
+	 * @param array<mixed> $value Filtered policy array.
+	 * @return array<string,mixed>
+	 */
+	private static function stringKeyedArray( array $value ): array {
+		$normalized = array();
+		foreach ( $value as $key => $item ) {
+			if ( is_string( $key ) ) {
+				$normalized[ $key ] = $item;
+			}
+		}
+
+		return $normalized;
+	}
+
+	/** @param array<string,mixed> $tool */
+	private static function toolId( string $tool_id, array $tool ): string {
+		$id = is_string( $tool['name'] ?? null ) && '' !== trim( $tool['name'] ) ? (string) $tool['name'] : $tool_id;
+		return trim( $id );
+	}
+
+	/** @param array<string,mixed> $tool */
+	private static function runtimeToolId( string $tool_id, array $tool ): string {
+		$runtime_tool_id = is_string( $tool['runtime_tool_id'] ?? null ) ? trim( $tool['runtime_tool_id'] ) : '';
+		if ( '' !== $runtime_tool_id ) {
+			return $runtime_tool_id;
+		}
+
+		return str_replace( array( '/', '-' ), '_', $tool_id );
+	}
+
+	/**
+	 * @param array<string,mixed> $tool Tool declaration.
+	 * @return array{environment:string, capability_scope:string}
+	 */
+	private static function runtimeMetadata( array $tool ): array {
+		$runtime = is_array( $tool['runtime'] ?? null ) ? $tool['runtime'] : array();
+
+		return array(
+			WP_Agent_Tool_Declaration::RUNTIME_ENVIRONMENT => self::runtimeValue(
+				$runtime[ WP_Agent_Tool_Declaration::RUNTIME_ENVIRONMENT ] ?? null,
+				WP_Agent_Tool_Declaration::ENVIRONMENT_CONTROL_PLANE
+			),
+			WP_Agent_Tool_Declaration::RUNTIME_CAPABILITY_SCOPE => self::runtimeValue(
+				$runtime[ WP_Agent_Tool_Declaration::RUNTIME_CAPABILITY_SCOPE ] ?? null,
+				WP_Agent_Tool_Declaration::CAPABILITY_SCOPE_CONTROL_PLANE
+			),
+		);
+	}
+
+	private static function runtimeValue( mixed $value, string $fallback ): string {
+		$value = is_string( $value ) ? trim( $value ) : '';
+		return '' !== $value ? $value : $fallback;
+	}
+
+	/** @param array{environment:string,capability_scope:string} $runtime */
+	private static function isRuntimeLocal( array $runtime ): bool {
+		return WP_Agent_Tool_Declaration::ENVIRONMENT_RUNTIME_LOCAL === $runtime[ WP_Agent_Tool_Declaration::RUNTIME_ENVIRONMENT ]
+			&& WP_Agent_Tool_Declaration::CAPABILITY_SCOPE_RUNTIME_LOCAL === $runtime[ WP_Agent_Tool_Declaration::RUNTIME_CAPABILITY_SCOPE ];
+	}
+
+	/** @param array{environment:string,capability_scope:string} $runtime */
+	private static function legacyExecutionLocation( array $runtime ): string {
+		return WP_Agent_Tool_Declaration::ENVIRONMENT_RUNTIME_LOCAL === $runtime[ WP_Agent_Tool_Declaration::RUNTIME_ENVIRONMENT ] ? 'sandbox' : 'parent';
+	}
+
+	/** @param array{environment:string,capability_scope:string} $runtime */
+	private static function legacyTransportVisibility( array $runtime ): string {
+		return WP_Agent_Tool_Declaration::CAPABILITY_SCOPE_RUNTIME_LOCAL === $runtime[ WP_Agent_Tool_Declaration::RUNTIME_CAPABILITY_SCOPE ] ? 'sandbox' : 'parent';
+	}
+
+	/**
+	 * @param array<string,mixed> $context Runtime context.
+	 * @return array<string,string|int|float|bool>
+	 */
+	private static function scalarContext( array $context ): array {
+		$allowed = array();
+		foreach ( $context as $key => $value ) {
+			if ( '' === $key ) {
+				continue;
+			}
+			if ( is_string( $value ) || is_int( $value ) || is_float( $value ) || is_bool( $value ) ) {
+				$allowed[ $key ] = $value;
+			}
+		}
+
+		return $allowed;
+	}
+}

--- a/tests/runtime-tool-policy-smoke.php
+++ b/tests/runtime-tool-policy-smoke.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * Pure-PHP smoke test for runtime tool policy projection.
+ *
+ * Run with: php tests/runtime-tool-policy-smoke.php
+ *
+ * @package AgentsAPI\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+$failures = array();
+$passes   = 0;
+
+echo "agents-api-runtime-tool-policy-smoke\n";
+
+require_once __DIR__ . '/agents-api-smoke-helpers.php';
+agents_api_smoke_require_module();
+
+use AgentsAPI\AI\Tools\WP_Agent_Runtime_Tool_Policy;
+use AgentsAPI\AI\Tools\WP_Agent_Tool_Declaration;
+
+$tools = array(
+	'filesystem-write'                 => array(
+		'name'            => 'filesystem-write',
+		'source'          => 'runtime',
+		'description'     => 'Write one generated website artifact file.',
+		'runtime_tool_id' => 'filesystem_write',
+		'runtime'         => array(
+			WP_Agent_Tool_Declaration::RUNTIME_ENVIRONMENT      => WP_Agent_Tool_Declaration::ENVIRONMENT_RUNTIME_LOCAL,
+			WP_Agent_Tool_Declaration::RUNTIME_CAPABILITY_SCOPE => WP_Agent_Tool_Declaration::CAPABILITY_SCOPE_RUNTIME_LOCAL,
+		),
+	),
+	'datamachine/workspace-git-push'   => array(
+		'name'        => 'datamachine/workspace-git-push',
+		'source'      => 'datamachine-code',
+		'description' => 'Push a workspace branch from the parent control plane.',
+		'runtime'     => array(
+			WP_Agent_Tool_Declaration::RUNTIME_ENVIRONMENT      => WP_Agent_Tool_Declaration::ENVIRONMENT_CONTROL_PLANE,
+			WP_Agent_Tool_Declaration::RUNTIME_CAPABILITY_SCOPE => WP_Agent_Tool_Declaration::CAPABILITY_SCOPE_CONTROL_PLANE,
+		),
+	),
+	'datamachine/workspace-read'       => array(
+		'name'        => 'datamachine/workspace-read',
+		'source'      => 'datamachine-code',
+		'description' => 'Read a workspace file through the parent control plane.',
+	),
+);
+
+$policy = WP_Agent_Runtime_Tool_Policy::fromTools(
+	$tools,
+	array(
+		'runtime_type' => 'wordpress-playground',
+		'session_id'   => 'abc123',
+		'ignored'      => array( 'nested' ),
+	)
+);
+
+agents_api_smoke_assert_equals( WP_Agent_Runtime_Tool_Policy::SCHEMA, $policy['schema'] ?? '', 'policy exposes canonical schema', $failures, $passes );
+agents_api_smoke_assert_equals( WP_Agent_Runtime_Tool_Policy::VERSION, $policy['version'] ?? 0, 'policy exposes canonical version', $failures, $passes );
+agents_api_smoke_assert_equals( 3, count( $policy['tools'] ?? array() ), 'policy includes all declared tools', $failures, $passes );
+agents_api_smoke_assert_equals( array( 'runtime_type' => 'wordpress-playground', 'session_id' => 'abc123' ), $policy['context'] ?? array(), 'policy context keeps only scalar metadata', $failures, $passes );
+
+$by_id = array();
+foreach ( $policy['tools'] as $tool ) {
+	$by_id[ $tool['id'] ] = $tool;
+}
+
+agents_api_smoke_assert_equals( true, $by_id['filesystem-write']['allowed'] ?? false, 'runtime-local tool is allowed', $failures, $passes );
+agents_api_smoke_assert_equals( 'filesystem_write', $by_id['filesystem-write']['runtime_tool_id'] ?? '', 'runtime tool id can be declared explicitly', $failures, $passes );
+agents_api_smoke_assert_equals( WP_Agent_Tool_Declaration::ENVIRONMENT_RUNTIME_LOCAL, $by_id['filesystem-write']['runtime'][ WP_Agent_Tool_Declaration::RUNTIME_ENVIRONMENT ] ?? '', 'runtime-local tool records execution environment', $failures, $passes );
+agents_api_smoke_assert_equals( 'sandbox', $by_id['filesystem-write']['execution_location'] ?? '', 'runtime-local tool projects legacy sandbox location for consumers', $failures, $passes );
+
+agents_api_smoke_assert_equals( false, $by_id['datamachine/workspace-git-push']['allowed'] ?? true, 'control-plane tool is denied to runtime-local agent', $failures, $passes );
+agents_api_smoke_assert_equals( 'parent', $by_id['datamachine/workspace-git-push']['transport_visibility'] ?? '', 'control-plane tool projects parent visibility', $failures, $passes );
+agents_api_smoke_assert_equals( 'datamachine_workspace_read', $by_id['datamachine/workspace-read']['runtime_tool_id'] ?? '', 'runtime tool id defaults from tool name', $failures, $passes );
+agents_api_smoke_assert_equals( false, $by_id['datamachine/workspace-read']['allowed'] ?? true, 'tools without runtime metadata default closed', $failures, $passes );
+
+add_filter(
+	'agents_api_runtime_tool_policy',
+	static function ( array $runtime_policy ): array {
+		$runtime_policy['metadata'] = array( 'filtered' => true );
+		return $runtime_policy;
+	}
+);
+$filtered_policy = WP_Agent_Runtime_Tool_Policy::fromTools( $tools );
+agents_api_smoke_assert_equals( true, $filtered_policy['metadata']['filtered'] ?? false, 'policy projection exposes a host mediation filter', $failures, $passes );
+
+agents_api_smoke_finish( 'runtime tool policy', $failures, $passes );


### PR DESCRIPTION
## Summary
- Adds `WP_Agent_Runtime_Tool_Policy` to project gathered tool declarations into a generic runtime-local policy envelope.
- Uses existing Agents API runtime metadata constants to mark runtime-local tools as allowed and control-plane/default tools as denied.
- Adds smoke coverage for the WP Codebox pressure point: `filesystem-write` can be represented as runtime-local while parent-only workspace tools fail closed.

## Why
This is the smallest upstream slice from #277 that lets disposable sandbox consumers rely on an Agents API-owned runtime/tool contract instead of carrying product-local sandbox policy vocabulary downstream.

## Verification
- `php tests/runtime-tool-policy-smoke.php`
- `php tests/tool-source-registry-smoke.php`
- `php tests/tool-runtime-smoke.php`
- `composer test`
- `composer run phpstan`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Investigated the upstream/downstream runtime-tool contract gap, drafted the implementation and smoke coverage, and ran verification. Chris remains responsible for review and merge.