### PR TITLE
Allow provider-turn continuation messages

### DIFF
--- a/src/Runtime/class-wp-agent-conversation-loop.php
+++ b/src/Runtime/class-wp-agent-conversation-loop.php
@@ -36,11 +36,14 @@ class WP_Agent_Conversation_Loop {
 	 * an array. Callers may also pass `provider_turn_adapter` in options; that
 	 * adapter receives `WP_Agent_Provider_Turn_Request` and returns a normalized
 	 * `WP_Agent_Provider_Turn_Result` shape while the loop keeps ownership of
-	 * continuation and mediated tool execution. When tool mediation is enabled
-	 * (`tool_executor` + `tool_declarations`), the turn runner or provider-turn
-	 * adapter can return a `tool_calls` key (array of `{name, parameters}`) and
-	 * the loop handles execution internally. Otherwise the turn runner must return
-	 * an `WP_Agent_Conversation_Result`-compatible array as before.
+	 * continuation and mediated tool execution. Provider-turn results may include
+		 * `continuation_messages` to append caller-supplied follow-up messages before
+		 * the next turn without taking over the whole runner. When tool mediation is
+		 * enabled (`tool_executor` + `tool_declarations`), the turn runner or
+		 * provider-turn adapter can return a `tool_calls` key (array of `{name,
+		 * parameters}`) and the loop handles execution internally. Otherwise the turn
+		 * runner must return an `WP_Agent_Conversation_Result`-compatible array as
+		 * before.
 	 *
 	 * Supported options:
 	 *
@@ -871,9 +874,27 @@ class WP_Agent_Conversation_Loop {
 			}
 		}
 
