### PR TITLE
Preserve chat result metadata

### DIFF
--- a/src/Runtime/class-wp-agent-byte-limit-tool-result-truncator.php
+++ b/src/Runtime/class-wp-agent-byte-limit-tool-result-truncator.php
@@ -78,7 +78,7 @@ final class WP_Agent_Byte_Limit_Tool_Result_Truncator implements WP_Agent_Tool_R
 	}
 
 	/**
-	 * Preserve compact UI metadata from oversized result payloads.
+	 * Preserve compact result metadata from oversized result payloads.
 	 *
 	 * @param array<string,mixed> $result Tool execution result.
 	 * @return array<string,mixed> Preserved metadata fields.

--- a/src/Runtime/class-wp-agent-byte-limit-tool-result-truncator.php
+++ b/src/Runtime/class-wp-agent-byte-limit-tool-result-truncator.php
@@ -44,15 +44,19 @@ final class WP_Agent_Byte_Limit_Tool_Result_Truncator implements WP_Agent_Tool_R
 			);
 		}
 
-		$excerpt   = substr( (string) $encoded, 0, $this->max_bytes );
-		$metadata  = isset( $result['metadata'] ) && is_array( $result['metadata'] ) ? $result['metadata'] : array();
-		$truncated = $result;
+		$excerpt            = substr( (string) $encoded, 0, $this->max_bytes );
+		$metadata           = isset( $result['metadata'] ) && is_array( $result['metadata'] ) ? $result['metadata'] : array();
+		$preserved_metadata = $this->preserve_result_metadata( $result );
+		$truncated          = $result;
 
-		$truncated['result']   = array(
-			'truncated'      => true,
-			'excerpt'        => $excerpt,
-			'original_bytes' => $original_bytes,
-			'excerpt_bytes'  => strlen( $excerpt ),
+		$truncated['result']   = array_merge(
+			array(
+				'truncated'      => true,
+				'excerpt'        => $excerpt,
+				'original_bytes' => $original_bytes,
+				'excerpt_bytes'  => strlen( $excerpt ),
+			),
+			$preserved_metadata
 		);
 		$truncated['metadata'] = array_merge(
 			$metadata,
@@ -71,5 +75,24 @@ final class WP_Agent_Byte_Limit_Tool_Result_Truncator implements WP_Agent_Tool_R
 				'excerpt_bytes'  => strlen( $excerpt ),
 			),
 		);
+	}
+
+	/**
+	 * Preserve compact UI metadata from oversized result payloads.
+	 *
+	 * @param array<string,mixed> $result Tool execution result.
+	 * @return array<string,mixed> Preserved metadata fields.
+	 */
+	private function preserve_result_metadata( array $result ): array {
+		$payload = isset( $result['result'] ) && is_array( $result['result'] ) ? $result['result'] : array();
+		$keep    = array();
+
+		foreach ( array( 'citations', 'retrieved_context', 'retrieved_contexts' ) as $field ) {
+			if ( array_key_exists( $field, $payload ) ) {
+				$keep[ $field ] = $payload[ $field ];
+			}
+		}
+
+		return $keep;
 	}
 }

--- a/src/Runtime/class-wp-agent-conversation-loop.php
+++ b/src/Runtime/class-wp-agent-conversation-loop.php
@@ -141,7 +141,7 @@ class WP_Agent_Conversation_Loop {
 			'completion_tokens' => 0,
 			'total_tokens'      => 0,
 		);
-		$result_metadata     = array();
+		$result_metadata      = array();
 		$request_metadata     = array();
 		$provider_diagnostics = array();
 

--- a/src/Runtime/class-wp-agent-conversation-loop.php
+++ b/src/Runtime/class-wp-agent-conversation-loop.php
@@ -141,6 +141,7 @@ class WP_Agent_Conversation_Loop {
 			'completion_tokens' => 0,
 			'total_tokens'      => 0,
 		);
+		$result_metadata     = array();
 		$request_metadata     = array();
 		$provider_diagnostics = array();
 
