### PR TITLE
Keep truncated result metadata generic

### DIFF
--- a/src/Runtime/class-wp-agent-byte-limit-tool-result-truncator.php
+++ b/src/Runtime/class-wp-agent-byte-limit-tool-result-truncator.php
@@ -87,7 +87,7 @@ final class WP_Agent_Byte_Limit_Tool_Result_Truncator implements WP_Agent_Tool_R
 		$payload = isset( $result['result'] ) && is_array( $result['result'] ) ? $result['result'] : array();
 		$keep    = array();
 
-		foreach ( array( 'citations', 'retrieved_context', 'retrieved_contexts' ) as $field ) {
+		foreach ( array( 'citations' ) as $field ) {
 			if ( array_key_exists( $field, $payload ) ) {
 				$keep[ $field ] = $payload[ $field ];
 			}

--- a/tests/conversation-loop-smoke.php
+++ b/tests/conversation-loop-smoke.php
@@ -60,8 +60,8 @@ $metadata_result = AgentsAPI\AI\WP_Agent_Conversation_Loop::run(
 			'messages'               => $messages,
 			'tool_execution_results' => array(),
 			'metadata'               => array(
-				'citations'         => array( array( 'url' => 'https://example.test/source' ) ),
-				'retrieved_context' => array( array( 'id' => 'ctx-1', 'title' => 'Source' ) ),
+				'citations'    => array( array( 'url' => 'https://example.test/source' ) ),
+				'source_items' => array( array( 'id' => 'source-item-1', 'title' => 'Source' ) ),
 			),
 			'request_metadata'       => array(
 				'provider_request_id' => 'req-citations-1',
@@ -72,7 +72,7 @@ $metadata_result = AgentsAPI\AI\WP_Agent_Conversation_Loop::run(
 );
 
 agents_api_smoke_assert_equals( 'https://example.test/source', $metadata_result['metadata']['citations'][0]['url'] ?? '', 'loop preserves generic result citation metadata', $failures, $passes );
-agents_api_smoke_assert_equals( 'ctx-1', $metadata_result['metadata']['retrieved_context'][0]['id'] ?? '', 'loop preserves generic retrieved-context metadata', $failures, $passes );
+agents_api_smoke_assert_equals( 'source-item-1', $metadata_result['metadata']['source_items'][0]['id'] ?? '', 'loop preserves caller-owned result metadata', $failures, $passes );
 agents_api_smoke_assert_equals( 'req-citations-1', $metadata_result['request_metadata']['provider_request_id'] ?? '', 'caller-managed loop preserves request metadata', $failures, $passes );
 
 echo "\n[2] Loop can apply caller-supplied compaction without owning model dispatch:\n";

--- a/tests/frontend-chat-rest-smoke.php
+++ b/tests/frontend-chat-rest-smoke.php
@@ -122,8 +122,8 @@ $ability  = new class( $captured ) {
 			'session_id' => 's-1',
 			'reply'      => 'hello from adapter',
 			'metadata'   => array(
-				'citations'         => array( array( 'url' => 'https://example.test/rest-source' ) ),
-				'retrieved_context' => array( array( 'id' => 'rest-context-1' ) ),
+				'citations'    => array( array( 'url' => 'https://example.test/rest-source' ) ),
+				'source_items' => array( array( 'id' => 'rest-source-item-1' ) ),
 			),
 		);
 	}
@@ -157,7 +157,7 @@ $response = AgentsAPI\AI\Channels\agents_frontend_chat_rest_dispatch( $request )
 agents_api_smoke_assert_equals( true, $response instanceof WP_REST_Response, 'dispatch returns REST response', $failures, $passes );
 agents_api_smoke_assert_equals( 'hello from adapter', $response->data['reply'] ?? null, 'dispatch returns ability reply', $failures, $passes );
 agents_api_smoke_assert_equals( 'https://example.test/rest-source', $response->data['metadata']['citations'][0]['url'] ?? null, 'dispatch preserves citation metadata', $failures, $passes );
-agents_api_smoke_assert_equals( 'rest-context-1', $response->data['metadata']['retrieved_context'][0]['id'] ?? null, 'dispatch preserves retrieved-context metadata', $failures, $passes );
+agents_api_smoke_assert_equals( 'rest-source-item-1', $response->data['metadata']['source_items'][0]['id'] ?? null, 'dispatch preserves caller-owned result metadata', $failures, $passes );
 agents_api_smoke_assert_equals( 'support-agent', $captured['agent'] ?? null, 'dispatch sanitizes agent slug', $failures, $passes );
 agents_api_smoke_assert_equals( 'Hi there', $captured['message'] ?? null, 'dispatch forwards message', $failures, $passes );
 agents_api_smoke_assert_equals( 'rest', $captured['client_context']['source'] ?? null, 'dispatch marks REST source', $failures, $passes );

--- a/tests/tool-result-truncator-smoke.php
+++ b/tests/tool-result-truncator-smoke.php
@@ -28,8 +28,7 @@ $executor = new class() implements AgentsAPI\AI\Tools\WP_Agent_Tool_Executor {
 			'tool_name' => $tool_call['tool_name'],
 			'result'    => array(
 				'body'              => str_repeat( 'x', 200 ),
-				'citations'         => array( array( 'url' => 'https://example.test/tool-source' ) ),
-				'retrieved_context' => array( array( 'id' => 'tool-context-1' ) ),
+				'citations' => array( array( 'url' => 'https://example.test/tool-source' ) ),
 			),
 		);
 	}
@@ -80,7 +79,6 @@ $truncated_result = $result['tool_execution_results'][0]['result'] ?? array();
 agents_api_smoke_assert_equals( true, (bool) ( $truncated_result['metadata']['truncated'] ?? false ), 'tool execution result is marked truncated', $failures, $passes );
 agents_api_smoke_assert_equals( true, isset( $truncated_result['result']['excerpt'] ), 'tool execution result stores excerpt payload', $failures, $passes );
 agents_api_smoke_assert_equals( 'https://example.test/tool-source', $truncated_result['result']['citations'][0]['url'] ?? '', 'tool execution result preserves citation metadata after truncation', $failures, $passes );
-agents_api_smoke_assert_equals( 'tool-context-1', $truncated_result['result']['retrieved_context'][0]['id'] ?? '', 'tool execution result preserves retrieved-context metadata after truncation', $failures, $passes );
 agents_api_smoke_assert_equals( false, str_contains( wp_json_encode( $truncated_result ), str_repeat( 'x', 200 ) ), 'truncated execution result omits full original body', $failures, $passes );
 
 $tool_result_messages = array_values(


### PR DESCRIPTION
## Summary
- Removes `retrieved_context` / `retrieved_contexts` from the byte-limit truncator's hard-coded preserved payload fields.
- Keeps `citations` as the only canonical preserved payload metadata after PR #298 defined the generic citation shape.
- Updates preservation tests to use neutral caller-owned `source_items` metadata instead of introducing retrieval-shaped substrate conventions.

## Tests
- `php tests/tool-result-truncator-smoke.php`
- `php tests/frontend-chat-rest-smoke.php`
- `php tests/conversation-loop-smoke.php`
- `php tests/citation-metadata-smoke.php`
- `php tests/no-product-imports-smoke.php`
- `composer phpstan`
- `composer smoke`
- Boundary grep for `retrieved_context`, `retrieved_contexts`, `KnowledgeBase`, `Corpus`, `VectorStore`, `RetrievalEngine`, `Indexer`, and embeddings terms in PHP/docs returned no matches.

## Remaining risks
- Consumers that were relying on oversized tool payloads preserving `retrieved_context` directly in `result` should move that data into caller-owned result metadata or the canonical `metadata['citations']` shape.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Reviewing the merged citation/client-context boundary, drafting the focused cleanup, and running verification; Chris remains responsible for review and submission.