### PR TITLE
Define citation metadata for retrieved context

### DIFF
--- a/agents-api.php
+++ b/agents-api.php
@@ -108,6 +108,7 @@ require_once AGENTS_API_PATH . 'src/Consent/class-wp-agent-consent-operation.php
 require_once AGENTS_API_PATH . 'src/Consent/class-wp-agent-consent-decision.php';
 require_once AGENTS_API_PATH . 'src/Consent/class-wp-agent-consent-policy.php';
 require_once AGENTS_API_PATH . 'src/Consent/class-wp-agent-default-consent-policy.php';
+require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-citation-metadata.php';
 require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-message.php';
 require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-execution-principal.php';
 require_once AGENTS_API_PATH . 'src/Transcripts/register-agents-conversation-session-abilities.php';

--- a/composer.json
+++ b/composer.json
@@ -69,6 +69,7 @@
       "php tests/spin-detector-smoke.php",
       "php tests/identical-failure-tracker-smoke.php",
       "php tests/tool-result-truncator-smoke.php",
+      "php tests/citation-metadata-smoke.php",
       "php tests/context-registry-smoke.php",
       "php tests/conversation-loop-smoke.php",
       "php tests/provider-turn-adapter-smoke.php",

--- a/docs/auth-consent-context-memory.md
+++ b/docs/auth-consent-context-memory.md
@@ -128,7 +128,7 @@ Context items carry both content and provenance:
 - `conflict_key`
 - `metadata`
 
-Retrieved context items place canonical citation metadata at `metadata['citations']`. Each citation is a generic associative array with optional `source`, `source_title`, `source_url`, `document_id`, `chunk_id`, `score`, and `excerpt` fields. Product-specific retrieval details belong outside the canonical citation object, in product-owned metadata keys.
+Retrieved context items place canonical citation metadata at `metadata['citations']`. Each citation is a generic associative array with optional `source`, `source_title`, `source_url`, `document_id`, `chunk_id`, `score`, and `excerpt` fields. Agents API normalizes these canonical fields and preserves additional caller-owned citation metadata without interpreting it.
 
 Authority tiers are generic, with platform/support/workspace/user/agent/conversation ordering defined in `WP_Agent_Context_Authority_Tier`. `WP_Agent_Default_Context_Conflict_Resolver` resolves authoritative facts by authority tier and preferences by specificity then authority.
 

--- a/docs/auth-consent-context-memory.md
+++ b/docs/auth-consent-context-memory.md
@@ -128,6 +128,8 @@ Context items carry both content and provenance:
 - `conflict_key`
 - `metadata`
 
+Retrieved context items place canonical citation metadata at `metadata['citations']`. Each citation is a generic associative array with optional `source`, `source_title`, `source_url`, `document_id`, `chunk_id`, `score`, and `excerpt` fields. Product-specific retrieval details belong outside the canonical citation object, in product-owned metadata keys.
+
 Authority tiers are generic, with platform/support/workspace/user/agent/conversation ordering defined in `WP_Agent_Context_Authority_Tier`. `WP_Agent_Default_Context_Conflict_Resolver` resolves authoritative facts by authority tier and preferences by specificity then authority.
 
 ## Memory store contract

--- a/docs/auth-consent-context-memory.md
+++ b/docs/auth-consent-context-memory.md
@@ -128,7 +128,7 @@ Context items carry both content and provenance:
 - `conflict_key`
 - `metadata`
 
-Retrieved context items place canonical citation metadata at `metadata['citations']`. Each citation is a generic associative array with optional `source`, `source_title`, `source_url`, `document_id`, `chunk_id`, `score`, and `excerpt` fields. Agents API normalizes these canonical fields and preserves additional caller-owned citation metadata without interpreting it.
+Retrieved context items place canonical citation metadata at `metadata['citations']`. Each citation is a generic associative array with optional `source`, `source_id`, `item_id`, `fragment_id`, `source_title`, `source_url`, `score`, and `excerpt` fields. Agents API normalizes these canonical fields and preserves additional caller-owned citation metadata without interpreting it.
 
 Authority tiers are generic, with platform/support/workspace/user/agent/conversation ordering defined in `WP_Agent_Context_Authority_Tier`. `WP_Agent_Default_Context_Conflict_Resolver` resolves authoritative facts by authority tier and preferences by specificity then authority.
 

