### PR TITLE
Fix completion policy tool batch mediation

### DIFF
--- a/src/Runtime/class-wp-agent-conversation-loop.php
+++ b/src/Runtime/class-wp-agent-conversation-loop.php
@@ -541,6 +541,7 @@ class WP_Agent_Conversation_Loop {
 		$events                 = array();
 		$spin_signatures        = array();
 		$complete               = false;
+		$completion_stop_recorded = false;
 		$exceeded_budget        = null;
 		$approval_required      = null;
 		$runtime_tool_pending   = null;
@@ -877,15 +878,18 @@ class WP_Agent_Conversation_Loop {
 
 				if ( $decision->isComplete() ) {
 					$complete = true;
-					$events[] = array(
-						'type'     => 'completion_policy_stop',
-						'metadata' => array(
-							'tool_name' => $tool_name,
-							'turn'      => $turn,
-							'message'   => $decision->message(),
-							'context'   => $decision->context(),
-						),
-					);
+					if ( ! $completion_stop_recorded ) {
+						$events[] = array(
+							'type'     => 'completion_policy_stop',
+							'metadata' => array(
+								'tool_name' => $tool_name,
+								'turn'      => $turn,
+								'message'   => $decision->message(),
+								'context'   => $decision->context(),
+							),
+						);
+						$completion_stop_recorded = true;
+					}
 					continue;
 				}
 

--- a/src/Runtime/class-wp-agent-conversation-loop.php
+++ b/src/Runtime/class-wp-agent-conversation-loop.php
@@ -531,20 +531,20 @@ class WP_Agent_Conversation_Loop {
 		// Fall back to the prior turn's messages when the turn runner omits
 		// `messages` from its return — without this, mediation starts from an
 		// empty list and silently drops history between rounds.
-		$messages               = isset( $result['messages'] ) && is_array( $result['messages'] )
+		$messages                 = isset( $result['messages'] ) && is_array( $result['messages'] )
 			? self::normalize_messages( $result['messages'] )
 			: $prior_messages;
-		$tool_calls             = isset( $result['tool_calls'] ) && is_array( $result['tool_calls'] ) ? $result['tool_calls'] : array();
-		$tool_execution_results = array();
-		$tool_events            = array();
-		$tool_audit_events      = array();
-		$events                 = array();
-		$spin_signatures        = array();
-		$complete               = false;
+		$tool_calls               = isset( $result['tool_calls'] ) && is_array( $result['tool_calls'] ) ? $result['tool_calls'] : array();
+		$tool_execution_results   = array();
+		$tool_events              = array();
+		$tool_audit_events        = array();
+		$events                   = array();
+		$spin_signatures          = array();
+		$complete                 = false;
 		$completion_stop_recorded = false;
-		$exceeded_budget        = null;
-		$approval_required      = null;
-		$runtime_tool_pending   = null;
+		$exceeded_budget          = null;
+		$approval_required        = null;
+		$runtime_tool_pending     = null;
 
 		// If the turn runner returned text content, add it as an assistant message.
 		if ( isset( $result['content'] ) && is_string( $result['content'] ) && '' !== $result['content'] ) {
@@ -867,7 +867,10 @@ class WP_Agent_Conversation_Loop {
 			// Consult completion policy. A complete decision stops future model turns,
 			// but the current provider turn may contain more tool calls that still
 			// require paired tool results before the transcript can be replayed.
-			if ( null !== $policy && ! $complete ) {
+			// The policy is consulted for every same-turn tool result — even after a
+			// prior call in the batch marked the conversation complete — so its
+			// internal state stays consistent; the stop event is still recorded once.
+			if ( null !== $policy ) {
 				$decision = $policy->recordToolResult(
 					$tool_name,
 					$tool_definition,
@@ -879,7 +882,7 @@ class WP_Agent_Conversation_Loop {
 				if ( $decision->isComplete() ) {
 					$complete = true;
 					if ( ! $completion_stop_recorded ) {
-						$events[] = array(
+						$events[]                 = array(
 							'type'     => 'completion_policy_stop',
 							'metadata' => array(
 								'tool_name' => $tool_name,
@@ -890,6 +893,13 @@ class WP_Agent_Conversation_Loop {
 						);
 						$completion_stop_recorded = true;
 					}
+					continue;
+				}
+
+				// Once the batch is complete, an incomplete decision from a later
+				// same-turn tool must not append a "keep going" continuation nudge —
+				// the conversation is already ending.
+				if ( $complete ) {
 					continue;
 				}
 

--- a/tests/conversation-loop-completion-policy-smoke.php
+++ b/tests/conversation-loop-completion-policy-smoke.php
@@ -131,6 +131,51 @@ agents_api_smoke_assert_equals( 1, count( $stop_events ), 'complete decision rec
 agents_api_smoke_assert_equals( 'finish tool called', $stop_events[0]['metadata']['message'] ?? '', 'stop event carries decision message', $failures, $passes );
 agents_api_smoke_assert_equals( array( 'tool_name' => 'client/finish', 'turn' => 3 ), $stop_events[0]['metadata']['context'] ?? array(), 'stop event carries decision context', $failures, $passes );
 
+echo "\n[1a] Completion policy does not truncate same-turn tool batches:\n";
+$policy_log = array();
+
+$batch_result = AgentsAPI\AI\WP_Agent_Conversation_Loop::run(
+	array( array( 'role' => 'user', 'content' => 'write files' ) ),
+	static function ( array $messages ): array {
+		return array(
+			'messages'   => $messages,
+			'tool_calls' => array(
+				array( 'name' => 'client/finish', 'parameters' => array( 'path' => 'index.html' ) ),
+				array( 'name' => 'client/work', 'parameters' => array( 'path' => 'style.css' ) ),
+			),
+		);
+	},
+	array(
+		'max_turns'         => 5,
+		'tool_executor'     => $executor,
+		'tool_declarations' => $tools,
+		'completion_policy' => $policy,
+		'should_continue'   => static function (): bool {
+			return true;
+		},
+	)
+);
+
+$batch_tool_names = array_map(
+	static function ( array $tool_result ): string {
+		return (string) ( $tool_result['tool_name'] ?? '' );
+	},
+	$batch_result['tool_execution_results']
+);
+
+$batch_stop_events = array_values(
+	array_filter(
+		$batch_result['events'],
+		static function ( array $event ): bool {
+			return 'completion_policy_stop' === ( $event['type'] ?? '' );
+		}
+	)
+);
+
+agents_api_smoke_assert_equals( array( 'client/finish', 'client/work' ), $batch_tool_names, 'same-turn tool batch executes after completion policy marks complete', $failures, $passes );
+agents_api_smoke_assert_equals( 1, count( $batch_stop_events ), 'same-turn batch records one completion stop event', $failures, $passes );
+agents_api_smoke_assert_equals( 2, count( $policy_log ), 'policy was consulted for each same-turn tool result', $failures, $passes );
+
 echo "\n[2] Completion policy coexists with should_continue — policy takes precedence:\n";
 $policy_log       = array();
 $continue_called  = 0;


### PR DESCRIPTION
## Summary
- Keeps executing the rest of a same-turn tool-call batch after completion policy marks the conversation complete.
- Records the completion-policy stop event once, while preserving immediate stops for budgets, mediator completion, and pending runtime tools.
- Adds smoke coverage for a completion tool followed by another tool in the same model turn.

## Verification
- `php tests/conversation-loop-completion-policy-smoke.php`
- `php tests/conversation-loop-tool-execution-smoke.php`

## Evidence
- Studio Web Workflow Bench live verification with this branch executed the full browser agent tool loop and reached editable preview.
- Without this fix, only the first `filesystem-write` in a same-turn batch was mediated before completion policy stopped the batch.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Diagnosed the same-turn tool mediation regression exposed by Studio Web Workflow Bench, drafted the minimal loop fix and smoke coverage, and ran targeted verification for Chris to review.