### PR TITLE
Centralize provider-turn tool-call extraction

### DIFF
--- a/src/Runtime/class-wp-agent-provider-turn-result.php
+++ b/src/Runtime/class-wp-agent-provider-turn-result.php
@@ -237,7 +237,7 @@ class WP_Agent_Provider_Turn_Result {
 						continue;
 					}
 
-					$parameter_value = function_exists( '\wp_strip_all_tags' )
+					$parameter_value               = function_exists( '\wp_strip_all_tags' )
 						? \wp_strip_all_tags( (string) $parameter_match[2] )
 						: (string) preg_replace( '/<[^>]*>/', '', (string) $parameter_match[2] );
 					$parameters[ $parameter_name ] = html_entity_decode( trim( $parameter_value ), ENT_QUOTES | ENT_HTML5, 'UTF-8' );
@@ -436,12 +436,12 @@ class WP_Agent_Provider_Turn_Result {
 	/**
 	 * Call a no-argument object method when available.
 	 *
-	 * @param mixed  $object Object candidate.
+	 * @param mixed  $candidate Object candidate.
 	 * @param string $method Method name.
 	 * @return mixed
 	 */
-	private static function call_no_args( $object, string $method ) {
-		return is_object( $object ) && method_exists( $object, $method ) ? $object->{$method}() : null;
+	private static function call_no_args( $candidate, string $method ) {
+		return is_object( $candidate ) && method_exists( $candidate, $method ) ? $candidate->{$method}() : null;
 	}
 
 	/**

--- a/src/Runtime/class-wp-agent-provider-turn-result.php
+++ b/src/Runtime/class-wp-agent-provider-turn-result.php
@@ -48,6 +48,8 @@ class WP_Agent_Provider_Turn_Result {
 				throw self::invalid( 'tool_calls', 'must be an array when present' );
 			}
 			$normalized['tool_calls'] = self::normalize_tool_calls( $result['tool_calls'] );
+		} else {
+			$normalized['tool_calls'] = self::extract_tool_calls( $result );
 		}
 
 		if ( isset( $result['continuation_messages'] ) ) {
@@ -71,6 +73,57 @@ class WP_Agent_Provider_Turn_Result {
 		}
 
 		return $normalized;
+	}
+
+	/**
+	 * Extract canonical tool calls from a provider-turn result.
+	 *
+	 * Structured function calls are preferred. Text fallback parsing is bounded to
+	 * explicit tool-call envelopes and whole-line named call forms so providers that
+	 * emit tool calls as text can still participate in loop mediation.
+	 *
+	 * @param mixed $result Provider-turn array or wp-ai-client generative result.
+	 * @return array<int, array<string, mixed>>
+	 */
+	public static function extract_tool_calls( $result ): array {
+		if ( is_array( $result ) && isset( $result['tool_calls'] ) ) {
+			return is_array( $result['tool_calls'] ) ? self::normalize_tool_calls( $result['tool_calls'] ) : array();
+		}
+
+		$texts      = array();
+		$tool_calls = self::extract_structured_tool_calls( $result, $texts );
+		if ( ! empty( $tool_calls ) ) {
+			return $tool_calls;
+		}
+
+		if ( is_array( $result ) ) {
+			foreach ( array( 'content', 'text', 'output_text' ) as $field ) {
+				if ( isset( $result[ $field ] ) && is_string( $result[ $field ] ) ) {
+					$texts[] = $result[ $field ];
+				}
+			}
+
+			if ( isset( $result['message'] ) && is_array( $result['message'] ) && isset( $result['message']['content'] ) && is_string( $result['message']['content'] ) ) {
+				$texts[] = $result['message']['content'];
+			}
+		}
+
+		$extracted = array();
+		foreach ( array_slice( array_unique( $texts ), 0, 8 ) as $text ) {
+			if ( '' === trim( $text ) ) {
+				continue;
+			}
+
+			$extracted = array_merge(
+				$extracted,
+				self::extract_xml_tool_calls( $text ),
+				self::extract_json_tool_calls( $text ),
+				self::extract_tag_tool_calls( $text ),
+				self::extract_named_text_tool_calls( $text )
+			);
+		}
+
+		return self::dedupe_tool_calls( $extracted );
 	}
 
 	/**
@@ -114,6 +167,303 @@ class WP_Agent_Provider_Turn_Result {
 		}
 
 		return $normalized;
+	}
+
+	/**
+	 * Extract structured function calls from wp-ai-client-style results.
+	 *
+	 * @param mixed              $result Provider result.
+	 * @param array<int,string>  $texts  Text parts discovered while scanning.
+	 * @return array<int, array<string, mixed>>
+	 */
+	private static function extract_structured_tool_calls( $result, array &$texts ): array {
+		$candidates = self::call_no_args( $result, 'getCandidates' );
+		if ( ! is_array( $candidates ) || empty( $candidates ) ) {
+			return array();
+		}
+
+		$message = self::call_no_args( reset( $candidates ), 'getMessage' );
+		$parts   = self::call_no_args( $message, 'getParts' );
+		if ( ! is_array( $parts ) ) {
+			return array();
+		}
+
+		$tool_calls = array();
+		foreach ( array_slice( $parts, 0, 64 ) as $part ) {
+			$function_call = self::call_no_args( $part, 'getFunctionCall' );
+			if ( null !== $function_call ) {
+				$name = self::call_no_args( $function_call, 'getName' );
+				if ( is_string( $name ) && '' !== $name ) {
+					$tool_calls[] = array(
+						'name'       => $name,
+						'parameters' => self::normalize_function_args( self::call_no_args( $function_call, 'getArgs' ) ),
+						'id'         => self::call_no_args( $function_call, 'getId' ),
+					);
+				}
+			}
+
+			$text = self::call_no_args( $part, 'getText' );
+			if ( is_string( $text ) ) {
+				$texts[] = $text;
+			}
+		}
+
+		return self::normalize_tool_calls( $tool_calls );
+	}
+
+	/**
+	 * Extract XML-style tool calls emitted as plain text.
+	 *
+	 * @param string $text Text candidate content.
+	 * @return array<int, array<string, mixed>>
+	 */
+	private static function extract_xml_tool_calls( string $text ): array {
+		if ( false === strpos( $text, '<function_calls>' ) || ! preg_match_all( '/<invoke\s+name=["\']([^"\']+)["\']\s*>(.*?)<\/invoke>/is', $text, $matches, PREG_SET_ORDER ) ) {
+			return array();
+		}
+
+		$tool_calls = array();
+		foreach ( array_slice( $matches, 0, 16 ) as $index => $match ) {
+			$name = self::clean_tool_name( (string) $match[1] );
+			if ( '' === $name ) {
+				continue;
+			}
+
+			$parameters = array();
+			if ( preg_match_all( '/<parameter\s+name=["\']([^"\']+)["\']\s*>(.*?)<\/parameter>/is', (string) $match[2], $parameter_matches, PREG_SET_ORDER ) ) {
+				foreach ( array_slice( $parameter_matches, 0, 32 ) as $parameter_match ) {
+					$parameter_name = self::clean_parameter_name( (string) $parameter_match[1] );
+					if ( '' === $parameter_name ) {
+						continue;
+					}
+
+					$parameter_value = function_exists( '\wp_strip_all_tags' )
+						? \wp_strip_all_tags( (string) $parameter_match[2] )
+						: (string) preg_replace( '/<[^>]*>/', '', (string) $parameter_match[2] );
+					$parameters[ $parameter_name ] = html_entity_decode( trim( $parameter_value ), ENT_QUOTES | ENT_HTML5, 'UTF-8' );
+				}
+			}
+
+			$tool_calls[] = array(
+				'name'       => $name,
+				'parameters' => $parameters,
+				'id'         => 'xml-tool-call-' . ( $index + 1 ),
+			);
+		}
+
+		return $tool_calls;
+	}
+
+	/**
+	 * Extract JSON tool calls emitted as text/code fences.
+	 *
+	 * @param string $text Text candidate content.
+	 * @return array<int, array<string, mixed>>
+	 */
+	private static function extract_json_tool_calls( string $text ): array {
+		$payloads = array();
+		if ( false !== strpos( $text, '<tool_call>' ) && preg_match_all( '/<tool_call>\s*(.*?)\s*<\/tool_call>/is', $text, $matches, PREG_SET_ORDER ) ) {
+			foreach ( $matches as $match ) {
+				$payloads[] = (string) $match[1];
+			}
+		}
+
+		if ( false !== strpos( $text, '```' ) && preg_match_all( '/```(?:json)?\s*(\{.*?\})\s*```/is', $text, $matches, PREG_SET_ORDER ) ) {
+			foreach ( $matches as $match ) {
+				$payloads[] = (string) $match[1];
+			}
+		}
+
+		return self::tool_calls_from_json_payloads( $payloads, 'json-tool-call' );
+	}
+
+	/**
+	 * Extract tag-style tool calls with JSON bodies.
+	 *
+	 * @param string $text Text candidate content.
+	 * @return array<int, array<string, mixed>>
+	 */
+	private static function extract_tag_tool_calls( string $text ): array {
+		if ( ! preg_match_all( '/<tool_call\s+name=["\']([^"\']+)["\']\s*>(.*?)<\/tool_call>/is', $text, $matches, PREG_SET_ORDER ) ) {
+			return array();
+		}
+
+		$tool_calls = array();
+		foreach ( array_slice( $matches, 0, 16 ) as $index => $match ) {
+			$name = self::clean_tool_name( (string) $match[1] );
+			if ( '' === $name ) {
+				continue;
+			}
+
+			$decoded      = json_decode( html_entity_decode( trim( (string) $match[2] ), ENT_QUOTES | ENT_HTML5, 'UTF-8' ), true );
+			$tool_calls[] = array(
+				'name'       => $name,
+				'parameters' => is_array( $decoded ) ? self::assoc_array( $decoded, 'tag_tool_call.parameters' ) : array(),
+				'id'         => 'tag-tool-call-' . ( $index + 1 ),
+			);
+		}
+
+		return $tool_calls;
+	}
+
+	/**
+	 * Extract a conservative whole-line named tool call form: `tool_name key=value`.
+	 *
+	 * @param string $text Text candidate content.
+	 * @return array<int, array<string, mixed>>
+	 */
+	private static function extract_named_text_tool_calls( string $text ): array {
+		$line = trim( $text );
+		if ( str_contains( $line, "\n" ) || ! preg_match( '/^([A-Za-z0-9_\/.:-]+)\s+(.+)$/', $line, $matches ) ) {
+			return array();
+		}
+
+		$name = self::clean_tool_name( (string) $matches[1] );
+		if ( '' === $name || ! preg_match_all( '/([A-Za-z_][A-Za-z0-9_-]*)=("[^"]*"|\'[^\']*\'|[^\s]+)/', (string) $matches[2], $parameter_matches, PREG_SET_ORDER ) ) {
+			return array();
+		}
+
+		$parameters = array();
+		foreach ( array_slice( $parameter_matches, 0, 32 ) as $parameter_match ) {
+			$key = self::clean_parameter_name( (string) $parameter_match[1] );
+			if ( '' === $key ) {
+				continue;
+			}
+
+			$parameters[ $key ] = trim( (string) $parameter_match[2], "\"'" );
+		}
+
+		return empty( $parameters ) ? array() : array(
+			array(
+				'name'       => $name,
+				'parameters' => $parameters,
+				'id'         => 'text-tool-call-1',
+			),
+		);
+	}
+
+	/**
+	 * Convert JSON payloads into canonical tool calls.
+	 *
+	 * @param array<int,string> $payloads Raw JSON payload strings.
+	 * @param string            $id_prefix Generated ID prefix.
+	 * @return array<int, array<string, mixed>>
+	 */
+	private static function tool_calls_from_json_payloads( array $payloads, string $id_prefix ): array {
+		$tool_calls = array();
+		foreach ( array_slice( $payloads, 0, 16 ) as $index => $raw_payload ) {
+			$payload = json_decode( html_entity_decode( trim( $raw_payload ), ENT_QUOTES | ENT_HTML5, 'UTF-8' ), true );
+			if ( ! is_array( $payload ) ) {
+				continue;
+			}
+
+			$calls = isset( $payload['tool_calls'] ) && is_array( $payload['tool_calls'] ) ? $payload['tool_calls'] : array( $payload );
+			foreach ( array_slice( $calls, 0, 16 ) as $call_index => $call ) {
+				if ( ! is_array( $call ) ) {
+					continue;
+				}
+
+				$function   = isset( $call['function'] ) && is_array( $call['function'] ) ? $call['function'] : array();
+				$raw_name   = $function['name'] ?? ( $call['name'] ?? '' );
+				$name       = is_string( $raw_name ) ? self::clean_tool_name( $raw_name ) : '';
+				$parameters = $function['arguments'] ?? ( $call['arguments'] ?? ( $call['parameters'] ?? array() ) );
+				if ( '' === $name ) {
+					continue;
+				}
+
+				$tool_calls[] = array(
+					'name'       => $name,
+					'parameters' => self::normalize_function_args( $parameters ),
+					'id'         => isset( $call['id'] ) && is_string( $call['id'] ) && '' !== $call['id'] ? $call['id'] : $id_prefix . '-' . ( $index + 1 ) . '-' . ( $call_index + 1 ),
+				);
+			}
+		}
+
+		return $tool_calls;
+	}
+
+	/**
+	 * Dedupe parser overlap while preserving first-seen order.
+	 *
+	 * @param array<int, array<string, mixed>> $tool_calls Tool calls.
+	 * @return array<int, array<string, mixed>>
+	 */
+	private static function dedupe_tool_calls( array $tool_calls ): array {
+		$seen   = array();
+		$result = array();
+		foreach ( self::normalize_tool_calls( $tool_calls ) as $tool_call ) {
+			if ( ! is_string( $tool_call['name'] ) || ! is_array( $tool_call['parameters'] ) ) {
+				continue;
+			}
+
+			$key = $tool_call['name'] . '|' . wp_json_encode( $tool_call['parameters'], JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE );
+			if ( isset( $seen[ $key ] ) ) {
+				continue;
+			}
+
+			$seen[ $key ] = true;
+			$result[]     = $tool_call;
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Coerce provider function-call args into tool parameters.
+	 *
+	 * @param mixed $args Raw function-call args.
+	 * @return array<string, mixed>
+	 */
+	private static function normalize_function_args( $args ): array {
+		if ( is_array( $args ) ) {
+			return self::assoc_array( $args, 'function_call.arguments' );
+		}
+
+		if ( is_string( $args ) && '' !== $args ) {
+			$decoded = json_decode( $args, true );
+			if ( is_array( $decoded ) ) {
+				return self::assoc_array( $decoded, 'function_call.arguments' );
+			}
+		}
+
+		if ( is_object( $args ) ) {
+			return self::assoc_array( (array) $args, 'function_call.arguments' );
+		}
+
+		return array();
+	}
+
+	/**
+	 * Call a no-argument object method when available.
+	 *
+	 * @param mixed  $object Object candidate.
+	 * @param string $method Method name.
+	 * @return mixed
+	 */
+	private static function call_no_args( $object, string $method ) {
+		return is_object( $object ) && method_exists( $object, $method ) ? $object->{$method}() : null;
+	}
+
+	/**
+	 * Normalize tool names without depending on WordPress sanitizers.
+	 *
+	 * @param string $name Raw tool name.
+	 * @return string
+	 */
+	private static function clean_tool_name( string $name ): string {
+		$name = trim( $name );
+		return preg_match( '/^[A-Za-z0-9_\/.:-]{1,128}$/', $name ) ? $name : '';
+	}
+
+	/**
+	 * Normalize parameter names without depending on WordPress sanitizers.
+	 *
+	 * @param string $name Raw parameter name.
+	 * @return string
+	 */
+	private static function clean_parameter_name( string $name ): string {
+		$name = trim( $name );
+		return preg_match( '/^[A-Za-z_][A-Za-z0-9_-]{0,127}$/', $name ) ? $name : '';
 	}
 
 	/**

--- a/tests/provider-turn-adapter-smoke.php
+++ b/tests/provider-turn-adapter-smoke.php
@@ -100,6 +100,87 @@ $normalized_turn = AgentsAPI\AI\WP_Agent_Provider_Turn_Result::normalize(
 agents_api_smoke_assert_equals( 'client/lookup', $normalized_turn['tool_calls'][0]['name'], 'provider result normalizes tool call names', $failures, $passes );
 agents_api_smoke_assert_equals( 3, $normalized_turn['usage']['total_tokens'], 'provider result preserves usage', $failures, $passes );
 
+echo "\n[1b] Provider-turn result extracts structured and fallback tool calls:\n";
+$structured_result = new class() {
+	public function getCandidates(): array {
+		return array(
+			new class() {
+				public function getMessage() {
+					return new class() {
+						public function getParts(): array {
+							return array(
+								new class() {
+									public function getFunctionCall() {
+										return new class() {
+											public function getName(): string {
+												return 'client/lookup';
+											}
+
+											public function getArgs(): string {
+												return '{"query":"structured"}';
+											}
+
+											public function getId(): string {
+												return 'structured-call-1';
+											}
+										};
+									}
+
+									public function getText(): string {
+										return '<function_calls><invoke name="client/lookup"><parameter name="query">fallback</parameter></invoke></function_calls>';
+									}
+								},
+							);
+						}
+					};
+				}
+			},
+		);
+	}
+};
+
+$structured_calls = AgentsAPI\AI\WP_Agent_Provider_Turn_Result::extract_tool_calls( $structured_result );
+agents_api_smoke_assert_equals( 1, count( $structured_calls ), 'structured function calls take precedence over fallback text', $failures, $passes );
+agents_api_smoke_assert_equals( 'structured-call-1', $structured_calls[0]['id'] ?? '', 'structured call id is preserved', $failures, $passes );
+agents_api_smoke_assert_equals( 'structured', $structured_calls[0]['parameters']['query'] ?? '', 'structured call JSON args are decoded', $failures, $passes );
+
+$xml_turn = AgentsAPI\AI\WP_Agent_Provider_Turn_Result::normalize(
+	array(
+		'content' => '<function_calls><invoke name="client/lookup"><parameter name="query">xml &amp; tags</parameter></invoke></function_calls>',
+	)
+);
+agents_api_smoke_assert_equals( 'client/lookup', $xml_turn['tool_calls'][0]['name'] ?? '', 'XML fallback extracts tool name', $failures, $passes );
+agents_api_smoke_assert_equals( 'xml & tags', $xml_turn['tool_calls'][0]['parameters']['query'] ?? '', 'XML fallback decodes parameters', $failures, $passes );
+
+$json_turn = AgentsAPI\AI\WP_Agent_Provider_Turn_Result::normalize(
+	array(
+		'content' => '```json' . "\n" . '{"tool_calls":[{"id":"json-1","function":{"name":"client/lookup","arguments":"{\\"query\\":\\"json\\"}"}}]}' . "\n" . '```',
+	)
+);
+agents_api_smoke_assert_equals( 'json-1', $json_turn['tool_calls'][0]['id'] ?? '', 'fenced JSON fallback preserves id', $failures, $passes );
+agents_api_smoke_assert_equals( 'json', $json_turn['tool_calls'][0]['parameters']['query'] ?? '', 'fenced JSON fallback decodes function arguments', $failures, $passes );
+
+$tag_turn = AgentsAPI\AI\WP_Agent_Provider_Turn_Result::normalize(
+	array(
+		'content' => '<tool_call name="client/lookup">{"query":"tag"}</tool_call>',
+	)
+);
+agents_api_smoke_assert_equals( 'tag', $tag_turn['tool_calls'][0]['parameters']['query'] ?? '', 'tag fallback extracts JSON body parameters', $failures, $passes );
+
+$named_turn = AgentsAPI\AI\WP_Agent_Provider_Turn_Result::normalize(
+	array(
+		'content' => 'client/lookup query="named text"',
+	)
+);
+agents_api_smoke_assert_equals( 'named text', $named_turn['tool_calls'][0]['parameters']['query'] ?? '', 'named text fallback extracts key value parameters', $failures, $passes );
+
+$deduped_turn = AgentsAPI\AI\WP_Agent_Provider_Turn_Result::normalize(
+	array(
+		'content' => '<tool_call>{"name":"client/lookup","parameters":{"query":"dup"}}</tool_call>' . "\n" . '```json' . "\n" . '{"name":"client/lookup","parameters":{"query":"dup"}}' . "\n" . '```',
+	)
+);
+agents_api_smoke_assert_equals( 1, count( $deduped_turn['tool_calls'] ), 'fallback parser overlap is deduplicated', $failures, $passes );
+
 echo "\n[2] Conversation loop can run through a fake provider-turn adapter without Data Machine:\n";
 $adapter_calls = array();
 $adapter       = new class( $adapter_calls ) implements AgentsAPI\AI\WP_Agent_Provider_Turn_Adapter {


### PR DESCRIPTION
## Summary
- Adds an Agents API provider-turn helper for extracting canonical `tool_calls` from wp-ai-client-style results or neutral provider-turn arrays.
- Prefers structured function calls and falls back to bounded XML, JSON/code-fence, tag, and whole-line named text parsing only when structured calls are absent.
- Extends provider-turn smoke coverage so downstream products like Data Machine can delegate extraction to Agents API.

## Tests
- `php tests/provider-turn-adapter-smoke.php`
- `composer smoke`
- `composer phpstan`

Closes #305.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implementing the provider-turn extraction helper, adding smoke coverage, and running verification; Chris remains responsible for review and merge decisions.