### PR TITLE
Fix tool source and policy normalization

### DIFF
--- a/src/Tools/class-wp-agent-tool-declaration.php
+++ b/src/Tools/class-wp-agent-tool-declaration.php
@@ -114,6 +114,8 @@ class WP_Agent_Tool_Declaration {
 			$normalized['runtime'] = $runtime;
 		}
 
+		$normalized = array_merge( $normalized, self::normalizeExtensionFields( $declaration ) );
+
 		return $normalized;
 	}
 

--- a/src/Tools/class-wp-agent-tool-policy-filter.php
+++ b/src/Tools/class-wp-agent-tool-policy-filter.php
@@ -147,7 +147,7 @@ if ( ! class_exists( 'WP_Agent_Tool_Policy_Filter' ) ) {
 		 * Exclude caller-provided runtime tools unless policy explicitly opts them in.
 		 *
 		 * Non-runtime tools are never affected by this guard. Runtime tools match neutral
-		 * declaration metadata (`runtime_tool`, `executor=client`, or `scope=run`) and
+		 * declaration metadata (`runtime_tool` or `executor=client`) and
 		 * must be explicitly named, category-matched, or preserved by host policy.
 		 *
 		 * @param array<string, array<string, mixed>> $tools              Tool definitions keyed by tool name.
@@ -193,8 +193,7 @@ if ( ! class_exists( 'WP_Agent_Tool_Policy_Filter' ) ) {
 		 */
 		public function is_runtime_tool( array $tool ): bool {
 			return true === ( $tool['runtime_tool'] ?? false )
-				|| 'client' === ( $tool['executor'] ?? null )
-				|| 'run' === ( $tool['scope'] ?? null );
+				|| 'client' === ( $tool['executor'] ?? null );
 		}
 
 		/**

--- a/src/Tools/class-wp-agent-tool-source-registry.php
+++ b/src/Tools/class-wp-agent-tool-source-registry.php
@@ -196,12 +196,15 @@ class WP_Agent_Tool_Source_Registry {
 	 * @return array<string, mixed>
 	 */
 	private function normalizeGatheredTool( string $tool_name, string $source_slug, array $tool_definition ): array {
-		$tool_definition['name']   = is_string( $tool_definition['name'] ?? null ) && '' !== $tool_definition['name'] ? $tool_definition['name'] : $tool_name;
-		$tool_definition['source'] = is_string( $tool_definition['source'] ?? null ) && '' !== $tool_definition['source'] ? $tool_definition['source'] : $source_slug;
+		$tool_definition['name'] = is_string( $tool_definition['name'] ?? null ) && '' !== $tool_definition['name'] ? $tool_definition['name'] : $tool_name;
+
+		if ( ! is_string( $tool_definition['source'] ?? null ) || '' === $tool_definition['source'] ) {
+			$tool_definition['source'] = 0 === strpos( $tool_definition['name'], 'client/' ) ? WP_Agent_Tool_Declaration::SOURCE_CLIENT : $source_slug;
+		}
 
 		try {
 			$normalized = array();
-			foreach ( WP_Agent_Tool_Declaration::normalizeForServer( $tool_definition ) as $key => $value ) {
+			foreach ( WP_Agent_Tool_Declaration::normalizeForConversationRequest( $tool_definition ) as $key => $value ) {
 				if ( is_string( $key ) ) {
 					$normalized[ $key ] = $value;
 				}

--- a/src/Tools/class-wp-agent-tool-source-registry.php
+++ b/src/Tools/class-wp-agent-tool-source-registry.php
@@ -198,6 +198,10 @@ class WP_Agent_Tool_Source_Registry {
 	private function normalizeGatheredTool( string $tool_name, string $source_slug, array $tool_definition ): array {
 		$tool_definition['name'] = is_string( $tool_definition['name'] ?? null ) && '' !== $tool_definition['name'] ? $tool_definition['name'] : $tool_name;
 
+		if ( ! is_string( $tool_definition['description'] ?? null ) || '' === trim( $tool_definition['description'] ) ) {
+			$tool_definition['description'] = $tool_definition['name'];
+		}
+
 		if ( ! is_string( $tool_definition['source'] ?? null ) || '' === $tool_definition['source'] ) {
 			$tool_definition['source'] = 0 === strpos( $tool_definition['name'], 'client/' ) ? WP_Agent_Tool_Declaration::SOURCE_CLIENT : $source_slug;
 		}

--- a/tests/tool-policy-contracts-smoke.php
+++ b/tests/tool-policy-contracts-smoke.php
@@ -68,6 +68,13 @@ $tools = array(
 		'scope'        => 'run',
 		'runtime_tool' => true,
 	),
+	'web_fetch'        => array(
+		'name'       => 'web_fetch',
+		'categories' => array( 'read' ),
+		'modes'      => array( 'chat' ),
+		'executor'   => 'host',
+		'scope'      => 'run',
+	),
 );
 
 $resolver = new WP_Agent_Tool_Policy();
@@ -142,7 +149,7 @@ $resolved = $resolver->resolve(
 );
 $resolved_names = array_keys( $resolved );
 sort( $resolved_names );
-agents_api_smoke_assert_equals( array( 'client/mandatory', 'client/read', 'client/write' ), $resolved_names, 'runtime tools are excluded by default without hiding ordinary tools', $failures, $passes );
+agents_api_smoke_assert_equals( array( 'client/mandatory', 'client/read', 'client/write', 'web_fetch' ), $resolved_names, 'runtime tools are excluded by default without hiding ordinary host tools', $failures, $passes );
 
 $resolved = $resolver->resolve(
 	$tools,
@@ -173,7 +180,7 @@ $resolved = $resolver->resolve(
 );
 $resolved_names = array_keys( $resolved );
 sort( $resolved_names );
-agents_api_smoke_assert_equals( array( 'client/mandatory', 'client/read', 'client/runtime' ), $resolved_names, 'deny policy still requires runtime_tools opt-in for runtime tools', $failures, $passes );
+agents_api_smoke_assert_equals( array( 'client/mandatory', 'client/read', 'client/runtime', 'web_fetch' ), $resolved_names, 'deny policy still requires runtime_tools opt-in for runtime tools without hiding host tools', $failures, $passes );
 
 $resolved = $resolver->resolve(
 	$tools,
@@ -199,7 +206,7 @@ $resolved = $resolver->resolve(
 );
 $resolved_names = array_keys( $resolved );
 sort( $resolved_names );
-agents_api_smoke_assert_equals( array( 'client/ambient', 'client/mandatory', 'client/read', 'client/write' ), $resolved_names, 'runtime category opt-in composes with final explicit deny', $failures, $passes );
+agents_api_smoke_assert_equals( array( 'client/ambient', 'client/mandatory', 'client/read', 'client/write', 'web_fetch' ), $resolved_names, 'runtime category opt-in composes with final explicit deny without hiding host tools', $failures, $passes );
 
 echo "\n[6] Sensitive required parameters stay auditable and intentional:\n";
 $parameters = AgentsAPI\AI\Tools\WP_Agent_Tool_Parameters::buildParameters(

--- a/tests/tool-source-registry-smoke.php
+++ b/tests/tool-source-registry-smoke.php
@@ -62,6 +62,7 @@ $registry->registerSource(
 			'static/only'  => array(
 				'description' => 'Static-only declaration.',
 			),
+			'static/minimal' => array(),
 		);
 	},
 	30
@@ -210,6 +211,7 @@ agents_api_smoke_assert_equals(
 		'runtime/filtered',
 		'filtered/only',
 		'static/only',
+		'static/minimal',
 	),
 	array_keys( $tools ),
 	'registry gathers multiple ordered sources with duplicate-name precedence',
@@ -234,6 +236,13 @@ agents_api_smoke_assert_equals(
 	array(),
 	$tools['static/only']['parameters'],
 	'registry normalizes missing parameters to an array',
+	$failures,
+	$passes
+);
+agents_api_smoke_assert_equals(
+	'static/minimal',
+	$tools['static/minimal']['description'],
+	'registry defaults missing source descriptions from the tool name',
 	$failures,
 	$passes
 );

--- a/tests/tool-source-registry-smoke.php
+++ b/tests/tool-source-registry-smoke.php
@@ -111,6 +111,8 @@ $registry->registerSource(
 			'client/pick'  => array(
 				'description' => 'Client runtime declaration.',
 				'executor'    => 'client',
+				'external_executor' => true,
+				'runtime_tool' => true,
 				'scope'       => 'run',
 			),
 			'runtime/only' => array(
@@ -271,6 +273,13 @@ agents_api_smoke_assert_equals(
 	'client',
 	$tools['client/pick']['source'] ?? null,
 	'registry preserves client runtime tool source declarations',
+	$failures,
+	$passes
+);
+agents_api_smoke_assert_equals(
+	true,
+	$tools['client/pick']['external_executor'] ?? false,
+	'registry preserves client runtime extension metadata',
 	$failures,
 	$passes
 );

--- a/tests/tool-source-registry-smoke.php
+++ b/tests/tool-source-registry-smoke.php
@@ -107,6 +107,11 @@ $registry->registerSource(
 				'source'      => 'runtime',
 				'description' => 'Runtime declaration.',
 			),
+			'client/pick'  => array(
+				'description' => 'Client runtime declaration.',
+				'executor'    => 'client',
+				'scope'       => 'run',
+			),
 			'runtime/only' => array(
 				'description' => 'Runtime-only declaration.',
 			),
@@ -200,6 +205,7 @@ agents_api_smoke_assert_equals(
 	array(
 		'agent/shared',
 		'adjacent/only',
+		'client/pick',
 		'runtime/only',
 		'runtime/filtered',
 		'filtered/only',
@@ -242,6 +248,20 @@ agents_api_smoke_assert_equals(
 	'run',
 	$tools['static/only']['scope'] ?? null,
 	'registry normalizes gathered tools to run scope declarations',
+	$failures,
+	$passes
+);
+agents_api_smoke_assert_equals(
+	'client',
+	$tools['client/pick']['executor'] ?? null,
+	'registry preserves client runtime tool executor declarations',
+	$failures,
+	$passes
+);
+agents_api_smoke_assert_equals(
+	'client',
+	$tools['client/pick']['source'] ?? null,
+	'registry preserves client runtime tool source declarations',
 	$failures,
 	$passes
 );


### PR DESCRIPTION
## Summary
- Normalize gathered tool-source declarations through the conversation-request contract so source registries can include both host and client runtime tools.
- Preserve the canonical `client` source for bare `client/*` declarations instead of replacing it with the source-provider slug.
- Keep ordinary host tools visible when they use the canonical host `scope: run`; only client/runtime declarations require runtime-tool opt-in.
- Default missing source-declaration descriptions from the tool name and preserve client runtime extension metadata such as `runtime_tool` / `external_executor`.
- Add smoke coverage for `client/*` declarations gathered from a tool source, minimal source declarations, host tools surviving runtime policy filtering, and client extension metadata.

## Testing
- `php tests/tool-source-registry-smoke.php`
- `php tests/tool-policy-contracts-smoke.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the source-registry and runtime-policy regressions, drafted the code/test changes, and ran the smoke tests.