--- a/docs/runtime-and-tools.md
+++ b/docs/runtime-and-tools.md
@@ -288,6 +288,10 @@ array(
 
 If a concrete executor returns its own `runtime` metadata, the normalized result merges it over declaration metadata for that execution result. This lets the declaration advertise generic defaults while an executor refines result-scoped signals without changing the declaration.
 
+### Citation metadata
+
+Retrieval tools place canonical citations in result metadata under `metadata['citations']`. The substrate citation shape is intentionally small and generic: each citation may include `source`, `source_title`, `source_url`, `document_id`, `chunk_id`, `score`, and `excerpt`. Agents API normalizes this citation list for mediated tool results and delegated runtime tool results while preserving unrelated caller-owned metadata. Concrete product/plugin details should stay in product-owned metadata keys outside each canonical citation object.
+
 ## Tool execution core
 
 `WP_Agent_Tool_Execution_Core` mediates calls without owning any concrete tool implementation.

--- a/docs/runtime-and-tools.md
+++ b/docs/runtime-and-tools.md
@@ -290,7 +290,7 @@ If a concrete executor returns its own `runtime` metadata, the normalized result
 
 ### Citation metadata
 
-Retrieval tools place canonical citations in result metadata under `metadata['citations']`. The substrate citation shape is intentionally small and generic: each citation may include `source`, `source_title`, `source_url`, `document_id`, `chunk_id`, `score`, and `excerpt`. Agents API normalizes this citation list for mediated tool results and delegated runtime tool results while preserving unrelated caller-owned metadata and additional caller-owned fields inside each citation.
+Retrieval tools place canonical citations in result metadata under `metadata['citations']`. The substrate citation shape is intentionally small and generic: each citation may include `source`, `source_id`, `item_id`, `fragment_id`, `source_title`, `source_url`, `score`, and `excerpt`. Agents API normalizes this citation list for mediated tool results and delegated runtime tool results while preserving unrelated caller-owned metadata and additional caller-owned fields inside each citation.
 
 ## Tool execution core
 

--- a/docs/runtime-and-tools.md
+++ b/docs/runtime-and-tools.md
@@ -290,7 +290,7 @@ If a concrete executor returns its own `runtime` metadata, the normalized result
 
 ### Citation metadata
 
-Retrieval tools place canonical citations in result metadata under `metadata['citations']`. The substrate citation shape is intentionally small and generic: each citation may include `source`, `source_title`, `source_url`, `document_id`, `chunk_id`, `score`, and `excerpt`. Agents API normalizes this citation list for mediated tool results and delegated runtime tool results while preserving unrelated caller-owned metadata. Concrete product/plugin details should stay in product-owned metadata keys outside each canonical citation object.
+Retrieval tools place canonical citations in result metadata under `metadata['citations']`. The substrate citation shape is intentionally small and generic: each citation may include `source`, `source_title`, `source_url`, `document_id`, `chunk_id`, `score`, and `excerpt`. Agents API normalizes this citation list for mediated tool results and delegated runtime tool results while preserving unrelated caller-owned metadata and additional caller-owned fields inside each citation.
 
 ## Tool execution core
 

--- a/src/Context/class-wp-agent-context-item.php
+++ b/src/Context/class-wp-agent-context-item.php
@@ -10,6 +10,8 @@
 
 namespace AgentsAPI\AI\Context;
 
+use AgentsAPI\AI\WP_Agent_Citation_Metadata;
+
 defined( 'ABSPATH' ) || exit;
 
 final class WP_Agent_Context_Item {
@@ -49,7 +51,7 @@ final class WP_Agent_Context_Item {
 			'provenance'     => $this->provenance,
 			'conflict_kind'  => WP_Agent_Context_Conflict_Kind::normalize( $this->conflict_kind ),
 			'conflict_key'   => $this->conflict_key,
-			'metadata'       => $this->metadata,
+			'metadata'       => WP_Agent_Citation_Metadata::normalize_metadata( $this->metadata ),
 		);
 	}
 }