@@ -275,6 +276,9 @@ class WP_Agent_Conversation_Loop {
 				if ( isset( $result['request_metadata'] ) && is_array( $result['request_metadata'] ) ) {
 					$request_metadata = self::normalize_assoc_array( $result['request_metadata'] );
 				}
+				if ( isset( $result['metadata'] ) && is_array( $result['metadata'] ) ) {
+					$result_metadata = array_merge( $result_metadata, self::normalize_assoc_array( $result['metadata'] ) );
+				}
 
 				// When mediation is enabled, the turn runner returns tool_calls
 				// and the loop handles execution. Otherwise, the caller-managed path applies.
@@ -319,7 +323,7 @@ class WP_Agent_Conversation_Loop {
 					}
 					$events = array_merge( $events, self::normalize_events( $result['events'] ?? array() ) );
 					if ( isset( $result['request_metadata'] ) && is_array( $result['request_metadata'] ) ) {
-						$last_request_metadata = self::normalize_assoc_array( $result['request_metadata'] );
+						$request_metadata = self::normalize_assoc_array( $result['request_metadata'] );
 					}
 
 					// Apply completion policy to tool results from the turn runner
@@ -408,6 +412,7 @@ class WP_Agent_Conversation_Loop {
 				'events'                 => $events,
 				'turn_count'             => $turns_run,
 				'final_content'          => self::extract_final_content( $messages ),
+				'metadata'               => $result_metadata,
 				'usage'                  => $total_usage,
 				'request_metadata'       => $request_metadata,
 				'provider_diagnostics'   => $provider_diagnostics,

--- a/src/Runtime/class-wp-agent-conversation-result.php
+++ b/src/Runtime/class-wp-agent-conversation-result.php
@@ -216,6 +216,10 @@ class WP_Agent_Conversation_Result {
 			throw self::invalid( 'usage', 'must be an array when present' );
 		}
 
+		if ( array_key_exists( 'metadata', $result ) && ! is_array( $result['metadata'] ) ) {
+			throw self::invalid( 'metadata', 'must be an array when present' );
+		}
+
 		if ( array_key_exists( 'request_metadata', $result ) && ! is_array( $result['request_metadata'] ) ) {
 			throw self::invalid( 'request_metadata', 'must be an array when present' );
 		}

--- a/tests/conversation-loop-smoke.php
+++ b/tests/conversation-loop-smoke.php
@@ -51,6 +51,30 @@ agents_api_smoke_assert_equals( array( 1, 2 ), $turns, 'loop runs until caller p
 agents_api_smoke_assert_equals( 3, count( $result['messages'] ), 'loop returns the final normalized transcript', $failures, $passes );
 agents_api_smoke_assert_equals( 2, count( $result['events'] ), 'loop preserves caller lifecycle events', $failures, $passes );
 
+$metadata_result = AgentsAPI\AI\WP_Agent_Conversation_Loop::run(
+	array( array( 'role' => 'user', 'content' => 'cite this' ) ),
+	static function ( array $messages ): array {
+		$messages[] = AgentsAPI\AI\WP_Agent_Message::text( 'assistant', 'cited answer' );
+
+		return array(
+			'messages'               => $messages,
+			'tool_execution_results' => array(),
+			'metadata'               => array(
+				'citations'         => array( array( 'url' => 'https://example.test/source' ) ),
+				'retrieved_context' => array( array( 'id' => 'ctx-1', 'title' => 'Source' ) ),
+			),
+			'request_metadata'       => array(
+				'provider_request_id' => 'req-citations-1',
+			),
+		);
+	},
+	array( 'max_turns' => 1 )
+);
+
+agents_api_smoke_assert_equals( 'https://example.test/source', $metadata_result['metadata']['citations'][0]['url'] ?? '', 'loop preserves generic result citation metadata', $failures, $passes );
+agents_api_smoke_assert_equals( 'ctx-1', $metadata_result['metadata']['retrieved_context'][0]['id'] ?? '', 'loop preserves generic retrieved-context metadata', $failures, $passes );
+agents_api_smoke_assert_equals( 'req-citations-1', $metadata_result['request_metadata']['provider_request_id'] ?? '', 'caller-managed loop preserves request metadata', $failures, $passes );
+
 echo "\n[2] Loop can apply caller-supplied compaction without owning model dispatch:\n";
 $summarized_messages = array();
 $compacted_result    = AgentsAPI\AI\WP_Agent_Conversation_Loop::run(

--- a/tests/frontend-chat-rest-smoke.php
+++ b/tests/frontend-chat-rest-smoke.php
@@ -111,7 +111,14 @@ $ability  = new class( $captured ) {
 
 	public function execute( array $input ): array {
 		$this->captured = $input;
-		return array( 'session_id' => 's-1', 'reply' => 'hello from adapter' );
+		return array(
+			'session_id' => 's-1',
+			'reply'      => 'hello from adapter',
+			'metadata'   => array(
+				'citations'         => array( array( 'url' => 'https://example.test/rest-source' ) ),
+				'retrieved_context' => array( array( 'id' => 'rest-context-1' ) ),
+			),
+		);
 	}
 };
 
@@ -135,6 +142,8 @@ agents_api_smoke_assert_equals( true, $permission, 'permission allows operator g
 $response = AgentsAPI\AI\Channels\agents_frontend_chat_rest_dispatch( $request );
 agents_api_smoke_assert_equals( true, $response instanceof WP_REST_Response, 'dispatch returns REST response', $failures, $passes );
 agents_api_smoke_assert_equals( 'hello from adapter', $response->data['reply'] ?? null, 'dispatch returns ability reply', $failures, $passes );
+agents_api_smoke_assert_equals( 'https://example.test/rest-source', $response->data['metadata']['citations'][0]['url'] ?? null, 'dispatch preserves citation metadata', $failures, $passes );
+agents_api_smoke_assert_equals( 'rest-context-1', $response->data['metadata']['retrieved_context'][0]['id'] ?? null, 'dispatch preserves retrieved-context metadata', $failures, $passes );
 agents_api_smoke_assert_equals( 'support-agent', $captured['agent'] ?? null, 'dispatch sanitizes agent slug', $failures, $passes );
 agents_api_smoke_assert_equals( 'Hi there', $captured['message'] ?? null, 'dispatch forwards message', $failures, $passes );
 agents_api_smoke_assert_equals( 'rest', $captured['client_context']['source'] ?? null, 'dispatch marks REST source', $failures, $passes );

--- a/tests/tool-result-truncator-smoke.php
+++ b/tests/tool-result-truncator-smoke.php
@@ -27,7 +27,9 @@ $executor = new class() implements AgentsAPI\AI\Tools\WP_Agent_Tool_Executor {
 			'success'   => true,
 			'tool_name' => $tool_call['tool_name'],
 			'result'    => array(
-				'body' => str_repeat( 'x', 200 ),
+				'body'              => str_repeat( 'x', 200 ),
+				'citations'         => array( array( 'url' => 'https://example.test/tool-source' ) ),
+				'retrieved_context' => array( array( 'id' => 'tool-context-1' ) ),
 			),
 		);
 	}
@@ -77,6 +79,8 @@ $truncated_result = $result['tool_execution_results'][0]['result'] ?? array();
 
 agents_api_smoke_assert_equals( true, (bool) ( $truncated_result['metadata']['truncated'] ?? false ), 'tool execution result is marked truncated', $failures, $passes );
 agents_api_smoke_assert_equals( true, isset( $truncated_result['result']['excerpt'] ), 'tool execution result stores excerpt payload', $failures, $passes );
+agents_api_smoke_assert_equals( 'https://example.test/tool-source', $truncated_result['result']['citations'][0]['url'] ?? '', 'tool execution result preserves citation metadata after truncation', $failures, $passes );
+agents_api_smoke_assert_equals( 'tool-context-1', $truncated_result['result']['retrieved_context'][0]['id'] ?? '', 'tool execution result preserves retrieved-context metadata after truncation', $failures, $passes );
 agents_api_smoke_assert_equals( false, str_contains( wp_json_encode( $truncated_result ), str_repeat( 'x', 200 ) ), 'truncated execution result omits full original body', $failures, $passes );
 
 $tool_result_messages = array_values(


### PR DESCRIPTION
## Summary
- Preserve generic conversation result `metadata` through canonical loop output so citations and retrieved context can reach chat clients.
- Keep caller-managed `request_metadata` on the final loop result and preserve citation/retrieved-context fields when byte-limit tool truncation compacts oversized payloads.
- Add smoke coverage for conversation loop metadata, frontend REST metadata forwarding, and truncation-safe citation metadata.

Fixes https://github.com/Automattic/agents-api/issues/295

## Tests run
- `php tests/conversation-loop-smoke.php`
- `php tests/tool-result-truncator-smoke.php`
- `php tests/frontend-chat-rest-smoke.php`
- `php tests/no-product-imports-smoke.php`
- `composer smoke`
- `composer phpstan`
- `homeboy lint agents-api`

## Remaining risks
- No known blockers. The truncator preserves the generic citation/retrieved-context fields called out in #295 while continuing to omit the oversized raw body.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the implementation, tests, and verification steps for Chris to review.