### PR TITLE
Add task execution target plumbing

### DIFF
--- a/agents-api.php
+++ b/agents-api.php
@@ -156,6 +156,7 @@ require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-runtime-tool-continua
 require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-runtime-tool-lifecycle.php';
 require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-conversation-result.php';
 require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-chat-run-control.php';
+require_once AGENTS_API_PATH . 'src/Tasks/class-wp-agent-task-run-control.php';
 require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-conversation-loop.php';
 require_once AGENTS_API_PATH . 'src/Tools/class-wp-agent-tool-call.php';
 require_once AGENTS_API_PATH . 'src/Tools/class-wp-agent-tool-parameters.php';
@@ -199,6 +200,7 @@ require_once AGENTS_API_PATH . 'src/Channels/class-wp-agent-bridge.php';
 require_once AGENTS_API_PATH . 'src/Channels/class-wp-agent-channel.php';
 require_once AGENTS_API_PATH . 'src/Channels/register-agents-chat-ability.php';
 require_once AGENTS_API_PATH . 'src/Channels/register-agents-chat-run-control-abilities.php';
+require_once AGENTS_API_PATH . 'src/Tasks/register-agents-task-abilities.php';
 require_once AGENTS_API_PATH . 'src/Channels/register-frontend-chat-rest-route.php';
 require_once AGENTS_API_PATH . 'src/Channels/register-agents-chat-jsonrpc-route.php';
 require_once AGENTS_API_PATH . 'src/Channels/register-agents-dispatch-message-ability.php';

--- a/composer.json
+++ b/composer.json
@@ -83,6 +83,7 @@
       "php tests/conversation-loop-budgets-smoke.php",
       "php tests/channels-smoke.php",
       "php tests/chat-run-control-smoke.php",
+      "php tests/task-execution-smoke.php",
       "php tests/frontend-chat-rest-smoke.php",
       "php tests/agents-chat-jsonrpc-route-smoke.php",
       "php tests/agents-dispatch-message-ability-smoke.php",

--- a/docs/capability-map.md
+++ b/docs/capability-map.md
@@ -21,6 +21,7 @@ the substrate can match their own components against it.
 | Iteration / runaway limits | `WP_Agent_Iteration_Budget` | [`src/Runtime/class-wp-agent-iteration-budget.php`](../src/Runtime/class-wp-agent-iteration-budget.php) | [Runtime and Tools](runtime-and-tools.md) |
 | Transcript persistence hook | `WP_Agent_Transcript_Persister` | [`src/Runtime/class-wp-agent-transcript-persister.php`](../src/Runtime/class-wp-agent-transcript-persister.php) | [Runtime and Tools](runtime-and-tools.md) |
 | Lifecycle events / observability | `agents_api_loop_event` action + `on_event` sink | [`src/Runtime/class-wp-agent-conversation-loop.php`](../src/Runtime/class-wp-agent-conversation-loop.php) | [Runtime and Tools](runtime-and-tools.md) |
