### PR TITLE
Parse function_call-wrapped and bare JSON tool calls

### DIFF
--- a/src/Runtime/class-wp-agent-provider-turn-result.php
+++ b/src/Runtime/class-wp-agent-provider-turn-result.php
@@ -274,6 +274,16 @@ class WP_Agent_Provider_Turn_Result {
 			}
 		}
 
+		// Some providers emit a bare JSON tool-call object as the entire message
+		// with no fence or tag wrapper. Treat a trimmed text that is a single JSON
+		// object as a payload candidate so those calls are not dropped.
+		if ( empty( $payloads ) ) {
+			$trimmed = trim( $text );
+			if ( '' !== $trimmed && '{' === $trimmed[0] && '}' === substr( $trimmed, -1 ) ) {
+				$payloads[] = $trimmed;
+			}
+		}
+
 		return self::tool_calls_from_json_payloads( $payloads, 'json-tool-call' );
 	}
 
@@ -361,6 +371,13 @@ class WP_Agent_Provider_Turn_Result {
 			foreach ( array_slice( $calls, 0, 16 ) as $call_index => $call ) {
 				if ( ! is_array( $call ) ) {
 					continue;
+				}
+
+				// Some providers wrap the call in a `function_call` object, often
+				// tagged with `{"type":"function_call", ...}`. Use that inner object
+				// as the call source so its name/arguments are read correctly.
+				if ( isset( $call['function_call'] ) && is_array( $call['function_call'] ) ) {
+					$call = $call['function_call'];
 				}
 
 				$function   = isset( $call['function'] ) && is_array( $call['function'] ) ? $call['function'] : array();

--- a/tests/provider-turn-adapter-smoke.php
+++ b/tests/provider-turn-adapter-smoke.php
@@ -160,6 +160,14 @@ $json_turn = AgentsAPI\AI\WP_Agent_Provider_Turn_Result::normalize(
 agents_api_smoke_assert_equals( 'json-1', $json_turn['tool_calls'][0]['id'] ?? '', 'fenced JSON fallback preserves id', $failures, $passes );
 agents_api_smoke_assert_equals( 'json', $json_turn['tool_calls'][0]['parameters']['query'] ?? '', 'fenced JSON fallback decodes function arguments', $failures, $passes );
 
+$function_call_turn = AgentsAPI\AI\WP_Agent_Provider_Turn_Result::normalize(
+	array(
+		'content' => '{"type":"function_call","function_call":{"name":"client/lookup","arguments":{"query":"wrapped"}}}',
+	)
+);
+agents_api_smoke_assert_equals( 'client/lookup', $function_call_turn['tool_calls'][0]['name'] ?? '', 'function_call wrapper extracts tool name', $failures, $passes );
+agents_api_smoke_assert_equals( 'wrapped', $function_call_turn['tool_calls'][0]['parameters']['query'] ?? '', 'function_call wrapper decodes object arguments', $failures, $passes );
+
 $tag_turn = AgentsAPI\AI\WP_Agent_Provider_Turn_Result::normalize(
 	array(
 		'content' => '<tool_call name="client/lookup">{"query":"tag"}</tool_call>',


### PR DESCRIPTION
## Summary

`WP_Agent_Provider_Turn_Result`'s text tool-call fallback dropped tool calls in two shapes that real providers emit, so the model's tool call silently never executed:

1. **Bare JSON object** — a tool call emitted as the entire message with no `<tool_call>` tag and no ` ```json ` fence. `extract_json_tool_calls()` only collected payloads from tags/fences, so bare JSON was never parsed.
2. **`function_call` wrapper** — `{"type":"function_call","function_call":{"name":...,"arguments":{...}}}`. The parser read `name`/`function`/`arguments` at the top level and never unwrapped the inner `function_call` object, yielding an empty call.

Both produced zero extracted tool calls.

## Changes

- `extract_json_tool_calls()`: when no tag/fence payloads are found, treat a trimmed message that is a single JSON object (`{...}`) as a payload candidate.
- `tool_calls_from_json_payloads()`: unwrap an inner `function_call` object before reading the tool name and arguments.
- Added smoke coverage in `tests/provider-turn-adapter-smoke.php` for the `function_call` wrapper shape.

## Testing

- `php tests/provider-turn-adapter-smoke.php` → all 49 assertions pass (2 new).
- Full agents-api smoke suite: all 80 `tests/*-smoke.php` files pass by exit code.
- Verified end-to-end against a live Codebox coding task (Claude Opus 4.8) — results posted on Extra-Chill/wp-coding-agents#197.

## Context

Discovered while landing the `ai-provider-for-claude-code` carried provider (Extra-Chill/wp-coding-agents#197) and the writable-workspace-tools fix (Extra-Chill/homeboy-extensions#1190). With those in place, Claude Opus 4.8 correctly emitted a `workspace_write` tool call, but it was dropped here because of the unrecognized shape. This is the final link making real Codebox coding tasks work.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Root-caused the dropped tool-call shapes from live transcripts, implemented the parser fix, added smoke coverage, and ran the full suite plus the end-to-end canary; Chris directed the work and remains responsible for review/testing.