### PR TITLE
Tighten truncator citation metadata boundary

### DIFF
--- a/src/Runtime/class-wp-agent-byte-limit-tool-result-truncator.php
+++ b/src/Runtime/class-wp-agent-byte-limit-tool-result-truncator.php
@@ -85,14 +85,12 @@ final class WP_Agent_Byte_Limit_Tool_Result_Truncator implements WP_Agent_Tool_R
 	 */
 	private function preserve_result_metadata( array $result ): array {
 		$payload = isset( $result['result'] ) && is_array( $result['result'] ) ? $result['result'] : array();
-		$keep    = array();
-
-		foreach ( array( 'citations', 'retrieved_context', 'retrieved_contexts' ) as $field ) {
-			if ( array_key_exists( $field, $payload ) ) {
-				$keep[ $field ] = $payload[ $field ];
-			}
+		if ( ! array_key_exists( WP_Agent_Citation_Metadata::KEY, $payload ) ) {
+			return array();
 		}
 
-		return $keep;
+		return array(
+			WP_Agent_Citation_Metadata::KEY => WP_Agent_Citation_Metadata::normalize_many( $payload[ WP_Agent_Citation_Metadata::KEY ] ),
+		);
 	}
 }

--- a/tests/tool-result-truncator-smoke.php
+++ b/tests/tool-result-truncator-smoke.php
@@ -28,7 +28,7 @@ $executor = new class() implements AgentsAPI\AI\Tools\WP_Agent_Tool_Executor {
 			'tool_name' => $tool_call['tool_name'],
 			'result'    => array(
 				'body'              => str_repeat( 'x', 200 ),
-				'citations'         => array( array( 'url' => 'https://example.test/tool-source' ) ),
+				'citations'         => array( array( 'source_url' => 'https://example.test/tool-source' ) ),
 				'retrieved_context' => array( array( 'id' => 'tool-context-1' ) ),
 			),
 		);
@@ -79,8 +79,8 @@ $truncated_result = $result['tool_execution_results'][0]['result'] ?? array();
 
 agents_api_smoke_assert_equals( true, (bool) ( $truncated_result['metadata']['truncated'] ?? false ), 'tool execution result is marked truncated', $failures, $passes );
 agents_api_smoke_assert_equals( true, isset( $truncated_result['result']['excerpt'] ), 'tool execution result stores excerpt payload', $failures, $passes );
-agents_api_smoke_assert_equals( 'https://example.test/tool-source', $truncated_result['result']['citations'][0]['url'] ?? '', 'tool execution result preserves citation metadata after truncation', $failures, $passes );
-agents_api_smoke_assert_equals( 'tool-context-1', $truncated_result['result']['retrieved_context'][0]['id'] ?? '', 'tool execution result preserves retrieved-context metadata after truncation', $failures, $passes );
+agents_api_smoke_assert_equals( 'https://example.test/tool-source', $truncated_result['result']['citations'][0]['source_url'] ?? '', 'tool execution result preserves citation metadata after truncation', $failures, $passes );
+agents_api_smoke_assert_equals( false, isset( $truncated_result['result']['retrieved_context'] ), 'tool execution result does not preserve bulky retrieved-context payloads after truncation', $failures, $passes );
 agents_api_smoke_assert_equals( false, str_contains( wp_json_encode( $truncated_result ), str_repeat( 'x', 200 ) ), 'truncated execution result omits full original body', $failures, $passes );
 
 $tool_result_messages = array_values(


### PR DESCRIPTION
## Summary
- Narrows byte-limit tool-result truncation preservation to canonical `metadata['citations']` only, using `WP_Agent_Citation_Metadata` instead of a parallel field whitelist.
- Stops preserving bulky `retrieved_context` / `retrieved_contexts` payloads inside truncated tool results; products can keep retrieval details in their own metadata before truncation, while the substrate preserves compact citation metadata for rendering/provenance.
- Updates smoke coverage to assert citations survive truncation and retrieved-context payloads do not bypass truncation.

Follow-up to https://github.com/Automattic/agents-api/pull/297, after adjacent citation metadata work in https://github.com/Automattic/agents-api/pull/298.

## Tests run
- `php tests/tool-result-truncator-smoke.php`
- `php tests/citation-metadata-smoke.php`
- `php tests/no-product-imports-smoke.php`
- `composer phpstan`
- `homeboy lint agents-api`

## Remaining risks
- No known blockers. This keeps Agents API at the generic citation/provenance layer and leaves corpus, indexing, retrieval, and prompt assembly semantics to consumer plugins.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Boundary audit, focused refactor, test updates, and verification steps; Chris remains responsible for review and merge.