### PR TITLE
Add runtime bundle import helper

### DIFF
--- a/src/Registry/register-agent-runtime-bundle-importer.php
+++ b/src/Registry/register-agent-runtime-bundle-importer.php
@@ -108,6 +108,7 @@ if ( ! function_exists( 'wp_agent_runtime_bundle_from_source' ) ) {
 			);
 		}
 
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Runtime bundle sources are local JSON files, not remote URLs.
 		$contents = file_get_contents( $source );
 		if ( false === $contents ) {
 			return new WP_Error(
@@ -174,7 +175,7 @@ add_filter(
 			}
 			$bundle = $source_bundle;
 		}
-		$agent  = is_array( $bundle['agent'] ?? null ) ? $bundle['agent'] : array();
+		$agent = is_array( $bundle['agent'] ?? null ) ? $bundle['agent'] : array();
 		if ( empty( $agent ) ) {
 			return null;
 		}

--- a/src/Registry/register-agent-runtime-bundle-importer.php
+++ b/src/Registry/register-agent-runtime-bundle-importer.php
@@ -7,6 +7,148 @@
 
 defined( 'ABSPATH' ) || exit;
 
+if ( ! function_exists( 'wp_agent_import_runtime_bundles' ) ) {
+	/**
+	 * Import one or more runtime agent bundle specs through the generic importer seam.
+	 *
+	 * Specs may include an inline `bundle` object or a `source` path to a JSON file.
+	 * Concrete storage stays with the active registry/materialization adapter; this
+	 * helper only normalizes transport and produces stable per-item result envelopes.
+	 *
+	 * @param array<int,mixed>    $bundle_specs Runtime bundle specs.
+	 * @param array<string,mixed> $input        Shared import input.
+	 * @return list<array<string,mixed>> Per-spec import results.
+	 */
+	function wp_agent_import_runtime_bundles( array $bundle_specs, array $input = array() ): array {
+		$results = array();
+		foreach ( $bundle_specs as $index => $spec ) {
+			if ( ! is_array( $spec ) ) {
+				$results[] = wp_agent_runtime_bundle_import_result( array(
+					'success' => false,
+					'index'   => $index,
+					'error'   => array(
+						'code'    => 'wp_agent_runtime_bundle_spec_invalid',
+						'message' => 'Runtime agent bundle spec must be an object.',
+					),
+				) );
+				continue;
+			}
+
+			$result = apply_filters( 'wp_agent_runtime_import_bundle', null, $spec, $input, $index );
+			if ( is_wp_error( $result ) ) {
+				$results[] = wp_agent_runtime_bundle_import_result( array(
+					'success' => false,
+					'index'   => $index,
+					'error'   => array(
+						'code'    => $result->get_error_code(),
+						'message' => $result->get_error_message(),
+						'data'    => $result->get_error_data(),
+					),
+				) );
+				continue;
+			}
+
+			if ( null === $result ) {
+				$results[] = wp_agent_runtime_bundle_import_result( array(
+					'success' => false,
+					'index'   => $index,
+					'error'   => array(
+						'code'    => 'wp_agent_runtime_bundle_unclaimed',
+						'message' => 'No runtime bundle importer accepted this spec.',
+					),
+				) );
+				continue;
+			}
+
+			$normalized          = is_array( $result ) ? $result : array( 'result' => $result );
+			$normalized['index'] = $index;
+			if ( ! array_key_exists( 'success', $normalized ) ) {
+				$normalized['success'] = true;
+			}
+			$results[] = wp_agent_runtime_bundle_import_result( $normalized );
+		}
+
+		return $results;
+	}
+}
+
+if ( ! function_exists( 'wp_agent_runtime_bundle_import_result' ) ) {
+	/**
+	 * Normalize one runtime bundle import result to a string-keyed envelope.
+	 *
+	 * @param array<mixed> $result Raw import result.
+	 * @return array<string,mixed>
+	 */
+	function wp_agent_runtime_bundle_import_result( array $result ): array {
+		$normalized = array();
+		foreach ( $result as $key => $value ) {
+			if ( is_string( $key ) ) {
+				$normalized[ $key ] = $value;
+			}
+		}
+		return $normalized;
+	}
+}
+
+if ( ! function_exists( 'wp_agent_runtime_bundle_from_source' ) ) {
+	/**
+	 * Load and decode a runtime bundle JSON file.
+	 *
+	 * @param string $source Source path.
+	 * @param int    $index  Spec index for error metadata.
+	 * @return array<string,mixed>|WP_Error Bundle array or error.
+	 */
+	function wp_agent_runtime_bundle_from_source( string $source, int $index ) {
+		$source = trim( $source );
+		if ( '' === $source || ! is_readable( $source ) ) {
+			return new WP_Error(
+				'wp_agent_runtime_bundle_source_unreadable',
+				'Runtime agent bundle source is not readable.',
+				array( 'index' => $index )
+			);
+		}
+
+		$contents = file_get_contents( $source );
+		if ( false === $contents ) {
+			return new WP_Error(
+				'wp_agent_runtime_bundle_source_read_failed',
+				'Runtime agent bundle source could not be read.',
+				array( 'index' => $index )
+			);
+		}
+
+		try {
+			$bundle = json_decode( $contents, true, 512, JSON_THROW_ON_ERROR );
+		} catch ( JsonException $error ) {
+			return new WP_Error(
+				'wp_agent_runtime_bundle_source_invalid_json',
+				'Runtime agent bundle source must contain valid JSON.',
+				array(
+					'index'  => $index,
+					'reason' => $error->getMessage(),
+				)
+			);
+		}
+
+		if ( ! is_array( $bundle ) ) {
+			return new WP_Error(
+				'wp_agent_runtime_bundle_source_invalid_shape',
+				'Runtime agent bundle source must decode to an object.',
+				array( 'index' => $index )
+			);
+		}
+
+		$normalized = array();
+		foreach ( $bundle as $key => $value ) {
+			if ( is_string( $key ) ) {
+				$normalized[ $key ] = $value;
+			}
+		}
+
+		return $normalized;
+	}
+}
+
 add_filter(
 	'wp_agent_runtime_import_bundle',
 	static function ( $result, array $spec, array $input = array(), int $index = 0 ) {
@@ -25,6 +167,13 @@ add_filter(
 		};
 
 		$bundle = is_array( $spec['bundle'] ?? null ) ? $spec['bundle'] : array();
+		if ( empty( $bundle ) && is_string( $spec['source'] ?? null ) ) {
+			$source_bundle = wp_agent_runtime_bundle_from_source( $spec['source'], $index );
+			if ( is_wp_error( $source_bundle ) ) {
+				return $source_bundle;
+			}
+			$bundle = $source_bundle;
+		}
 		$agent  = is_array( $bundle['agent'] ?? null ) ? $bundle['agent'] : array();
 		if ( empty( $agent ) ) {
 			return null;

--- a/tests/runtime-agent-bundle-importer-smoke.php
+++ b/tests/runtime-agent-bundle-importer-smoke.php
@@ -90,4 +90,63 @@ echo "\n[3] Non-agent bundles remain available for other importers:\n";
 $unclaimed = apply_filters( 'wp_agent_runtime_import_bundle', null, array( 'bundle' => array( 'not_agent' => true ) ), array(), 3 );
 agents_api_smoke_assert_equals( null, $unclaimed, 'non-agent bundle is not claimed', $failures, $passes );
 
+echo "\n[4] Bundle list helper normalizes per-spec results:\n";
+$helper_results = wp_agent_import_runtime_bundles(
+	array(
+		array(
+			'bundle'      => array(
+				'bundle_slug' => 'helper-runtime-agent',
+				'agent'       => array(
+					'agent_slug' => 'helper-runtime-agent',
+					'agent_name' => 'Helper Runtime Agent',
+				),
+			),
+			'on_conflict' => 'upgrade',
+		),
+		array( 'bundle' => array( 'not_agent' => true ) ),
+		'not-a-spec',
+	),
+	array( 'on_conflict' => 'upgrade' )
+);
+
+agents_api_smoke_assert_equals( true, $helper_results[0]['success'] ?? null, 'helper import succeeds for inline bundle', $failures, $passes );
+agents_api_smoke_assert_equals( 0, $helper_results[0]['index'] ?? null, 'helper preserves successful result index', $failures, $passes );
+agents_api_smoke_assert_equals( 'helper-runtime-agent', $helper_results[0]['agent_slug'] ?? null, 'helper returns registered agent slug', $failures, $passes );
+agents_api_smoke_assert_equals( true, wp_has_agent( 'helper-runtime-agent' ), 'helper registers runtime agent', $failures, $passes );
+agents_api_smoke_assert_equals( false, $helper_results[1]['success'] ?? null, 'helper marks unclaimed bundle as failure envelope', $failures, $passes );
+agents_api_smoke_assert_equals( 'wp_agent_runtime_bundle_unclaimed', $helper_results[1]['error']['code'] ?? null, 'helper reports unclaimed bundle code', $failures, $passes );
+agents_api_smoke_assert_equals( false, $helper_results[2]['success'] ?? null, 'helper marks invalid spec as failure envelope', $failures, $passes );
+agents_api_smoke_assert_equals( 'wp_agent_runtime_bundle_spec_invalid', $helper_results[2]['error']['code'] ?? null, 'helper reports invalid spec code', $failures, $passes );
+
+echo "\n[5] Source bundle specs load JSON files:\n";
+$source_path = tempnam( sys_get_temp_dir(), 'agents-api-bundle-' );
+if ( false === $source_path ) {
+	$failures[] = 'could not allocate temp bundle path';
+} else {
+	file_put_contents(
+		$source_path,
+		json_encode(
+			array(
+				'bundle_slug' => 'source-runtime-agent',
+				'agent'       => array(
+					'agent_slug'   => 'source-runtime-agent',
+					'agent_name'   => 'Source Runtime Agent',
+					'agent_config' => array( 'loaded_from_source' => true ),
+				),
+			),
+			JSON_PRETTY_PRINT
+		)
+	);
+
+	$source_results = wp_agent_import_runtime_bundles( array( array( 'source' => $source_path ) ) );
+	agents_api_smoke_assert_equals( true, $source_results[0]['success'] ?? null, 'source import succeeds', $failures, $passes );
+	agents_api_smoke_assert_equals( 'source-runtime-agent', $source_results[0]['agent_slug'] ?? null, 'source import returns agent slug', $failures, $passes );
+	agents_api_smoke_assert_equals( true, wp_get_agent( 'source-runtime-agent' )->get_default_config()['loaded_from_source'] ?? null, 'source import preserves decoded config', $failures, $passes );
+	unlink( $source_path );
+}
+
+$missing_source_results = wp_agent_import_runtime_bundles( array( array( 'source' => sys_get_temp_dir() . '/agents-api-missing-runtime-bundle.json' ) ) );
+agents_api_smoke_assert_equals( false, $missing_source_results[0]['success'] ?? null, 'missing source returns failure envelope', $failures, $passes );
+agents_api_smoke_assert_equals( 'wp_agent_runtime_bundle_source_unreadable', $missing_source_results[0]['error']['code'] ?? null, 'missing source reports stable code', $failures, $passes );
+
 agents_api_smoke_finish( 'Agents API runtime agent bundle importer', $failures, $passes );


### PR DESCRIPTION
## Summary
- Add `wp_agent_import_runtime_bundles()` as a generic list helper for runtime bundle import specs.
- Support `source` specs that load runtime agent bundle JSON files before passing through the existing importer seam.
- Normalize per-spec success/error envelopes without coupling Agents API to a concrete bundle storage backend.

## Testing
- `composer run phpstan`
- `php tests/runtime-agent-bundle-importer-smoke.php`
- `php tests/registry-smoke.php`
- `php tests/channels-smoke.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** implementation drafted by coding agent, reviewed/tested by Chris.