### PR TITLE
Add task execution metrics envelope

### DIFF
--- a/src/Tasks/class-wp-agent-task-run-control.php
+++ b/src/Tasks/class-wp-agent-task-run-control.php
@@ -75,19 +75,20 @@ class WP_Agent_Task_Run_Control {
 		}
 
 		return array(
-			'schema'        => self::string_value( $run['schema'] ?? 'agents-api/task-result/v1' ),
-			'run_id'        => $run_id,
-			'session_id'    => $session_id,
-			'status'        => $status,
-			'executor_id'   => $executor_id,
-			'artifact_refs' => self::list_value( $run['artifact_refs'] ?? array() ),
-			'diagnostics'   => self::map_value( $run['diagnostics'] ?? array() ),
-			'events'        => self::list_value( $run['events'] ?? array() ),
-			'provenance'    => self::map_value( $run['provenance'] ?? array() ),
-			'output'        => $run['output'] ?? null,
-			'started_at'    => self::string_value( $run['started_at'] ?? null ),
-			'updated_at'    => self::string_value( $run['updated_at'] ?? null ),
-			'metadata'      => self::map_value( $run['metadata'] ?? array() ),
+			'schema'            => self::string_value( $run['schema'] ?? 'agents-api/task-result/v1' ),
+			'run_id'            => $run_id,
+			'session_id'        => $session_id,
+			'status'            => $status,
+			'executor_id'       => $executor_id,
+			'execution_metrics' => self::execution_metrics_value( $run['execution_metrics'] ?? array(), $executor_id ),
+			'artifact_refs'     => self::list_value( $run['artifact_refs'] ?? array() ),
+			'diagnostics'       => self::map_value( $run['diagnostics'] ?? array() ),
+			'events'            => self::list_value( $run['events'] ?? array() ),
+			'provenance'        => self::map_value( $run['provenance'] ?? array() ),
+			'output'            => $run['output'] ?? null,
+			'started_at'        => self::string_value( $run['started_at'] ?? null ),
+			'updated_at'        => self::string_value( $run['updated_at'] ?? null ),
+			'metadata'          => self::map_value( $run['metadata'] ?? array() ),
 		);
 	}
 
@@ -210,6 +211,81 @@ class WP_Agent_Task_Run_Control {
 		}
 
 		return $map;
+	}
+
+	/** @return array<string,mixed> */
+	private static function execution_metrics_value( mixed $value, string $executor_id ): array {
+		$metrics = self::map_value( $value );
+		if ( array() === $metrics ) {
+			return array();
+		}
+
+		$metrics['schema'] = self::non_empty_string_value( $metrics['schema'] ?? null ) ?? 'agents-api/execution-metrics/v1';
+		if ( ! isset( $metrics['executor_id'] ) && '' !== $executor_id ) {
+			$metrics['executor_id'] = $executor_id;
+		}
+
+		foreach ( array( 'environment', 'executor_id', 'failure_class' ) as $field ) {
+			if ( isset( $metrics[ $field ] ) ) {
+				$value = self::non_empty_string_value( $metrics[ $field ] );
+				if ( null === $value ) {
+					unset( $metrics[ $field ] );
+				} else {
+					$metrics[ $field ] = $value;
+				}
+			}
+		}
+
+		foreach ( array( 'wall_time_ms', 'startup_time_ms', 'tool_call_count', 'payload_bytes_in', 'payload_bytes_out', 'artifact_bytes' ) as $field ) {
+			if ( isset( $metrics[ $field ] ) ) {
+				$value = self::non_negative_int_value( $metrics[ $field ] );
+				if ( null === $value ) {
+					unset( $metrics[ $field ] );
+				} else {
+					$metrics[ $field ] = $value;
+				}
+			}
+		}
+
+		if ( isset( $metrics['per_tool_timings_ms'] ) ) {
+			$metrics['per_tool_timings_ms'] = self::non_negative_int_map_value( $metrics['per_tool_timings_ms'] );
+		}
+		if ( isset( $metrics['quality_signals'] ) ) {
+			$metrics['quality_signals'] = self::map_value( $metrics['quality_signals'] );
+		}
+		if ( isset( $metrics['raw_refs'] ) ) {
+			$metrics['raw_refs'] = self::list_value( $metrics['raw_refs'] );
+		}
+
+		return $metrics;
+	}
+
+	private static function non_empty_string_value( mixed $value ): ?string {
+		$value = trim( self::string_value( $value ) );
+		return '' === $value ? null : $value;
+	}
+
+	private static function non_negative_int_value( mixed $value ): ?int {
+		if ( ! is_int( $value ) && ! is_float( $value ) && ! ( is_string( $value ) && is_numeric( $value ) ) ) {
+			return null;
+		}
+
+		$value = (int) $value;
+		return 0 <= $value ? $value : null;
+	}
+
+	/** @return array<string,int> */
+	private static function non_negative_int_map_value( mixed $value ): array {
+		$map        = self::map_value( $value );
+		$normalized = array();
+		foreach ( $map as $key => $item ) {
+			$item = self::non_negative_int_value( $item );
+			if ( null !== $item ) {
+				$normalized[ $key ] = $item;
+			}
+		}
+
+		return $normalized;
 	}
 
 	/** @return array<int,mixed> */