-		// No tool calls at all = natural completion (assistant responded with text only).
+		$continuation_messages = self::normalize_messages(
+			is_array( $result['continuation_messages'] ?? null ) ? $result['continuation_messages'] : array()
+		);
+		foreach ( $continuation_messages as $continuation_message ) {
+			$messages[] = $continuation_message;
+			$events[]   = array(
+				'type'     => 'continuation_message_added',
+				'metadata' => array(
+					'turn' => $turn,
+					'role' => (string) ( $continuation_message['role'] ?? '' ),
+				),
+			);
+			self::emit_event( $on_event, 'continuation_message_added', array(
+				'turn' => $turn,
+				'role' => (string) ( $continuation_message['role'] ?? '' ),
+			) );
+		}
+
+		// No tool calls and no continuation messages = natural completion.
 		if ( empty( $tool_calls ) ) {
-			$complete = true;
+			$complete = empty( $continuation_messages );
 		}
 
 		return array(
@@ -1600,6 +1621,7 @@ class WP_Agent_Conversation_Loop {
 			}
 
 			if ( ! $mediation_enabled ) {
+				$events = array();
 				if ( isset( $result['message'] ) && is_array( $result['message'] ) ) {
 					$messages[] = $result['message'];
 				} else {
@@ -1608,9 +1630,21 @@ class WP_Agent_Conversation_Loop {
 						$messages[] = WP_Agent_Message::text( 'assistant', $content );
 					}
 				}
+				$continuation_messages = self::normalize_messages(
+					is_array( $result['continuation_messages'] ?? null ) ? $result['continuation_messages'] : array()
+				);
+				foreach ( $continuation_messages as $continuation_message ) {
+					$messages[] = $continuation_message;
+					$events[]   = array(
+						'type'     => 'continuation_message_added',
+						'metadata' => array(
+							'role' => (string) ( $continuation_message['role'] ?? '' ),
+						),
+					);
+				}
 
 				$result['tool_execution_results'] = array();
-				$result['events']                 = array();
+				$result['events']                 = $events;
 			}
 
 			$result['messages'] = $messages;

--- a/src/Runtime/class-wp-agent-conversation-loop.php
+++ b/src/Runtime/class-wp-agent-conversation-loop.php
@@ -878,17 +878,18 @@ class WP_Agent_Conversation_Loop {
 			is_array( $result['continuation_messages'] ?? null ) ? $result['continuation_messages'] : array()
 		);
 		foreach ( $continuation_messages as $continuation_message ) {
-			$messages[] = $continuation_message;
+			$continuation_role = is_string( $continuation_message['role'] ?? null ) ? $continuation_message['role'] : '';
+			$messages[]        = $continuation_message;
 			$events[]   = array(
 				'type'     => 'continuation_message_added',
 				'metadata' => array(
 					'turn' => $turn,
-					'role' => (string) ( $continuation_message['role'] ?? '' ),
+					'role' => $continuation_role,
 				),
 			);
 			self::emit_event( $on_event, 'continuation_message_added', array(
 				'turn' => $turn,
-				'role' => (string) ( $continuation_message['role'] ?? '' ),
+				'role' => $continuation_role,
 			) );
 		}
 
@@ -1634,11 +1635,12 @@ class WP_Agent_Conversation_Loop {
 					is_array( $result['continuation_messages'] ?? null ) ? $result['continuation_messages'] : array()
 				);
 				foreach ( $continuation_messages as $continuation_message ) {
-					$messages[] = $continuation_message;
+					$continuation_role = is_string( $continuation_message['role'] ?? null ) ? $continuation_message['role'] : '';
+					$messages[]        = $continuation_message;
 					$events[]   = array(
 						'type'     => 'continuation_message_added',
 						'metadata' => array(
-							'role' => (string) ( $continuation_message['role'] ?? '' ),
+							'role' => $continuation_role,
 						),
 					);
 				}

--- a/src/Runtime/class-wp-agent-provider-turn-result.php
+++ b/src/Runtime/class-wp-agent-provider-turn-result.php
@@ -27,12 +27,13 @@ class WP_Agent_Provider_Turn_Result {
 	 */
 	public static function normalize( array $result ): array {
 		$normalized = array(
-			'content'              => self::string_value( $result['content'] ?? '' ),
-			'message'              => null,
-			'tool_calls'           => array(),
-			'usage'                => self::assoc_array( $result['usage'] ?? array(), 'usage' ),
-			'request_metadata'     => self::assoc_array( $result['request_metadata'] ?? array(), 'request_metadata' ),
-			'provider_diagnostics' => self::assoc_array( $result['provider_diagnostics'] ?? array(), 'provider_diagnostics' ),
+			'content'               => self::string_value( $result['content'] ?? '' ),
+			'message'               => null,
+			'continuation_messages' => array(),
+			'tool_calls'            => array(),
+			'usage'                 => self::assoc_array( $result['usage'] ?? array(), 'usage' ),
+			'request_metadata'      => self::assoc_array( $result['request_metadata'] ?? array(), 'request_metadata' ),
+			'provider_diagnostics'  => self::assoc_array( $result['provider_diagnostics'] ?? array(), 'provider_diagnostics' ),
 		);
 
 		if ( isset( $result['message'] ) ) {
@@ -47,6 +48,13 @@ class WP_Agent_Provider_Turn_Result {
 				throw self::invalid( 'tool_calls', 'must be an array when present' );
 			}
 			$normalized['tool_calls'] = self::normalize_tool_calls( $result['tool_calls'] );
+		}
+
+		if ( isset( $result['continuation_messages'] ) ) {
+			if ( ! is_array( $result['continuation_messages'] ) ) {
+				throw self::invalid( 'continuation_messages', 'must be an array when present' );
+			}
+			$normalized['continuation_messages'] = WP_Agent_Message::normalize_many( $result['continuation_messages'] );
 		}
 
 		if ( isset( $result['failure'] ) ) {

--- a/src/Tools/class-wp-agent-tool-declaration.php
+++ b/src/Tools/class-wp-agent-tool-declaration.php
@@ -261,11 +261,7 @@ class WP_Agent_Tool_Declaration {
 		$errors = array();
 
 		$name = $declaration['name'] ?? null;
-		if (
-			! is_string( $name )
-			|| '' === $name
-			|| ! preg_match( '/^[a-z][a-z0-9_-]*\/[a-z][a-z0-9_-]*$/', $name )
-		) {
+		if ( ! is_string( $name ) || '' === $name || ! self::isValidHostToolName( $name ) ) {
 			$errors[] = 'name';
 		}
 
@@ -318,7 +314,7 @@ class WP_Agent_Tool_Declaration {
 	private static function applyServerDefaults( array $declaration ): array {
 		$name = is_string( $declaration['name'] ?? null ) ? $declaration['name'] : '';
 		if ( ! isset( $declaration['source'] ) || ! is_string( $declaration['source'] ) || '' === $declaration['source'] ) {
-			$declaration['source'] = self::sourceFromName( $name );
+			$declaration['source'] = self::sourceFromName( $name ) ?: 'host';
 		}
 
 		if ( ! isset( $declaration['parameters'] ) ) {
@@ -479,6 +475,17 @@ class WP_Agent_Tool_Declaration {
 	public static function sourceFromName( string $name ): string {
 		$parts = explode( '/', $name, 2 );
 		return count( $parts ) === 2 ? $parts[0] : '';
+	}
+
+	/**
+	 * Whether a host-mediated tool name is valid.
+	 *
+	 * @param string $name Tool name.
+	 * @return bool Whether the name is valid.
+	 */
+	private static function isValidHostToolName( string $name ): bool {
+		return 1 === preg_match( '/^[a-z][a-z0-9_-]*$/', $name )
+			|| 1 === preg_match( '/^[a-z][a-z0-9_-]*\/[a-z][a-z0-9_-]*$/', $name );
 	}
 
 	/**

--- a/tests/provider-turn-adapter-smoke.php
+++ b/tests/provider-turn-adapter-smoke.php
@@ -72,6 +72,16 @@ agents_api_smoke_assert_equals( 'fake-runtime', $request->runtime()['runtime_id'
 agents_api_smoke_assert_equals( 'run-123', $request->runId(), 'provider request carries run id', $failures, $passes );
 agents_api_smoke_assert_equals( 'session-456', $request->sessionId(), 'provider request carries session id', $failures, $passes );
 
+$host_tool = AgentsAPI\AI\Tools\WP_Agent_Tool_Declaration::normalizeForConversationRequest(
+	array(
+		'name'        => 'workspace_read',
+		'description' => 'Read a workspace file.',
+		'parameters'  => array( 'type' => 'object' ),
+	)
+);
+agents_api_smoke_assert_equals( 'workspace_read', $host_tool['name'], 'host tool declarations allow unnamespaced names', $failures, $passes );
+agents_api_smoke_assert_equals( 'host', $host_tool['source'], 'unnamespaced host tools receive a host source', $failures, $passes );
+
 $normalized_turn = AgentsAPI\AI\WP_Agent_Provider_Turn_Result::normalize(
 	array(
 		'content'              => 'Using a tool.',

--- a/tests/provider-turn-adapter-smoke.php
+++ b/tests/provider-turn-adapter-smoke.php
@@ -184,7 +184,51 @@ agents_api_smoke_assert_equals( 'Plain assistant answer.', $content_only_result[
 agents_api_smoke_assert_equals( 2, count( $content_only_result['messages'] ), 'content-only adapter appends one assistant message', $failures, $passes );
 agents_api_smoke_assert_equals( 'content-only-1', $content_only_result['request_metadata']['provider_request_id'], 'content-only adapter preserves request metadata', $failures, $passes );
 
-echo "\n[4] Provider-turn typed failures become canonical failed loop results:\n";
+echo "\n[4] Provider-turn adapters can append continuation messages before the next turn:\n";
+$continuation_adapter = new class() implements AgentsAPI\AI\WP_Agent_Provider_Turn_Adapter {
+	/** @var array<int, array<string, mixed>> Captured requests. */
+	public array $requests = array();
+
+	public function run_turn( AgentsAPI\AI\WP_Agent_Provider_Turn_Request $request ): array {
+		$this->requests[] = $request->to_array();
+		$turn             = (int) ( $request->context()['turn'] ?? 0 );
+
+		if ( 1 === $turn ) {
+			return array(
+				'content'               => 'I am not done yet.',
+				'continuation_messages' => array(
+					array(
+						'role'    => 'user',
+						'content' => 'Please continue until the task is complete.',
+					),
+				),
+			);
+		}
+
+		return array(
+			'content' => 'Complete after continuation.',
+		);
+	}
+};
+
+$continuation_result = AgentsAPI\AI\WP_Agent_Conversation_Loop::run(
+	array( array( 'role' => 'user', 'content' => 'finish with a continuation if needed' ) ),
+	null,
+	array(
+		'provider_turn_adapter' => $continuation_adapter,
+		'max_turns'             => 3,
+		'should_continue'       => static function ( array $turn_result ): bool {
+			return ! empty( $turn_result['continuation_messages'] );
+		},
+	)
+);
+
+agents_api_smoke_assert_equals( 2, count( $continuation_adapter->requests ), 'continuation message causes a second provider turn', $failures, $passes );
+agents_api_smoke_assert_equals( 'Please continue until the task is complete.', $continuation_adapter->requests[1]['messages'][2]['content'] ?? '', 'second provider turn receives continuation message', $failures, $passes );
+agents_api_smoke_assert_equals( 'Complete after continuation.', $continuation_result['final_content'], 'continuation run surfaces final content', $failures, $passes );
+agents_api_smoke_assert_equals( 'continuation_message_added', $continuation_result['events'][0]['type'] ?? '', 'continuation run records an event', $failures, $passes );
+
+echo "\n[5] Provider-turn typed failures become canonical failed loop results:\n";
 $failing_adapter = static function ( AgentsAPI\AI\WP_Agent_Provider_Turn_Request $unused ): array {
 	unset( $unused );
 	return array(


### PR DESCRIPTION
## Summary
- Allow provider-turn adapter results to include normalized continuation messages.
- Append continuation messages to the transcript before the next turn in mediated and non-mediated provider-turn paths.
- Preserve existing host-mediated tool compatibility by allowing unnamespaced host tool names such as `workspace_read` while keeping client runtime tools namespaced.
- Cover provider-turn continuation behavior and unnamespaced host tool declarations with pure-PHP smoke tests.

## Tests
- `php tests/provider-turn-adapter-smoke.php`
- `php tests/conversation-loop-smoke.php`
- `php tests/conversation-loop-tool-execution-smoke.php`
- `php tests/conversation-runner-contracts-smoke.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the provider-turn continuation and host-tool compatibility updates plus smoke coverage; Chris remains responsible for review and acceptance.