### PR TITLE
Conversation loop: surface rejected tool declarations instead of dropping silently

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -77,6 +77,7 @@
       "php tests/conversation-loop-completion-policy-smoke.php",
       "php tests/conversation-loop-transcript-persister-smoke.php",
       "php tests/conversation-loop-events-smoke.php",
+      "php tests/tool-declaration-rejection-smoke.php",
       "php tests/conversation-loop-interrupt-source-smoke.php",
       "php tests/iteration-budget-smoke.php",
       "php tests/conversation-loop-budgets-smoke.php",

--- a/docs/runtime-and-tools.md
+++ b/docs/runtime-and-tools.md
@@ -140,6 +140,27 @@ $result = AgentsAPI\AI\WP_Agent_Conversation_Loop::run(
 );
 ```
 
+Mediation turns on only when both `tool_executor` and at least one **valid**
+`tool_declarations` entry are present. Declarations are validated through
+`WP_Agent_Tool_Declaration::normalizeForConversationRequest()`, and the client
+runtime contract is strict (see [Runtime tool declarations](#runtime-tool-declarations)):
+names must be `client/<slug>` and the namespace must resolve to `source: client`.
+A declaration like `openclawp__get-recent-posts` (no slash) or
+`openclawp/get-recent-posts` (source `openclawp`) fails validation.
+
+Invalid declarations are dropped from the mediation list. So the loop can detect
+that misconfiguration instead of silently degrading to a no-tools turn, it emits:
+
+- `tool_declarations_rejected` — whenever any declaration is dropped, with
+  `rejected` (each `{ name, reason }`), `rejected_count`, and `accepted_count`.
+- `tool_mediation_disabled` — when a `tool_executor` was supplied but **every**
+  declaration was rejected (so mediation is off and tool calls will never run),
+  with `reason: 'all_declarations_rejected'`.
+
+Both fire through the `on_event` sink and the `agents_api_loop_event` action.
+Without this, a name-format mismatch surfaces only as "the model emitted a tool
+call but nothing executed and the reply is empty," with no indication why.
+
 ### Pre-tool mediation decisions
 
 `pre_tool_mediator` lets a host make a synchronous product-owned decision after the loop has appended the canonical tool-call message and prepared the call, but before concrete execution. Agents API does not persist mediation decisions; hosts can observe the resulting canonical messages, `tool_execution_results`, `tool_events`, `tool_audit_events`, and loop events through existing surfaces.

--- a/src/Runtime/class-wp-agent-conversation-loop.php
+++ b/src/Runtime/class-wp-agent-conversation-loop.php
@@ -94,7 +94,8 @@ class WP_Agent_Conversation_Loop {
 		$max_turns             = self::max_turns( $options['max_turns'] ?? 1 );
 		$context               = self::normalize_assoc_array( $options['context'] ?? array() );
 		$tool_executor         = self::resolve_tool_executor( $options );
-		$tool_declarations     = self::resolve_tool_declarations( $options );
+		$rejected_declarations = array();
+		$tool_declarations     = self::resolve_tool_declarations( $options, $rejected_declarations );
 		$should_continue       = self::resolve_should_continue( $options, $tool_executor, $tool_declarations );
 		$completion_policy     = self::resolve_completion_policy( $options );
 		$transcript_persister  = self::resolve_transcript_persister( $options );
@@ -118,7 +119,8 @@ class WP_Agent_Conversation_Loop {
 		$wall_clock_started_at = microtime( true );
 		$wall_clock_initial    = isset( $budgets['wall_clock_seconds'] ) ? $budgets['wall_clock_seconds']->current() : 0;
 		$mediation_enabled     = null !== $tool_executor && ! empty( $tool_declarations );
-		$messages              = self::normalize_messages( $messages );
+		self::emit_tool_declaration_diagnostics( $on_event, $rejected_declarations, $tool_declarations, $tool_executor );
+		$messages = self::normalize_messages( $messages );
 		if ( '' !== $run_id && '' !== $lock_session_id ) {
 			WP_Agent_Chat_Run_Control::start_run( $run_id, $lock_session_id, array( 'source' => 'conversation_loop' ) );
 		}
@@ -285,7 +287,7 @@ class WP_Agent_Conversation_Loop {
 
 				// When mediation is enabled, the turn runner returns tool_calls
 				// and the loop handles execution. Otherwise, the caller-managed path applies.
-				if ( $mediation_enabled && isset( $result['tool_calls'] ) && is_array( $result['tool_calls'] ) ) {
+				if ( null !== $tool_executor && $mediation_enabled && isset( $result['tool_calls'] ) && is_array( $result['tool_calls'] ) ) {
 					$mediation_result = self::mediate_tool_calls(
 						self::normalize_assoc_array( $result ),
 						$tool_executor,
@@ -880,7 +882,7 @@ class WP_Agent_Conversation_Loop {
 		foreach ( $continuation_messages as $continuation_message ) {
 			$continuation_role = is_string( $continuation_message['role'] ?? null ) ? $continuation_message['role'] : '';
 			$messages[]        = $continuation_message;
-			$events[]   = array(
+			$events[]          = array(
 				'type'     => 'continuation_message_added',
 				'metadata' => array(
 					'turn' => $turn,
@@ -1637,7 +1639,7 @@ class WP_Agent_Conversation_Loop {
 				foreach ( $continuation_messages as $continuation_message ) {
 					$continuation_role = is_string( $continuation_message['role'] ?? null ) ? $continuation_message['role'] : '';
 					$messages[]        = $continuation_message;
-					$events[]   = array(
+					$events[]          = array(
 						'type'     => 'continuation_message_added',
 						'metadata' => array(
 							'role' => $continuation_role,
@@ -1706,6 +1708,50 @@ class WP_Agent_Conversation_Loop {
 		}
 
 		return $metadata;
+	}
+
+	/**
+	 * Surface tool declarations that were dropped during normalization.
+	 *
+	 * Invalid declarations are silently removed from the mediation list, which
+	 * can flip mediation off entirely when every declaration is rejected — the
+	 * model emits tool calls but nothing executes, with no indication why. This
+	 * emits a `tool_declarations_rejected` event (with each declaration's name
+	 * and validation reason) whenever any are dropped, plus a prominent
+	 * `tool_mediation_disabled` event when declarations were supplied alongside a
+	 * tool executor but all of them were rejected.
+	 *
+	 * @param callable|null                                    $on_event          Event sink.
+	 * @param array<int, array{name: string, reason: string}>  $rejected          Rejected declarations with reasons.
+	 * @param array<string, array<string, mixed>>              $tool_declarations Accepted declarations.
+	 * @param WP_Agent_Tool_Executor|null                      $tool_executor     Resolved tool executor.
+	 */
+	private static function emit_tool_declaration_diagnostics( ?callable $on_event, array $rejected, array $tool_declarations, ?WP_Agent_Tool_Executor $tool_executor ): void {
+		if ( empty( $rejected ) ) {
+			return;
+		}
+
+		self::emit_event(
+			$on_event,
+			'tool_declarations_rejected',
+			array(
+				'rejected'       => array_values( $rejected ),
+				'rejected_count' => count( $rejected ),
+				'accepted_count' => count( $tool_declarations ),
+			)
+		);
+
+		if ( empty( $tool_declarations ) && null !== $tool_executor ) {
+			self::emit_event(
+				$on_event,
+				'tool_mediation_disabled',
+				array(
+					'reason'         => 'all_declarations_rejected',
+					'rejected'       => array_values( $rejected ),
+					'rejected_count' => count( $rejected ),
+				)
+			);
+		}
 	}
 
 	/**
@@ -1977,12 +2023,13 @@ class WP_Agent_Conversation_Loop {
 	/**
 	 * Resolve tool declarations from options.
 	 *
-	 * @param array<string, mixed> $options Loop options.
+	 * @param array<string, mixed>                            $options  Loop options.
+	 * @param array<int, array{name: string, reason: string}> $rejected Out: rejected declarations with reasons.
 	 * @return array<string, array<string, mixed>> Tool declarations keyed by name.
 	 */
-	private static function resolve_tool_declarations( array $options ): array {
+	private static function resolve_tool_declarations( array $options, array &$rejected = array() ): array {
 		$declarations = $options['tool_declarations'] ?? null;
-		return is_array( $declarations ) ? self::normalize_tool_declarations( $declarations ) : array();
+		return is_array( $declarations ) ? self::normalize_tool_declarations( $declarations, $rejected ) : array();
 	}
 
 	/**
@@ -2528,25 +2575,43 @@ class WP_Agent_Conversation_Loop {
 	/**
 	 * Normalize tool declarations to declarations keyed by tool name.
 	 *
-	 * @param array<mixed> $declarations Raw declarations.
+	 * Declarations that fail validation are dropped from the result and recorded
+	 * in `$rejected` (with their declared name and validation reason) so callers
+	 * can surface them instead of degrading silently.
+	 *
+	 * @param array<mixed>                                  $declarations Raw declarations.
+	 * @param array<int, array{name: string, reason: string}> $rejected   Out: rejected declarations with reasons.
 	 * @return array<string, array<string, mixed>> Tool declarations.
 	 */
-	private static function normalize_tool_declarations( array $declarations ): array {
+	private static function normalize_tool_declarations( array $declarations, array &$rejected = array() ): array {
 		$normalized = array();
 		foreach ( $declarations as $name => $declaration ) {
+			$declared_name = is_string( $name ) && '' !== $name ? $name : '';
+
 			if ( ! is_array( $declaration ) ) {
+				$rejected[] = array(
+					'name'   => $declared_name,
+					'reason' => 'declaration must be an array',
+				);
 				continue;
 			}
 
 			$declaration = self::normalize_assoc_array( $declaration );
-			if ( is_string( $name ) && '' !== $name && ! isset( $declaration['name'] ) ) {
-				$declaration['name'] = $name;
+			if ( '' !== $declared_name && ! isset( $declaration['name'] ) ) {
+				$declaration['name'] = $declared_name;
+			}
+
+			if ( '' === $declared_name && is_string( $declaration['name'] ?? null ) ) {
+				$declared_name = $declaration['name'];
 			}
 
 			try {
 				$tool = self::normalize_assoc_array( WP_Agent_Tool_Declaration::normalizeForConversationRequest( $declaration ) );
 			} catch ( \InvalidArgumentException $error ) {
-				unset( $error );
+				$rejected[] = array(
+					'name'   => $declared_name,
+					'reason' => $error->getMessage(),
+				);
 				continue;
 			}
 

--- a/tests/tool-declaration-rejection-smoke.php
+++ b/tests/tool-declaration-rejection-smoke.php
@@ -1,0 +1,200 @@
+<?php
+/**
+ * Pure-PHP smoke test for tool-declaration rejection diagnostics.
+ *
+ * Covers issue #292: when tool declarations fail validation they were dropped
+ * silently, which could flip mediation off entirely with no indication. The
+ * loop now emits `tool_declarations_rejected` (with reasons) whenever any are
+ * dropped, plus `tool_mediation_disabled` when a tool executor was supplied but
+ * every declaration was rejected.
+ *
+ * Run with: php tests/tool-declaration-rejection-smoke.php
+ *
+ * @package AgentsAPI\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+$failures = array();
+$passes   = 0;
+
+echo "agents-api-tool-declaration-rejection-smoke\n";
+
+require_once __DIR__ . '/agents-api-smoke-helpers.php';
+agents_api_smoke_require_module();
+
+$executor = new class() implements AgentsAPI\AI\Tools\WP_Agent_Tool_Executor {
+	public function executeWP_Agent_Tool_Call( array $tool_call, array $tool_definition, array $context = array() ): array {
+		unset( $tool_definition, $context );
+		return array(
+			'success'   => true,
+			'tool_name' => $tool_call['tool_name'] ?? '',
+			'result'    => array( 'ok' => true ),
+		);
+	}
+};
+
+/**
+ * Collect emitted loop events by name.
+ *
+ * @param array<int, array{event:string, payload:array<mixed>}> $log Event log.
+ * @param string                                                $name Event name.
+ * @return array<int, array<mixed>> Matching payloads.
+ */
+function rejection_smoke_events_named( array $log, string $name ): array {
+	$matches = array();
+	foreach ( $log as $entry ) {
+		if ( $entry['event'] === $name ) {
+			$matches[] = $entry['payload'];
+		}
+	}
+	return $matches;
+}
+
+// --- [1] All declarations rejected: mediation flips off, both events fire ----
+echo "\n[1] Every declaration rejected -> rejected + mediation_disabled events:\n";
+
+$log_all = array();
+$result  = AgentsAPI\AI\WP_Agent_Conversation_Loop::run(
+	array( array( 'role' => 'user', 'content' => 'go' ) ),
+	static function ( array $messages, array $context ): array {
+		unset( $context );
+		return array(
+			'messages'   => $messages,
+			'tool_calls' => array(
+				array( 'name' => 'foo__bar', 'parameters' => array() ),
+			),
+		);
+	},
+	array(
+		'tool_executor'     => $executor,
+		'max_turns'         => 2,
+		'tool_declarations' => array(
+			// No slash, and source isn't `client` -> rejected.
+			'foo__bar' => array(
+				'name'        => 'foo__bar',
+				'source'      => 'mything',
+				'description' => 'Invalid name format.',
+				'parameters'  => array( 'type' => 'object' ),
+				'executor'    => 'client',
+				'scope'       => 'run',
+			),
+		),
+		'on_event'          => static function ( string $event, array $payload ) use ( &$log_all ): void {
+			$log_all[] = array(
+				'event'   => $event,
+				'payload' => $payload,
+			);
+		},
+	)
+);
+
+$rejected_events = rejection_smoke_events_named( $log_all, 'tool_declarations_rejected' );
+agents_api_smoke_assert_equals( 1, count( $rejected_events ), 'rejected event emitted once', $failures, $passes );
+agents_api_smoke_assert_equals( 1, $rejected_events[0]['rejected_count'] ?? null, 'rejected_count is 1', $failures, $passes );
+agents_api_smoke_assert_equals( 0, $rejected_events[0]['accepted_count'] ?? null, 'accepted_count is 0', $failures, $passes );
+agents_api_smoke_assert_equals( 'foo__bar', $rejected_events[0]['rejected'][0]['name'] ?? null, 'rejected entry carries declared name', $failures, $passes );
+$reason = $rejected_events[0]['rejected'][0]['reason'] ?? '';
+agents_api_smoke_assert_equals( true, is_string( $reason ) && '' !== $reason, 'rejected entry carries a non-empty reason', $failures, $passes );
+
+$disabled_events = rejection_smoke_events_named( $log_all, 'tool_mediation_disabled' );
+agents_api_smoke_assert_equals( 1, count( $disabled_events ), 'mediation_disabled event emitted once', $failures, $passes );
+agents_api_smoke_assert_equals( 'all_declarations_rejected', $disabled_events[0]['reason'] ?? null, 'mediation_disabled reason is all_declarations_rejected', $failures, $passes );
+
+// Mediation was off, so the emitted tool call produced no results.
+agents_api_smoke_assert_equals( 0, count( $result['tool_execution_results'] ?? array() ), 'no tools executed when all declarations rejected', $failures, $passes );
+
+// --- [2] Mixed valid + invalid: only invalid rejected, mediation stays on ----
+echo "\n[2] Mixed declarations -> only invalid rejected, mediation still runs:\n";
+
+$log_mixed = array();
+$result2   = AgentsAPI\AI\WP_Agent_Conversation_Loop::run(
+	array( array( 'role' => 'user', 'content' => 'go' ) ),
+	static function ( array $messages, array $context ): array {
+		if ( 1 === ( $context['turn'] ?? 0 ) ) {
+			return array(
+				'messages'   => $messages,
+				'tool_calls' => array(
+					array( 'name' => 'client/work', 'parameters' => array() ),
+				),
+			);
+		}
+		return array(
+			'messages' => array_merge( $messages, array( array( 'role' => 'assistant', 'content' => 'done' ) ) ),
+		);
+	},
+	array(
+		'tool_executor'     => $executor,
+		'max_turns'         => 3,
+		'tool_declarations' => array(
+			'client/work' => array(
+				'name'        => 'client/work',
+				'source'      => 'client',
+				'description' => 'Valid client tool.',
+				'parameters'  => array( 'type' => 'object' ),
+				'executor'    => 'client',
+				'scope'       => 'run',
+			),
+			'bad__name'   => array(
+				'name'        => 'bad__name',
+				'source'      => 'mything',
+				'description' => 'Invalid.',
+				'parameters'  => array( 'type' => 'object' ),
+				'executor'    => 'client',
+				'scope'       => 'run',
+			),
+		),
+		'on_event'          => static function ( string $event, array $payload ) use ( &$log_mixed ): void {
+			$log_mixed[] = array(
+				'event'   => $event,
+				'payload' => $payload,
+			);
+		},
+	)
+);
+
+$rejected_mixed = rejection_smoke_events_named( $log_mixed, 'tool_declarations_rejected' );
+agents_api_smoke_assert_equals( 1, count( $rejected_mixed ), 'mixed: rejected event emitted once', $failures, $passes );
+agents_api_smoke_assert_equals( 1, $rejected_mixed[0]['rejected_count'] ?? null, 'mixed: one declaration rejected', $failures, $passes );
+agents_api_smoke_assert_equals( 1, $rejected_mixed[0]['accepted_count'] ?? null, 'mixed: one declaration accepted', $failures, $passes );
+agents_api_smoke_assert_equals( 0, count( rejection_smoke_events_named( $log_mixed, 'tool_mediation_disabled' ) ), 'mixed: no mediation_disabled event', $failures, $passes );
+agents_api_smoke_assert_equals( true, count( $result2['tool_execution_results'] ?? array() ) >= 1, 'mixed: valid tool still executed', $failures, $passes );
+
+// --- [3] All valid: no rejection events at all ------------------------------
+echo "\n[3] All declarations valid -> no rejection events:\n";
+
+$log_clean = array();
+AgentsAPI\AI\WP_Agent_Conversation_Loop::run(
+	array( array( 'role' => 'user', 'content' => 'go' ) ),
+	static function ( array $messages, array $context ): array {
+		unset( $context );
+		return array( 'messages' => $messages );
+	},
+	array(
+		'tool_executor'     => $executor,
+		'max_turns'         => 1,
+		'tool_declarations' => array(
+			'client/work' => array(
+				'name'        => 'client/work',
+				'source'      => 'client',
+				'description' => 'Valid client tool.',
+				'parameters'  => array( 'type' => 'object' ),
+				'executor'    => 'client',
+				'scope'       => 'run',
+			),
+		),
+		'on_event'          => static function ( string $event, array $payload ) use ( &$log_clean ): void {
+			$log_clean[] = array(
+				'event'   => $event,
+				'payload' => $payload,
+			);
+		},
+	)
+);
+
+agents_api_smoke_assert_equals( 0, count( rejection_smoke_events_named( $log_clean, 'tool_declarations_rejected' ) ), 'clean: no rejected event', $failures, $passes );
+agents_api_smoke_assert_equals( 0, count( rejection_smoke_events_named( $log_clean, 'tool_mediation_disabled' ) ), 'clean: no mediation_disabled event', $failures, $passes );
+
+agents_api_smoke_finish( 'tool declaration rejection diagnostics', $failures, $passes );


### PR DESCRIPTION
Fixes #292.

## Summary
- `WP_Agent_Conversation_Loop` dropped invalid `tool_declarations` silently during normalization. When **every** declaration was rejected, `mediation_enabled` flipped to `false` and tool calls never executed — the model emitted a tool call, nothing ran, and the reply came back empty with zero indication why.
- The loop now records each dropped declaration (declared name + validation reason) and emits diagnostic events through the `on_event` sink and the `agents_api_loop_event` action:
  - `tool_declarations_rejected` — whenever any declaration is dropped (`rejected` list of `{ name, reason }`, `rejected_count`, `accepted_count`).
  - `tool_mediation_disabled` — when a `tool_executor` was supplied but **all** declarations were rejected (`reason: all_declarations_rejected`), the prominent "you configured tools but none will run" signal.
- Execution behavior is unchanged (invalid declarations are still dropped); this only adds observability. Mixed valid/invalid declaration sets keep mediating with the valid subset.
- Documented the client tool-name contract and the new diagnostics in `docs/runtime-and-tools.md` — previously the `client/<slug>` + `source === client` requirement was only discoverable by reading `validate()`.

This addresses all three suggestions in the issue (surface the drops with reasons, fail loudly when all are dropped, document the contract).

## Test plan
- [ ] `composer smoke` — green (new `tests/tool-declaration-rejection-smoke.php`, 15 assertions)
- [ ] `composer phpstan` — `[OK] No errors` (level max)
- [ ] New smoke covers: all-rejected (both events fire, no tools run), mixed valid/invalid (only invalid rejected, valid tool still executes, no `tool_mediation_disabled`), all-valid (no rejection events)

## Quality gate results
- Smoke suite: **pass** (exit 0)
- PHPStan max: **pass** (`[OK] No errors`)
- PHPCS alignment (Generic.Formatting.MultipleStatementAlignment): **clean**
- Browser test: **n/a** (backend-only, no UI surface)