### PR TITLE
Keep frontend chat context examples opaque

### DIFF
--- a/docs/external-clients.md
+++ b/docs/external-clients.md
@@ -291,11 +291,9 @@ array(
 		'external_conversation_id'     => 'opaque-channel-or-thread-id',
 		'external_message_id'          => 'opaque-message-id',
 		'room_kind'                    => 'dm',
-		'context_source_type'          => 'optional-opaque-source-type',
-		'context_source_id'            => 'optional-opaque-source-id',
-		'context_scope_id'             => 'optional-opaque-scope-id',
-		'context_selection_policy'     => 'optional-policy-name-or-object',
-		'current_context_item_id'      => 'optional-opaque-item-id',
+		'host_context'                 => array(
+			'opaque_id' => 'optional-caller-owned-id',
+		),
 	),
 )
 ```
@@ -306,12 +304,12 @@ storage, or observability.
 Clients may include additional opaque `client_context` metadata when a turn
 should be associated with selected material, whether that material is docs,
 memory, tool output, search results, files, CRM records, support articles, or
-another host-defined source. The example `context_*` keys above are conventions,
-not schema requirements. Agents API preserves the envelope and forwards it to
-host-owned permission/access hooks; it does not define the source model, lookup
-algorithm, authorization policy, or prompt assembly rules. Hosts that support
-scoped context selection should validate any opaque ids and policy values
-against their own workspace/access model before using them.
+another host-defined source. The example `host_context` key above is
+caller-owned, not an Agents API schema requirement. Agents API preserves the
+envelope and forwards it to host-owned permission/access hooks; it does not
+define the source model, lookup algorithm, authorization policy, or prompt
+assembly rules. Hosts that support scoped context selection should validate any
+opaque values against their own workspace/access model before using them.
 
 ### Normalized External Message
 

--- a/tests/frontend-chat-rest-smoke.php
+++ b/tests/frontend-chat-rest-smoke.php
@@ -138,12 +138,11 @@ $request = new WP_REST_Request(
 		'session_id'     => 'existing-session',
 		'attachments'    => array( array( 'type' => 'image' ) ),
 		'client_context' => array(
-			'client_name'              => 'block-chat',
-			'context_source_type'      => 'docs',
-			'context_source_id'        => 'source-123',
-			'context_scope_id'         => 'workspace-help',
-			'context_selection_policy' => array( 'mode' => 'focused', 'limit' => 4 ),
-			'current_context_item_id'  => 'item-789',
+			'client_name'  => 'block-chat',
+			'host_context' => array(
+				'opaque_id' => 'selected-material-123',
+				'hints'     => array( 'current-item' ),
+			),
 		),
 		'workspace_id'   => 'site:42',
 		'client_id'      => 'browser-1',
@@ -162,13 +161,10 @@ agents_api_smoke_assert_equals( 'support-agent', $captured['agent'] ?? null, 'di
 agents_api_smoke_assert_equals( 'Hi there', $captured['message'] ?? null, 'dispatch forwards message', $failures, $passes );
 agents_api_smoke_assert_equals( 'rest', $captured['client_context']['source'] ?? null, 'dispatch marks REST source', $failures, $passes );
 agents_api_smoke_assert_equals( 'block-chat', $captured['client_context']['client_name'] ?? null, 'dispatch preserves client name', $failures, $passes );
-agents_api_smoke_assert_equals( 'docs', $captured['client_context']['context_source_type'] ?? null, 'dispatch preserves opaque context source type', $failures, $passes );
-agents_api_smoke_assert_equals( 'source-123', $captured['client_context']['context_source_id'] ?? null, 'dispatch preserves opaque context source id', $failures, $passes );
-agents_api_smoke_assert_equals( array( 'mode' => 'focused', 'limit' => 4 ), $captured['client_context']['context_selection_policy'] ?? null, 'dispatch preserves opaque context policy', $failures, $passes );
-agents_api_smoke_assert_equals( 'item-789', $captured['client_context']['current_context_item_id'] ?? null, 'dispatch preserves opaque current item id', $failures, $passes );
-agents_api_smoke_assert_equals( 'workspace-help', $access_contexts[0]['client_context']['context_scope_id'] ?? null, 'access scope receives opaque context scope id', $failures, $passes );
-agents_api_smoke_assert_equals( array( 'mode' => 'focused', 'limit' => 4 ), $access_contexts[0]['client_context']['context_selection_policy'] ?? null, 'access scope receives opaque context policy', $failures, $passes );
-agents_api_smoke_assert_equals( 'item-789', $access_contexts[0]['request_metadata']['client_context']['current_context_item_id'] ?? null, 'access metadata receives opaque current item id', $failures, $passes );
+agents_api_smoke_assert_equals( 'selected-material-123', $captured['client_context']['host_context']['opaque_id'] ?? null, 'dispatch preserves caller-owned context metadata', $failures, $passes );
+agents_api_smoke_assert_equals( array( 'current-item' ), $captured['client_context']['host_context']['hints'] ?? null, 'dispatch preserves nested caller-owned context metadata', $failures, $passes );
+agents_api_smoke_assert_equals( 'selected-material-123', $access_contexts[0]['client_context']['host_context']['opaque_id'] ?? null, 'access scope receives caller-owned context metadata', $failures, $passes );
+agents_api_smoke_assert_equals( array( 'current-item' ), $access_contexts[0]['request_metadata']['client_context']['host_context']['hints'] ?? null, 'access metadata receives nested caller-owned context metadata', $failures, $passes );
 
 $blocked = AgentsAPI\AI\Channels\agents_frontend_chat_rest_permission(
 	new WP_REST_Request(


### PR DESCRIPTION
## Summary
- Removes convention-looking `context_*` example keys from frontend chat client-context docs and tests.
- Keeps the boundary from #296/#299 focused on preserving opaque caller-owned `client_context` metadata instead of defining substrate context-selection fields.
- Updates REST smoke coverage to prove nested host-owned metadata still reaches both dispatch input and access-scope metadata.

Follow-up to https://github.com/Automattic/agents-api/issues/296 and https://github.com/Automattic/agents-api/pull/299.

## Tests run
- `php tests/frontend-chat-rest-smoke.php`
- `php tests/agents-chat-ability-smoke.php`
- `php tests/citation-metadata-smoke.php`
- `composer phpstan`
- `git diff --check`

## Remaining risks
- No known blockers. Citation/retrieved-context metadata remains generic; hosts still own source models, authorization, indexing, lookup, and prompt assembly.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Boundary review, cleanup patch, smoke-test updates, and PR drafting; Chris remains responsible for review and merge.