### PR TITLE
Add runtime tool lifecycle contract

### DIFF
--- a/agents-api.php
+++ b/agents-api.php
@@ -152,6 +152,8 @@ require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-byte-limit-tool-resul
 require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-runtime-tool-request.php';
 require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-runtime-tool-result.php';
 require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-runtime-tool-request-store.php';
+require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-runtime-tool-continuation.php';
+require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-runtime-tool-lifecycle.php';
 require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-conversation-result.php';
 require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-chat-run-control.php';
 require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-conversation-loop.php';

--- a/docs/runtime-and-tools.md
+++ b/docs/runtime-and-tools.md
@@ -202,6 +202,45 @@ array(
 
 `proceed` preserves normal execution. `reject` creates a normalized failed tool result without calling the executor. `replace_result` appends the supplied normalized result without calling the executor. Setting `complete` truthy stops the mediated turn after the canonical tool-result message and result/event/audit entries have been appended.
 
+### Durable runtime-tool lifecycle
+
+External runtime tools can pause the loop with `status: runtime_tool_pending`. Agents API owns the product-neutral lifecycle contract for those requests while hosts own concrete storage, queues, session lookup, and continuation scheduling.
+
+Public lifecycle contracts:
+
+- `WP_Agent_Runtime_Tool_Request` normalizes pending requests and timeout transitions.
+- `WP_Agent_Runtime_Tool_Result` normalizes submitted client/runtime results, including results normalized against a stored request.
+- `WP_Agent_Runtime_Tool_Request_Store` is the host persistence boundary with `create`, `get`, `complete`, `timeout`, and `recent_pending` methods.
+- `WP_Agent_Runtime_Tool_Continuation` is the host resume boundary for continuing a paused run after submit or timeout.
+- `WP_Agent_Runtime_Tool_Lifecycle` coordinates create, submit, timeout, recent-pending reads, transcript-compatible result payloads, and continuation callbacks.
+
+The conversation loop accepts an optional `runtime_tool_request_store` (or `runtime_tool_store`) option. When supplied, pending runtime-tool requests are normalized and handed to `WP_Agent_Runtime_Tool_Lifecycle::create_pending_request()` before the loop returns `status: runtime_tool_pending`.
+
+```php
+$result = AgentsAPI\AI\WP_Agent_Conversation_Loop::run(
+	$messages,
+	$turn_runner,
+	array(
+		'tool_executor'              => $executor,
+		'tool_declarations'          => $tools,
+		'runtime_tool_request_store' => $request_store,
+	)
+);
+
+$submission = AgentsAPI\AI\WP_Agent_Runtime_Tool_Lifecycle::submit_result(
+	$request_store,
+	array(
+		'request_id' => $request_id,
+		'success'    => true,
+		'result'     => array( 'value' => 'client supplied result' ),
+	),
+	$continuation,
+	array( 'source' => 'browser' )
+);
+```
+
+Generic lifecycle events fire as WordPress actions: `agents_api_runtime_tool_request_created`, `agents_api_runtime_tool_result_submitted`, `agents_api_runtime_tool_request_timed_out`, and `agents_api_runtime_tool_request_resumed`. The event payloads contain normalized request/result envelopes plus caller-owned context. Agents API does not define Data Machine jobs, chat-session metadata, browser storage, or any other product-specific persistence shape.
+
 ## Runtime tool declarations
 
 `AgentsAPI\AI\Tools\WP_Agent_Tool_Declaration::normalize()` validates per-run client tool declarations. The runtime-client shape is intentionally narrow:

--- a/src/Runtime/class-wp-agent-conversation-loop.php
+++ b/src/Runtime/class-wp-agent-conversation-loop.php
@@ -81,6 +81,7 @@ class WP_Agent_Conversation_Loop {
 	 * - `transcript_session_id` (string): Session ID to lock when a lock store is provided.
 	 * - `transcript_lock_ttl` (int): Lock TTL in seconds. Defaults to 300.
 	 * - `transcript_persister` (WP_Agent_Transcript_Persister|null): Transcript persister.
+	 * - `runtime_tool_request_store` (WP_Agent_Runtime_Tool_Request_Store|null): Optional durable store for pending runtime-tool requests.
 	 * - `on_event` (callable|null): Caller-owned lifecycle event sink `fn(string $event, array $payload)`.
 	 *
 	 * @param array<int, array<string, mixed>> $messages    Initial transcript messages.
@@ -99,6 +100,7 @@ class WP_Agent_Conversation_Loop {
 		$should_continue       = self::resolve_should_continue( $options, $tool_executor, $tool_declarations );
 		$completion_policy     = self::resolve_completion_policy( $options );
 		$transcript_persister  = self::resolve_transcript_persister( $options );
+		$runtime_tool_store    = self::resolve_runtime_tool_request_store( $options );
 		$transcript_lock       = self::resolve_transcript_lock( $options );
 		$on_event              = self::resolve_event_sink( $options );
 		$spin_detector         = self::resolve_spin_detector( $options );
@@ -302,7 +304,8 @@ class WP_Agent_Conversation_Loop {
 						$messages,
 						$pre_tool_mediator,
 						$tool_results,
-						$post_tool_diagnostics
+						$post_tool_diagnostics,
+						$runtime_tool_store
 					);
 
 					$messages              = $mediation_result['messages'];
@@ -503,6 +506,7 @@ class WP_Agent_Conversation_Loop {
 	 * @param callable|null                            $pre_tool_mediator Optional pre-tool mediator.
 	 * @param array<int, array<string, mixed>>         $prior_tool_results Prior mediated tool results.
 	 * @param callable|null                            $post_tool_diagnostics Optional post-result diagnostics callback.
+	 * @param WP_Agent_Runtime_Tool_Request_Store|null $runtime_tool_store Optional durable runtime tool request store.
 	 * @return array{messages: array<int, array<string, mixed>>, tool_execution_results: array<int, array<string, mixed>>, tool_events: array<int, array<string, mixed>>, tool_audit_events: array<int, array<string, mixed>>, events: array<int, array<string, mixed>>, conversation_complete: bool, exceeded_budget: string|null, approval_required: array<string, mixed>|null, runtime_tool_pending: array<string, mixed>|null, spin_signatures: array<int, WP_Agent_Spin_Signature>}
 	 */
 	private static function mediate_tool_calls(
@@ -519,7 +523,8 @@ class WP_Agent_Conversation_Loop {
 		array $prior_messages = array(),
 		?callable $pre_tool_mediator = null,
 		array $prior_tool_results = array(),
-		?callable $post_tool_diagnostics = null
+		?callable $post_tool_diagnostics = null,
+		?WP_Agent_Runtime_Tool_Request_Store $runtime_tool_store = null
 	): array {
 		$core = new WP_Agent_Tool_Execution_Core();
 
@@ -645,6 +650,22 @@ class WP_Agent_Conversation_Loop {
 
 			$pending_request = self::runtime_tool_pending_request( $exec_result, $tool_name, $tool_call_id, $parameters_for_policy, $turn_context );
 			if ( null !== $pending_request ) {
+				$pending_request['metadata'] = array_merge(
+					self::normalize_assoc_array( $pending_request['metadata'] ?? array() ),
+					array( 'turn_count' => $turn )
+				);
+				if ( null !== $runtime_tool_store ) {
+					$pending_request = WP_Agent_Runtime_Tool_Lifecycle::create_pending_request(
+						$runtime_tool_store,
+						$pending_request,
+						array(
+							'turn'         => $turn,
+							'tool_name'    => $tool_name,
+							'tool_call_id' => $tool_call_id,
+							'turn_context' => $turn_context,
+						)
+					);
+				}
 				$pending_request_json = self::json_encode_safe( $pending_request );
 				$runtime_tool_pending = $pending_request;
 				$messages[]           = WP_Agent_Message::toolResult(
@@ -2151,6 +2172,23 @@ class WP_Agent_Conversation_Loop {
 	private static function resolve_transcript_persister( array $options ): ?WP_Agent_Transcript_Persister {
 		$persister = $options['transcript_persister'] ?? null;
 		return $persister instanceof WP_Agent_Transcript_Persister ? $persister : null;
+	}
+
+	/**
+	 * Resolve the durable runtime-tool request store from options.
+	 *
+	 * @param array<string, mixed> $options Loop options.
+	 * @return WP_Agent_Runtime_Tool_Request_Store|null
+	 */
+	private static function resolve_runtime_tool_request_store( array $options ): ?WP_Agent_Runtime_Tool_Request_Store {
+		foreach ( array( 'runtime_tool_request_store', 'runtime_tool_store' ) as $key ) {
+			$store = $options[ $key ] ?? null;
+			if ( $store instanceof WP_Agent_Runtime_Tool_Request_Store ) {
+				return $store;
+			}
+		}
+
+		return null;
 	}
 
 	/**

--- a/src/Runtime/class-wp-agent-runtime-tool-continuation.php
+++ b/src/Runtime/class-wp-agent-runtime-tool-continuation.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * External runtime tool continuation contract.
+ *
+ * @package AgentsAPI
+ */
+
+namespace AgentsAPI\AI;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Host-provided callback boundary for resuming a paused runtime-tool run.
+ */
+interface WP_Agent_Runtime_Tool_Continuation {
+
+	/**
+	 * Resume the paused run after a runtime tool result or timeout.
+	 *
+	 * Agents API owns the normalized request/result handoff. Hosts own concrete
+	 * session lookup, job scheduling, transcript storage, and provider dispatch.
+	 *
+	 * @param array<string, mixed> $request Normalized runtime tool request.
+	 * @param array<string, mixed> $result Normalized runtime tool result or timeout result.
+	 * @param array<string, mixed> $context Caller-owned continuation context.
+	 * @return array<string, mixed> Host-owned resume result.
+	 */
+	public function resume( array $request, array $result, array $context = array() ): array;
+}

--- a/src/Runtime/class-wp-agent-runtime-tool-lifecycle.php
+++ b/src/Runtime/class-wp-agent-runtime-tool-lifecycle.php
@@ -1,0 +1,251 @@
+<?php
+/**
+ * External runtime tool durable lifecycle service.
+ *
+ * @package AgentsAPI
+ */
+
+namespace AgentsAPI\AI;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Product-neutral runtime-tool lifecycle operations.
+ */
+class WP_Agent_Runtime_Tool_Lifecycle {
+
+	/**
+	 * Persist a pending runtime tool request through a host-provided store.
+	 *
+	 * @param WP_Agent_Runtime_Tool_Request_Store $store Request store.
+	 * @param array<string, mixed>                $request Raw or normalized request.
+	 * @param array<string, mixed>                $context Caller-owned context.
+	 * @return array<string, mixed> Normalized pending request.
+	 */
+	public static function create_pending_request( WP_Agent_Runtime_Tool_Request_Store $store, array $request, array $context = array() ): array {
+		$normalized = WP_Agent_Runtime_Tool_Request::normalize( $request );
+		$store->create( $normalized );
+
+		do_action( 'agents_api_runtime_tool_request_created', $normalized, $context );
+
+		return $normalized;
+	}
+
+	/**
+	 * Submit a runtime tool result, complete the request, and optionally resume.
+	 *
+	 * @param WP_Agent_Runtime_Tool_Request_Store                    $store Request store.
+	 * @param array<string, mixed>                                   $result Raw submitted result.
+	 * @param WP_Agent_Runtime_Tool_Continuation|callable|null       $continuation Optional host continuation adapter.
+	 * @param array<string, mixed>                                   $context Caller-owned context.
+	 * @return array<string, mixed> Submission envelope.
+	 */
+	public static function submit_result( WP_Agent_Runtime_Tool_Request_Store $store, array $result, $continuation = null, array $context = array() ): array {
+		$request_id = self::request_id_from_payload( $result, 'invalid_runtime_tool_result: request_id must be a non-empty string' );
+		$request    = $store->get( $request_id );
+
+		if ( null === $request ) {
+			throw new \InvalidArgumentException( 'invalid_runtime_tool_result: request not found' );
+		}
+
+		$normalized_request = WP_Agent_Runtime_Tool_Request::normalize( $request );
+		$normalized_result  = WP_Agent_Runtime_Tool_Result::from_request( $normalized_request, $result );
+		$store->complete( self::string_field( $normalized_request, 'request_id' ), $normalized_result );
+
+		do_action( 'agents_api_runtime_tool_result_submitted', $normalized_request, $normalized_result, $context );
+
+		$envelope = array(
+			'status'                 => WP_Agent_Runtime_Tool_Result::STATUS_SUBMITTED,
+			'request'                => $normalized_request,
+			'result'                 => $normalized_result,
+			'tool_result_message'    => self::tool_result_message_payload( $normalized_request, $normalized_result ),
+			'tool_execution_result'  => self::tool_execution_result_payload( $normalized_request, $normalized_result ),
+			'continuation_result'    => null,
+		);
+
+		if ( null !== $continuation ) {
+			$envelope['continuation_result'] = self::resume( $continuation, $normalized_request, $normalized_result, $context );
+		}
+
+		return $envelope;
+	}
+
+	/**
+	 * Mark a pending request timed out and optionally resume with a timeout result.
+	 *
+	 * @param WP_Agent_Runtime_Tool_Request_Store                    $store Request store.
+	 * @param string                                                 $request_id Runtime tool request id.
+	 * @param WP_Agent_Runtime_Tool_Continuation|callable|null       $continuation Optional host continuation adapter.
+	 * @param array<string, mixed>                                   $context Caller-owned context.
+	 * @return array<string, mixed> Timeout envelope.
+	 */
+	public static function timeout_request( WP_Agent_Runtime_Tool_Request_Store $store, string $request_id, $continuation = null, array $context = array() ): array {
+		$request_id = trim( $request_id );
+		if ( '' === $request_id ) {
+			throw new \InvalidArgumentException( 'invalid_runtime_tool_timeout: request_id must be a non-empty string' );
+		}
+
+		$request = $store->get( $request_id );
+		if ( null === $request ) {
+			throw new \InvalidArgumentException( 'invalid_runtime_tool_timeout: request not found' );
+		}
+
+		$normalized_request = WP_Agent_Runtime_Tool_Request::normalize( $request );
+		$timeout_request    = WP_Agent_Runtime_Tool_Request::timeout( $normalized_request );
+		$timeout_result     = WP_Agent_Runtime_Tool_Result::from_request(
+			$normalized_request,
+			array(
+				'success' => false,
+				'error'   => 'Runtime tool request timed out.',
+				'metadata' => array( 'status' => WP_Agent_Runtime_Tool_Request::STATUS_TIMEOUT ),
+			)
+		);
+
+		$store->timeout( self::string_field( $normalized_request, 'request_id' ) );
+
+		do_action( 'agents_api_runtime_tool_request_timed_out', $timeout_request, $timeout_result, $context );
+
+		$envelope = array(
+			'status'                 => WP_Agent_Runtime_Tool_Request::STATUS_TIMEOUT,
+			'request'                => $timeout_request,
+			'result'                 => $timeout_result,
+			'tool_result_message'    => self::tool_result_message_payload( $normalized_request, $timeout_result ),
+			'tool_execution_result'  => self::tool_execution_result_payload( $normalized_request, $timeout_result ),
+			'continuation_result'    => null,
+		);
+
+		if ( null !== $continuation ) {
+			$envelope['continuation_result'] = self::resume( $continuation, $normalized_request, $timeout_result, $context );
+		}
+
+		return $envelope;
+	}
+
+	/**
+	 * Read recent pending requests from the configured store.
+	 *
+	 * @param WP_Agent_Runtime_Tool_Request_Store $store Request store.
+	 * @param array<string, mixed>                $query Product-neutral query hints.
+	 * @return array<int, array<string, mixed>> Normalized pending requests.
+	 */
+	public static function recent_pending_requests( WP_Agent_Runtime_Tool_Request_Store $store, array $query = array() ): array {
+		$requests = array();
+		foreach ( $store->recent_pending( $query ) as $request ) {
+			$requests[] = WP_Agent_Runtime_Tool_Request::normalize( $request );
+		}
+
+		return $requests;
+	}
+
+	/**
+	 * Resume through a host continuation adapter.
+	 *
+	 * @param WP_Agent_Runtime_Tool_Continuation|callable $continuation Host adapter.
+	 * @param array<string, mixed>                        $request Normalized request.
+	 * @param array<string, mixed>                        $result Normalized result.
+	 * @param array<string, mixed>                        $context Caller-owned context.
+	 * @return array<string, mixed> Host-owned resume result.
+	 */
+	private static function resume( $continuation, array $request, array $result, array $context ): array {
+		if ( $continuation instanceof WP_Agent_Runtime_Tool_Continuation ) {
+			$resume_result = $continuation->resume( $request, $result, $context );
+		} elseif ( is_callable( $continuation ) ) {
+			$resume_result = call_user_func( $continuation, $request, $result, $context );
+		} else {
+			throw new \InvalidArgumentException( 'invalid_runtime_tool_continuation: continuation must be callable or implement WP_Agent_Runtime_Tool_Continuation' );
+		}
+
+		if ( ! is_array( $resume_result ) ) {
+			throw new \InvalidArgumentException( 'invalid_runtime_tool_continuation: resume result must be an array' );
+		}
+
+		$resume_result = self::normalize_assoc_array( $resume_result );
+
+		do_action( 'agents_api_runtime_tool_request_resumed', $request, $result, $resume_result, $context );
+
+		return $resume_result;
+	}
+
+	/**
+	 * Build the transcript-compatible tool-result message payload.
+	 *
+	 * @param array<string, mixed> $request Normalized request.
+	 * @param array<string, mixed> $result Normalized result.
+	 * @return array<string, mixed> Tool-result message data.
+	 */
+	private static function tool_result_message_payload( array $request, array $result ): array {
+		return array(
+			'tool_name'    => self::string_field( $request, 'tool_name' ),
+			'tool_call_id' => self::string_field( $request, 'tool_call_id' ),
+			'success'      => (bool) ( $result['success'] ?? false ),
+			'status'       => self::string_field( $result, 'status' ),
+			'result'       => $result,
+		);
+	}
+
+	/**
+	 * Build the loop-compatible tool execution result payload.
+	 *
+	 * @param array<string, mixed> $request Normalized request.
+	 * @param array<string, mixed> $result Normalized result.
+	 * @return array<string, mixed> Tool execution result data.
+	 */
+	private static function tool_execution_result_payload( array $request, array $result ): array {
+		$metadata   = isset( $request['metadata'] ) && is_array( $request['metadata'] ) ? $request['metadata'] : array();
+		$turn_count = isset( $metadata['turn_count'] ) && is_int( $metadata['turn_count'] ) ? $metadata['turn_count'] : 0;
+
+		return array(
+			'tool_name'    => self::string_field( $request, 'tool_name' ),
+			'tool_call_id' => self::string_field( $request, 'tool_call_id' ),
+			'parameters'   => is_array( $request['parameters'] ?? null ) ? $request['parameters'] : array(),
+			'result'       => $result,
+			'runtime'      => is_array( $request['runtime'] ?? null ) ? $request['runtime'] : array(),
+			'turn_count'   => $turn_count,
+		);
+	}
+
+	/**
+	 * Extract a required request id from a payload.
+	 *
+	 * @param array<string, mixed> $payload Raw payload.
+	 * @param string               $message Validation message.
+	 * @return string Request id.
+	 */
+	private static function request_id_from_payload( array $payload, string $message ): string {
+		$request_id = $payload['request_id'] ?? '';
+		if ( ! is_string( $request_id ) || '' === trim( $request_id ) ) {
+			throw new \InvalidArgumentException( $message );
+		}
+
+		return trim( $request_id );
+	}
+
+	/**
+	 * Read a required string field from a normalized payload.
+	 *
+	 * @param array<string, mixed> $payload Normalized payload.
+	 * @param string               $field Field name.
+	 * @return string Field value.
+	 */
+	private static function string_field( array $payload, string $field ): string {
+		$value = $payload[ $field ] ?? '';
+		return is_string( $value ) ? $value : '';
+	}
+
+	/**
+	 * Normalize a mixed-key array into an associative string-key array.
+	 *
+	 * @param array<mixed, mixed> $value Raw array.
+	 * @return array<string, mixed> Normalized array.
+	 */
+	private static function normalize_assoc_array( array $value ): array {
+		$normalized = array();
+		foreach ( $value as $key => $item ) {
+			if ( is_string( $key ) ) {
+				$normalized[ $key ] = $item;
+			}
+		}
+
+		return $normalized;
+	}
+}

--- a/src/Runtime/class-wp-agent-runtime-tool-lifecycle.php
+++ b/src/Runtime/class-wp-agent-runtime-tool-lifecycle.php
@@ -12,6 +12,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Product-neutral runtime-tool lifecycle operations.
  */
+// phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Validation exceptions are not rendered output.
 class WP_Agent_Runtime_Tool_Lifecycle {
 
 	/**
@@ -55,12 +56,12 @@ class WP_Agent_Runtime_Tool_Lifecycle {
 		do_action( 'agents_api_runtime_tool_result_submitted', $normalized_request, $normalized_result, $context );
 
 		$envelope = array(
-			'status'                 => WP_Agent_Runtime_Tool_Result::STATUS_SUBMITTED,
-			'request'                => $normalized_request,
-			'result'                 => $normalized_result,
-			'tool_result_message'    => self::tool_result_message_payload( $normalized_request, $normalized_result ),
-			'tool_execution_result'  => self::tool_execution_result_payload( $normalized_request, $normalized_result ),
-			'continuation_result'    => null,
+			'status'                => WP_Agent_Runtime_Tool_Result::STATUS_SUBMITTED,
+			'request'               => $normalized_request,
+			'result'                => $normalized_result,
+			'tool_result_message'   => self::tool_result_message_payload( $normalized_request, $normalized_result ),
+			'tool_execution_result' => self::tool_execution_result_payload( $normalized_request, $normalized_result ),
+			'continuation_result'   => null,
 		);
 
 		if ( null !== $continuation ) {
@@ -95,8 +96,8 @@ class WP_Agent_Runtime_Tool_Lifecycle {
 		$timeout_result     = WP_Agent_Runtime_Tool_Result::from_request(
 			$normalized_request,
 			array(
-				'success' => false,
-				'error'   => 'Runtime tool request timed out.',
+				'success'  => false,
+				'error'    => 'Runtime tool request timed out.',
 				'metadata' => array( 'status' => WP_Agent_Runtime_Tool_Request::STATUS_TIMEOUT ),
 			)
 		);
@@ -106,12 +107,12 @@ class WP_Agent_Runtime_Tool_Lifecycle {
 		do_action( 'agents_api_runtime_tool_request_timed_out', $timeout_request, $timeout_result, $context );
 
 		$envelope = array(
-			'status'                 => WP_Agent_Runtime_Tool_Request::STATUS_TIMEOUT,
-			'request'                => $timeout_request,
-			'result'                 => $timeout_result,
-			'tool_result_message'    => self::tool_result_message_payload( $normalized_request, $timeout_result ),
-			'tool_execution_result'  => self::tool_execution_result_payload( $normalized_request, $timeout_result ),
-			'continuation_result'    => null,
+			'status'                => WP_Agent_Runtime_Tool_Request::STATUS_TIMEOUT,
+			'request'               => $timeout_request,
+			'result'                => $timeout_result,
+			'tool_result_message'   => self::tool_result_message_payload( $normalized_request, $timeout_result ),
+			'tool_execution_result' => self::tool_execution_result_payload( $normalized_request, $timeout_result ),
+			'continuation_result'   => null,
 		);
 
 		if ( null !== $continuation ) {

--- a/src/Runtime/class-wp-agent-runtime-tool-request-store.php
+++ b/src/Runtime/class-wp-agent-runtime-tool-request-store.php
@@ -43,4 +43,16 @@ interface WP_Agent_Runtime_Tool_Request_Store {
 	 * @param string $request_id Runtime tool request id.
 	 */
 	public function timeout( string $request_id ): void;
+
+	/**
+	 * Return recent pending requests for timeout scans or client polling.
+	 *
+	 * Implementations own concrete filtering semantics, but should support
+	 * product-neutral query keys such as `run_id`, `tool_name`, `before`, and
+	 * `limit` when they are meaningful for the host store.
+	 *
+	 * @param array<string, mixed> $query Product-neutral query hints.
+	 * @return array<int, array<string, mixed>> Normalized pending requests.
+	 */
+	public function recent_pending( array $query = array() ): array;
 }

--- a/src/Runtime/class-wp-agent-runtime-tool-request.php
+++ b/src/Runtime/class-wp-agent-runtime-tool-request.php
@@ -80,6 +80,19 @@ class WP_Agent_Runtime_Tool_Request {
 	}
 
 	/**
+	 * Mark a normalized request as timed out without changing its identity.
+	 *
+	 * @param array<string, mixed> $request Raw or normalized runtime tool request.
+	 * @return array<string, mixed> Timeout request payload.
+	 */
+	public static function timeout( array $request ): array {
+		$normalized           = self::normalize( $request );
+		$normalized['status'] = self::STATUS_TIMEOUT;
+
+		return $normalized;
+	}
+
+	/**
 	 * Build a stable request id when the host did not supply one.
 	 *
 	 * @param string $tool_name Tool name.

--- a/src/Runtime/class-wp-agent-runtime-tool-result.php
+++ b/src/Runtime/class-wp-agent-runtime-tool-result.php
@@ -54,4 +54,23 @@ class WP_Agent_Runtime_Tool_Result {
 
 		return $normalized;
 	}
+
+	/**
+	 * Normalize a submitted result against its stored pending request.
+	 *
+	 * @param array<string, mixed> $request Normalized runtime tool request.
+	 * @param array<string, mixed> $result Raw submitted result.
+	 * @return array<string, mixed> Normalized result payload.
+	 */
+	public static function from_request( array $request, array $result ): array {
+		$request = WP_Agent_Runtime_Tool_Request::normalize( $request );
+
+		return self::normalize( array_merge(
+			$result,
+			array(
+				'request_id' => $result['request_id'] ?? $request['request_id'],
+				'tool_name'  => $result['tool_name'] ?? $request['tool_name'],
+			)
+		) );
+	}
 }

--- a/tests/conversation-loop-tool-execution-smoke.php
+++ b/tests/conversation-loop-tool-execution-smoke.php
@@ -605,6 +605,60 @@ agents_api_smoke_assert_equals( array( 'tool_call', AgentsAPI\AI\WP_Agent_Runtim
 agents_api_smoke_assert_equals( AgentsAPI\AI\WP_Agent_Conversation_Result::OUTCOME_STATUS_PENDING_RUNTIME_TOOL, $pending_result['run_outcome']['status'] ?? '', 'pending runtime tool run outcome is pending', $failures, $passes );
 agents_api_smoke_assert_equals( AgentsAPI\AI\WP_Agent_Runtime_Tool_Request::STATUS_PENDING, $pending_result['run_outcome']['stop_reason'] ?? '', 'pending runtime tool run outcome stop reason is pending', $failures, $passes );
 
+$loop_runtime_tool_store = new class() implements AgentsAPI\AI\WP_Agent_Runtime_Tool_Request_Store {
+	public array $requests = array();
+
+	public function create( array $request ): void {
+		$this->requests[ $request['request_id'] ] = $request;
+	}
+
+	public function get( string $request_id ): ?array {
+		return $this->requests[ $request_id ] ?? null;
+	}
+
+	public function complete( string $request_id, array $result ): void {
+		unset( $result );
+		$this->requests[ $request_id ]['status'] = 'completed';
+	}
+
+	public function timeout( string $request_id ): void {
+		$this->requests[ $request_id ]['status'] = AgentsAPI\AI\WP_Agent_Runtime_Tool_Request::STATUS_TIMEOUT;
+	}
+
+	public function recent_pending( array $query = array() ): array {
+		unset( $query );
+		return array_values( $this->requests );
+	}
+};
+
+$stored_pending_result = AgentsAPI\AI\WP_Agent_Conversation_Loop::run(
+	array( array( 'role' => 'user', 'content' => 'choose stored' ) ),
+	static function ( array $messages ): array {
+		return array(
+			'messages'   => $messages,
+			'tool_calls' => array(
+				array(
+					'id'         => 'client-call-store-1',
+					'name'       => 'client/summarize',
+					'parameters' => array( 'text' => 'needs durable browser handoff' ),
+				),
+			),
+		);
+	},
+	array(
+		'max_turns'                  => 3,
+		'tool_executor'              => $pending_executor,
+		'tool_declarations'          => $tools,
+		'runtime_tool_request_store' => $loop_runtime_tool_store,
+		'context'                    => array( 'run_id' => 'run-loop-store' ),
+	)
+);
+
+$stored_request_id = $stored_pending_result['runtime_tool_pending']['request_id'] ?? '';
+agents_api_smoke_assert_equals( true, isset( $loop_runtime_tool_store->requests[ $stored_request_id ] ), 'loop hands pending runtime tool request to configured lifecycle store', $failures, $passes );
+agents_api_smoke_assert_equals( 1, did_action( 'agents_api_runtime_tool_request_created' ), 'loop persistence emits generic runtime tool created event', $failures, $passes );
+agents_api_smoke_assert_equals( 1, $loop_runtime_tool_store->requests[ $stored_request_id ]['metadata']['turn_count'] ?? 0, 'stored pending request records generic turn metadata for replay', $failures, $passes );
+
 echo "\n[Pre-tool filter hook allows, rejects, or pauses external runtime tools (#259):\n";
 
 $filter_contexts = array();

--- a/tests/tool-runtime-smoke.php
+++ b/tests/tool-runtime-smoke.php
@@ -374,4 +374,96 @@ $submitted_result = AgentsAPI\AI\WP_Agent_Runtime_Tool_Result::normalize(
 agents_api_smoke_assert_equals( AgentsAPI\AI\WP_Agent_Runtime_Tool_Result::STATUS_SUBMITTED, $submitted_result['status'], 'runtime tool result has canonical submitted status', $failures, $passes );
 agents_api_smoke_assert_equals( 123, $submitted_result['result']['post_id'] ?? null, 'runtime tool result preserves payload', $failures, $passes );
 
+$runtime_tool_store = new class() implements AgentsAPI\AI\WP_Agent_Runtime_Tool_Request_Store {
+	public array $requests = array();
+	public array $results  = array();
+
+	public function create( array $request ): void {
+		$this->requests[ $request['request_id'] ] = $request;
+	}
+
+	public function get( string $request_id ): ?array {
+		return $this->requests[ $request_id ] ?? null;
+	}
+
+	public function complete( string $request_id, array $result ): void {
+		$this->requests[ $request_id ]['status'] = 'completed';
+		$this->results[ $request_id ]            = $result;
+	}
+
+	public function timeout( string $request_id ): void {
+		$this->requests[ $request_id ]['status'] = AgentsAPI\AI\WP_Agent_Runtime_Tool_Request::STATUS_TIMEOUT;
+	}
+
+	public function recent_pending( array $query = array() ): array {
+		$limit   = isset( $query['limit'] ) && is_int( $query['limit'] ) ? $query['limit'] : 100;
+		$pending = array_filter(
+			$this->requests,
+			static fn( array $request ): bool => AgentsAPI\AI\WP_Agent_Runtime_Tool_Request::STATUS_PENDING === ( $request['status'] ?? '' )
+		);
+
+		return array_slice( array_values( $pending ), 0, $limit );
+	}
+};
+
+$created_request = AgentsAPI\AI\WP_Agent_Runtime_Tool_Lifecycle::create_pending_request( $runtime_tool_store, $pending_request, array( 'source' => 'smoke' ) );
+agents_api_smoke_assert_equals( $pending_request['request_id'], $created_request['request_id'], 'lifecycle creates normalized pending runtime tool requests', $failures, $passes );
+agents_api_smoke_assert_equals( 1, count( AgentsAPI\AI\WP_Agent_Runtime_Tool_Lifecycle::recent_pending_requests( $runtime_tool_store, array( 'limit' => 1 ) ) ), 'lifecycle exposes recent pending requests through store contract', $failures, $passes );
+
+$continuation_calls = array();
+$submission         = AgentsAPI\AI\WP_Agent_Runtime_Tool_Lifecycle::submit_result(
+	$runtime_tool_store,
+	array(
+		'request_id' => $pending_request['request_id'],
+		'success'    => true,
+		'result'     => array( 'post_id' => 456 ),
+	),
+	static function ( array $request, array $result, array $context ) use ( &$continuation_calls ): array {
+		$continuation_calls[] = compact( 'request', 'result', 'context' );
+		return array( 'resumed' => true );
+	},
+	array( 'resume_source' => 'smoke' )
+);
+agents_api_smoke_assert_equals( AgentsAPI\AI\WP_Agent_Runtime_Tool_Result::STATUS_SUBMITTED, $submission['status'], 'lifecycle submission has canonical submitted status', $failures, $passes );
+agents_api_smoke_assert_equals( 'client/choose_post', $submission['result']['tool_name'], 'lifecycle fills submitted result tool name from stored request', $failures, $passes );
+agents_api_smoke_assert_equals( 456, $submission['tool_result_message']['result']['result']['post_id'] ?? null, 'lifecycle creates transcript-compatible tool result message payload', $failures, $passes );
+agents_api_smoke_assert_equals( true, $submission['continuation_result']['resumed'] ?? false, 'lifecycle invokes continuation callback after submission', $failures, $passes );
+agents_api_smoke_assert_equals( 'smoke', $continuation_calls[0]['context']['resume_source'] ?? '', 'continuation receives caller context', $failures, $passes );
+
+$timeout_store = new class() implements AgentsAPI\AI\WP_Agent_Runtime_Tool_Request_Store {
+	public array $requests = array();
+
+	public function create( array $request ): void {
+		$this->requests[ $request['request_id'] ] = $request;
+	}
+
+	public function get( string $request_id ): ?array {
+		return $this->requests[ $request_id ] ?? null;
+	}
+
+	public function complete( string $request_id, array $result ): void {
+		unset( $result );
+		$this->requests[ $request_id ]['status'] = 'completed';
+	}
+
+	public function timeout( string $request_id ): void {
+		$this->requests[ $request_id ]['status'] = AgentsAPI\AI\WP_Agent_Runtime_Tool_Request::STATUS_TIMEOUT;
+	}
+
+	public function recent_pending( array $query = array() ): array {
+		unset( $query );
+		return array_values( array_filter(
+			$this->requests,
+			static fn( array $request ): bool => AgentsAPI\AI\WP_Agent_Runtime_Tool_Request::STATUS_PENDING === ( $request['status'] ?? '' )
+		) );
+	}
+};
+
+$timeout_request = AgentsAPI\AI\WP_Agent_Runtime_Tool_Request::from_tool_call( 'client/choose_post', 'call_timeout', array(), array( 'run_id' => 'run-timeout' ) );
+AgentsAPI\AI\WP_Agent_Runtime_Tool_Lifecycle::create_pending_request( $timeout_store, $timeout_request );
+$timeout = AgentsAPI\AI\WP_Agent_Runtime_Tool_Lifecycle::timeout_request( $timeout_store, $timeout_request['request_id'] );
+agents_api_smoke_assert_equals( AgentsAPI\AI\WP_Agent_Runtime_Tool_Request::STATUS_TIMEOUT, $timeout['status'], 'lifecycle timeout has canonical timeout status', $failures, $passes );
+agents_api_smoke_assert_equals( false, $timeout['result']['success'] ?? true, 'lifecycle timeout creates failed runtime tool result', $failures, $passes );
+agents_api_smoke_assert_equals( AgentsAPI\AI\WP_Agent_Runtime_Tool_Request::STATUS_TIMEOUT, $timeout_store->requests[ $timeout_request['request_id'] ]['status'] ?? '', 'lifecycle delegates timeout transition to store', $failures, $passes );
+
 agents_api_smoke_finish( 'Agents API tool runtime', $failures, $passes );


### PR DESCRIPTION
## Summary
- Adds a product-neutral runtime-tool lifecycle service with create, submit, timeout, recent-pending, and continuation contracts.
- Lets the conversation loop hand pending runtime-tool requests to an optional host-provided store while keeping concrete storage/jobs/sessions outside Agents API.
- Documents the durable runtime-tool lifecycle boundary and expands smoke coverage for lifecycle primitives plus loop persistence handoff.

Closes #306.

## Tests
- `php tests/tool-runtime-smoke.php`
- `php tests/conversation-loop-tool-execution-smoke.php`
- `composer smoke`
- `composer phpstan`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implementing the runtime-tool lifecycle contract, smoke coverage, documentation updates, and verification runs; Chris remains responsible for review and acceptance.