### PR TITLE
Wire runtime principals through agents/chat

### DIFF
--- a/src/Channels/register-agents-chat-ability.php
+++ b/src/Channels/register-agents-chat-ability.php
@@ -325,31 +325,31 @@ function agents_chat_input_schema(): array {
 		'type'       => 'object',
 		'required'   => array( 'agent', 'message' ),
 		'properties' => array(
-			'agent'          => array(
+			'agent'                 => array(
 				'type'        => 'string',
 				'description' => 'Slug or ID of the registered agent that should handle this turn.',
 			),
-			'message'        => array(
+			'message'               => array(
 				'type'        => 'string',
 				'description' => 'User-side text for the agent to respond to.',
 			),
-			'session_id'     => array(
+			'session_id'            => array(
 				'type'        => array( 'string', 'null' ),
 				'description' => 'Existing session ID to continue, or null to start a new session.',
 			),
-			'run_id'         => array(
+			'run_id'                => array(
 				'type'        => array( 'string', 'null' ),
 				'description' => 'Optional client-supplied idempotency/run key. If omitted, the dispatcher provides an opaque run ID to the runtime and response.',
 			),
-			'principal'      => agents_chat_principal_schema(),
-			'session_owner'  => agents_chat_session_owner_schema(),
-			'attachments'    => array(
+			'principal'             => agents_chat_principal_schema(),
+			'session_owner'         => agents_chat_session_owner_schema(),
+			'attachments'           => array(
 				'type'        => 'array',
 				'description' => 'Channel-side attachments (images, voice notes, files, link previews). Shape is runtime-defined; runtimes ignore unknown attachment types.',
 				'default'     => array(),
 				'items'       => array( 'type' => 'object' ),
 			),
-			'tool_policy'    => array(
+			'tool_policy'           => array(
 				'type'        => array( 'object', 'null' ),
 				'description' => 'Optional caller-owned tool policy for this turn. Runtimes may use this to narrow tool visibility for peer-agent or sandbox invocations.',
 				'properties'  => array(
@@ -363,7 +363,7 @@ function agents_chat_input_schema(): array {
 					),
 				),
 			),
-			'allow_only'     => array(
+			'allow_only'            => array(
 				'type'        => 'array',
 				'description' => 'Optional per-turn allow-list of tool names. Runtimes may intersect this with agent policy and available tool declarations.',
 				'default'     => array(),
@@ -379,7 +379,7 @@ function agents_chat_input_schema(): array {
 					),
 				),
 			),
-			'client_context' => array(
+			'client_context'        => array(
 				'type'        => 'object',
 				'description' => 'Transport-level context describing where this turn originated.',
 				'properties'  => array(

--- a/src/Channels/register-agents-chat-ability.php
+++ b/src/Channels/register-agents-chat-ability.php
@@ -40,6 +40,7 @@
 namespace AgentsAPI\AI\Channels;
 
 use AgentsAPI\AI\WP_Agent_Chat_Run_Control;
+use AgentsAPI\AI\WP_Agent_Execution_Principal;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -110,6 +111,16 @@ add_action(
  * @return array<string,mixed>|\WP_Error Canonical output, or WP_Error if no runtime is registered.
  */
 function agents_chat_dispatch( array $input ) {
+	$principal = agents_chat_principal_from_input( $input );
+	if ( is_wp_error( $principal ) ) {
+		do_action( 'agents_chat_dispatch_failed', $principal->get_error_code(), $input );
+		return $principal;
+	}
+
+	if ( $principal instanceof WP_Agent_Execution_Principal ) {
+		$input['principal'] = $principal->to_array();
+	}
+
 	$run_id = agents_chat_optional_string( $input['run_id'] ?? null );
 	if ( null === $run_id ) {
 		$input['run_id'] = WP_Agent_Chat_Run_Control::generate_run_id();
@@ -237,6 +248,27 @@ function agents_chat_string_keyed_array( array $data ): array {
  * @return bool
  */
 function agents_chat_permission( array $input ): bool {
+	$allowed   = current_user_can( 'manage_options' );
+	$principal = agents_chat_principal_from_input( $input );
+	if ( is_wp_error( $principal ) ) {
+		return false;
+	}
+
+	if ( $principal instanceof WP_Agent_Execution_Principal ) {
+		/**
+		 * Filter permission for host-attested runtime principals.
+		 *
+		 * Hosts can authorize disposable runtimes here after validating their own
+		 * runtime binding/session claims. Agents API normalizes the principal but
+		 * does not trust arbitrary runtime principal input by default.
+		 *
+		 * @param bool                         $allowed   Current permission decision.
+		 * @param WP_Agent_Execution_Principal $principal Normalized principal.
+		 * @param array<mixed>                 $input     Canonical chat input.
+		 */
+		$allowed = (bool) apply_filters( 'agents_chat_runtime_principal_permission', $allowed, $principal, $input );
+	}
+
 	/**
 	 * Filter the permission decision for the canonical chat ability.
 	 *
@@ -245,9 +277,39 @@ function agents_chat_permission( array $input ): bool {
 	 */
 	return (bool) apply_filters(
 		'agents_chat_permission',
-		current_user_can( 'manage_options' ),
+		$allowed,
 		$input
 	);
+}
+
+/**
+ * Normalize optional execution principal input for agents/chat.
+ *
+ * @param array<mixed> $input Canonical chat input.
+ * @return WP_Agent_Execution_Principal|\WP_Error|null
+ */
+function agents_chat_principal_from_input( array $input ) {
+	if ( ! array_key_exists( 'principal', $input ) || null === $input['principal'] ) {
+		return null;
+	}
+
+	if ( $input['principal'] instanceof WP_Agent_Execution_Principal ) {
+		return $input['principal'];
+	}
+
+	if ( ! is_array( $input['principal'] ) ) {
+		return new \WP_Error( 'agents_chat_invalid_principal', 'agents/chat principal must be an object when provided.' );
+	}
+
+	try {
+		return WP_Agent_Execution_Principal::from_array( agents_chat_string_keyed_array( $input['principal'] ) );
+	} catch ( \Throwable $error ) {
+		return new \WP_Error(
+			'agents_chat_invalid_principal',
+			'Invalid agents/chat execution principal.',
+			array( 'reason' => $error->getMessage() )
+		);
+	}
 }
 
 /**
@@ -279,6 +341,7 @@ function agents_chat_input_schema(): array {
 				'type'        => array( 'string', 'null' ),
 				'description' => 'Optional client-supplied idempotency/run key. If omitted, the dispatcher provides an opaque run ID to the runtime and response.',
 			),
+			'principal'      => agents_chat_principal_schema(),
 			'session_owner'  => agents_chat_session_owner_schema(),
 			'attachments'    => array(
 				'type'        => 'array',
@@ -368,6 +431,33 @@ function agents_chat_input_schema(): array {
 					),
 				),
 			),
+		),
+	);
+}
+
+/**
+ * Canonical execution principal schema for agents/chat.
+ *
+ * @return array<string, mixed>
+ */
+function agents_chat_principal_schema(): array {
+	return array(
+		'type'        => array( 'object', 'null' ),
+		'description' => 'Optional execution principal resolved by a trusted host/runtime. Disposable runtimes should use auth_source=runtime and request_context=runtime with opaque owner isolation.',
+		'properties'  => array(
+			'acting_user_id'     => array( 'type' => 'integer' ),
+			'effective_agent_id' => array( 'type' => 'string' ),
+			'auth_source'        => array( 'type' => 'string' ),
+			'request_context'    => array( 'type' => 'string' ),
+			'token_id'           => array( 'type' => array( 'integer', 'null' ) ),
+			'request_metadata'   => array( 'type' => 'object' ),
+			'workspace_id'       => array( 'type' => array( 'string', 'null' ) ),
+			'client_id'          => array( 'type' => array( 'string', 'null' ) ),
+			'audience_id'        => array( 'type' => array( 'string', 'null' ) ),
+			'audience_claims'    => array( 'type' => 'object' ),
+			'owner_type'         => array( 'type' => array( 'string', 'null' ) ),
+			'owner_key'          => array( 'type' => array( 'string', 'null' ) ),
+			'binding'            => array( 'type' => array( 'object', 'null' ) ),
 		),
 	);
 }

--- a/tests/agents-chat-ability-smoke.php
+++ b/tests/agents-chat-ability-smoke.php
@@ -17,9 +17,10 @@ echo "agents-chat-ability-smoke\n";
 // ─── Minimal WP stubs ──────────────────────────────────────────────
 
 class WP_Error {
-	public function __construct( private string $code = '', private string $message = '' ) {}
+	public function __construct( private string $code = '', private string $message = '', private mixed $data = null ) {}
 	public function get_error_code(): string { return $this->code; }
 	public function get_error_message(): string { return $this->message; }
+	public function get_error_data(): mixed { return $this->data; }
 }
 
 function is_wp_error( $value ): bool {
@@ -75,6 +76,7 @@ function smoke_assert( $expected, $actual, string $name, array &$failures, int &
 	echo '    actual:   ' . var_export( $actual, true ) . "\n";
 }
 
+require_once __DIR__ . '/../src/Runtime/class-wp-agent-execution-principal.php';
 require_once __DIR__ . '/../src/Channels/register-agents-chat-ability.php';
 
 use function AgentsAPI\AI\Channels\agents_chat_dispatch;
@@ -179,9 +181,42 @@ smoke_assert( true, isset( $in['properties']['client_context']['properties']['ca
 smoke_assert( true, isset( $in['properties']['client_context']['properties']['caller_session_id'] ), 'client_context_schema_has_caller_session_id', $failures, $passes );
 smoke_assert( true, isset( $in['properties']['client_context']['properties']['peer_agent_call'] ), 'client_context_schema_has_peer_agent_call', $failures, $passes );
 smoke_assert( false, isset( $in['properties']['client_context']['properties']['agent_chat_depth'] ), 'client_context_schema_omits_tool_specific_depth', $failures, $passes );
+smoke_assert( true, isset( $in['properties']['principal'] ), 'input_schema_has_principal', $failures, $passes );
+smoke_assert( true, isset( $in['properties']['principal']['properties']['auth_source'] ), 'principal_schema_has_auth_source', $failures, $passes );
 
 $out_schema = agents_chat_output_schema();
 smoke_assert( array( 'session_id', 'reply' ), $out_schema['required'] ?? array(), 'output_schema_required_fields', $failures, $passes );
+
+// 9. Runtime principal input is normalized before dispatch and has a scoped permission filter.
+$GLOBALS['__smoke_filters'] = array();
+$runtime_principal = AgentsAPI\AI\WP_Agent_Execution_Principal::runtime(
+	'runtime-session-1',
+	'sandbox-agent',
+	array( 'source' => 'wp-codebox' ),
+	'workspace:demo',
+	'wp-codebox-cli',
+	array( AgentsAPI\AI\WP_Agent_Execution_Principal::AUDIENCE_CLAIM_RUNTIME_TYPE => 'wordpress-playground' )
+)->to_array();
+$captured_principal = array();
+register_chat_handler( static function ( array $input ) use ( &$captured_principal ) {
+	$captured_principal = is_array( $input['principal'] ?? null ) ? $input['principal'] : array();
+	return array( 'session_id' => 'runtime-s-1', 'reply' => 'runtime ok', 'completed' => true );
+} );
+$runtime_result = agents_chat_dispatch( array( 'agent' => 'sandbox-agent', 'message' => 'go', 'principal' => $runtime_principal ) );
+smoke_assert( 'runtime ok', $runtime_result['reply'] ?? null, 'runtime_principal_dispatch_succeeds', $failures, $passes );
+smoke_assert( AgentsAPI\AI\WP_Agent_Execution_Principal::AUTH_SOURCE_RUNTIME, $captured_principal['auth_source'] ?? null, 'runtime_principal_normalized_for_handler', $failures, $passes );
+smoke_assert( array( 'type' => AgentsAPI\AI\WP_Agent_Execution_Principal::OWNER_TYPE_RUNTIME, 'key' => 'runtime-session-1' ), AgentsAPI\AI\WP_Agent_Execution_Principal::from_array( $captured_principal )->conversation_owner(), 'runtime_principal_preserves_owner', $failures, $passes );
+
+$GLOBALS['__smoke_can'] = false;
+smoke_assert( false, agents_chat_permission( array( 'principal' => $runtime_principal ) ), 'runtime_principal_permission_denied_by_default', $failures, $passes );
+add_filter( 'agents_chat_runtime_principal_permission', static function ( bool $allowed, AgentsAPI\AI\WP_Agent_Execution_Principal $principal ): bool {
+	return $allowed || AgentsAPI\AI\WP_Agent_Execution_Principal::AUTH_SOURCE_RUNTIME === $principal->auth_source;
+}, 10, 2 );
+smoke_assert( true, agents_chat_permission( array( 'principal' => $runtime_principal ) ), 'runtime_principal_permission_filter_allows', $failures, $passes );
+
+$invalid_principal_result = agents_chat_dispatch( array( 'agent' => 'sandbox-agent', 'message' => 'go', 'principal' => 'not-object' ) );
+smoke_assert( true, $invalid_principal_result instanceof WP_Error, 'invalid_principal_returns_wp_error', $failures, $passes );
+smoke_assert( 'agents_chat_invalid_principal', $invalid_principal_result->get_error_code(), 'invalid_principal_error_code', $failures, $passes );
 
 // ─── Done ───────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Normalize optional `principal` input before `agents/chat` dispatch so runtimes receive a canonical execution-principal array.
- Add a scoped `agents_chat_runtime_principal_permission` filter so hosts can authorize attested disposable runtime principals without globally bypassing `agents_chat_permission`.
- Document the principal input schema and cover invalid-principal behavior.

## Testing
- `composer run phpstan`
- `php tests/agents-chat-ability-smoke.php`
- `php tests/channels-smoke.php`
- `php tests/chat-run-control-smoke.php`
- `php tests/frontend-chat-rest-smoke.php`
- `php tests/agents-chat-jsonrpc-route-smoke.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** implementation drafted by coding agent, reviewed/tested by Chris.