--- a/src/Runtime/class-wp-agent-citation-metadata.php
+++ b/src/Runtime/class-wp-agent-citation-metadata.php
@@ -77,7 +77,7 @@ class WP_Agent_Citation_Metadata {
 			}
 		}
 
-		foreach ( array( 'source', 'source_title', 'source_url', 'document_id', 'chunk_id', 'excerpt' ) as $key ) {
+		foreach ( array( 'source', 'source_id', 'item_id', 'fragment_id', 'source_title', 'source_url', 'excerpt' ) as $key ) {
 			unset( $normalized[ $key ] );
 
 			if ( isset( $citation[ $key ] ) && is_scalar( $citation[ $key ] ) ) {

--- a/src/Runtime/class-wp-agent-citation-metadata.php
+++ b/src/Runtime/class-wp-agent-citation-metadata.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * Canonical citation metadata normalizer.
+ *
+ * @package AgentsAPI
+ */
+
+namespace AgentsAPI\AI;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Normalizes generic retrieved-context citation metadata.
+ */
+class WP_Agent_Citation_Metadata {
+
+	/**
+	 * Canonical citation metadata key.
+	 */
+	public const KEY = 'citations';
+
+	/**
+	 * Normalize metadata and canonicalize metadata.citations when present.
+	 *
+	 * @param mixed $metadata Raw metadata.
+	 * @return array<mixed>
+	 */
+	public static function normalize_metadata( $metadata ): array {
+		if ( ! is_array( $metadata ) ) {
+			return array();
+		}
+
+		if ( array_key_exists( self::KEY, $metadata ) ) {
+			$metadata[ self::KEY ] = self::normalize_many( $metadata[ self::KEY ] );
+		}
+
+		return $metadata;
+	}
+
+	/**
+	 * Normalize a list of citations.
+	 *
+	 * @param mixed $citations Raw citation list.
+	 * @return array<int, array<string, mixed>>
+	 */
+	public static function normalize_many( $citations ): array {
+		if ( ! is_array( $citations ) ) {
+			return array();
+		}
+
+		$normalized = array();
+		foreach ( $citations as $citation ) {
+			if ( ! is_array( $citation ) ) {
+				continue;
+			}
+
+			$citation = self::normalize( $citation );
+			if ( ! empty( $citation ) ) {
+				$normalized[] = $citation;
+			}
+		}
+
+		return $normalized;
+	}
+
+	/**
+	 * Normalize one citation to the substrate citation shape.
+	 *
+	 * @param array<mixed> $citation Raw citation.
+	 * @return array<string, mixed>
+	 */
+	public static function normalize( array $citation ): array {
+		$normalized = array();
+
+		foreach ( array( 'source', 'source_title', 'source_url', 'document_id', 'chunk_id', 'excerpt' ) as $key ) {
+			if ( isset( $citation[ $key ] ) && is_scalar( $citation[ $key ] ) ) {
+				$value = trim( (string) $citation[ $key ] );
+				if ( '' !== $value ) {
+					$normalized[ $key ] = $value;
+				}
+			}
+		}
+
+		if ( isset( $citation['score'] ) && is_numeric( $citation['score'] ) ) {
+			$normalized['score'] = (float) $citation['score'];
+		}
+
+		return $normalized;
+	}
+}

--- a/src/Runtime/class-wp-agent-citation-metadata.php
+++ b/src/Runtime/class-wp-agent-citation-metadata.php
@@ -71,8 +71,15 @@ class WP_Agent_Citation_Metadata {
 	 */
 	public static function normalize( array $citation ): array {
 		$normalized = array();
+		foreach ( $citation as $key => $value ) {
+			if ( is_string( $key ) ) {
+				$normalized[ $key ] = $value;
+			}
+		}
 
 		foreach ( array( 'source', 'source_title', 'source_url', 'document_id', 'chunk_id', 'excerpt' ) as $key ) {
+			unset( $normalized[ $key ] );
+
 			if ( isset( $citation[ $key ] ) && is_scalar( $citation[ $key ] ) ) {
 				$value = trim( (string) $citation[ $key ] );
 				if ( '' !== $value ) {
@@ -81,6 +88,7 @@ class WP_Agent_Citation_Metadata {
 			}
 		}
 
+		unset( $normalized['score'] );
 		if ( isset( $citation['score'] ) && is_numeric( $citation['score'] ) ) {
 			$normalized['score'] = (float) $citation['score'];
 		}

--- a/src/Runtime/class-wp-agent-runtime-tool-result.php
+++ b/src/Runtime/class-wp-agent-runtime-tool-result.php
@@ -34,14 +34,14 @@ class WP_Agent_Runtime_Tool_Result {
 		}
 
 		$payload  = $result['result'] ?? array();
-		$metadata = $result['metadata'] ?? array();
+		$metadata = WP_Agent_Citation_Metadata::normalize_metadata( $result['metadata'] ?? array() );
 
 		$normalized = array(
 			'status'     => self::STATUS_SUBMITTED,
 			'request_id' => trim( $request_id ),
 			'tool_name'  => trim( $tool_name ),
 			'success'    => (bool) ( $result['success'] ?? true ),
-			'metadata'   => is_array( $metadata ) ? $metadata : array(),
+			'metadata'   => $metadata,
 		);
 
 		if ( $normalized['success'] ) {

--- a/src/Tools/class-wp-agent-tool-result.php
+++ b/src/Tools/class-wp-agent-tool-result.php
@@ -7,6 +7,8 @@
 
 namespace AgentsAPI\AI\Tools;
 
+use AgentsAPI\AI\WP_Agent_Citation_Metadata;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -69,10 +71,7 @@ class WP_Agent_Tool_Result {
 		}
 
 		$success = (bool) ( $result['success'] ?? false );
-		$metadata = $result['metadata'] ?? array();
-		if ( ! is_array( $metadata ) ) {
-			$metadata = array();
-		}
+		$metadata = WP_Agent_Citation_Metadata::normalize_metadata( $result['metadata'] ?? array() );
 
 		$runtime = WP_Agent_Tool_Declaration::normalizeRuntimeMetadata( $result['runtime'] ?? array() );
 

--- a/tests/citation-metadata-smoke.php
+++ b/tests/citation-metadata-smoke.php
@@ -41,7 +41,7 @@ $normalized_metadata = AgentsAPI\AI\WP_Agent_Citation_Metadata::normalize_metada
 agents_api_smoke_assert_equals( 'trace-123', $normalized_metadata['trace_id'] ?? '', 'citation normalization preserves unrelated metadata', $failures, $passes );
 agents_api_smoke_assert_equals( 'docs', $normalized_metadata['citations'][0]['source'] ?? '', 'citation preserves generic source label', $failures, $passes );
 agents_api_smoke_assert_equals( 0.87, $normalized_metadata['citations'][0]['score'] ?? null, 'citation normalizes numeric score', $failures, $passes );
-agents_api_smoke_assert_equals( false, array_key_exists( 'plugin_name', $normalized_metadata['citations'][0] ?? array() ), 'citation drops product-specific fields from canonical shape', $failures, $passes );
+agents_api_smoke_assert_equals( 'product-specific-field', $normalized_metadata['citations'][0]['plugin_name'] ?? '', 'citation preserves caller-owned extension fields', $failures, $passes );
 
 $context_item = new AgentsAPI\AI\Context\WP_Agent_Context_Item(
 	'Retrieved context excerpt.',

--- a/tests/citation-metadata-smoke.php
+++ b/tests/citation-metadata-smoke.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * Pure-PHP smoke test for canonical citation metadata.
+ *
+ * Run with: php tests/citation-metadata-smoke.php
+ *
+ * @package AgentsAPI\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+$failures = array();
+$passes   = 0;
+
+echo "agents-api-citation-metadata-smoke\n";
+
+require_once __DIR__ . '/agents-api-smoke-helpers.php';
+agents_api_smoke_require_module();
+
+$citations = array(
+	array(
+		'source'       => 'docs',
+		'source_title' => 'Agents Handbook',
+		'source_url'   => 'https://example.com/agents',
+		'document_id'  => 'doc-1',
+		'chunk_id'     => 'chunk-2',
+		'score'        => '0.87',
+		'excerpt'      => 'Retrieved context excerpt.',
+		'plugin_name'  => 'product-specific-field',
+	),
+);
+
+$metadata = array(
+	'citations' => $citations,
+	'trace_id'  => 'trace-123',
+);
+
+$normalized_metadata = AgentsAPI\AI\WP_Agent_Citation_Metadata::normalize_metadata( $metadata );
+agents_api_smoke_assert_equals( 'trace-123', $normalized_metadata['trace_id'] ?? '', 'citation normalization preserves unrelated metadata', $failures, $passes );
+agents_api_smoke_assert_equals( 'docs', $normalized_metadata['citations'][0]['source'] ?? '', 'citation preserves generic source label', $failures, $passes );
+agents_api_smoke_assert_equals( 0.87, $normalized_metadata['citations'][0]['score'] ?? null, 'citation normalizes numeric score', $failures, $passes );
+agents_api_smoke_assert_equals( false, array_key_exists( 'plugin_name', $normalized_metadata['citations'][0] ?? array() ), 'citation drops product-specific fields from canonical shape', $failures, $passes );
+
+$context_item = new AgentsAPI\AI\Context\WP_Agent_Context_Item(
+	'Retrieved context excerpt.',
+	array( 'type' => 'workspace' ),
+	AgentsAPI\AI\Context\WP_Agent_Context_Authority_Tier::WORKSPACE_SHARED,
+	array( 'source' => 'search' ),
+	AgentsAPI\AI\Context\WP_Agent_Context_Conflict_Kind::PREFERENCE,
+	null,
+	$metadata
+);
+$context_array = $context_item->to_array();
+agents_api_smoke_assert_equals( 'doc-1', $context_array['metadata']['citations'][0]['document_id'] ?? '', 'context item carries citation metadata through array export', $failures, $passes );
+
+$tool_result = AgentsAPI\AI\Tools\WP_Agent_Tool_Result::success(
+	'ability/search_docs',
+	array( 'matches' => array( 'doc-1' ) ),
+	$metadata
+);
+agents_api_smoke_assert_equals( 'chunk-2', $tool_result['metadata']['citations'][0]['chunk_id'] ?? '', 'tool result normalization preserves citation metadata', $failures, $passes );
+
+$runtime_result = AgentsAPI\AI\WP_Agent_Runtime_Tool_Result::normalize(
+	array(
+		'request_id' => 'request-1',
+		'tool_name'  => 'client/search_docs',
+		'success'    => true,
+		'result'     => array( 'matches' => array( 'doc-1' ) ),
+		'metadata'   => $metadata,
+	)
+);
+agents_api_smoke_assert_equals( 'https://example.com/agents', $runtime_result['metadata']['citations'][0]['source_url'] ?? '', 'runtime tool result normalization preserves citation metadata', $failures, $passes );
+
+agents_api_smoke_finish( 'Agents API citation metadata', $failures, $passes );

--- a/tests/citation-metadata-smoke.php
+++ b/tests/citation-metadata-smoke.php
@@ -22,12 +22,14 @@ agents_api_smoke_require_module();
 $citations = array(
 	array(
 		'source'       => 'docs',
+		'source_id'    => 'docs-primary',
 		'source_title' => 'Agents Handbook',
 		'source_url'   => 'https://example.com/agents',
-		'document_id'  => 'doc-1',
-		'chunk_id'     => 'chunk-2',
+		'item_id'      => 'item-1',
+		'fragment_id'  => 'fragment-2',
 		'score'        => '0.87',
 		'excerpt'      => 'Retrieved context excerpt.',
+		'document_id'  => 'doc-extension',
 		'plugin_name'  => 'product-specific-field',
 	),
 );
@@ -40,8 +42,10 @@ $metadata = array(
 $normalized_metadata = AgentsAPI\AI\WP_Agent_Citation_Metadata::normalize_metadata( $metadata );
 agents_api_smoke_assert_equals( 'trace-123', $normalized_metadata['trace_id'] ?? '', 'citation normalization preserves unrelated metadata', $failures, $passes );
 agents_api_smoke_assert_equals( 'docs', $normalized_metadata['citations'][0]['source'] ?? '', 'citation preserves generic source label', $failures, $passes );
+agents_api_smoke_assert_equals( 'docs-primary', $normalized_metadata['citations'][0]['source_id'] ?? '', 'citation preserves generic source id', $failures, $passes );
 agents_api_smoke_assert_equals( 0.87, $normalized_metadata['citations'][0]['score'] ?? null, 'citation normalizes numeric score', $failures, $passes );
 agents_api_smoke_assert_equals( 'product-specific-field', $normalized_metadata['citations'][0]['plugin_name'] ?? '', 'citation preserves caller-owned extension fields', $failures, $passes );
+agents_api_smoke_assert_equals( 'doc-extension', $normalized_metadata['citations'][0]['document_id'] ?? '', 'citation preserves non-canonical caller-owned ids as extensions', $failures, $passes );
 
 $context_item = new AgentsAPI\AI\Context\WP_Agent_Context_Item(
 	'Retrieved context excerpt.',
@@ -53,14 +57,14 @@ $context_item = new AgentsAPI\AI\Context\WP_Agent_Context_Item(
 	$metadata
 );
 $context_array = $context_item->to_array();
-agents_api_smoke_assert_equals( 'doc-1', $context_array['metadata']['citations'][0]['document_id'] ?? '', 'context item carries citation metadata through array export', $failures, $passes );
+agents_api_smoke_assert_equals( 'item-1', $context_array['metadata']['citations'][0]['item_id'] ?? '', 'context item carries citation metadata through array export', $failures, $passes );
 
 $tool_result = AgentsAPI\AI\Tools\WP_Agent_Tool_Result::success(
 	'ability/search_docs',
 	array( 'matches' => array( 'doc-1' ) ),
 	$metadata
 );
-agents_api_smoke_assert_equals( 'chunk-2', $tool_result['metadata']['citations'][0]['chunk_id'] ?? '', 'tool result normalization preserves citation metadata', $failures, $passes );
+agents_api_smoke_assert_equals( 'fragment-2', $tool_result['metadata']['citations'][0]['fragment_id'] ?? '', 'tool result normalization preserves citation metadata', $failures, $passes );
 
 $runtime_result = AgentsAPI\AI\WP_Agent_Runtime_Tool_Result::normalize(
 	array(


### PR DESCRIPTION
## Summary
- Adds a small canonical `metadata['citations']` normalizer for retrieved context and retrieval tool-result metadata.
- Uses generic citation identifiers (`source_id`, `item_id`, `fragment_id`) instead of document/chunk-specific canonical fields, while preserving caller-owned extension fields.
- Applies citation normalization to context item export, mediated tool results, and delegated runtime tool results while preserving unrelated caller metadata.
- Documents citation placement and the generic citation fields for context/tool-result contracts.

Closes https://github.com/Automattic/agents-api/issues/294

## Tests
- `php tests/citation-metadata-smoke.php`
- `php tests/tool-runtime-smoke.php`
- `php tests/tool-result-truncator-smoke.php`
- `php tests/context-authority-smoke.php`
- `composer smoke`
- `php tests/no-product-imports-smoke.php`
- `composer phpstan`

## Remaining risks
- Citation fields are intentionally substrate-only and small; products may still need their own display-specific metadata as preserved extension fields.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafting and testing the substrate citation metadata contract, docs, and smoke coverage; Chris remains responsible for review and submission.