--- a/src/Tasks/register-agents-task-abilities.php
+++ b/src/Tasks/register-agents-task-abilities.php
@@ -582,28 +582,57 @@ function agents_task_result_schema(): array {
 		'type'       => 'object',
 		'required'   => array( 'schema', 'run_id', 'session_id', 'status', 'executor_id' ),
 		'properties' => array(
-			'schema'        => array( 'type' => 'string' ),
-			'run_id'        => array( 'type' => 'string' ),
-			'session_id'    => array( 'type' => 'string' ),
-			'status'        => array(
+			'schema'            => array( 'type' => 'string' ),
+			'run_id'            => array( 'type' => 'string' ),
+			'session_id'        => array( 'type' => 'string' ),
+			'status'            => array(
 				'type' => 'string',
 				'enum' => WP_Agent_Task_Run_Control::statuses(),
 			),
-			'executor_id'   => array( 'type' => 'string' ),
-			'artifact_refs' => array(
+			'executor_id'       => array( 'type' => 'string' ),
+			'execution_metrics' => agents_execution_metrics_schema(),
+			'artifact_refs'     => array(
 				'type'  => 'array',
 				'items' => array( 'type' => 'object' ),
 			),
-			'diagnostics'   => array( 'type' => 'object' ),
-			'events'        => array(
+			'diagnostics'       => array( 'type' => 'object' ),
+			'events'            => array(
 				'type'  => 'array',
 				'items' => array( 'type' => 'object' ),
 			),
-			'provenance'    => array( 'type' => 'object' ),
-			'output'        => array( 'type' => array( 'object', 'array', 'string', 'number', 'boolean', 'null' ) ),
-			'started_at'    => array( 'type' => 'string' ),
-			'updated_at'    => array( 'type' => 'string' ),
-			'metadata'      => array( 'type' => 'object' ),
+			'provenance'        => array( 'type' => 'object' ),
+			'output'            => array( 'type' => array( 'object', 'array', 'string', 'number', 'boolean', 'null' ) ),
+			'started_at'        => array( 'type' => 'string' ),
+			'updated_at'        => array( 'type' => 'string' ),
+			'metadata'          => array( 'type' => 'object' ),
+		),
+	);
+}
+
+/** @return array<string,mixed> */
+function agents_execution_metrics_schema(): array {
+	return array(
+		'type'       => 'object',
+		'properties' => array(
+			'schema'              => array( 'type' => 'string' ),
+			'environment'         => array( 'type' => 'string' ),
+			'executor_id'         => array( 'type' => 'string' ),
+			'wall_time_ms'        => array( 'type' => 'integer' ),
+			'startup_time_ms'     => array( 'type' => 'integer' ),
+			'tool_call_count'     => array( 'type' => 'integer' ),
+			'per_tool_timings_ms' => array(
+				'type'                 => 'object',
+				'additionalProperties' => array( 'type' => 'integer' ),
+			),
+			'payload_bytes_in'    => array( 'type' => 'integer' ),
+			'payload_bytes_out'   => array( 'type' => 'integer' ),
+			'artifact_bytes'      => array( 'type' => 'integer' ),
+			'failure_class'       => array( 'type' => 'string' ),
+			'quality_signals'     => array( 'type' => 'object' ),
+			'raw_refs'            => array(
+				'type'  => 'array',
+				'items' => array( 'type' => 'object' ),
+			),
 		),
 	);
 }

--- a/tests/task-execution-smoke.php
+++ b/tests/task-execution-smoke.php
@@ -108,25 +108,42 @@ add_filter(
 		$captured_target = $target;
 		return static function ( array $runtime_input, array $runtime_target ): array {
 			return array(
-				'run_id'        => $runtime_input['run_id'],
-				'session_id'    => $runtime_input['session_id'],
-				'executor_id'   => $runtime_target['id'],
-				'status'        => 'succeeded',
-				'artifact_refs' => array(
+				'run_id'            => $runtime_input['run_id'],
+				'session_id'        => $runtime_input['session_id'],
+				'executor_id'       => $runtime_target['id'],
+				'status'            => 'succeeded',
+				'execution_metrics' => array(
+					'environment'         => 'test',
+					'wall_time_ms'        => '42',
+					'startup_time_ms'     => 7,
+					'tool_call_count'     => 2,
+					'per_tool_timings_ms' => array( 'inspect' => '11' ),
+					'payload_bytes_in'    => 100,
+					'payload_bytes_out'   => 200,
+					'artifact_bytes'      => 300,
+					'quality_signals'     => array( 'confidence' => 'high' ),
+					'raw_refs'            => array(
+						array(
+							'id'   => 'metrics-raw-1',
+							'type' => 'trace',
+						),
+					),
+				),
+				'artifact_refs'     => array(
 					array(
 						'id'   => 'artifact-1',
 						'type' => 'log',
 					),
 				),
-				'diagnostics'   => array( 'summary' => 'ok' ),
-				'events'        => array(
+				'diagnostics'       => array( 'summary' => 'ok' ),
+				'events'            => array(
 					array(
 						'id'   => 'evt-1',
 						'type' => 'completed',
 					),
 				),
-				'provenance'    => array( 'source' => 'fake' ),
-				'output'        => array( 'answer' => 'done' ),
+				'provenance'        => array( 'source' => 'fake' ),
+				'output'            => array( 'answer' => 'done' ),
 			);
 		};
 	},
@@ -161,6 +178,12 @@ agents_api_smoke_assert_equals( 'fake-executor', $captured_target['id'] ?? null,
 agents_api_smoke_assert_equals( 'agents-api/task-result/v1', $result['schema'] ?? null, 'run-task returns result envelope schema', $failures, $passes );
 agents_api_smoke_assert_equals( 'succeeded', $result['status'] ?? null, 'run-task normalizes task result status', $failures, $passes );
 agents_api_smoke_assert_equals( 'fake-executor', $result['executor_id'] ?? null, 'run-task preserves executor id', $failures, $passes );
+agents_api_smoke_assert_equals( 'object', $GLOBALS['__agents_api_smoke_abilities'][ AgentsAPI\AI\Tasks\AGENTS_RUN_TASK_ABILITY ]['output_schema']['properties']['execution_metrics']['type'] ?? null, 'run-task result schema allows execution metrics', $failures, $passes );
+agents_api_smoke_assert_equals( 'agents-api/execution-metrics/v1', $result['execution_metrics']['schema'] ?? null, 'run-task normalizes execution metrics schema', $failures, $passes );
+agents_api_smoke_assert_equals( 'test', $result['execution_metrics']['environment'] ?? null, 'run-task preserves metrics environment', $failures, $passes );
+agents_api_smoke_assert_equals( 'fake-executor', $result['execution_metrics']['executor_id'] ?? null, 'run-task fills metrics executor id', $failures, $passes );
+agents_api_smoke_assert_equals( 42, $result['execution_metrics']['wall_time_ms'] ?? null, 'run-task normalizes metrics wall time', $failures, $passes );
+agents_api_smoke_assert_equals( 11, $result['execution_metrics']['per_tool_timings_ms']['inspect'] ?? null, 'run-task normalizes per-tool timing metrics', $failures, $passes );
 agents_api_smoke_assert_equals( 'artifact-1', $result['artifact_refs'][0]['id'] ?? null, 'run-task preserves artifact refs', $failures, $passes );
 
 $stored = AgentsAPI\AI\Tasks\agents_get_task_run(
@@ -170,6 +193,9 @@ $stored = AgentsAPI\AI\Tasks\agents_get_task_run(
 	)
 );
 agents_api_smoke_assert_equals( 'succeeded', $stored['status'] ?? null, 'get-task-run reads stored normalized result', $failures, $passes );
+agents_api_smoke_assert_equals( 'agents-api/execution-metrics/v1', $stored['execution_metrics']['schema'] ?? null, 'get-task-run preserves stored metrics schema', $failures, $passes );
+agents_api_smoke_assert_equals( 300, $stored['execution_metrics']['artifact_bytes'] ?? null, 'get-task-run preserves stored metrics artifact bytes', $failures, $passes );
+agents_api_smoke_assert_equals( 'metrics-raw-1', $stored['execution_metrics']['raw_refs'][0]['id'] ?? null, 'get-task-run preserves stored metrics raw refs', $failures, $passes );
 
 AgentsAPI\AI\Tasks\WP_Agent_Task_Run_Control::start_run( 'task-run-cancel', 'task-session-cancel', 'fake-executor' );
 $cancelled = AgentsAPI\AI\Tasks\agents_cancel_task_run(


### PR DESCRIPTION
## Summary
- Adds a product-neutral `execution_metrics` envelope to Agents API task result schemas.
- Normalizes and preserves executor-owned metrics through task run-control storage and `agents/get-task-run` reads.
- Extends task execution smoke coverage for schema exposure and metrics round-trip preservation.

Closes #311.

## Verification
- `php tests/task-execution-smoke.php`
- `php -l src/Tasks/class-wp-agent-task-run-control.php`
- `php -l src/Tasks/register-agents-task-abilities.php`
- `composer smoke`
- `composer phpstan`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the generic execution metrics normalization/schema change and smoke coverage; Chris remains responsible for review and testing.