### PR TITLE
Complete disposable runtime contract gaps

### DIFF
--- a/src/Channels/register-agents-chat-ability.php
+++ b/src/Channels/register-agents-chat-ability.php
@@ -325,31 +325,31 @@ function agents_chat_input_schema(): array {
 		'type'       => 'object',
 		'required'   => array( 'agent', 'message' ),
 		'properties' => array(
-			'agent'          => array(
+			'agent'                 => array(
 				'type'        => 'string',
 				'description' => 'Slug or ID of the registered agent that should handle this turn.',
 			),
-			'message'        => array(
+			'message'               => array(
 				'type'        => 'string',
 				'description' => 'User-side text for the agent to respond to.',
 			),
-			'session_id'     => array(
+			'session_id'            => array(
 				'type'        => array( 'string', 'null' ),
 				'description' => 'Existing session ID to continue, or null to start a new session.',
 			),
-			'run_id'         => array(
+			'run_id'                => array(
 				'type'        => array( 'string', 'null' ),
 				'description' => 'Optional client-supplied idempotency/run key. If omitted, the dispatcher provides an opaque run ID to the runtime and response.',
 			),
-			'principal'      => agents_chat_principal_schema(),
-			'session_owner'  => agents_chat_session_owner_schema(),
-			'attachments'    => array(
+			'principal'             => agents_chat_principal_schema(),
+			'session_owner'         => agents_chat_session_owner_schema(),
+			'attachments'           => array(
 				'type'        => 'array',
 				'description' => 'Channel-side attachments (images, voice notes, files, link previews). Shape is runtime-defined; runtimes ignore unknown attachment types.',
 				'default'     => array(),
 				'items'       => array( 'type' => 'object' ),
 			),
-			'tool_policy'    => array(
+			'tool_policy'           => array(
 				'type'        => array( 'object', 'null' ),
 				'description' => 'Optional caller-owned tool policy for this turn. Runtimes may use this to narrow tool visibility for peer-agent or sandbox invocations.',
 				'properties'  => array(
@@ -363,7 +363,7 @@ function agents_chat_input_schema(): array {
 					),
 				),
 			),
-			'allow_only'     => array(
+			'allow_only'            => array(
 				'type'        => 'array',
 				'description' => 'Optional per-turn allow-list of tool names. Runtimes may intersect this with agent policy and available tool declarations.',
 				'default'     => array(),
@@ -379,7 +379,7 @@ function agents_chat_input_schema(): array {
 					),
 				),
 			),
-			'client_context' => array(
+			'client_context'        => array(
 				'type'        => 'object',
 				'description' => 'Transport-level context describing where this turn originated.',
 				'properties'  => array(

--- a/src/Channels/register-agents-chat-ability.php
+++ b/src/Channels/register-agents-chat-ability.php
@@ -40,6 +40,7 @@
 namespace AgentsAPI\AI\Channels;
 
 use AgentsAPI\AI\WP_Agent_Chat_Run_Control;
+use AgentsAPI\AI\WP_Agent_Execution_Principal;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -110,6 +111,16 @@ add_action(
  * @return array<string,mixed>|\WP_Error Canonical output, or WP_Error if no runtime is registered.
  */
 function agents_chat_dispatch( array $input ) {
+	$principal = agents_chat_principal_from_input( $input );
+	if ( is_wp_error( $principal ) ) {
+		do_action( 'agents_chat_dispatch_failed', $principal->get_error_code(), $input );
+		return $principal;
+	}
+
+	if ( $principal instanceof WP_Agent_Execution_Principal ) {
+		$input['principal'] = $principal->to_array();
+	}
+
 	$run_id = agents_chat_optional_string( $input['run_id'] ?? null );
 	if ( null === $run_id ) {
 		$input['run_id'] = WP_Agent_Chat_Run_Control::generate_run_id();
@@ -237,6 +248,27 @@ function agents_chat_string_keyed_array( array $data ): array {
  * @return bool
  */
 function agents_chat_permission( array $input ): bool {
+	$allowed   = current_user_can( 'manage_options' );
+	$principal = agents_chat_principal_from_input( $input );
+	if ( is_wp_error( $principal ) ) {
+		return false;
+	}
+
+	if ( $principal instanceof WP_Agent_Execution_Principal ) {
+		/**
+		 * Filter permission for host-attested runtime principals.
+		 *
+		 * Hosts can authorize disposable runtimes here after validating their own
+		 * runtime binding/session claims. Agents API normalizes the principal but
+		 * does not trust arbitrary runtime principal input by default.
+		 *
+		 * @param bool                         $allowed   Current permission decision.
+		 * @param WP_Agent_Execution_Principal $principal Normalized principal.
+		 * @param array<mixed>                 $input     Canonical chat input.
+		 */
+		$allowed = (bool) apply_filters( 'agents_chat_runtime_principal_permission', $allowed, $principal, $input );
+	}
+
 	/**
 	 * Filter the permission decision for the canonical chat ability.
 	 *
@@ -245,9 +277,39 @@ function agents_chat_permission( array $input ): bool {
 	 */
 	return (bool) apply_filters(
 		'agents_chat_permission',
-		current_user_can( 'manage_options' ),
+		$allowed,
 		$input
 	);
+}
+
+/**
+ * Normalize optional execution principal input for agents/chat.
+ *
+ * @param array<mixed> $input Canonical chat input.
+ * @return WP_Agent_Execution_Principal|\WP_Error|null
+ */
+function agents_chat_principal_from_input( array $input ) {
+	if ( ! array_key_exists( 'principal', $input ) || null === $input['principal'] ) {
+		return null;
+	}
+
+	if ( $input['principal'] instanceof WP_Agent_Execution_Principal ) {
+		return $input['principal'];
+	}
+
+	if ( ! is_array( $input['principal'] ) ) {
+		return new \WP_Error( 'agents_chat_invalid_principal', 'agents/chat principal must be an object when provided.' );
+	}
+
+	try {
+		return WP_Agent_Execution_Principal::from_array( agents_chat_string_keyed_array( $input['principal'] ) );
+	} catch ( \Throwable $error ) {
+		return new \WP_Error(
+			'agents_chat_invalid_principal',
+			'Invalid agents/chat execution principal.',
+			array( 'reason' => $error->getMessage() )
+		);
+	}
 }
 
 /**
@@ -279,6 +341,7 @@ function agents_chat_input_schema(): array {
 				'type'        => array( 'string', 'null' ),
 				'description' => 'Optional client-supplied idempotency/run key. If omitted, the dispatcher provides an opaque run ID to the runtime and response.',
 			),
+			'principal'      => agents_chat_principal_schema(),
 			'session_owner'  => agents_chat_session_owner_schema(),
 			'attachments'    => array(
 				'type'        => 'array',
@@ -368,6 +431,33 @@ function agents_chat_input_schema(): array {
 					),
 				),
 			),
+		),
+	);
+}
+
+/**
+ * Canonical execution principal schema for agents/chat.
+ *
+ * @return array<string, mixed>
+ */
+function agents_chat_principal_schema(): array {
+	return array(
+		'type'        => array( 'object', 'null' ),
+		'description' => 'Optional execution principal resolved by a trusted host/runtime. Disposable runtimes should use auth_source=runtime and request_context=runtime with opaque owner isolation.',
+		'properties'  => array(
+			'acting_user_id'     => array( 'type' => 'integer' ),
+			'effective_agent_id' => array( 'type' => 'string' ),
+			'auth_source'        => array( 'type' => 'string' ),
+			'request_context'    => array( 'type' => 'string' ),
+			'token_id'           => array( 'type' => array( 'integer', 'null' ) ),
+			'request_metadata'   => array( 'type' => 'object' ),
+			'workspace_id'       => array( 'type' => array( 'string', 'null' ) ),
+			'client_id'          => array( 'type' => array( 'string', 'null' ) ),
+			'audience_id'        => array( 'type' => array( 'string', 'null' ) ),
+			'audience_claims'    => array( 'type' => 'object' ),
+			'owner_type'         => array( 'type' => array( 'string', 'null' ) ),
+			'owner_key'          => array( 'type' => array( 'string', 'null' ) ),
+			'binding'            => array( 'type' => array( 'object', 'null' ) ),
 		),
 	);
 }

--- a/src/Registry/register-agent-runtime-bundle-importer.php
+++ b/src/Registry/register-agent-runtime-bundle-importer.php
@@ -108,6 +108,7 @@ if ( ! function_exists( 'wp_agent_runtime_bundle_from_source' ) ) {
 			);
 		}
 
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Runtime bundle sources are local JSON files, not remote URLs.
 		$contents = file_get_contents( $source );
 		if ( false === $contents ) {
 			return new WP_Error(
@@ -174,7 +175,7 @@ add_filter(
 			}
 			$bundle = $source_bundle;
 		}
-		$agent  = is_array( $bundle['agent'] ?? null ) ? $bundle['agent'] : array();
+		$agent = is_array( $bundle['agent'] ?? null ) ? $bundle['agent'] : array();
 		if ( empty( $agent ) ) {
 			return null;
 		}

--- a/src/Registry/register-agent-runtime-bundle-importer.php
+++ b/src/Registry/register-agent-runtime-bundle-importer.php
@@ -7,6 +7,148 @@
 
 defined( 'ABSPATH' ) || exit;
 
+if ( ! function_exists( 'wp_agent_import_runtime_bundles' ) ) {
+	/**
+	 * Import one or more runtime agent bundle specs through the generic importer seam.
+	 *
+	 * Specs may include an inline `bundle` object or a `source` path to a JSON file.
+	 * Concrete storage stays with the active registry/materialization adapter; this
+	 * helper only normalizes transport and produces stable per-item result envelopes.
+	 *
+	 * @param array<int,mixed>    $bundle_specs Runtime bundle specs.
+	 * @param array<string,mixed> $input        Shared import input.
+	 * @return list<array<string,mixed>> Per-spec import results.
+	 */
+	function wp_agent_import_runtime_bundles( array $bundle_specs, array $input = array() ): array {
+		$results = array();
+		foreach ( $bundle_specs as $index => $spec ) {
+			if ( ! is_array( $spec ) ) {
+				$results[] = wp_agent_runtime_bundle_import_result( array(
+					'success' => false,
+					'index'   => $index,
+					'error'   => array(
+						'code'    => 'wp_agent_runtime_bundle_spec_invalid',
+						'message' => 'Runtime agent bundle spec must be an object.',
+					),
+				) );
+				continue;
+			}
+
+			$result = apply_filters( 'wp_agent_runtime_import_bundle', null, $spec, $input, $index );
+			if ( is_wp_error( $result ) ) {
+				$results[] = wp_agent_runtime_bundle_import_result( array(
+					'success' => false,
+					'index'   => $index,
+					'error'   => array(
+						'code'    => $result->get_error_code(),
+						'message' => $result->get_error_message(),
+						'data'    => $result->get_error_data(),
+					),
+				) );
+				continue;
+			}
+
+			if ( null === $result ) {
+				$results[] = wp_agent_runtime_bundle_import_result( array(
+					'success' => false,
+					'index'   => $index,
+					'error'   => array(
+						'code'    => 'wp_agent_runtime_bundle_unclaimed',
+						'message' => 'No runtime bundle importer accepted this spec.',
+					),
+				) );
+				continue;
+			}
+
+			$normalized          = is_array( $result ) ? $result : array( 'result' => $result );
+			$normalized['index'] = $index;
+			if ( ! array_key_exists( 'success', $normalized ) ) {
+				$normalized['success'] = true;
+			}
+			$results[] = wp_agent_runtime_bundle_import_result( $normalized );
+		}
+
+		return $results;
+	}
+}
+
+if ( ! function_exists( 'wp_agent_runtime_bundle_import_result' ) ) {
+	/**
+	 * Normalize one runtime bundle import result to a string-keyed envelope.
+	 *
+	 * @param array<mixed> $result Raw import result.
+	 * @return array<string,mixed>
+	 */
+	function wp_agent_runtime_bundle_import_result( array $result ): array {
+		$normalized = array();
+		foreach ( $result as $key => $value ) {
+			if ( is_string( $key ) ) {
+				$normalized[ $key ] = $value;
+			}
+		}
+		return $normalized;
+	}
+}
+
+if ( ! function_exists( 'wp_agent_runtime_bundle_from_source' ) ) {
+	/**
+	 * Load and decode a runtime bundle JSON file.
+	 *
+	 * @param string $source Source path.
+	 * @param int    $index  Spec index for error metadata.
+	 * @return array<string,mixed>|WP_Error Bundle array or error.
+	 */
+	function wp_agent_runtime_bundle_from_source( string $source, int $index ) {
+		$source = trim( $source );
+		if ( '' === $source || ! is_readable( $source ) ) {
+			return new WP_Error(
+				'wp_agent_runtime_bundle_source_unreadable',
+				'Runtime agent bundle source is not readable.',
+				array( 'index' => $index )
+			);
+		}
+
+		$contents = file_get_contents( $source );
+		if ( false === $contents ) {
+			return new WP_Error(
+				'wp_agent_runtime_bundle_source_read_failed',
+				'Runtime agent bundle source could not be read.',
+				array( 'index' => $index )
+			);
+		}
+
+		try {
+			$bundle = json_decode( $contents, true, 512, JSON_THROW_ON_ERROR );
+		} catch ( JsonException $error ) {
+			return new WP_Error(
+				'wp_agent_runtime_bundle_source_invalid_json',
+				'Runtime agent bundle source must contain valid JSON.',
+				array(
+					'index'  => $index,
+					'reason' => $error->getMessage(),
+				)
+			);
+		}
+
+		if ( ! is_array( $bundle ) ) {
+			return new WP_Error(
+				'wp_agent_runtime_bundle_source_invalid_shape',
+				'Runtime agent bundle source must decode to an object.',
+				array( 'index' => $index )
+			);
+		}
+
+		$normalized = array();
+		foreach ( $bundle as $key => $value ) {
+			if ( is_string( $key ) ) {
+				$normalized[ $key ] = $value;
+			}
+		}
+
+		return $normalized;
+	}
+}
+
 add_filter(
 	'wp_agent_runtime_import_bundle',
 	static function ( $result, array $spec, array $input = array(), int $index = 0 ) {
@@ -25,6 +167,13 @@ add_filter(
 		};
 
 		$bundle = is_array( $spec['bundle'] ?? null ) ? $spec['bundle'] : array();
+		if ( empty( $bundle ) && is_string( $spec['source'] ?? null ) ) {
+			$source_bundle = wp_agent_runtime_bundle_from_source( $spec['source'], $index );
+			if ( is_wp_error( $source_bundle ) ) {
+				return $source_bundle;
+			}
+			$bundle = $source_bundle;
+		}
 		$agent  = is_array( $bundle['agent'] ?? null ) ? $bundle['agent'] : array();
 		if ( empty( $agent ) ) {
 			return null;

--- a/src/Runtime/class-wp-agent-conversation-result.php
+++ b/src/Runtime/class-wp-agent-conversation-result.php
@@ -20,6 +20,17 @@ class WP_Agent_Conversation_Result {
 	public const SCHEMA  = 'agents-api.conversation-result';
 	public const VERSION = 1;
 
+	public const RUN_OUTCOME_SCHEMA  = 'agents-api.run-outcome';
+	public const RUN_OUTCOME_VERSION = 1;
+
+	public const OUTCOME_STATUS_COMPLETED            = 'completed';
+	public const OUTCOME_STATUS_INCOMPLETE           = 'incomplete';
+	public const OUTCOME_STATUS_FAILED               = 'failed';
+	public const OUTCOME_STATUS_PENDING_RUNTIME_TOOL = 'runtime_tool_pending';
+	public const OUTCOME_STOP_NATURAL                = 'natural';
+	public const OUTCOME_STOP_MAX_TURNS              = 'max_turns';
+	public const OUTCOME_STOP_PROVIDER_ERROR         = 'provider_error';
+
 	/**
 	 * Validate and normalize a loop result.
 	 *
@@ -237,7 +248,125 @@ class WP_Agent_Conversation_Result {
 			throw self::invalid( 'runtime_tool_pending', 'must be an array when present' );
 		}
 
+		$result['run_outcome'] = self::normalizeRunOutcome( $result['run_outcome'] ?? null, $result );
+
 		return $result;
+	}
+
+	/**
+	 * Normalize the stable run outcome envelope.
+	 *
+	 * The envelope is intentionally generic: products can map it to their own
+	 * artifact/remediation contracts without parsing provider or runtime metadata.
+	 *
+	 * @param mixed        $outcome Raw outcome value.
+	 * @param array<mixed> $result  Normalized conversation result fields.
+	 * @return array<string,mixed>
+	 */
+	private static function normalizeRunOutcome( $outcome, array $result ): array {
+		$raw       = is_array( $outcome ) ? $outcome : array();
+		$status    = self::stringValue( $raw['status'] ?? null );
+		$completed = array_key_exists( 'completed', $raw ) ? (bool) $raw['completed'] : (bool) ( $result['completed'] ?? true );
+
+		if ( '' === $status ) {
+			$status = self::deriveOutcomeStatus( $result, $completed );
+		}
+
+		$normalized = array(
+			'schema'      => self::RUN_OUTCOME_SCHEMA,
+			'version'     => self::RUN_OUTCOME_VERSION,
+			'status'      => $status,
+			'completed'   => $completed,
+			'stop_reason' => self::deriveStopReason( $raw, $result, $status, $completed ),
+			'retryable'   => array_key_exists( 'retryable', $raw ) ? (bool) $raw['retryable'] : self::deriveRetryable( $result, $status ),
+		);
+
+		if ( isset( $raw['failure'] ) && is_array( $raw['failure'] ) ) {
+			$normalized['failure'] = self::stringKeyedArray( $raw['failure'] );
+		} elseif ( isset( $result['failure'] ) && is_array( $result['failure'] ) ) {
+			$normalized['failure'] = self::stringKeyedArray( $result['failure'] );
+		}
+
+		if ( isset( $raw['assertions'] ) && is_array( $raw['assertions'] ) ) {
+			$normalized['assertions'] = self::stringKeyedArray( $raw['assertions'] );
+		}
+
+		if ( isset( $raw['provider_error'] ) && is_array( $raw['provider_error'] ) ) {
+			$normalized['provider_error'] = self::stringKeyedArray( $raw['provider_error'] );
+		} elseif ( isset( $result['failure'] ) && is_array( $result['failure'] ) && self::OUTCOME_STOP_PROVIDER_ERROR === $normalized['stop_reason'] ) {
+			$normalized['provider_error'] = self::stringKeyedArray( $result['failure'] );
+		}
+
+		if ( isset( $raw['metadata'] ) && is_array( $raw['metadata'] ) ) {
+			$normalized['metadata'] = self::stringKeyedArray( $raw['metadata'] );
+		}
+
+		return $normalized;
+	}
+
+	/** @param array<mixed> $result */
+	private static function deriveOutcomeStatus( array $result, bool $completed ): string {
+		$status = self::stringValue( $result['status'] ?? null );
+		if ( self::OUTCOME_STATUS_PENDING_RUNTIME_TOOL === $status ) {
+			return self::OUTCOME_STATUS_PENDING_RUNTIME_TOOL;
+		}
+		if ( 'failed' === $status || isset( $result['failure'] ) ) {
+			return self::OUTCOME_STATUS_FAILED;
+		}
+		return $completed ? self::OUTCOME_STATUS_COMPLETED : self::OUTCOME_STATUS_INCOMPLETE;
+	}
+
+	/**
+	 * @param array<mixed> $raw    Raw outcome fields.
+	 * @param array<mixed> $result Normalized result fields.
+	 */
+	private static function deriveStopReason( array $raw, array $result, string $status, bool $completed ): string {
+		$stop_reason = self::stringValue( $raw['stop_reason'] ?? null );
+		if ( '' !== $stop_reason ) {
+			return $stop_reason;
+		}
+
+		$result_status = self::stringValue( $result['status'] ?? null );
+		if ( 'budget_exceeded' === $result_status && 'turns' === self::stringValue( $result['budget'] ?? null ) ) {
+			return self::OUTCOME_STOP_MAX_TURNS;
+		}
+		if ( self::OUTCOME_STATUS_PENDING_RUNTIME_TOOL === $status ) {
+			return self::OUTCOME_STATUS_PENDING_RUNTIME_TOOL;
+		}
+		if ( self::OUTCOME_STATUS_FAILED === $status ) {
+			return self::OUTCOME_STOP_PROVIDER_ERROR;
+		}
+		return $completed ? self::OUTCOME_STOP_NATURAL : $result_status;
+	}
+
+	/** @param array<mixed> $result */
+	private static function deriveRetryable( array $result, string $status ): bool {
+		if ( self::OUTCOME_STATUS_PENDING_RUNTIME_TOOL === $status ) {
+			return false;
+		}
+		if ( 'budget_exceeded' === self::stringValue( $result['status'] ?? null ) ) {
+			return true;
+		}
+		return self::OUTCOME_STATUS_FAILED === $status;
+	}
+
+	/** @param mixed $value Raw value. */
+	private static function stringValue( $value ): string {
+		return is_scalar( $value ) ? trim( (string) $value ) : '';
+	}
+
+	/**
+	 * @param array<mixed> $value Raw array.
+	 * @return array<string,mixed>
+	 */
+	private static function stringKeyedArray( array $value ): array {
+		$normalized = array();
+		foreach ( $value as $key => $item ) {
+			if ( is_string( $key ) ) {
+				$normalized[ $key ] = $item;
+			}
+		}
+		return $normalized;
 	}
 
 	/**

--- a/tests/agents-chat-ability-smoke.php
+++ b/tests/agents-chat-ability-smoke.php
@@ -17,9 +17,10 @@ echo "agents-chat-ability-smoke\n";
 // ─── Minimal WP stubs ──────────────────────────────────────────────
 
 class WP_Error {
-	public function __construct( private string $code = '', private string $message = '' ) {}
+	public function __construct( private string $code = '', private string $message = '', private mixed $data = null ) {}
 	public function get_error_code(): string { return $this->code; }
 	public function get_error_message(): string { return $this->message; }
+	public function get_error_data(): mixed { return $this->data; }
 }
 
 function is_wp_error( $value ): bool {
@@ -75,6 +76,7 @@ function smoke_assert( $expected, $actual, string $name, array &$failures, int &
 	echo '    actual:   ' . var_export( $actual, true ) . "\n";
 }
 
+require_once __DIR__ . '/../src/Runtime/class-wp-agent-execution-principal.php';
 require_once __DIR__ . '/../src/Channels/register-agents-chat-ability.php';
 
 use function AgentsAPI\AI\Channels\agents_chat_dispatch;
@@ -179,9 +181,42 @@ smoke_assert( true, isset( $in['properties']['client_context']['properties']['ca
 smoke_assert( true, isset( $in['properties']['client_context']['properties']['caller_session_id'] ), 'client_context_schema_has_caller_session_id', $failures, $passes );
 smoke_assert( true, isset( $in['properties']['client_context']['properties']['peer_agent_call'] ), 'client_context_schema_has_peer_agent_call', $failures, $passes );
 smoke_assert( false, isset( $in['properties']['client_context']['properties']['agent_chat_depth'] ), 'client_context_schema_omits_tool_specific_depth', $failures, $passes );
+smoke_assert( true, isset( $in['properties']['principal'] ), 'input_schema_has_principal', $failures, $passes );
+smoke_assert( true, isset( $in['properties']['principal']['properties']['auth_source'] ), 'principal_schema_has_auth_source', $failures, $passes );
 
 $out_schema = agents_chat_output_schema();
 smoke_assert( array( 'session_id', 'reply' ), $out_schema['required'] ?? array(), 'output_schema_required_fields', $failures, $passes );
+
+// 9. Runtime principal input is normalized before dispatch and has a scoped permission filter.
+$GLOBALS['__smoke_filters'] = array();
+$runtime_principal = AgentsAPI\AI\WP_Agent_Execution_Principal::runtime(
+	'runtime-session-1',
+	'sandbox-agent',
+	array( 'source' => 'wp-codebox' ),
+	'workspace:demo',
+	'wp-codebox-cli',
+	array( AgentsAPI\AI\WP_Agent_Execution_Principal::AUDIENCE_CLAIM_RUNTIME_TYPE => 'wordpress-playground' )
+)->to_array();
+$captured_principal = array();
+register_chat_handler( static function ( array $input ) use ( &$captured_principal ) {
+	$captured_principal = is_array( $input['principal'] ?? null ) ? $input['principal'] : array();
+	return array( 'session_id' => 'runtime-s-1', 'reply' => 'runtime ok', 'completed' => true );
+} );
+$runtime_result = agents_chat_dispatch( array( 'agent' => 'sandbox-agent', 'message' => 'go', 'principal' => $runtime_principal ) );
+smoke_assert( 'runtime ok', $runtime_result['reply'] ?? null, 'runtime_principal_dispatch_succeeds', $failures, $passes );
+smoke_assert( AgentsAPI\AI\WP_Agent_Execution_Principal::AUTH_SOURCE_RUNTIME, $captured_principal['auth_source'] ?? null, 'runtime_principal_normalized_for_handler', $failures, $passes );
+smoke_assert( array( 'type' => AgentsAPI\AI\WP_Agent_Execution_Principal::OWNER_TYPE_RUNTIME, 'key' => 'runtime-session-1' ), AgentsAPI\AI\WP_Agent_Execution_Principal::from_array( $captured_principal )->conversation_owner(), 'runtime_principal_preserves_owner', $failures, $passes );
+
+$GLOBALS['__smoke_can'] = false;
+smoke_assert( false, agents_chat_permission( array( 'principal' => $runtime_principal ) ), 'runtime_principal_permission_denied_by_default', $failures, $passes );
+add_filter( 'agents_chat_runtime_principal_permission', static function ( bool $allowed, AgentsAPI\AI\WP_Agent_Execution_Principal $principal ): bool {
+	return $allowed || AgentsAPI\AI\WP_Agent_Execution_Principal::AUTH_SOURCE_RUNTIME === $principal->auth_source;
+}, 10, 2 );
+smoke_assert( true, agents_chat_permission( array( 'principal' => $runtime_principal ) ), 'runtime_principal_permission_filter_allows', $failures, $passes );
+
+$invalid_principal_result = agents_chat_dispatch( array( 'agent' => 'sandbox-agent', 'message' => 'go', 'principal' => 'not-object' ) );
+smoke_assert( true, $invalid_principal_result instanceof WP_Error, 'invalid_principal_returns_wp_error', $failures, $passes );
+smoke_assert( 'agents_chat_invalid_principal', $invalid_principal_result->get_error_code(), 'invalid_principal_error_code', $failures, $passes );
 
 // ─── Done ───────────────────────────────────────────────────────────
 

--- a/tests/conversation-loop-budgets-smoke.php
+++ b/tests/conversation-loop-budgets-smoke.php
@@ -298,6 +298,9 @@ $result     = AgentsAPI\AI\WP_Agent_Conversation_Loop::run(
 agents_api_smoke_assert_equals( 3, $turn_count, 'explicit turns budget overrides higher max_turns', $failures, $passes );
 agents_api_smoke_assert_equals( 'budget_exceeded', $result['status'] ?? null, 'explicit turns budget produces budget_exceeded status', $failures, $passes );
 agents_api_smoke_assert_equals( 'turns', $result['budget'] ?? null, 'explicit turns budget identified in result', $failures, $passes );
+agents_api_smoke_assert_equals( AgentsAPI\AI\WP_Agent_Conversation_Result::OUTCOME_STATUS_INCOMPLETE, $result['run_outcome']['status'] ?? '', 'explicit turns budget run outcome is incomplete', $failures, $passes );
+agents_api_smoke_assert_equals( AgentsAPI\AI\WP_Agent_Conversation_Result::OUTCOME_STOP_MAX_TURNS, $result['run_outcome']['stop_reason'] ?? '', 'explicit turns budget run outcome stop reason is max turns', $failures, $passes );
+agents_api_smoke_assert_equals( true, $result['run_outcome']['retryable'] ?? false, 'explicit turns budget run outcome is retryable', $failures, $passes );
 
 echo "\n[9] Agent runtime max_iterations clamps loop turns and reaches runner context:\n";
 $turn_count  = 0;

--- a/tests/conversation-loop-tool-execution-smoke.php
+++ b/tests/conversation-loop-tool-execution-smoke.php
@@ -602,6 +602,8 @@ agents_api_smoke_assert_equals( false, $pending_result['completed'] ?? true, 'pe
 agents_api_smoke_assert_equals( 'client/summarize', $pending_result['runtime_tool_pending']['tool_name'] ?? '', 'pending request carries tool name', $failures, $passes );
 agents_api_smoke_assert_equals( 'client-call-1', $pending_result['runtime_tool_pending']['tool_call_id'] ?? '', 'pending request carries tool call id', $failures, $passes );
 agents_api_smoke_assert_equals( array( 'tool_call', AgentsAPI\AI\WP_Agent_Runtime_Tool_Request::STATUS_PENDING ), array_column( $pending_result['tool_events'], 'type' ), 'pending request is recorded in canonical tool events', $failures, $passes );
+agents_api_smoke_assert_equals( AgentsAPI\AI\WP_Agent_Conversation_Result::OUTCOME_STATUS_PENDING_RUNTIME_TOOL, $pending_result['run_outcome']['status'] ?? '', 'pending runtime tool run outcome is pending', $failures, $passes );
+agents_api_smoke_assert_equals( AgentsAPI\AI\WP_Agent_Runtime_Tool_Request::STATUS_PENDING, $pending_result['run_outcome']['stop_reason'] ?? '', 'pending runtime tool run outcome stop reason is pending', $failures, $passes );
 
 echo "\n[Pre-tool filter hook allows, rejects, or pauses external runtime tools (#259):\n";
 
@@ -722,6 +724,7 @@ agents_api_smoke_assert_equals( 0, count( $executor->executed ), 'pre-tool filte
 agents_api_smoke_assert_equals( AgentsAPI\AI\WP_Agent_Runtime_Tool_Request::STATUS_PENDING, $filter_pending_result['status'] ?? '', 'pre-tool filter pending sets canonical loop status', $failures, $passes );
 agents_api_smoke_assert_equals( 'call_filter_pending', $filter_pending_result['runtime_tool_pending']['tool_call_id'] ?? '', 'pre-tool filter pending request carries tool call id', $failures, $passes );
 agents_api_smoke_assert_equals( 'browser', $filter_pending_result['runtime_tool_pending']['metadata']['transport'] ?? '', 'pre-tool filter pending request preserves host metadata', $failures, $passes );
+agents_api_smoke_assert_equals( AgentsAPI\AI\WP_Agent_Conversation_Result::OUTCOME_STATUS_PENDING_RUNTIME_TOOL, $filter_pending_result['run_outcome']['status'] ?? '', 'pre-tool filter pending run outcome is pending', $failures, $passes );
 
 echo "\n[Post-tool diagnostics option and filter attach audit metadata (#259):\n";
 

--- a/tests/conversation-runner-contracts-smoke.php
+++ b/tests/conversation-runner-contracts-smoke.php
@@ -102,6 +102,8 @@ agents_api_smoke_assert_equals( AgentsAPI\AI\WP_Agent_Conversation_Result::SCHEM
 agents_api_smoke_assert_equals( AgentsAPI\AI\WP_Agent_Conversation_Result::VERSION, $runner_result['version'], 'runner result exposes canonical version', $failures, $passes );
 agents_api_smoke_assert_equals( 1, count( $runner_result['messages'] ), 'runner returns normalized messages', $failures, $passes );
 agents_api_smoke_assert_equals( array(), $runner_result['tool_execution_results'], 'runner result normalization provides empty tool results', $failures, $passes );
+agents_api_smoke_assert_equals( AgentsAPI\AI\WP_Agent_Conversation_Result::RUN_OUTCOME_SCHEMA, $runner_result['run_outcome']['schema'] ?? '', 'runner result exposes run outcome schema', $failures, $passes );
+agents_api_smoke_assert_equals( AgentsAPI\AI\WP_Agent_Conversation_Result::OUTCOME_STATUS_COMPLETED, $runner_result['run_outcome']['status'] ?? '', 'runner result defaults to completed outcome', $failures, $passes );
 
 echo "\n[3] Completion decisions and policies are immutable value contracts:\n";
 $policy = new class() implements AgentsAPI\AI\WP_Agent_Conversation_Completion_Policy {

--- a/tests/provider-turn-adapter-smoke.php
+++ b/tests/provider-turn-adapter-smoke.php
@@ -162,6 +162,8 @@ agents_api_smoke_assert_equals( 'Final answer from fake adapter.', $result['fina
 agents_api_smoke_assert_equals( 19, $result['usage']['total_tokens'], 'loop accumulates adapter usage', $failures, $passes );
 agents_api_smoke_assert_equals( 'provider-req-2', $result['request_metadata']['provider_request_id'], 'loop surfaces latest provider request metadata', $failures, $passes );
 agents_api_smoke_assert_equals( 2, count( $result['provider_diagnostics'] ), 'loop accumulates provider diagnostics per turn', $failures, $passes );
+agents_api_smoke_assert_equals( AgentsAPI\AI\WP_Agent_Conversation_Result::OUTCOME_STATUS_COMPLETED, $result['run_outcome']['status'] ?? '', 'loop successful run outcome is completed', $failures, $passes );
+agents_api_smoke_assert_equals( AgentsAPI\AI\WP_Agent_Conversation_Result::OUTCOME_STOP_NATURAL, $result['run_outcome']['stop_reason'] ?? '', 'loop successful run outcome stop reason is natural', $failures, $passes );
 
 echo "\n[3] Content-only provider-turn adapters work without tool mediation:\n";
 $content_only_result = AgentsAPI\AI\WP_Agent_Conversation_Loop::run(
@@ -208,5 +210,8 @@ agents_api_smoke_assert_equals( 'failed', $failure_result['status'] ?? '', 'type
 agents_api_smoke_assert_equals( false, $failure_result['completed'] ?? true, 'typed provider failure is incomplete', $failures, $passes );
 agents_api_smoke_assert_equals( 'rate_limit', $failure_result['failure']['type'] ?? '', 'typed provider failure preserves type', $failures, $passes );
 agents_api_smoke_assert_equals( 30, $failure_result['provider_diagnostics'][0]['retry_after_seconds'] ?? 0, 'typed provider failure preserves diagnostics', $failures, $passes );
+agents_api_smoke_assert_equals( AgentsAPI\AI\WP_Agent_Conversation_Result::OUTCOME_STATUS_FAILED, $failure_result['run_outcome']['status'] ?? '', 'provider failure run outcome is failed', $failures, $passes );
+agents_api_smoke_assert_equals( AgentsAPI\AI\WP_Agent_Conversation_Result::OUTCOME_STOP_PROVIDER_ERROR, $failure_result['run_outcome']['stop_reason'] ?? '', 'provider failure run outcome stop reason is provider error', $failures, $passes );
+agents_api_smoke_assert_equals( 'rate_limit', $failure_result['run_outcome']['provider_error']['type'] ?? '', 'provider failure run outcome preserves provider error', $failures, $passes );
 
 agents_api_smoke_finish( 'Agents API provider-turn adapter', $failures, $passes );

--- a/tests/runtime-agent-bundle-importer-smoke.php
+++ b/tests/runtime-agent-bundle-importer-smoke.php
@@ -90,4 +90,40 @@ echo "\n[3] Non-agent bundles remain available for other importers:\n";
 $unclaimed = apply_filters( 'wp_agent_runtime_import_bundle', null, array( 'bundle' => array( 'not_agent' => true ) ), array(), 3 );
 agents_api_smoke_assert_equals( null, $unclaimed, 'non-agent bundle is not claimed', $failures, $passes );
 
+echo "\n[4] Source bundle files and list helper use the generic importer:\n";
+$source_bundle = array(
+	'bundle_version' => '1.0.0',
+	'bundle_slug'    => 'runtime-source-agent',
+	'agent'          => array(
+		'agent_slug'   => 'runtime-source-agent',
+		'agent_name'   => 'Runtime Source Agent',
+		'agent_config' => array( 'runtime' => array( 'source' => 'file' ) ),
+	),
+);
+$source_file = tempnam( sys_get_temp_dir(), 'agents-api-runtime-bundle-' );
+file_put_contents( $source_file, wp_json_encode( $source_bundle, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ) );
+$source_result = apply_filters( 'wp_agent_runtime_import_bundle', null, array( 'source' => $source_file ), array( 'on_conflict' => 'upgrade' ), 4 );
+agents_api_smoke_assert_equals( true, is_array( $source_result ) && true === ( $source_result['success'] ?? false ), 'source bundle import succeeds', $failures, $passes );
+agents_api_smoke_assert_equals( true, wp_has_agent( 'runtime-source-agent' ), 'source bundle registered agent', $failures, $passes );
+
+$helper_results = wp_agent_import_runtime_bundles(
+	array(
+		array( 'bundle' => array(
+			'bundle_slug' => 'runtime-helper-agent',
+			'agent'       => array(
+				'agent_slug'   => 'runtime-helper-agent',
+				'agent_name'   => 'Runtime Helper Agent',
+				'agent_config' => array( 'runtime' => array( 'source' => 'helper' ) ),
+			),
+		) ),
+		array( 'bundle' => array( 'not_agent' => true ) ),
+	),
+	array( 'on_conflict' => 'upgrade' )
+);
+agents_api_smoke_assert_equals( true, $helper_results[0]['success'] ?? false, 'helper import marks accepted bundle successful', $failures, $passes );
+agents_api_smoke_assert_equals( 'registered', $helper_results[0]['status'] ?? '', 'helper import preserves registered status', $failures, $passes );
+agents_api_smoke_assert_equals( false, $helper_results[1]['success'] ?? true, 'helper import marks unclaimed bundle failed', $failures, $passes );
+agents_api_smoke_assert_equals( 'wp_agent_runtime_bundle_unclaimed', $helper_results[1]['error']['code'] ?? '', 'helper import has stable unclaimed error', $failures, $passes );
+@unlink( $source_file );
+
 agents_api_smoke_finish( 'Agents API runtime agent bundle importer', $failures, $passes );


### PR DESCRIPTION
## Summary
- Add optional `agents/chat` execution principal normalization plus a scoped runtime-principal permission filter for trusted disposable runtimes.
- Add generic runtime bundle import helpers with inline/source JSON support and stable per-item result envelopes.
- Add a normalized `run_outcome` envelope to conversation results so consumers can distinguish completed, pending runtime tool, max-turn, and provider-error outcomes without parsing runtime metadata.

## Testing
- `composer run phpstan`
- `composer run smoke`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the Agents API contract additions, added smoke coverage, and ran static analysis/test verification for Chris to review.