+| Task execution target plumbing | `agents/run-task`, task run-control helpers, executor target filters | [`src/Tasks/`](../src/Tasks/) | [Runtime and Tools](runtime-and-tools.md#task-execution-targets) |
 
 ## Tools
 
@@ -88,5 +89,9 @@ filter, so a consumer plugs in its own backend without forking:
 | `wp_agent_conversation_store` | Transcript / session backend |
 | `wp_agent_memory_store` | Memory backend |
 | `wp_agent_pending_action_store` | Approval queue backend |
+| `wp_agent_execution_targets` | Task executor target declarations |
+| `wp_agent_task_handler` | Task executor dispatch handler |
+| `wp_agent_task_run_status_handler` | Task run status backend |
+| `wp_agent_task_run_cancel_handler` | Task cancellation backend |
 | `agents_api_execution_principal` | How the current principal is resolved |
 | `agents_api_enable_default_conversation_store` | Opt in to the built-in WordPress-native conversation store |

--- a/docs/runtime-and-tools.md
+++ b/docs/runtime-and-tools.md
@@ -20,6 +20,84 @@ Agents API owns reusable runtime mechanics:
 
 Consumers own provider/model dispatch, prompt assembly, concrete tools, durable storage, streaming UX, product-specific continuation policy, and final business semantics.
 
+## Task execution targets
+
+Agents API also exposes product-neutral task execution plumbing for work that is
+larger than one chat turn but should still flow through a generic agent/session
+contract. The substrate owns normalization, placement hints, executor discovery,
+dispatch, result envelopes, and run-control helpers. Executor providers own all
+concrete side effects.
+
+Public task contracts:
+
+- `agents-api/task-input/v1` normalizes task ID, instructions, structured input,
+  attachments, client context, metadata, session ID, and run ID.
+- `agents-api/execution-placement/v1` carries placement hints: preferred target,
+  allowed targets, resource class, required capabilities, and provider-owned
+  metadata.
+- `agents-api/executor-target/v1` lets providers declare executor targets with
+  IDs, labels, kind, capabilities, resource classes, and opaque metadata.
+- `agents-api/task-result/v1` is the canonical result envelope with status,
+  run/session IDs, executor ID, artifact refs, diagnostics, events, provenance,
+  optional output, timestamps, and metadata.
+
+Registered abilities:
+
+| Ability | Purpose |
+| --- | --- |
+| `agents/run-task` | Dispatch a normalized task to a registered executor target. |
+| `agents/list-execution-targets` | Discover registered targets and filter by placement needs. |
+| `agents/get-task-run` | Read the canonical status/result for an addressable task run. |
+| `agents/cancel-task-run` | Request best-effort cancellation for an addressable task run. |
+
+Executor providers register targets through `wp_agent_execution_targets` and
+dispatch handlers through `wp_agent_task_handler`, mirroring the `agents/chat`
+and `wp_agent_chat_handler` pattern:
+
+```php
+add_filter(
+	'wp_agent_execution_targets',
+	static function ( array $targets ): array {
+		$targets[] = array(
+			'id'               => 'example-runtime',
+			'label'            => 'Example Runtime',
+			'kind'             => 'runtime',
+			'capabilities'     => array( 'tasks.run', 'artifacts.reference' ),
+			'resource_classes' => array( 'generic' ),
+		);
+
+		return $targets;
+	}
+);
+
+add_filter(
+	'wp_agent_task_handler',
+	static function ( $handler, array $input, array $target ) {
+		if ( null !== $handler || 'example-runtime' !== $target['id'] ) {
+			return $handler;
+		}
+
+		return static function ( array $input, array $target ): array {
+			return array(
+				'schema'      => 'agents-api/task-result/v1',
+				'run_id'      => $input['run_id'],
+				'session_id'  => $input['session_id'],
+				'executor_id' => $target['id'],
+				'status'      => 'succeeded',
+				'diagnostics' => array( 'summary' => 'completed' ),
+			);
+		};
+	},
+	10,
+	3
+);
+```
+
+Agents API does not read or write files, create worktrees, run Git, run browser
+runtimes, open pull requests, or mutate sites from this contract. Providers can
+implement those side effects behind executor targets, but they remain provider
+responsibilities and must not be encoded into the generic task schema.
+
 ## Message and request shapes
 
 `AgentsAPI\AI\WP_Agent_Message` normalizes transcript entries into JSON-friendly message arrays. The loop accepts arrays and normalizes them before passing them to caller adapters.

--- a/src/Tasks/class-wp-agent-task-run-control.php
+++ b/src/Tasks/class-wp-agent-task-run-control.php
@@ -1,0 +1,249 @@
+<?php
+/**
+ * Generic task run-control primitives.
+ *
+ * @package AgentsAPI
+ */
+
+namespace AgentsAPI\AI\Tasks;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Shared helpers for canonical task execution contracts.
+ */
+class WP_Agent_Task_Run_Control {
+
+	public const STATUS_QUEUED     = 'queued';
+	public const STATUS_RUNNING    = 'running';
+	public const STATUS_CANCELLING = 'cancelling';
+	public const STATUS_CANCELLED  = 'cancelled';
+	public const STATUS_SUCCEEDED  = 'succeeded';
+	public const STATUS_FAILED     = 'failed';
+	private const OPTION_KEY       = 'agents_api_task_run_control';
+
+	/** @return string[] */
+	public static function statuses(): array {
+		return array(
+			self::STATUS_QUEUED,
+			self::STATUS_RUNNING,
+			self::STATUS_CANCELLING,
+			self::STATUS_CANCELLED,
+			self::STATUS_SUCCEEDED,
+			self::STATUS_FAILED,
+		);
+	}
+
+	/**
+	 * Generate an opaque client-addressable run ID.
+	 */
+	public static function generate_run_id(): string {
+		if ( function_exists( 'wp_generate_uuid4' ) ) {
+			return 'task_run_' . str_replace( '-', '', wp_generate_uuid4() );
+		}
+
+		try {
+			return 'task_run_' . bin2hex( random_bytes( 16 ) );
+		} catch ( \Throwable $error ) {
+			unset( $error );
+			return 'task_run_' . str_replace( '.', '', uniqid( '', true ) );
+		}
+	}
+
+	/**
+	 * Normalize a task run status/result payload returned by an executor.
+	 *
+	 * @param array<string,mixed> $run Raw run payload.
+	 * @return array<string,mixed>
+	 */
+	public static function normalize_run( array $run ): array {
+		$run_id      = trim( self::string_value( $run['run_id'] ?? null ) );
+		$session_id  = trim( self::string_value( $run['session_id'] ?? null ) );
+		$executor_id = trim( self::string_value( $run['executor_id'] ?? null ) );
+		$status      = self::normalize_status( $run['status'] ?? self::STATUS_RUNNING );
+
+		if ( '' === $run_id ) {
+			throw new \InvalidArgumentException( 'run_id must be a non-empty string' );
+		}
+
+		if ( '' === $session_id ) {
+			throw new \InvalidArgumentException( 'session_id must be a non-empty string' );
+		}
+
+		if ( '' === $executor_id ) {
+			throw new \InvalidArgumentException( 'executor_id must be a non-empty string' );
+		}
+
+		return array(
+			'schema'        => self::string_value( $run['schema'] ?? 'agents-api/task-result/v1' ),
+			'run_id'        => $run_id,
+			'session_id'    => $session_id,
+			'status'        => $status,
+			'executor_id'   => $executor_id,
+			'artifact_refs' => self::list_value( $run['artifact_refs'] ?? array() ),
+			'diagnostics'   => self::map_value( $run['diagnostics'] ?? array() ),
+			'events'        => self::list_value( $run['events'] ?? array() ),
+			'provenance'    => self::map_value( $run['provenance'] ?? array() ),
+			'output'        => $run['output'] ?? null,
+			'started_at'    => self::string_value( $run['started_at'] ?? null ),
+			'updated_at'    => self::string_value( $run['updated_at'] ?? null ),
+			'metadata'      => self::map_value( $run['metadata'] ?? array() ),
+		);
+	}
+
+	/**
+	 * Normalize status values while keeping the public vocabulary bounded.
+	 */
+	public static function normalize_status( mixed $status ): string {
+		$status = is_string( $status ) ? strtolower( trim( $status ) ) : '';
+		return in_array( $status, self::statuses(), true ) ? $status : self::STATUS_RUNNING;
+	}
+
+	/**
+	 * Start or update an addressable task run in the default store.
+	 *
+	 * @param string              $run_id      Run ID.
+	 * @param string              $session_id  Session ID.
+	 * @param string              $executor_id Executor ID.
+	 * @param array<string,mixed> $metadata    Run metadata.
+	 * @return array<string,mixed> Normalized run.
+	 */
+	public static function start_run( string $run_id, string $session_id, string $executor_id, array $metadata = array() ): array {
+		$now = self::now();
+		$run = array(
+			'run_id'      => $run_id,
+			'session_id'  => $session_id,
+			'executor_id' => $executor_id,
+			'status'      => self::STATUS_RUNNING,
+			'started_at'  => $metadata['started_at'] ?? $now,
+			'updated_at'  => $now,
+			'metadata'    => $metadata,
+		);
+
+		$state                    = self::state();
+		$state['runs'][ $run_id ] = $run;
+		self::save_state( $state );
+
+		return self::normalize_run( $run );
+	}
+
+	/**
+	 * Store a normalized executor result.
+	 *
+	 * @param array<string,mixed> $run Run/result payload.
+	 * @return array<string,mixed> Normalized run.
+	 */
+	public static function save_run( array $run ): array {
+		$normalized              = self::normalize_run( $run );
+		$normalized['updated_at'] = '' !== $normalized['updated_at'] ? $normalized['updated_at'] : self::now();
+		$run_id                  = self::string_value( $normalized['run_id'] );
+
+		$state                    = self::state();
+		$state['runs'][ $run_id ] = $normalized;
+		self::save_state( $state );
+
+		return $normalized;
+	}
+
+	/**
+	 * Read a stored task run.
+	 *
+	 * @param string $run_id Run ID.
+	 * @return array<string,mixed>|null Normalized run, or null when absent.
+	 */
+	public static function get_run( string $run_id ): ?array {
+		$state = self::state();
+		$run   = $state['runs'][ $run_id ] ?? null;
+		return is_array( $run ) ? self::normalize_run( $run ) : null;
+	}
+
+	/**
+	 * Request cancellation of a stored task run.
+	 *
+	 * @param string $run_id Run ID.
+	 * @return array<string,mixed>|null Normalized run, or null when absent.
+	 */
+	public static function request_cancel( string $run_id ): ?array {
+		$state = self::state();
+		if ( ! isset( $state['runs'][ $run_id ] ) ) {
+			return null;
+		}
+
+		$run      = $state['runs'][ $run_id ];
+		$terminal = in_array( self::normalize_status( $run['status'] ?? '' ), array( self::STATUS_SUCCEEDED, self::STATUS_FAILED, self::STATUS_CANCELLED ), true );
+
+		$run['status']     = $terminal ? self::normalize_status( $run['status'] ?? '' ) : self::STATUS_CANCELLING;
+		$run['cancelled']  = ! $terminal;
+		$run['updated_at'] = self::now();
+
+		$state['runs'][ $run_id ] = $run;
+		self::save_state( $state );
+
+		return self::normalize_run( $run ) + array( 'cancelled' => (bool) $run['cancelled'] );
+	}
+
+	/** @return array{runs:array<string,array<string,mixed>>} */
+	private static function state(): array {
+		$state = function_exists( 'get_option' ) ? get_option( self::OPTION_KEY, array() ) : array();
+		if ( ! is_array( $state ) ) {
+			$state = array();
+		}
+
+		return array( 'runs' => self::stored_runs( $state['runs'] ?? array() ) );
+	}
+
+	private static function string_value( mixed $value ): string {
+		return is_int( $value ) || is_float( $value ) || is_string( $value ) || is_bool( $value ) ? (string) $value : '';
+	}
+
+	/** @return array<string,mixed> */
+	private static function map_value( mixed $value ): array {
+		if ( ! is_array( $value ) ) {
+			return array();
+		}
+
+		$map = array();
+		foreach ( $value as $key => $item ) {
+			if ( is_string( $key ) ) {
+				$map[ $key ] = $item;
+			}
+		}
+
+		return $map;
+	}
+
+	/** @return array<int,mixed> */
+	private static function list_value( mixed $value ): array {
+		return is_array( $value ) ? array_values( $value ) : array();
+	}
+
+	/**
+	 * @param mixed $runs Raw stored runs.
+	 * @return array<string,array<string,mixed>>
+	 */
+	private static function stored_runs( mixed $runs ): array {
+		if ( ! is_array( $runs ) ) {
+			return array();
+		}
+
+		$stored = array();
+		foreach ( $runs as $run_id => $run ) {
+			if ( is_string( $run_id ) && is_array( $run ) ) {
+				$stored[ $run_id ] = self::map_value( $run );
+			}
+		}
+
+		return $stored;
+	}
+
+	/** @param array<string,mixed> $state State to persist. */
+	private static function save_state( array $state ): void {
+		if ( function_exists( 'update_option' ) ) {
+			update_option( self::OPTION_KEY, $state, false );
+		}
+	}
+
+	private static function now(): string {
+		return gmdate( 'c' );
+	}
+}

--- a/src/Tasks/class-wp-agent-task-run-control.php
+++ b/src/Tasks/class-wp-agent-task-run-control.php
@@ -134,9 +134,9 @@ class WP_Agent_Task_Run_Control {
 	 * @return array<string,mixed> Normalized run.
 	 */
 	public static function save_run( array $run ): array {
-		$normalized              = self::normalize_run( $run );
+		$normalized               = self::normalize_run( $run );
 		$normalized['updated_at'] = '' !== $normalized['updated_at'] ? $normalized['updated_at'] : self::now();
-		$run_id                  = self::string_value( $normalized['run_id'] );
+		$run_id                   = self::string_value( $normalized['run_id'] );
 
 		$state                    = self::state();
 		$state['runs'][ $run_id ] = $normalized;

--- a/src/Tasks/register-agents-task-abilities.php
+++ b/src/Tasks/register-agents-task-abilities.php
@@ -1,0 +1,656 @@
+<?php
+/**
+ * Canonical task execution ability registration.
+ *
+ * @package AgentsAPI
+ */
+
+namespace AgentsAPI\AI\Tasks;
+
+defined( 'ABSPATH' ) || exit;
+
+const AGENTS_RUN_TASK_ABILITY              = 'agents/run-task';
+const AGENTS_LIST_EXECUTION_TARGETS_ABILITY = 'agents/list-execution-targets';
+const AGENTS_GET_TASK_RUN_ABILITY          = 'agents/get-task-run';
+const AGENTS_CANCEL_TASK_RUN_ABILITY       = 'agents/cancel-task-run';
+
+add_action(
+	'wp_abilities_api_categories_init',
+	static function (): void {
+		if ( wp_has_ability_category( 'agents-api' ) ) {
+			return;
+		}
+
+		wp_register_ability_category(
+			'agents-api',
+			array(
+				'label'       => 'Agents API',
+				'description' => 'Cross-cutting abilities provided by the Agents API substrate.',
+			)
+		);
+	}
+);
+
+add_action(
+	'wp_abilities_api_init',
+	static function (): void {
+		$abilities = array(
+			AGENTS_RUN_TASK_ABILITY               => array(
+				'label'            => 'Run Task',
+				'description'      => 'Dispatch a product-neutral task request to a registered executor target.',
+				'input_schema'     => agents_task_input_schema(),
+				'output_schema'    => agents_task_result_schema(),
+				'execute_callback' => __NAMESPACE__ . '\\agents_run_task',
+				'annotations'      => array(
+					'destructive' => true,
+					'idempotent'  => false,
+				),
+			),
+			AGENTS_LIST_EXECUTION_TARGETS_ABILITY => array(
+				'label'            => 'List Execution Targets',
+				'description'      => 'Discover registered product-neutral executor targets and their capabilities.',
+				'input_schema'     => agents_list_execution_targets_input_schema(),
+				'output_schema'    => agents_list_execution_targets_output_schema(),
+				'execute_callback' => __NAMESPACE__ . '\\agents_list_execution_targets',
+				'annotations'      => array( 'idempotent' => true ),
+			),
+			AGENTS_GET_TASK_RUN_ABILITY           => array(
+				'label'            => 'Get Task Run',
+				'description'      => 'Read the canonical status/result envelope for an addressable task run.',
+				'input_schema'     => agents_task_run_id_input_schema(),
+				'output_schema'    => agents_task_result_schema(),
+				'execute_callback' => __NAMESPACE__ . '\\agents_get_task_run',
+				'annotations'      => array( 'idempotent' => true ),
+			),
+			AGENTS_CANCEL_TASK_RUN_ABILITY        => array(
+				'label'            => 'Cancel Task Run',
+				'description'      => 'Request best-effort cancellation for an addressable task run.',
+				'input_schema'     => agents_task_run_id_input_schema(),
+				'output_schema'    => agents_cancel_task_run_output_schema(),
+				'execute_callback' => __NAMESPACE__ . '\\agents_cancel_task_run',
+				'annotations'      => array(
+					'destructive' => true,
+					'idempotent'  => true,
+				),
+			),
+		);
+
+		foreach ( $abilities as $ability => $args ) {
+			if ( wp_has_ability( $ability ) ) {
+				continue;
+			}
+
+			wp_register_ability(
+				$ability,
+				array(
+					'label'               => $args['label'],
+					'description'         => $args['description'],
+					'category'            => 'agents-api',
+					'input_schema'        => $args['input_schema'],
+					'output_schema'       => $args['output_schema'],
+					'execute_callback'    => $args['execute_callback'],
+					'permission_callback' => __NAMESPACE__ . '\\agents_task_permission',
+					'meta'                => array(
+						'show_in_rest' => true,
+						'annotations'  => $args['annotations'],
+					),
+				)
+			);
+		}
+	}
+);
+
+/**
+ * Dispatch a task request to the selected executor target.
+ *
+ * @param array<string,mixed> $input Canonical task input.
+ * @return array<string,mixed>|\WP_Error
+ */
+function agents_run_task( array $input ) {
+	$input = agents_task_normalize_input( $input );
+	if ( is_wp_error( $input ) ) {
+		return $input;
+	}
+
+	$targets = agents_execution_targets();
+	if ( is_wp_error( $targets ) ) {
+		return $targets;
+	}
+	$placement = is_array( $input['placement'] ?? null ) ? agents_task_string_keyed_array( $input['placement'] ) : array();
+	$run_id    = agents_task_string( $input['run_id'] ?? '' );
+	$session_id = agents_task_string( $input['session_id'] ?? '' );
+
+	$target = agents_task_select_target( $targets, $placement );
+	if ( null === $target ) {
+		do_action( 'agents_task_dispatch_failed', 'no_handler', $input );
+		return new \WP_Error( 'agents_task_no_handler', 'No agents/run-task executor target is registered for the requested placement.' );
+	}
+
+	$handler = apply_filters( 'wp_agent_task_handler', null, $input, $target );
+	if ( ! is_callable( $handler ) ) {
+		do_action( 'agents_task_dispatch_failed', 'no_handler', $input );
+		return new \WP_Error( 'agents_task_no_handler', 'No agents/run-task handler is registered for the selected executor target.' );
+	}
+
+	$executor_id          = agents_task_string( $target['id'] ?? '' );
+	$input['executor_id'] = $executor_id;
+	$metadata            = array(
+		'executor_id'    => $executor_id,
+		'target_kind'    => $target['kind'],
+		'resource_class' => $placement['resource_class'] ?? '',
+	);
+	WP_Agent_Task_Run_Control::start_run( $run_id, $session_id, $executor_id, $metadata );
+
+	$result = call_user_func( $handler, $input, $target );
+	if ( is_wp_error( $result ) ) {
+		WP_Agent_Task_Run_Control::save_run(
+			array(
+				'run_id'      => $run_id,
+				'session_id'  => $session_id,
+				'executor_id' => $executor_id,
+				'status'      => WP_Agent_Task_Run_Control::STATUS_FAILED,
+				'diagnostics' => array(
+					'error_code'    => $result->get_error_code(),
+					'error_message' => $result->get_error_message(),
+				),
+			)
+		);
+		do_action( 'agents_task_dispatch_failed', $result->get_error_code(), $input );
+		return $result;
+	}
+
+	if ( ! is_array( $result ) ) {
+		WP_Agent_Task_Run_Control::save_run(
+			array(
+				'run_id'      => $run_id,
+				'session_id'  => $session_id,
+				'executor_id' => $executor_id,
+				'status'      => WP_Agent_Task_Run_Control::STATUS_FAILED,
+			)
+		);
+		do_action( 'agents_task_dispatch_failed', 'invalid_result', $input );
+		return new \WP_Error( 'agents_task_invalid_result', 'agents/run-task handlers must return an array matching agents-api/task-result/v1 or WP_Error.' );
+	}
+
+	$result = agents_task_string_keyed_array( $result );
+	$result = array_merge(
+		array(
+			'schema'      => 'agents-api/task-result/v1',
+			'run_id'      => $run_id,
+			'session_id'  => $session_id,
+			'executor_id' => $executor_id,
+		),
+		$result
+	);
+
+	try {
+		return WP_Agent_Task_Run_Control::save_run( $result );
+	} catch ( \InvalidArgumentException $error ) {
+		do_action( 'agents_task_dispatch_failed', 'invalid_result', $input );
+		return new \WP_Error( 'agents_task_invalid_result', $error->getMessage() );
+	}
+}
+
+/**
+ * @param array<string,mixed> $input Ability input.
+ * @return array<string,mixed>|\WP_Error
+ */
+function agents_list_execution_targets( array $input ) {
+	$targets = agents_execution_targets();
+	if ( is_wp_error( $targets ) ) {
+		return $targets;
+	}
+
+	$required_capabilities = agents_task_string_list( $input['required_capabilities'] ?? array() );
+	$allowed_targets       = agents_task_string_list( $input['allowed_targets'] ?? array() );
+	$resource_class        = agents_task_optional_string( $input['resource_class'] ?? null );
+
+	$filtered = array();
+	foreach ( $targets as $target ) {
+		$target_id        = agents_task_string( $target['id'] ?? '' );
+		$resource_classes = agents_task_string_list( $target['resource_classes'] ?? array() );
+		$capabilities     = agents_task_string_list( $target['capabilities'] ?? array() );
+
+		if ( array() !== $allowed_targets && ! in_array( $target_id, $allowed_targets, true ) ) {
+			continue;
+		}
+		if ( null !== $resource_class && array() !== $resource_classes && ! in_array( $resource_class, $resource_classes, true ) ) {
+			continue;
+		}
+		if ( array() !== array_diff( $required_capabilities, $capabilities ) ) {
+			continue;
+		}
+		$filtered[] = $target;
+	}
+
+	return array(
+		'schema'  => 'agents-api/execution-target-list/v1',
+		'targets' => $filtered,
+	);
+}
+
+/**
+ * @param array<string,mixed> $input Ability input.
+ * @return array<string,mixed>|\WP_Error
+ */
+function agents_get_task_run( array $input ) {
+	$handler = apply_filters( 'wp_agent_task_run_status_handler', null, $input );
+	if ( is_callable( $handler ) ) {
+		return agents_task_normalize_run_control_result( call_user_func( $handler, $input ), 'agents_task_run_invalid_status' );
+	}
+
+	$run                  = WP_Agent_Task_Run_Control::get_run( agents_task_string( $input['run_id'] ?? '' ) );
+	$requested_session_id = agents_task_string( $input['session_id'] ?? '' );
+	if ( null !== $run && agents_task_string( $run['session_id'] ?? '' ) !== $requested_session_id ) {
+		return new \WP_Error( 'agents_task_run_not_found', 'No task run was found for the requested session_id and run_id.' );
+	}
+	if ( null !== $run ) {
+		return $run;
+	}
+
+	return new \WP_Error( 'agents_task_run_not_found', 'No task run was found for the requested run_id.' );
+}
+
+/**
+ * @param array<string,mixed> $input Ability input.
+ * @return array<string,mixed>|\WP_Error
+ */
+function agents_cancel_task_run( array $input ) {
+	$handler = apply_filters( 'wp_agent_task_run_cancel_handler', null, $input );
+	if ( is_callable( $handler ) ) {
+		$result = agents_task_normalize_run_control_result( call_user_func( $handler, $input ), 'agents_task_run_invalid_cancel_result' );
+	} else {
+		$run                  = WP_Agent_Task_Run_Control::get_run( agents_task_string( $input['run_id'] ?? '' ) );
+		$requested_session_id = agents_task_string( $input['session_id'] ?? '' );
+		if ( null === $run || agents_task_string( $run['session_id'] ?? '' ) !== $requested_session_id ) {
+			return new \WP_Error( 'agents_task_run_not_found', 'No task run was found for the requested session_id and run_id.' );
+		}
+
+		$result = WP_Agent_Task_Run_Control::request_cancel( agents_task_string( $input['run_id'] ?? '' ) );
+		if ( null === $result ) {
+			return new \WP_Error( 'agents_task_run_not_found', 'No task run was found for the requested run_id.' );
+		}
+	}
+
+	if ( is_wp_error( $result ) ) {
+		return $result;
+	}
+
+	$status              = WP_Agent_Task_Run_Control::normalize_status( $result['status'] ?? WP_Agent_Task_Run_Control::STATUS_RUNNING );
+	$result['status']    = $status;
+	$result['cancelled'] = (bool) ( $result['cancelled'] ?? in_array( $status, array( WP_Agent_Task_Run_Control::STATUS_CANCELLING, WP_Agent_Task_Run_Control::STATUS_CANCELLED ), true ) );
+
+	return $result;
+}
+
+/**
+ * @return array<int,array<string,mixed>>|\WP_Error
+ */
+function agents_execution_targets() {
+	$targets = apply_filters( 'wp_agent_execution_targets', array() );
+	if ( ! is_array( $targets ) ) {
+		return new \WP_Error( 'agents_execution_targets_invalid', 'Execution target registration must return an array.' );
+	}
+
+	$normalized = array();
+	foreach ( $targets as $target ) {
+		if ( ! is_array( $target ) ) {
+			return new \WP_Error( 'agents_execution_targets_invalid', 'Execution target declarations must be arrays.' );
+		}
+
+		$target = agents_execution_target_normalize( agents_task_string_keyed_array( $target ) );
+		if ( is_wp_error( $target ) ) {
+			return $target;
+		}
+		$normalized[] = $target;
+	}
+
+	return $normalized;
+}
+
+/**
+ * @param array<string,mixed> $target Raw target declaration.
+ * @return array<string,mixed>|\WP_Error
+ */
+function agents_execution_target_normalize( array $target ) {
+	$id = agents_task_optional_string( $target['id'] ?? null );
+	if ( null === $id ) {
+		return new \WP_Error( 'agents_execution_target_invalid', 'Execution target declarations must include id.' );
+	}
+
+	return array(
+		'schema'           => agents_task_optional_string( $target['schema'] ?? null ) ?? 'agents-api/executor-target/v1',
+		'id'               => $id,
+		'label'            => agents_task_optional_string( $target['label'] ?? null ) ?? $id,
+		'kind'             => agents_task_optional_string( $target['kind'] ?? null ) ?? 'executor',
+		'description'      => agents_task_optional_string( $target['description'] ?? null ) ?? '',
+		'capabilities'     => agents_task_string_list( $target['capabilities'] ?? array() ),
+		'resource_classes' => agents_task_string_list( $target['resource_classes'] ?? array() ),
+		'metadata'         => is_array( $target['metadata'] ?? null ) ? agents_task_string_keyed_array( $target['metadata'] ) : array(),
+	);
+}
+
+/**
+ * @param array<string,mixed> $input Raw input.
+ * @return array<string,mixed>|\WP_Error
+ */
+function agents_task_normalize_input( array $input ) {
+	$input = agents_task_string_keyed_array( $input );
+	$task  = is_array( $input['task'] ?? null ) ? agents_task_string_keyed_array( $input['task'] ) : array();
+
+	$task_id = agents_task_optional_string( $task['id'] ?? null ) ?? agents_task_optional_string( $input['task_id'] ?? null );
+	if ( null === $task_id ) {
+		return new \WP_Error( 'agents_task_invalid_input', 'agents/run-task input must include task.id or task_id.' );
+	}
+
+	$session_id = agents_task_optional_string( $input['session_id'] ?? null );
+	if ( null === $session_id ) {
+		$session_id = 'task_session_' . str_replace( 'task_run_', '', WP_Agent_Task_Run_Control::generate_run_id() );
+	}
+
+	$run_id = agents_task_optional_string( $input['run_id'] ?? null ) ?? WP_Agent_Task_Run_Control::generate_run_id();
+
+	$task['schema']       = agents_task_optional_string( $task['schema'] ?? null ) ?? 'agents-api/task-input/v1';
+	$task['id']           = $task_id;
+	$task['instructions'] = agents_task_optional_string( $task['instructions'] ?? null ) ?? agents_task_optional_string( $input['instructions'] ?? null ) ?? '';
+	$task['input']        = is_array( $task['input'] ?? null ) ? agents_task_string_keyed_array( $task['input'] ) : ( is_array( $input['input'] ?? null ) ? agents_task_string_keyed_array( $input['input'] ) : array() );
+	$task['attachments']  = is_array( $task['attachments'] ?? null ) ? array_values( $task['attachments'] ) : ( is_array( $input['attachments'] ?? null ) ? array_values( $input['attachments'] ) : array() );
+	$task['metadata']     = is_array( $task['metadata'] ?? null ) ? agents_task_string_keyed_array( $task['metadata'] ) : array();
+
+	$input['schema']        = agents_task_optional_string( $input['schema'] ?? null ) ?? 'agents-api/task-input/v1';
+	$input['task']          = $task;
+	$input['task_id']       = $task_id;
+	$input['session_id']    = $session_id;
+	$input['run_id']        = $run_id;
+	$input['placement']     = agents_task_normalize_placement( is_array( $input['placement'] ?? null ) ? agents_task_string_keyed_array( $input['placement'] ) : $input );
+	$input['client_context'] = is_array( $input['client_context'] ?? null ) ? agents_task_string_keyed_array( $input['client_context'] ) : array();
+	$input['metadata']      = is_array( $input['metadata'] ?? null ) ? agents_task_string_keyed_array( $input['metadata'] ) : array();
+
+	return $input;
+}
+
+/**
+ * @param array<string,mixed> $placement Raw placement hints.
+ * @return array<string,mixed>
+ */
+function agents_task_normalize_placement( array $placement ): array {
+	return array(
+		'schema'                => 'agents-api/execution-placement/v1',
+		'preferred_target'      => agents_task_optional_string( $placement['preferred_target'] ?? null ),
+		'allowed_targets'       => agents_task_string_list( $placement['allowed_targets'] ?? array() ),
+		'resource_class'        => agents_task_optional_string( $placement['resource_class'] ?? null ) ?? 'generic',
+		'required_capabilities' => agents_task_string_list( $placement['required_capabilities'] ?? array() ),
+		'metadata'              => is_array( $placement['metadata'] ?? null ) ? agents_task_string_keyed_array( $placement['metadata'] ) : array(),
+	);
+}
+
+/**
+ * @param array<int,array<string,mixed>> $targets Registered targets.
+ * @param array<string,mixed>            $placement Placement hints.
+ * @return array<string,mixed>|null
+ */
+function agents_task_select_target( array $targets, array $placement ): ?array {
+	$allowed      = agents_task_string_list( $placement['allowed_targets'] ?? array() );
+	$required     = agents_task_string_list( $placement['required_capabilities'] ?? array() );
+	$resource     = agents_task_optional_string( $placement['resource_class'] ?? null );
+	$preferred_id = agents_task_optional_string( $placement['preferred_target'] ?? null );
+	$candidates   = array();
+
+	foreach ( $targets as $target ) {
+		$target_id        = agents_task_string( $target['id'] ?? '' );
+		$resource_classes = agents_task_string_list( $target['resource_classes'] ?? array() );
+		$capabilities     = agents_task_string_list( $target['capabilities'] ?? array() );
+
+		if ( array() !== $allowed && ! in_array( $target_id, $allowed, true ) ) {
+			continue;
+		}
+		if ( null !== $resource && array() !== $resource_classes && ! in_array( $resource, $resource_classes, true ) ) {
+			continue;
+		}
+		if ( array() !== array_diff( $required, $capabilities ) ) {
+			continue;
+		}
+		if ( null !== $preferred_id && $preferred_id === $target_id ) {
+			return $target;
+		}
+		$candidates[] = $target;
+	}
+
+	return $candidates[0] ?? null;
+}
+
+/**
+ * @param mixed  $result Handler result.
+ * @param string $error_code Error code for invalid results.
+ * @return array<string,mixed>|\WP_Error
+ */
+function agents_task_normalize_run_control_result( $result, string $error_code ) {
+	if ( is_wp_error( $result ) ) {
+		return $result;
+	}
+
+	if ( ! is_array( $result ) ) {
+		return new \WP_Error( $error_code, 'Task run-control handlers must return an array or WP_Error.' );
+	}
+
+	try {
+		return WP_Agent_Task_Run_Control::normalize_run( agents_task_string_keyed_array( $result ) );
+	} catch ( \InvalidArgumentException $error ) {
+		return new \WP_Error( $error_code, $error->getMessage() );
+	}
+}
+
+/**
+ * @param array<string,mixed> $input Ability input.
+ */
+function agents_task_permission( array $input ): bool {
+	$allowed = function_exists( 'current_user_can' ) ? current_user_can( 'read' ) : false;
+	return (bool) apply_filters( 'agents_task_permission', $allowed, $input );
+}
+
+function agents_task_optional_string( mixed $value ): ?string {
+	if ( ! is_scalar( $value ) && ! $value instanceof \Stringable ) {
+		return null;
+	}
+
+	$value = trim( (string) $value );
+	return '' === $value ? null : $value;
+}
+
+function agents_task_string( mixed $value ): string {
+	return is_scalar( $value ) ? (string) $value : '';
+}
+
+/**
+ * @param mixed $value Raw list.
+ * @return string[]
+ */
+function agents_task_string_list( mixed $value ): array {
+	if ( null === agents_task_optional_string( $value ) && ! is_array( $value ) ) {
+		return array();
+	}
+
+	$values = is_array( $value ) ? $value : array( $value );
+	$list   = array();
+	foreach ( $values as $item ) {
+		$item = agents_task_optional_string( $item );
+		if ( null !== $item ) {
+			$list[] = $item;
+		}
+	}
+
+	return array_values( array_unique( $list ) );
+}
+
+/**
+ * @param array<array-key,mixed> $data Raw array.
+ * @return array<string,mixed>
+ */
+function agents_task_string_keyed_array( array $data ): array {
+	$result = array();
+	foreach ( $data as $key => $value ) {
+		if ( is_string( $key ) ) {
+			$result[ $key ] = $value;
+		}
+	}
+	return $result;
+}
+
+/** @return array<string,mixed> */
+function agents_task_input_schema(): array {
+	return array(
+		'type'       => 'object',
+		'required'   => array( 'task' ),
+		'properties' => array(
+			'schema'         => array( 'type' => 'string' ),
+			'task'           => agents_task_payload_schema(),
+			'task_id'        => array( 'type' => 'string' ),
+			'instructions'   => array( 'type' => 'string' ),
+			'session_id'     => array( 'type' => array( 'string', 'null' ) ),
+			'run_id'         => array( 'type' => array( 'string', 'null' ) ),
+			'placement'      => agents_task_placement_schema(),
+			'client_context' => array( 'type' => 'object' ),
+			'metadata'       => array( 'type' => 'object' ),
+		),
+	);
+}
+
+/** @return array<string,mixed> */
+function agents_task_payload_schema(): array {
+	return array(
+		'type'       => 'object',
+		'required'   => array( 'id' ),
+		'properties' => array(
+			'schema'       => array( 'type' => 'string' ),
+			'id'           => array( 'type' => 'string' ),
+			'instructions' => array( 'type' => 'string' ),
+			'input'        => array( 'type' => 'object' ),
+			'attachments'  => array( 'type' => 'array' ),
+			'metadata'     => array( 'type' => 'object' ),
+		),
+	);
+}
+
+/** @return array<string,mixed> */
+function agents_task_placement_schema(): array {
+	return array(
+		'type'       => array( 'object', 'null' ),
+		'properties' => array(
+			'schema'                => array( 'type' => 'string' ),
+			'preferred_target'      => array( 'type' => array( 'string', 'null' ) ),
+			'allowed_targets'       => array( 'type' => 'array', 'items' => array( 'type' => 'string' ) ),
+			'resource_class'        => array( 'type' => 'string' ),
+			'required_capabilities' => array( 'type' => 'array', 'items' => array( 'type' => 'string' ) ),
+			'metadata'              => array( 'type' => 'object' ),
+		),
+	);
+}
+
+/** @return array<string,mixed> */
+function agents_executor_target_schema(): array {
+	return array(
+		'type'       => 'object',
+		'required'   => array( 'id', 'kind', 'capabilities' ),
+		'properties' => array(
+			'schema'           => array( 'type' => 'string' ),
+			'id'               => array( 'type' => 'string' ),
+			'label'            => array( 'type' => 'string' ),
+			'kind'             => array( 'type' => 'string' ),
+			'description'      => array( 'type' => 'string' ),
+			'capabilities'     => array( 'type' => 'array', 'items' => array( 'type' => 'string' ) ),
+			'resource_classes' => array( 'type' => 'array', 'items' => array( 'type' => 'string' ) ),
+			'metadata'         => array( 'type' => 'object' ),
+		),
+	);
+}
+
+/** @return array<string,mixed> */
+function agents_task_result_schema(): array {
+	return array(
+		'type'       => 'object',
+		'required'   => array( 'schema', 'run_id', 'session_id', 'status', 'executor_id' ),
+		'properties' => array(
+			'schema'        => array( 'type' => 'string' ),
+			'run_id'        => array( 'type' => 'string' ),
+			'session_id'    => array( 'type' => 'string' ),
+			'status'        => array( 'type' => 'string', 'enum' => WP_Agent_Task_Run_Control::statuses() ),
+			'executor_id'   => array( 'type' => 'string' ),
+			'artifact_refs' => array( 'type' => 'array', 'items' => array( 'type' => 'object' ) ),
+			'diagnostics'   => array( 'type' => 'object' ),
+			'events'        => array( 'type' => 'array', 'items' => array( 'type' => 'object' ) ),
+			'provenance'    => array( 'type' => 'object' ),
+			'output'        => array( 'type' => array( 'object', 'array', 'string', 'number', 'boolean', 'null' ) ),
+			'started_at'    => array( 'type' => 'string' ),
+			'updated_at'    => array( 'type' => 'string' ),
+			'metadata'      => array( 'type' => 'object' ),
+		),
+	);
+}
+
+/** @return array<string,mixed> */
+function agents_task_run_id_input_schema(): array {
+	return array(
+		'type'       => 'object',
+		'required'   => array( 'session_id', 'run_id' ),
+		'properties' => array(
+			'session_id' => array( 'type' => 'string' ),
+			'run_id'     => array( 'type' => 'string' ),
+		),
+	);
+}
+
+/** @return array<string,mixed> */
+function agents_cancel_task_run_output_schema(): array {
+	$schema     = agents_task_result_schema();
+	$required   = is_array( $schema['required'] ?? null ) ? array_values( $schema['required'] ) : array();
+	$properties = is_array( $schema['properties'] ?? null ) ? agents_task_string_keyed_array( $schema['properties'] ) : array();
+
+	$required[]              = 'cancelled';
+	$properties['cancelled'] = array( 'type' => 'boolean' );
+	$schema['required']      = $required;
+	$schema['properties']    = $properties;
+
+	return $schema;
+}
+
+/** @return array<string,mixed> */
+function agents_list_execution_targets_input_schema(): array {
+	return array(
+		'type'       => 'object',
+		'properties' => array(
+			'allowed_targets'       => array( 'type' => 'array', 'items' => array( 'type' => 'string' ) ),
+			'resource_class'        => array( 'type' => 'string' ),
+			'required_capabilities' => array( 'type' => 'array', 'items' => array( 'type' => 'string' ) ),
+		),
+	);
+}
+
+/** @return array<string,mixed> */
+function agents_list_execution_targets_output_schema(): array {
+	return array(
+		'type'       => 'object',
+		'required'   => array( 'schema', 'targets' ),
+		'properties' => array(
+			'schema'  => array( 'type' => 'string' ),
+			'targets' => array( 'type' => 'array', 'items' => agents_executor_target_schema() ),
+		),
+	);
+}
+
+/**
+ * Convenience helper for consumers: register a callable as the task handler.
+ *
+ * @param callable $handler Receives canonical input and selected target.
+ * @param int      $priority Filter priority. Default 10.
+ */
+function register_task_handler( callable $handler, int $priority = 10 ): void {
+	add_filter(
+		'wp_agent_task_handler',
+		static function ( $existing, array $input, array $target ) use ( $handler ) {
+			unset( $input, $target );
+			return null !== $existing ? $existing : $handler;
+		},
+		$priority,
+		3
+	);
+}

--- a/src/Tasks/register-agents-task-abilities.php
+++ b/src/Tasks/register-agents-task-abilities.php
@@ -9,10 +9,10 @@ namespace AgentsAPI\AI\Tasks;
 
 defined( 'ABSPATH' ) || exit;
 
-const AGENTS_RUN_TASK_ABILITY              = 'agents/run-task';
+const AGENTS_RUN_TASK_ABILITY               = 'agents/run-task';
 const AGENTS_LIST_EXECUTION_TARGETS_ABILITY = 'agents/list-execution-targets';
-const AGENTS_GET_TASK_RUN_ABILITY          = 'agents/get-task-run';
-const AGENTS_CANCEL_TASK_RUN_ABILITY       = 'agents/cancel-task-run';
+const AGENTS_GET_TASK_RUN_ABILITY           = 'agents/get-task-run';
+const AGENTS_CANCEL_TASK_RUN_ABILITY        = 'agents/cancel-task-run';
 
 add_action(
 	'wp_abilities_api_categories_init',
@@ -116,8 +116,8 @@ function agents_run_task( array $input ) {
 	if ( is_wp_error( $targets ) ) {
 		return $targets;
 	}
-	$placement = is_array( $input['placement'] ?? null ) ? agents_task_string_keyed_array( $input['placement'] ) : array();
-	$run_id    = agents_task_string( $input['run_id'] ?? '' );
+	$placement  = is_array( $input['placement'] ?? null ) ? agents_task_string_keyed_array( $input['placement'] ) : array();
+	$run_id     = agents_task_string( $input['run_id'] ?? '' );
 	$session_id = agents_task_string( $input['session_id'] ?? '' );
 
 	$target = agents_task_select_target( $targets, $placement );
@@ -134,7 +134,7 @@ function agents_run_task( array $input ) {
 
 	$executor_id          = agents_task_string( $target['id'] ?? '' );
 	$input['executor_id'] = $executor_id;
-	$metadata            = array(
+	$metadata             = array(
 		'executor_id'    => $executor_id,
 		'target_kind'    => $target['kind'],
 		'resource_class' => $placement['resource_class'] ?? '',
@@ -357,14 +357,14 @@ function agents_task_normalize_input( array $input ) {
 	$task['attachments']  = is_array( $task['attachments'] ?? null ) ? array_values( $task['attachments'] ) : ( is_array( $input['attachments'] ?? null ) ? array_values( $input['attachments'] ) : array() );
 	$task['metadata']     = is_array( $task['metadata'] ?? null ) ? agents_task_string_keyed_array( $task['metadata'] ) : array();
 
-	$input['schema']        = agents_task_optional_string( $input['schema'] ?? null ) ?? 'agents-api/task-input/v1';
-	$input['task']          = $task;
-	$input['task_id']       = $task_id;
-	$input['session_id']    = $session_id;
-	$input['run_id']        = $run_id;
-	$input['placement']     = agents_task_normalize_placement( is_array( $input['placement'] ?? null ) ? agents_task_string_keyed_array( $input['placement'] ) : $input );
+	$input['schema']         = agents_task_optional_string( $input['schema'] ?? null ) ?? 'agents-api/task-input/v1';
+	$input['task']           = $task;
+	$input['task_id']        = $task_id;
+	$input['session_id']     = $session_id;
+	$input['run_id']         = $run_id;
+	$input['placement']      = agents_task_normalize_placement( is_array( $input['placement'] ?? null ) ? agents_task_string_keyed_array( $input['placement'] ) : $input );
 	$input['client_context'] = is_array( $input['client_context'] ?? null ) ? agents_task_string_keyed_array( $input['client_context'] ) : array();
-	$input['metadata']      = is_array( $input['metadata'] ?? null ) ? agents_task_string_keyed_array( $input['metadata'] ) : array();
+	$input['metadata']       = is_array( $input['metadata'] ?? null ) ? agents_task_string_keyed_array( $input['metadata'] ) : array();
 
 	return $input;
 }
@@ -538,9 +538,15 @@ function agents_task_placement_schema(): array {
 		'properties' => array(
 			'schema'                => array( 'type' => 'string' ),
 			'preferred_target'      => array( 'type' => array( 'string', 'null' ) ),
-			'allowed_targets'       => array( 'type' => 'array', 'items' => array( 'type' => 'string' ) ),
+			'allowed_targets'       => array(
+				'type'  => 'array',
+				'items' => array( 'type' => 'string' ),
+			),
 			'resource_class'        => array( 'type' => 'string' ),
-			'required_capabilities' => array( 'type' => 'array', 'items' => array( 'type' => 'string' ) ),
+			'required_capabilities' => array(
+				'type'  => 'array',
+				'items' => array( 'type' => 'string' ),
+			),
 			'metadata'              => array( 'type' => 'object' ),
 		),
 	);
@@ -557,8 +563,14 @@ function agents_executor_target_schema(): array {
 			'label'            => array( 'type' => 'string' ),
 			'kind'             => array( 'type' => 'string' ),
 			'description'      => array( 'type' => 'string' ),
-			'capabilities'     => array( 'type' => 'array', 'items' => array( 'type' => 'string' ) ),
-			'resource_classes' => array( 'type' => 'array', 'items' => array( 'type' => 'string' ) ),
+			'capabilities'     => array(
+				'type'  => 'array',
+				'items' => array( 'type' => 'string' ),
+			),
+			'resource_classes' => array(
+				'type'  => 'array',
+				'items' => array( 'type' => 'string' ),
+			),
 			'metadata'         => array( 'type' => 'object' ),
 		),
 	);
@@ -573,11 +585,20 @@ function agents_task_result_schema(): array {
 			'schema'        => array( 'type' => 'string' ),
 			'run_id'        => array( 'type' => 'string' ),
 			'session_id'    => array( 'type' => 'string' ),
-			'status'        => array( 'type' => 'string', 'enum' => WP_Agent_Task_Run_Control::statuses() ),
+			'status'        => array(
+				'type' => 'string',
+				'enum' => WP_Agent_Task_Run_Control::statuses(),
+			),
 			'executor_id'   => array( 'type' => 'string' ),
-			'artifact_refs' => array( 'type' => 'array', 'items' => array( 'type' => 'object' ) ),
+			'artifact_refs' => array(
+				'type'  => 'array',
+				'items' => array( 'type' => 'object' ),
+			),
 			'diagnostics'   => array( 'type' => 'object' ),
-			'events'        => array( 'type' => 'array', 'items' => array( 'type' => 'object' ) ),
+			'events'        => array(
+				'type'  => 'array',
+				'items' => array( 'type' => 'object' ),
+			),
 			'provenance'    => array( 'type' => 'object' ),
 			'output'        => array( 'type' => array( 'object', 'array', 'string', 'number', 'boolean', 'null' ) ),
 			'started_at'    => array( 'type' => 'string' ),
@@ -618,9 +639,15 @@ function agents_list_execution_targets_input_schema(): array {
 	return array(
 		'type'       => 'object',
 		'properties' => array(
-			'allowed_targets'       => array( 'type' => 'array', 'items' => array( 'type' => 'string' ) ),
+			'allowed_targets'       => array(
+				'type'  => 'array',
+				'items' => array( 'type' => 'string' ),
+			),
 			'resource_class'        => array( 'type' => 'string' ),
-			'required_capabilities' => array( 'type' => 'array', 'items' => array( 'type' => 'string' ) ),
+			'required_capabilities' => array(
+				'type'  => 'array',
+				'items' => array( 'type' => 'string' ),
+			),
 		),
 	);
 }
@@ -632,7 +659,10 @@ function agents_list_execution_targets_output_schema(): array {
 		'required'   => array( 'schema', 'targets' ),
 		'properties' => array(
 			'schema'  => array( 'type' => 'string' ),
-			'targets' => array( 'type' => 'array', 'items' => agents_executor_target_schema() ),
+			'targets' => array(
+				'type'  => 'array',
+				'items' => agents_executor_target_schema(),
+			),
 		),
 	);
 }

--- a/tests/bootstrap-smoke.php
+++ b/tests/bootstrap-smoke.php
@@ -186,6 +186,7 @@ $expected_source_directories = array(
 	'Registry',
 	'Routines',
 	'Runtime',
+	'Tasks',
 	'Tools',
 	'Transcripts',
 	'Triggers',

--- a/tests/task-execution-smoke.php
+++ b/tests/task-execution-smoke.php
@@ -1,0 +1,202 @@
+<?php
+/**
+ * Pure-PHP smoke test for canonical task execution abilities.
+ *
+ * Run with: php tests/task-execution-smoke.php
+ *
+ * @package AgentsAPI\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+$failures = array();
+$passes   = 0;
+
+echo "task-execution-smoke\n";
+
+require_once __DIR__ . '/agents-api-smoke-helpers.php';
+
+$GLOBALS['__agents_api_smoke_abilities']  = array();
+$GLOBALS['__agents_api_smoke_categories'] = array();
+$GLOBALS['__agents_api_smoke_options']    = array();
+
+class WP_Error {
+	public function __construct( private string $code = '', private string $message = '', private array $data = array() ) {}
+	public function get_error_code(): string { return $this->code; }
+	public function get_error_message(): string { return $this->message; }
+	public function get_error_data(): array { return $this->data; }
+}
+
+function current_user_can( string $capability ): bool {
+	unset( $capability );
+	return true;
+}
+
+function wp_has_ability_category( string $category ): bool {
+	return isset( $GLOBALS['__agents_api_smoke_categories'][ $category ] );
+}
+
+function wp_register_ability_category( string $category, array $args ): void {
+	$GLOBALS['__agents_api_smoke_categories'][ $category ] = $args;
+}
+
+function wp_has_ability( string $ability ): bool {
+	return isset( $GLOBALS['__agents_api_smoke_abilities'][ $ability ] );
+}
+
+function wp_register_ability( string $ability, array $args ): void {
+	$GLOBALS['__agents_api_smoke_abilities'][ $ability ] = $args;
+}
+
+function get_option( string $option, $default = false ) {
+	return $GLOBALS['__agents_api_smoke_options'][ $option ] ?? $default;
+}
+
+function update_option( string $option, $value, $autoload = null ): bool {
+	unset( $autoload );
+	$GLOBALS['__agents_api_smoke_options'][ $option ] = $value;
+	return true;
+}
+
+agents_api_smoke_require_module();
+
+do_action( 'wp_abilities_api_categories_init' );
+do_action( 'wp_abilities_api_init' );
+
+agents_api_smoke_assert_equals( true, isset( $GLOBALS['__agents_api_smoke_abilities'][ AgentsAPI\AI\Tasks\AGENTS_RUN_TASK_ABILITY ] ), 'run-task ability registers', $failures, $passes );
+agents_api_smoke_assert_equals( true, isset( $GLOBALS['__agents_api_smoke_abilities'][ AgentsAPI\AI\Tasks\AGENTS_LIST_EXECUTION_TARGETS_ABILITY ] ), 'list-execution-targets ability registers', $failures, $passes );
+agents_api_smoke_assert_equals( true, isset( $GLOBALS['__agents_api_smoke_abilities'][ AgentsAPI\AI\Tasks\AGENTS_GET_TASK_RUN_ABILITY ] ), 'get-task-run ability registers', $failures, $passes );
+agents_api_smoke_assert_equals( true, isset( $GLOBALS['__agents_api_smoke_abilities'][ AgentsAPI\AI\Tasks\AGENTS_CANCEL_TASK_RUN_ABILITY ] ), 'cancel-task-run ability registers', $failures, $passes );
+
+$no_executor = AgentsAPI\AI\Tasks\agents_run_task(
+	array(
+		'task' => array(
+			'id'           => 'task-no-executor',
+			'instructions' => 'Do something generic.',
+		),
+	)
+);
+agents_api_smoke_assert_equals( true, $no_executor instanceof WP_Error, 'no executor returns typed error', $failures, $passes );
+agents_api_smoke_assert_equals( 'agents_task_no_handler', $no_executor->get_error_code(), 'no executor error code is typed', $failures, $passes );
+
+$captured_input  = array();
+$captured_target = array();
+add_filter(
+	'wp_agent_execution_targets',
+	static function ( array $targets ): array {
+		$targets[] = array(
+			'id'               => 'fake-executor',
+			'label'            => 'Fake Executor',
+			'kind'             => 'test',
+			'capabilities'     => array( 'test.run', 'artifacts.reference' ),
+			'resource_classes' => array( 'generic', 'test' ),
+			'metadata'         => array( 'provider' => 'smoke' ),
+		);
+		return $targets;
+	}
+);
+add_filter(
+	'wp_agent_task_handler',
+	static function ( $handler, array $input, array $target ) use ( &$captured_input, &$captured_target ) {
+		if ( null !== $handler ) {
+			return $handler;
+		}
+
+		$captured_input  = $input;
+		$captured_target = $target;
+		return static function ( array $runtime_input, array $runtime_target ): array {
+			return array(
+				'run_id'        => $runtime_input['run_id'],
+				'session_id'    => $runtime_input['session_id'],
+				'executor_id'   => $runtime_target['id'],
+				'status'        => 'succeeded',
+				'artifact_refs' => array(
+					array(
+						'id'   => 'artifact-1',
+						'type' => 'log',
+					),
+				),
+				'diagnostics'   => array( 'summary' => 'ok' ),
+				'events'        => array(
+					array(
+						'id'   => 'evt-1',
+						'type' => 'completed',
+					),
+				),
+				'provenance'    => array( 'source' => 'fake' ),
+				'output'        => array( 'answer' => 'done' ),
+			);
+		};
+	},
+	10,
+	3
+);
+
+$targets = AgentsAPI\AI\Tasks\agents_list_execution_targets(
+	array(
+		'resource_class'        => 'test',
+		'required_capabilities' => array( 'test.run' ),
+	)
+);
+agents_api_smoke_assert_equals( 'fake-executor', $targets['targets'][0]['id'] ?? null, 'list-execution-targets filters registered target', $failures, $passes );
+
+$result = AgentsAPI\AI\Tasks\agents_run_task(
+	array(
+		'task'      => array(
+			'id'           => 'task-1',
+			'instructions' => 'Run the fake task.',
+		),
+		'placement' => array(
+			'preferred_target'      => 'fake-executor',
+			'resource_class'        => 'test',
+			'required_capabilities' => array( 'test.run' ),
+		),
+	)
+);
+agents_api_smoke_assert_equals( 'agents-api/task-input/v1', $captured_input['schema'] ?? null, 'run-task normalizes task input schema', $failures, $passes );
+agents_api_smoke_assert_equals( 'agents-api/execution-placement/v1', $captured_input['placement']['schema'] ?? null, 'run-task normalizes placement schema', $failures, $passes );
+agents_api_smoke_assert_equals( 'fake-executor', $captured_target['id'] ?? null, 'run-task dispatches selected target', $failures, $passes );
+agents_api_smoke_assert_equals( 'agents-api/task-result/v1', $result['schema'] ?? null, 'run-task returns result envelope schema', $failures, $passes );
+agents_api_smoke_assert_equals( 'succeeded', $result['status'] ?? null, 'run-task normalizes task result status', $failures, $passes );
+agents_api_smoke_assert_equals( 'fake-executor', $result['executor_id'] ?? null, 'run-task preserves executor id', $failures, $passes );
+agents_api_smoke_assert_equals( 'artifact-1', $result['artifact_refs'][0]['id'] ?? null, 'run-task preserves artifact refs', $failures, $passes );
+
+$stored = AgentsAPI\AI\Tasks\agents_get_task_run(
+	array(
+		'session_id' => $result['session_id'],
+		'run_id'     => $result['run_id'],
+	)
+);
+agents_api_smoke_assert_equals( 'succeeded', $stored['status'] ?? null, 'get-task-run reads stored normalized result', $failures, $passes );
+
+AgentsAPI\AI\Tasks\WP_Agent_Task_Run_Control::start_run( 'task-run-cancel', 'task-session-cancel', 'fake-executor' );
+$cancelled = AgentsAPI\AI\Tasks\agents_cancel_task_run(
+	array(
+		'session_id' => 'task-session-cancel',
+		'run_id'     => 'task-run-cancel',
+	)
+);
+agents_api_smoke_assert_equals( 'cancelling', $cancelled['status'] ?? null, 'cancel-task-run marks running runs as cancelling', $failures, $passes );
+agents_api_smoke_assert_equals( true, $cancelled['cancelled'] ?? null, 'cancel-task-run reports cancellation accepted', $failures, $passes );
+
+add_filter(
+	'wp_agent_task_handler',
+	static function (): callable {
+		return static fn(): string => 'bad-result';
+	},
+	1,
+	3
+);
+
+$invalid = AgentsAPI\AI\Tasks\agents_run_task(
+	array(
+		'task'      => array( 'id' => 'task-invalid-result' ),
+		'placement' => array( 'preferred_target' => 'fake-executor' ),
+	)
+);
+agents_api_smoke_assert_equals( true, $invalid instanceof WP_Error, 'invalid executor result returns typed error', $failures, $passes );
+agents_api_smoke_assert_equals( 'agents_task_invalid_result', $invalid->get_error_code(), 'invalid executor result error code is typed', $failures, $passes );
+
+agents_api_smoke_finish( 'task execution', $failures, $passes );


### PR DESCRIPTION
## Summary
- Add generic task execution contracts for `agents-api/task-input/v1`, placement hints, executor target discovery, and task result envelopes.
- Register `agents/run-task`, `agents/list-execution-targets`, `agents/get-task-run`, and `agents/cancel-task-run` with filter-based executor discovery/dispatch.
- Add task run-control storage/helpers, smoke coverage, and docs clarifying executor providers own concrete side effects.

## Testing
- `php tests/task-execution-smoke.php`
- `composer smoke`
- `composer phpstan`

Closes #309.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the generic task execution plumbing, smoke tests, and documentation; Chris remains responsible for review and validation.