### PR TITLE
Fix host-loaded channel smoke tests

### DIFF
--- a/tests/ability-meta-abilities-smoke.php
+++ b/tests/ability-meta-abilities-smoke.php
@@ -11,32 +11,38 @@ if ( ! defined( 'ABSPATH' ) ) {
 	define( 'ABSPATH', __DIR__ . '/' );
 }
 
-class WP_Error {
-	public function __construct( private string $code = '', private string $message = '', private $data = null ) {}
-	public function get_error_code(): string { return $this->code; }
-	public function get_error_message(): string { return $this->message; }
-	public function get_error_data() { return $this->data; }
+if ( ! class_exists( 'WP_Error' ) ) {
+	class WP_Error {
+		public function __construct( private string $code = '', private string $message = '', private $data = null ) {}
+		public function get_error_code(): string { return $this->code; }
+		public function get_error_message(): string { return $this->message; }
+		public function get_error_data() { return $this->data; }
+	}
 }
 
-class WP_Ability_Category {}
+if ( ! class_exists( 'WP_Ability_Category' ) ) {
+	class WP_Ability_Category {}
+}
 
-class WP_Ability {
-	public function __construct( private string $name, private array $args ) {}
-	public function get_name(): string { return $this->name; }
-	public function get_label(): string { return (string) ( $this->args['label'] ?? '' ); }
-	public function get_description(): string { return (string) ( $this->args['description'] ?? '' ); }
-	public function get_category(): string { return (string) ( $this->args['category'] ?? '' ); }
-	public function get_input_schema(): array { return isset( $this->args['input_schema'] ) && is_array( $this->args['input_schema'] ) ? $this->args['input_schema'] : array(); }
-	public function get_output_schema(): array { return isset( $this->args['output_schema'] ) && is_array( $this->args['output_schema'] ) ? $this->args['output_schema'] : array(); }
-	public function get_meta_item( string $key, $default = null ) { return $this->args['meta'][ $key ] ?? $default; }
-	public function execute( $input = null ) {
-		$permission = $this->args['permission_callback'] ?? null;
-		if ( is_callable( $permission ) && true !== call_user_func( $permission, is_array( $input ) ? $input : array() ) ) {
-			return new WP_Error( 'ability_invalid_permissions', 'Permission denied.' );
+if ( ! class_exists( 'WP_Ability' ) ) {
+	class WP_Ability {
+		public function __construct( private string $name, private array $args ) {}
+		public function get_name(): string { return $this->name; }
+		public function get_label(): string { return (string) ( $this->args['label'] ?? '' ); }
+		public function get_description(): string { return (string) ( $this->args['description'] ?? '' ); }
+		public function get_category(): string { return (string) ( $this->args['category'] ?? '' ); }
+		public function get_input_schema(): array { return isset( $this->args['input_schema'] ) && is_array( $this->args['input_schema'] ) ? $this->args['input_schema'] : array(); }
+		public function get_output_schema(): array { return isset( $this->args['output_schema'] ) && is_array( $this->args['output_schema'] ) ? $this->args['output_schema'] : array(); }
+		public function get_meta_item( string $key, $default = null ) { return $this->args['meta'][ $key ] ?? $default; }
+		public function execute( $input = null ) {
+			$permission = $this->args['permission_callback'] ?? null;
+			if ( is_callable( $permission ) && true !== call_user_func( $permission, is_array( $input ) ? $input : array() ) ) {
+				return new WP_Error( 'ability_invalid_permissions', 'Permission denied.' );
+			}
+
+			$callback = $this->args['execute_callback'] ?? null;
+			return is_callable( $callback ) ? call_user_func( $callback, is_array( $input ) ? $input : array() ) : null;
 		}
-
-		$callback = $this->args['execute_callback'] ?? null;
-		return is_callable( $callback ) ? call_user_func( $callback, is_array( $input ) ? $input : array() ) : null;
 	}
 }
 
@@ -51,82 +57,132 @@ $GLOBALS['__agents_api_smoke_abilities']          = array();
 $GLOBALS['__agents_api_smoke_ability_categories'] = array();
 $GLOBALS['__agents_api_smoke_can']                = true;
 
-function current_user_can( string $capability ): bool {
-	unset( $capability );
-	return (bool) $GLOBALS['__agents_api_smoke_can'];
+if ( ! function_exists( 'current_user_can' ) ) {
+	function current_user_can( string $capability ): bool {
+		unset( $capability );
+		return (bool) $GLOBALS['__agents_api_smoke_can'];
+	}
+} else {
+	add_filter(
+		'user_has_cap',
+		static function ( array $allcaps ): array {
+			$allcaps['manage_options'] = (bool) ( $GLOBALS['__agents_api_smoke_can'] ?? false );
+			return $allcaps;
+		}
+	);
 }
 
-function wp_has_ability_category( string $slug ): bool {
-	return isset( $GLOBALS['__agents_api_smoke_ability_categories'][ $slug ] );
+if ( ! function_exists( 'wp_has_ability_category' ) ) {
+	function wp_has_ability_category( string $slug ): bool {
+		return isset( $GLOBALS['__agents_api_smoke_ability_categories'][ $slug ] );
+	}
 }
 
-function wp_register_ability_category( string $slug, array $args ): ?WP_Ability_Category {
-	$GLOBALS['__agents_api_smoke_ability_categories'][ $slug ] = $args;
-	return null;
+if ( ! function_exists( 'wp_register_ability_category' ) ) {
+	function wp_register_ability_category( string $slug, array $args ): ?WP_Ability_Category {
+		$GLOBALS['__agents_api_smoke_ability_categories'][ $slug ] = $args;
+		return null;
+	}
 }
 
-function wp_has_ability( string $name ): bool {
-	return isset( $GLOBALS['__agents_api_smoke_abilities'][ $name ] );
+if ( ! function_exists( 'wp_has_ability' ) ) {
+	function wp_has_ability( string $name ): bool {
+		return isset( $GLOBALS['__agents_api_smoke_abilities'][ $name ] );
+	}
 }
 
-function wp_register_ability( string $name, array $args ): ?WP_Ability {
-	$ability = new WP_Ability( $name, $args );
-	$GLOBALS['__agents_api_smoke_abilities'][ $name ] = $ability;
-	return $ability;
+if ( ! function_exists( 'wp_register_ability' ) ) {
+	function wp_register_ability( string $name, array $args ): ?WP_Ability {
+		$ability = new WP_Ability( $name, $args );
+		$GLOBALS['__agents_api_smoke_abilities'][ $name ] = $ability;
+		return $ability;
+	}
 }
 
-function wp_get_ability( string $name ): ?WP_Ability {
-	return $GLOBALS['__agents_api_smoke_abilities'][ $name ] ?? null;
+if ( ! function_exists( 'wp_get_ability' ) ) {
+	function wp_get_ability( string $name ): ?WP_Ability {
+		return $GLOBALS['__agents_api_smoke_abilities'][ $name ] ?? null;
+	}
 }
 
-function wp_get_abilities(): array {
-	return array_values( $GLOBALS['__agents_api_smoke_abilities'] );
+if ( ! function_exists( 'wp_get_abilities' ) ) {
+	function wp_get_abilities(): array {
+		return array_values( $GLOBALS['__agents_api_smoke_abilities'] );
+	}
 }
 
 agents_api_smoke_require_module();
+
+// Ability categories must be registered on wp_abilities_api_categories_init and
+// must exist before an ability can be assigned to them under real WordPress.
+add_action(
+	'wp_abilities_api_categories_init',
+	static function (): void {
+		foreach ( array( 'demo-tools', 'content' ) as $category_slug ) {
+			if ( ! wp_has_ability_category( $category_slug ) ) {
+				wp_register_ability_category(
+					$category_slug,
+					array(
+						'label'       => ucfirst( str_replace( '-', ' ', $category_slug ) ),
+						'description' => 'Smoke test category.',
+					)
+				);
+			}
+		}
+	}
+);
+
+// Abilities must be registered on the wp_abilities_api_init action under real
+// WordPress; register the demo abilities there so the host backend keeps them,
+// then fire the init actions.
+add_action(
+	'wp_abilities_api_init',
+	static function (): void {
+		wp_register_ability(
+			'demo/weather-forecast',
+			array(
+				'label'               => 'Weather Forecast',
+				'description'         => 'Fetch a local weather forecast for a city.',
+				'category'            => 'demo-tools',
+				'input_schema'        => array(
+					'type'       => 'object',
+					'required'   => array( 'city' ),
+					'properties' => array(
+						'city' => array( 'type' => 'string' ),
+					),
+				),
+				'execute_callback'    => static function ( array $input ): array {
+					return array( 'forecast' => 'sunny in ' . ( $input['city'] ?? '' ) );
+				},
+				'permission_callback' => static function (): bool {
+					return true;
+				},
+			)
+		);
+
+		wp_register_ability(
+			'demo/publish-post',
+			array(
+				'label'               => 'Publish Post',
+				'description'         => 'Publish a draft post by ID.',
+				'category'            => 'content',
+				'input_schema'        => array(
+					'type'     => 'object',
+					'required' => array( 'post_id' ),
+				),
+				'execute_callback'    => static function ( array $input ): array {
+					return array( 'published' => (int) ( $input['post_id'] ?? 0 ) );
+				},
+				'permission_callback' => static function (): bool {
+					return true;
+				},
+			)
+		);
+	}
+);
+
 do_action( 'wp_abilities_api_categories_init' );
 do_action( 'wp_abilities_api_init' );
-
-wp_register_ability(
-	'demo/weather-forecast',
-	array(
-		'label'               => 'Weather Forecast',
-		'description'         => 'Fetch a local weather forecast for a city.',
-		'category'            => 'demo-tools',
-		'input_schema'        => array(
-			'type'       => 'object',
-			'required'   => array( 'city' ),
-			'properties' => array(
-				'city' => array( 'type' => 'string' ),
-			),
-		),
-		'execute_callback'    => static function ( array $input ): array {
-			return array( 'forecast' => 'sunny in ' . ( $input['city'] ?? '' ) );
-		},
-		'permission_callback' => static function (): bool {
-			return true;
-		},
-	)
-);
-
-wp_register_ability(
-	'demo/publish-post',
-	array(
-		'label'               => 'Publish Post',
-		'description'         => 'Publish a draft post by ID.',
-		'category'            => 'content',
-		'input_schema'        => array(
-			'type'     => 'object',
-			'required' => array( 'post_id' ),
-		),
-		'execute_callback'    => static function ( array $input ): array {
-			return array( 'published' => (int) ( $input['post_id'] ?? 0 ) );
-		},
-		'permission_callback' => static function (): bool {
-			return true;
-		},
-	)
-);
 
 echo "\n[1] Meta-abilities register in canonical namespace:\n";
 agents_api_smoke_assert_equals( true, wp_has_ability( 'agents/ability-search' ), 'ability-search is registered', $failures, $passes );

--- a/tests/agents-access-ability-smoke.php
+++ b/tests/agents-access-ability-smoke.php
@@ -23,15 +23,14 @@ $GLOBALS['__agents_api_smoke_abilities']       = array();
 $GLOBALS['__agents_api_smoke_categories']      = array();
 
 /**
- * Switch the acting user for both backends: the pure-PHP shim reads the smoke
- * global; under real WordPress we also pin the real current user so that the
- * native get_current_user_id() / is_user_logged_in() agree with the test.
+ * Switch the acting user for both backends. The pure-PHP shim reads the smoke
+ * global directly. Under real WordPress get_current_user_id() can only return a
+ * real user, so instead of inventing a user row we synthesize the execution
+ * principal from this smoke user id through the agents_api_execution_principal
+ * filter registered below — environment-independent and Playground-safe.
  */
 function agents_access_smoke_set_user( int $user_id ): void {
 	$GLOBALS['__agents_api_smoke_current_user_id'] = $user_id;
-	if ( function_exists( 'wp_set_current_user' ) ) {
-		wp_set_current_user( $user_id );
-	}
 }
 
 if ( ! function_exists( 'get_current_user_id' ) ) {
@@ -73,6 +72,33 @@ if ( ! function_exists( 'wp_register_ability' ) ) {
 agents_access_smoke_set_user( 7 );
 
 agents_api_smoke_require_module();
+
+// Under real WordPress get_current_user_id() cannot conjure the smoke user, so
+// synthesize a user-session execution principal for the active smoke user id
+// (when > 0) through the resolution filter. The later audience filter handles
+// the anonymous (user id 0) case.
+if ( ! function_exists( 'get_current_user_id' ) || function_exists( 'wp_set_current_user' ) ) {
+	add_filter(
+		'agents_api_execution_principal',
+		static function ( $principal, array $context ) {
+			$smoke_user = (int) ( $GLOBALS['__agents_api_smoke_current_user_id'] ?? 0 );
+			if ( $smoke_user <= 0 ) {
+				return $principal;
+			}
+
+			return AgentsAPI\AI\WP_Agent_Execution_Principal::user_session(
+				$smoke_user,
+				'current-user',
+				$context['request_context'] ?? AgentsAPI\AI\WP_Agent_Execution_Principal::REQUEST_CONTEXT_REST,
+				array( 'source' => 'smoke-test' ),
+				$context['workspace_id'] ?? null,
+				$context['client_id'] ?? null
+			);
+		},
+		5,
+		2
+	);
+}
 
 add_action(
 	'wp_agents_api_init',

--- a/tests/agents-access-ability-smoke.php
+++ b/tests/agents-access-ability-smoke.php
@@ -22,29 +22,55 @@ $GLOBALS['__agents_api_smoke_current_user_id'] = 7;
 $GLOBALS['__agents_api_smoke_abilities']       = array();
 $GLOBALS['__agents_api_smoke_categories']      = array();
 
-function get_current_user_id(): int {
-	return (int) $GLOBALS['__agents_api_smoke_current_user_id'];
+/**
+ * Switch the acting user for both backends: the pure-PHP shim reads the smoke
+ * global; under real WordPress we also pin the real current user so that the
+ * native get_current_user_id() / is_user_logged_in() agree with the test.
+ */
+function agents_access_smoke_set_user( int $user_id ): void {
+	$GLOBALS['__agents_api_smoke_current_user_id'] = $user_id;
+	if ( function_exists( 'wp_set_current_user' ) ) {
+		wp_set_current_user( $user_id );
+	}
 }
 
-function is_user_logged_in(): bool {
-	return get_current_user_id() > 0;
+if ( ! function_exists( 'get_current_user_id' ) ) {
+	function get_current_user_id(): int {
+		return (int) $GLOBALS['__agents_api_smoke_current_user_id'];
+	}
 }
 
-function wp_has_ability_category( string $category ): bool {
-	return isset( $GLOBALS['__agents_api_smoke_categories'][ $category ] );
+if ( ! function_exists( 'is_user_logged_in' ) ) {
+	function is_user_logged_in(): bool {
+		return get_current_user_id() > 0;
+	}
 }
 
-function wp_register_ability_category( string $category, array $args ): void {
-	$GLOBALS['__agents_api_smoke_categories'][ $category ] = $args;
+if ( ! function_exists( 'wp_has_ability_category' ) ) {
+	function wp_has_ability_category( string $category ): bool {
+		return isset( $GLOBALS['__agents_api_smoke_categories'][ $category ] );
+	}
 }
 
-function wp_has_ability( string $ability ): bool {
-	return isset( $GLOBALS['__agents_api_smoke_abilities'][ $ability ] );
+if ( ! function_exists( 'wp_register_ability_category' ) ) {
+	function wp_register_ability_category( string $category, array $args ): void {
+		$GLOBALS['__agents_api_smoke_categories'][ $category ] = $args;
+	}
 }
 
-function wp_register_ability( string $ability, array $args ): void {
-	$GLOBALS['__agents_api_smoke_abilities'][ $ability ] = $args;
+if ( ! function_exists( 'wp_has_ability' ) ) {
+	function wp_has_ability( string $ability ): bool {
+		return isset( $GLOBALS['__agents_api_smoke_abilities'][ $ability ] );
+	}
 }
+
+if ( ! function_exists( 'wp_register_ability' ) ) {
+	function wp_register_ability( string $ability, array $args ): void {
+		$GLOBALS['__agents_api_smoke_abilities'][ $ability ] = $args;
+	}
+}
+
+agents_access_smoke_set_user( 7 );
 
 agents_api_smoke_require_module();
 
@@ -208,7 +234,7 @@ agents_api_smoke_assert_equals( true, $public_access['allowed'] ?? false, 'logge
 $ability_list = AgentsAPI\AI\Auth\agents_list_accessible_agents( array( 'workspace_id' => 'site:42' ) );
 agents_api_smoke_assert_equals( 'editor-agent', $ability_list['agents'][0]['slug'] ?? null, 'list-accessible ability returns granted registered agent', $failures, $passes );
 
-$GLOBALS['__agents_api_smoke_current_user_id'] = 0;
+agents_access_smoke_set_user( 0 );
 add_filter(
 	'agents_api_execution_principal',
 	static function ( $principal, array $context ) {

--- a/tests/agents-api-smoke-helpers.php
+++ b/tests/agents-api-smoke-helpers.php
@@ -19,168 +19,220 @@ $GLOBALS['__agents_api_smoke_terms']      = array();
 $GLOBALS['__agents_api_smoke_posts']      = array();
 $GLOBALS['__agents_api_smoke_post_meta']  = array();
 
-function __( string $text, string $domain = 'default' ): string {
-	unset( $domain );
-	return $text;
+if ( ! function_exists( '__' ) ) {
+	function __( string $text, string $domain = 'default' ): string {
+		unset( $domain );
+		return $text;
+	}
 }
 
-function _x( string $text, string $context, string $domain = 'default' ): string {
-	unset( $context, $domain );
-	return $text;
+if ( ! function_exists( '_x' ) ) {
+	function _x( string $text, string $context, string $domain = 'default' ): string {
+		unset( $context, $domain );
+		return $text;
+	}
 }
 
-function sanitize_title( string $value ): string {
-	$value = strtolower( $value );
-	$value = preg_replace( '/[^a-z0-9]+/', '-', $value );
-	return trim( (string) $value, '-' );
+if ( ! function_exists( 'sanitize_title' ) ) {
+	function sanitize_title( string $value ): string {
+		$value = strtolower( $value );
+		$value = preg_replace( '/[^a-z0-9]+/', '-', $value );
+		return trim( (string) $value, '-' );
+	}
 }
 
-function sanitize_file_name( string $value ): string {
-	return basename( $value );
+if ( ! function_exists( 'sanitize_file_name' ) ) {
+	function sanitize_file_name( string $value ): string {
+		return basename( $value );
+	}
 }
 
-function add_action( string $hook, callable $callback, int $priority = 10, int $accepted_args = 1 ): void {
-	unset( $accepted_args );
-	$GLOBALS['__agents_api_smoke_actions'][ $hook ][ $priority ][] = $callback;
+if ( ! function_exists( 'add_action' ) ) {
+	function add_action( string $hook, callable $callback, int $priority = 10, int $accepted_args = 1 ): void {
+		unset( $accepted_args );
+		$GLOBALS['__agents_api_smoke_actions'][ $hook ][ $priority ][] = $callback;
+	}
 }
 
-function do_action( string $hook, ...$args ): void {
-	$GLOBALS['__agents_api_smoke_current'][] = $hook;
-	$callbacks = $GLOBALS['__agents_api_smoke_actions'][ $hook ] ?? array();
-	ksort( $callbacks );
+if ( ! function_exists( 'do_action' ) ) {
+	function do_action( string $hook, ...$args ): void {
+		$GLOBALS['__agents_api_smoke_current'][] = $hook;
+		$callbacks = $GLOBALS['__agents_api_smoke_actions'][ $hook ] ?? array();
+		ksort( $callbacks );
 
-	foreach ( $callbacks as $priority_callbacks ) {
-		foreach ( $priority_callbacks as $callback ) {
-			call_user_func_array( $callback, $args );
+		foreach ( $callbacks as $priority_callbacks ) {
+			foreach ( $priority_callbacks as $callback ) {
+				call_user_func_array( $callback, $args );
+			}
 		}
+
+		array_pop( $GLOBALS['__agents_api_smoke_current'] );
+		$GLOBALS['__agents_api_smoke_done'][ $hook ] = ( $GLOBALS['__agents_api_smoke_done'][ $hook ] ?? 0 ) + 1;
 	}
-
-	array_pop( $GLOBALS['__agents_api_smoke_current'] );
-	$GLOBALS['__agents_api_smoke_done'][ $hook ] = ( $GLOBALS['__agents_api_smoke_done'][ $hook ] ?? 0 ) + 1;
 }
 
-function add_filter( string $hook, callable $callback, int $priority = 10, int $accepted_args = 1 ): void {
-	add_action( $hook, $callback, $priority, $accepted_args );
+if ( ! function_exists( 'add_filter' ) ) {
+	function add_filter( string $hook, callable $callback, int $priority = 10, int $accepted_args = 1 ): void {
+		add_action( $hook, $callback, $priority, $accepted_args );
+	}
 }
 
-function apply_filters( string $hook, $value, ...$args ) {
-	$GLOBALS['__agents_api_smoke_current'][] = $hook;
-	$callbacks = $GLOBALS['__agents_api_smoke_actions'][ $hook ] ?? array();
-	ksort( $callbacks );
+if ( ! function_exists( 'apply_filters' ) ) {
+	function apply_filters( string $hook, $value, ...$args ) {
+		$GLOBALS['__agents_api_smoke_current'][] = $hook;
+		$callbacks = $GLOBALS['__agents_api_smoke_actions'][ $hook ] ?? array();
+		ksort( $callbacks );
 
-	foreach ( $callbacks as $priority_callbacks ) {
-		foreach ( $priority_callbacks as $callback ) {
-			$value = call_user_func_array( $callback, array_merge( array( $value ), $args ) );
+		foreach ( $callbacks as $priority_callbacks ) {
+			foreach ( $priority_callbacks as $callback ) {
+				$value = call_user_func_array( $callback, array_merge( array( $value ), $args ) );
+			}
 		}
+
+		array_pop( $GLOBALS['__agents_api_smoke_current'] );
+		$GLOBALS['__agents_api_smoke_done'][ $hook ] = ( $GLOBALS['__agents_api_smoke_done'][ $hook ] ?? 0 ) + 1;
+
+		return $value;
 	}
-
-	array_pop( $GLOBALS['__agents_api_smoke_current'] );
-	$GLOBALS['__agents_api_smoke_done'][ $hook ] = ( $GLOBALS['__agents_api_smoke_done'][ $hook ] ?? 0 ) + 1;
-
-	return $value;
 }
 
-function doing_action( string $hook ): bool {
-	return in_array( $hook, $GLOBALS['__agents_api_smoke_current'], true );
-}
-
-function did_action( string $hook ): int {
-	return (int) ( $GLOBALS['__agents_api_smoke_done'][ $hook ] ?? 0 );
-}
-
-function esc_html( string $value ): string {
-	return htmlspecialchars( $value, ENT_QUOTES, 'UTF-8' );
-}
-
-function wp_json_encode( $value, int $flags = 0, int $depth = 512 ) {
-	return json_encode( $value, $flags, max( 1, $depth ) );
-}
-
-function wp_parse_url( string $url, int $component = -1 ) {
-	return parse_url( $url, $component );
-}
-
-function _doing_it_wrong( string $function_name, string $message, string $version ): void {
-	$GLOBALS['__agents_api_smoke_wrong'][] = array(
-		'function' => $function_name,
-		'message'  => $message,
-		'version'  => $version,
-	);
-}
-
-function post_type_exists( string $post_type ): bool {
-	return isset( $GLOBALS['__agents_api_smoke_post_types'][ $post_type ] );
-}
-
-function register_post_type( string $post_type, array $args = array() ) {
-	$GLOBALS['__agents_api_smoke_post_types'][ $post_type ] = $args;
-	return (object) array(
-		'name' => $post_type,
-		'args' => $args,
-	);
-}
-
-function get_post( int $post_id ) {
-	return $GLOBALS['__agents_api_smoke_posts'][ $post_id ] ?? null;
-}
-
-function get_post_meta( int $post_id, string $key = '', bool $single = false ) {
-	$meta = $GLOBALS['__agents_api_smoke_post_meta'][ $post_id ] ?? array();
-
-	if ( '' === $key ) {
-		return $meta;
+if ( ! function_exists( 'doing_action' ) ) {
+	function doing_action( string $hook ): bool {
+		return in_array( $hook, $GLOBALS['__agents_api_smoke_current'], true );
 	}
-
-	$value = $meta[ $key ] ?? ( $single ? '' : array() );
-	return $single && is_array( $value ) ? reset( $value ) : $value;
 }
 
-function taxonomy_exists( string $taxonomy ): bool {
-	return isset( $GLOBALS['__agents_api_smoke_taxonomies'][ $taxonomy ] );
+if ( ! function_exists( 'did_action' ) ) {
+	function did_action( string $hook ): int {
+		return (int) ( $GLOBALS['__agents_api_smoke_done'][ $hook ] ?? 0 );
+	}
 }
 
-function register_taxonomy( string $taxonomy, $object_type, array $args = array() ) {
-	$GLOBALS['__agents_api_smoke_taxonomies'][ $taxonomy ] = array(
-		'object_type' => $object_type,
-		'args'        => $args,
-	);
-	return (object) array(
-		'name' => $taxonomy,
-		'args' => $args,
-	);
+if ( ! function_exists( 'esc_html' ) ) {
+	function esc_html( string $value ): string {
+		return htmlspecialchars( $value, ENT_QUOTES, 'UTF-8' );
+	}
 }
 
-function wp_is_post_revision( int $post_id ) {
-	unset( $post_id );
-	return false;
+if ( ! function_exists( 'wp_json_encode' ) ) {
+	function wp_json_encode( $value, int $flags = 0, int $depth = 512 ) {
+		return json_encode( $value, $flags, max( 1, $depth ) );
+	}
 }
 
-function get_the_terms( int $post_id, string $taxonomy ) {
-	return $GLOBALS['__agents_api_smoke_object_terms'][ $post_id ][ $taxonomy ] ?? array();
+if ( ! function_exists( 'wp_parse_url' ) ) {
+	function wp_parse_url( string $url, int $component = -1 ) {
+		return parse_url( $url, $component );
+	}
 }
 
-function term_exists( string $term, string $taxonomy ) {
-	return $GLOBALS['__agents_api_smoke_terms'][ $taxonomy ][ $term ] ?? null;
+if ( ! function_exists( '_doing_it_wrong' ) ) {
+	function _doing_it_wrong( string $function_name, string $message, string $version ): void {
+		$GLOBALS['__agents_api_smoke_wrong'][] = array(
+			'function' => $function_name,
+			'message'  => $message,
+			'version'  => $version,
+		);
+	}
 }
 
-function wp_insert_term( string $term, string $taxonomy, array $args = array() ) {
-	$slug    = isset( $args['slug'] ) ? (string) $args['slug'] : sanitize_title( $term );
-	$term_id = count( $GLOBALS['__agents_api_smoke_terms'][ $taxonomy ] ?? array() ) + 1;
-	$created = array(
-		'term_id' => $term_id,
-		'slug'    => $slug,
-		'name'    => $term,
-	);
-	$GLOBALS['__agents_api_smoke_terms'][ $taxonomy ][ $slug ] = $created;
-	return $created;
+if ( ! function_exists( 'post_type_exists' ) ) {
+	function post_type_exists( string $post_type ): bool {
+		return isset( $GLOBALS['__agents_api_smoke_post_types'][ $post_type ] );
+	}
 }
 
-function wp_set_object_terms( int $post_id, $terms, string $taxonomy ): void {
-	$GLOBALS['__agents_api_smoke_object_terms'][ $post_id ][ $taxonomy ] = (array) $terms;
+if ( ! function_exists( 'register_post_type' ) ) {
+	function register_post_type( string $post_type, array $args = array() ) {
+		$GLOBALS['__agents_api_smoke_post_types'][ $post_type ] = $args;
+		return (object) array(
+			'name' => $post_type,
+			'args' => $args,
+		);
+	}
 }
 
-function is_wp_error( $value ): bool {
-	return class_exists( 'WP_Error' ) && $value instanceof WP_Error;
+if ( ! function_exists( 'get_post' ) ) {
+	function get_post( int $post_id ) {
+		return $GLOBALS['__agents_api_smoke_posts'][ $post_id ] ?? null;
+	}
+}
+
+if ( ! function_exists( 'get_post_meta' ) ) {
+	function get_post_meta( int $post_id, string $key = '', bool $single = false ) {
+		$meta = $GLOBALS['__agents_api_smoke_post_meta'][ $post_id ] ?? array();
+
+		if ( '' === $key ) {
+			return $meta;
+		}
+
+		$value = $meta[ $key ] ?? ( $single ? '' : array() );
+		return $single && is_array( $value ) ? reset( $value ) : $value;
+	}
+}
+
+if ( ! function_exists( 'taxonomy_exists' ) ) {
+	function taxonomy_exists( string $taxonomy ): bool {
+		return isset( $GLOBALS['__agents_api_smoke_taxonomies'][ $taxonomy ] );
+	}
+}
+
+if ( ! function_exists( 'register_taxonomy' ) ) {
+	function register_taxonomy( string $taxonomy, $object_type, array $args = array() ) {
+		$GLOBALS['__agents_api_smoke_taxonomies'][ $taxonomy ] = array(
+			'object_type' => $object_type,
+			'args'        => $args,
+		);
+		return (object) array(
+			'name' => $taxonomy,
+			'args' => $args,
+		);
+	}
+}
+
+if ( ! function_exists( 'wp_is_post_revision' ) ) {
+	function wp_is_post_revision( int $post_id ) {
+		unset( $post_id );
+		return false;
+	}
+}
+
+if ( ! function_exists( 'get_the_terms' ) ) {
+	function get_the_terms( int $post_id, string $taxonomy ) {
+		return $GLOBALS['__agents_api_smoke_object_terms'][ $post_id ][ $taxonomy ] ?? array();
+	}
+}
+
+if ( ! function_exists( 'term_exists' ) ) {
+	function term_exists( string $term, string $taxonomy ) {
+		return $GLOBALS['__agents_api_smoke_terms'][ $taxonomy ][ $term ] ?? null;
+	}
+}
+
+if ( ! function_exists( 'wp_insert_term' ) ) {
+	function wp_insert_term( string $term, string $taxonomy, array $args = array() ) {
+		$slug    = isset( $args['slug'] ) ? (string) $args['slug'] : sanitize_title( $term );
+		$term_id = count( $GLOBALS['__agents_api_smoke_terms'][ $taxonomy ] ?? array() ) + 1;
+		$created = array(
+			'term_id' => $term_id,
+			'slug'    => $slug,
+			'name'    => $term,
+		);
+		$GLOBALS['__agents_api_smoke_terms'][ $taxonomy ][ $slug ] = $created;
+		return $created;
+	}
+}
+
+if ( ! function_exists( 'wp_set_object_terms' ) ) {
+	function wp_set_object_terms( int $post_id, $terms, string $taxonomy ): void {
+		$GLOBALS['__agents_api_smoke_object_terms'][ $post_id ][ $taxonomy ] = (array) $terms;
+	}
+}
+
+if ( ! function_exists( 'is_wp_error' ) ) {
+	function is_wp_error( $value ): bool {
+		return class_exists( 'WP_Error' ) && $value instanceof WP_Error;
+	}
 }
 
 function agents_api_smoke_assert_equals( $expected, $actual, string $name, array &$failures, int &$passes ): void {

--- a/tests/agents-chat-ability-smoke.php
+++ b/tests/agents-chat-ability-smoke.php
@@ -14,53 +14,47 @@ $passes   = 0;
 
 echo "agents-chat-ability-smoke\n";
 
-// ─── Minimal WP stubs ──────────────────────────────────────────────
+require_once __DIR__ . '/agents-api-smoke-helpers.php';
 
-class WP_Error {
-	public function __construct( private string $code = '', private string $message = '', private mixed $data = null ) {}
-	public function get_error_code(): string { return $this->code; }
-	public function get_error_message(): string { return $this->message; }
-	public function get_error_data(): mixed { return $this->data; }
-}
-
-function is_wp_error( $value ): bool {
-	return $value instanceof WP_Error;
-}
-
-function current_user_can( string $cap ): bool {
-	unset( $cap );
-	return $GLOBALS['__smoke_can'] ?? false;
-}
-
-$GLOBALS['__smoke_filters'] = array();
-
-function add_filter( string $hook, callable $cb, int $priority = 10, int $accepted_args = 1 ): void {
-	unset( $accepted_args );
-	$GLOBALS['__smoke_filters'][ $hook ][ $priority ][] = $cb;
-}
-
-function apply_filters( string $hook, $value, ...$args ) {
-	$callbacks = $GLOBALS['__smoke_filters'][ $hook ] ?? array();
-	ksort( $callbacks );
-	foreach ( $callbacks as $priority_callbacks ) {
-		foreach ( $priority_callbacks as $cb ) {
-			$value = call_user_func_array( $cb, array_merge( array( $value ), $args ) );
-		}
+if ( ! class_exists( 'WP_Error' ) ) {
+	class WP_Error {
+		public function __construct( private string $code = '', private string $message = '', private mixed $data = null ) {}
+		public function get_error_code(): string { return $this->code; }
+		public function get_error_message(): string { return $this->message; }
+		public function get_error_data(): mixed { return $this->data; }
 	}
-	return $value;
 }
 
-function add_action( string $hook, callable $cb, int $priority = 10, int $accepted_args = 1 ): void {
-	add_filter( $hook, $cb, $priority, $accepted_args );
-}
-
-function do_action( string $hook, ...$args ): void {
-	$callbacks = $GLOBALS['__smoke_filters'][ $hook ] ?? array();
-	ksort( $callbacks );
-	foreach ( $callbacks as $priority_callbacks ) {
-		foreach ( $priority_callbacks as $cb ) {
-			call_user_func_array( $cb, $args );
+if ( ! function_exists( 'current_user_can' ) ) {
+	function current_user_can( string $cap ): bool {
+		unset( $cap );
+		return $GLOBALS['__smoke_can'] ?? false;
+	}
+} else {
+	add_filter(
+		'user_has_cap',
+		static function ( array $allcaps ): array {
+			$allcaps['manage_options'] = (bool) ( $GLOBALS['__smoke_can'] ?? false );
+			return $allcaps;
 		}
+	);
+}
+
+function smoke_reset_chat_filters(): void {
+	$hooks = array(
+		'agents_chat_dispatch_failed',
+		'agents_chat_permission',
+		'agents_chat_runtime_principal_permission',
+		'wp_agent_chat_handler',
+	);
+
+	foreach ( $hooks as $hook ) {
+		if ( function_exists( 'remove_all_filters' ) ) {
+			remove_all_filters( $hook );
+			continue;
+		}
+
+		unset( $GLOBALS['__agents_api_smoke_actions'][ $hook ] );
 	}
 }
 
@@ -76,8 +70,7 @@ function smoke_assert( $expected, $actual, string $name, array &$failures, int &
 	echo '    actual:   ' . var_export( $actual, true ) . "\n";
 }
 
-require_once __DIR__ . '/../src/Runtime/class-wp-agent-execution-principal.php';
-require_once __DIR__ . '/../src/Channels/register-agents-chat-ability.php';
+agents_api_smoke_require_module();
 
 use function AgentsAPI\AI\Channels\agents_chat_dispatch;
 use function AgentsAPI\AI\Channels\agents_chat_permission;
@@ -124,7 +117,7 @@ smoke_assert( 'channel', $captured['client_context']['source'] ?? null, 'handler
 smoke_assert( 'hello back', $result['reply'] ?? null, 'handler_result_returned', $failures, $passes );
 
 // 4. Handler returning non-array → WP_Error agents_chat_invalid_result + observability fires.
-$GLOBALS['__smoke_filters'] = array();
+smoke_reset_chat_filters();
 $dispatch_failures2 = array();
 add_filter( 'agents_chat_dispatch_failed', static function ( $reason ) use ( &$dispatch_failures2 ) {
 	$dispatch_failures2[] = $reason;
@@ -136,7 +129,7 @@ smoke_assert( 'agents_chat_invalid_result', $bad->get_error_code(), 'invalid_res
 smoke_assert( 'invalid_result', $dispatch_failures2[0] ?? 'missing', 'invalid_result_fires_dispatch_failed', $failures, $passes );
 
 // 5. Handler returning WP_Error → propagated + observability fires with the error code.
-$GLOBALS['__smoke_filters'] = array();
+smoke_reset_chat_filters();
 $dispatch_failures3 = array();
 add_filter( 'agents_chat_dispatch_failed', static function ( $reason ) use ( &$dispatch_failures3 ) {
 	$dispatch_failures3[] = $reason;
@@ -148,7 +141,7 @@ smoke_assert( 'agent_blew_up', $err->get_error_code(), 'handler_wp_error_code_pr
 smoke_assert( 'agent_blew_up', $dispatch_failures3[0] ?? 'missing', 'handler_wp_error_fires_dispatch_failed_with_code', $failures, $passes );
 
 // 6. First-handler-wins: second register call doesn't override.
-$GLOBALS['__smoke_filters'] = array();
+smoke_reset_chat_filters();
 register_chat_handler( static fn( array $i ) => array( 'session_id' => 'A', 'reply' => 'first wins' ) );
 register_chat_handler( static fn( array $i ) => array( 'session_id' => 'B', 'reply' => 'never reached' ) );
 $out = agents_chat_dispatch( array( 'agent' => 'x', 'message' => 'y' ) );
@@ -189,7 +182,7 @@ $out_schema = agents_chat_output_schema();
 smoke_assert( array( 'session_id', 'reply' ), $out_schema['required'] ?? array(), 'output_schema_required_fields', $failures, $passes );
 
 // 9. Runtime principal input is normalized before dispatch and has a scoped permission filter.
-$GLOBALS['__smoke_filters'] = array();
+smoke_reset_chat_filters();
 $runtime_principal = AgentsAPI\AI\WP_Agent_Execution_Principal::runtime(
 	'runtime-session-1',
 	'sandbox-agent',

--- a/tests/agents-chat-jsonrpc-route-smoke.php
+++ b/tests/agents-chat-jsonrpc-route-smoke.php
@@ -28,62 +28,94 @@ $GLOBALS['__agents_api_smoke_routes']          = array();
 $GLOBALS['__agents_api_smoke_abilities']       = array();
 $GLOBALS['__agents_api_smoke_categories']      = array();
 
-class WP_Error {
-	public function __construct( private string $code = '', private string $message = '', private array $data = array() ) {}
-	public function get_error_code(): string { return $this->code; }
-	public function get_error_message(): string { return $this->message; }
-	public function get_error_data(): array { return $this->data; }
-}
-
-class WP_REST_Request {
-	public function __construct( private array $params = array(), private array $json = array() ) {}
-	public function get_param( string $key ) {
-		return $this->params[ $key ] ?? null;
-	}
-	public function get_json_params(): array {
-		return $this->json;
+if ( ! class_exists( 'WP_Error' ) ) {
+	class WP_Error {
+		public function __construct( private string $code = '', private string $message = '', private array $data = array() ) {}
+		public function get_error_code(): string { return $this->code; }
+		public function get_error_message(): string { return $this->message; }
+		public function get_error_data(): array { return $this->data; }
 	}
 }
 
-class WP_REST_Response {
-	public function __construct( public mixed $data ) {}
+if ( ! class_exists( 'WP_REST_Request' ) ) {
+	class WP_REST_Request {
+		public function __construct( private array $params = array(), private array $json = array() ) {}
+		public function get_param( string $key ) {
+			return $this->params[ $key ] ?? null;
+		}
+		public function get_json_params(): array {
+			return $this->json;
+		}
+	}
 }
 
-function rest_ensure_response( $value ): WP_REST_Response {
-	return $value instanceof WP_REST_Response ? $value : new WP_REST_Response( $value );
+if ( ! class_exists( 'WP_REST_Response' ) ) {
+	class WP_REST_Response {
+		public function __construct( public mixed $data ) {}
+	}
 }
 
-function register_rest_route( string $namespace, string $route, array $args ): void {
-	$GLOBALS['__agents_api_smoke_routes'][ $namespace . $route ] = $args;
+if ( ! function_exists( 'rest_ensure_response' ) ) {
+	function rest_ensure_response( $value ): WP_REST_Response {
+		return $value instanceof WP_REST_Response ? $value : new WP_REST_Response( $value );
+	}
 }
 
-function get_current_user_id(): int {
-	return (int) $GLOBALS['__agents_api_smoke_current_user_id'];
+if ( ! function_exists( 'register_rest_route' ) ) {
+	function register_rest_route( string $namespace, string $route, array $args ): void {
+		$GLOBALS['__agents_api_smoke_routes'][ $namespace . $route ] = $args;
+	}
 }
 
-function current_user_can( string $capability ): bool {
-	unset( $capability );
-	return (bool) ( $GLOBALS['__agents_api_smoke_can_manage'] ?? false );
+if ( ! function_exists( 'get_current_user_id' ) ) {
+	function get_current_user_id(): int {
+		return (int) $GLOBALS['__agents_api_smoke_current_user_id'];
+	}
 }
 
-function wp_has_ability_category( string $category ): bool {
-	return isset( $GLOBALS['__agents_api_smoke_categories'][ $category ] );
+if ( ! function_exists( 'current_user_can' ) ) {
+	function current_user_can( string $capability ): bool {
+		unset( $capability );
+		return (bool) ( $GLOBALS['__agents_api_smoke_can_manage'] ?? false );
+	}
+} else {
+	add_filter(
+		'user_has_cap',
+		static function ( array $allcaps ): array {
+			$allcaps['manage_options'] = (bool) ( $GLOBALS['__agents_api_smoke_can_manage'] ?? false );
+			return $allcaps;
+		}
+	);
 }
 
-function wp_register_ability_category( string $category, array $args ): void {
-	$GLOBALS['__agents_api_smoke_categories'][ $category ] = $args;
+if ( ! function_exists( 'wp_has_ability_category' ) ) {
+	function wp_has_ability_category( string $category ): bool {
+		return isset( $GLOBALS['__agents_api_smoke_categories'][ $category ] );
+	}
 }
 
-function wp_has_ability( string $ability ): bool {
-	return isset( $GLOBALS['__agents_api_smoke_abilities'][ $ability ] );
+if ( ! function_exists( 'wp_register_ability_category' ) ) {
+	function wp_register_ability_category( string $category, array $args ): void {
+		$GLOBALS['__agents_api_smoke_categories'][ $category ] = $args;
+	}
 }
 
-function wp_register_ability( string $ability, array $args ): void {
-	$GLOBALS['__agents_api_smoke_abilities'][ $ability ] = $args;
+if ( ! function_exists( 'wp_has_ability' ) ) {
+	function wp_has_ability( string $ability ): bool {
+		return isset( $GLOBALS['__agents_api_smoke_abilities'][ $ability ] );
+	}
 }
 
-function wp_get_ability( string $name ) {
-	return $GLOBALS['__agents_api_smoke_abilities'][ $name ] ?? null;
+if ( ! function_exists( 'wp_register_ability' ) ) {
+	function wp_register_ability( string $ability, array $args ): void {
+		$GLOBALS['__agents_api_smoke_abilities'][ $ability ] = $args;
+	}
+}
+
+if ( ! function_exists( 'wp_get_ability' ) ) {
+	function wp_get_ability( string $name ) {
+		return $GLOBALS['__agents_api_smoke_abilities'][ $name ] ?? null;
+	}
 }
 
 agents_api_smoke_require_module();
@@ -102,8 +134,20 @@ do_action( 'rest_api_init' );
 
 // --- Route registration -----------------------------------------------------
 $route_key = 'agents-api/v1/agent/(?P<agent_id>[A-Za-z0-9._-]+)';
-agents_api_smoke_assert_equals( true, isset( $GLOBALS['__agents_api_smoke_routes'][ $route_key ] ), 'JSON-RPC agent route registers', $failures, $passes );
-agents_api_smoke_assert_equals( 'POST', $GLOBALS['__agents_api_smoke_routes'][ $route_key ]['methods'] ?? null, 'JSON-RPC route uses POST', $failures, $passes );
+$route     = $GLOBALS['__agents_api_smoke_routes'][ $route_key ] ?? null;
+
+if ( null === $route && function_exists( 'rest_get_server' ) ) {
+	$routes = rest_get_server()->get_routes();
+	$route  = $routes[ '/' . $route_key ] ?? null;
+}
+
+$route_methods = $route['methods'] ?? null;
+if ( is_array( $route ) && isset( $route[0]['methods'] ) ) {
+	$route_methods = $route[0]['methods'];
+}
+
+agents_api_smoke_assert_equals( true, null !== $route, 'JSON-RPC agent route registers', $failures, $passes );
+agents_api_smoke_assert_equals( true, 'POST' === $route_methods || ( is_array( $route_methods ) && ! empty( $route_methods['POST'] ) ), 'JSON-RPC route uses POST', $failures, $passes );
 
 // --- Input mapping: MessageSendParams -> canonical agents/chat input --------
 $params = array(

--- a/tests/agents-conversation-session-abilities-smoke.php
+++ b/tests/agents-conversation-session-abilities-smoke.php
@@ -14,80 +14,82 @@ $passes   = 0;
 
 echo "agents-conversation-session-abilities-smoke\n";
 
-class WP_Error {
-	public function __construct( private string $code = '', private string $message = '' ) {}
-	public function get_error_code(): string { return $this->code; }
-	public function get_error_message(): string { return $this->message; }
+require_once __DIR__ . '/agents-api-smoke-helpers.php';
+
+if ( ! class_exists( 'WP_Error' ) ) {
+	class WP_Error {
+		public function __construct( private string $code = '', private string $message = '' ) {}
+		public function get_error_code(): string { return $this->code; }
+		public function get_error_message(): string { return $this->message; }
+	}
 }
 
-function is_wp_error( $value ): bool {
-	return $value instanceof WP_Error;
+if ( ! function_exists( 'current_user_can' ) ) {
+	function current_user_can( string $cap ): bool {
+		return in_array( $cap, $GLOBALS['__smoke_caps'] ?? array(), true );
+	}
+} else {
+	add_filter(
+		'user_has_cap',
+		static function ( array $allcaps ): array {
+			foreach ( $GLOBALS['__smoke_caps'] ?? array() as $cap ) {
+				$allcaps[ $cap ] = true;
+			}
+			return $allcaps;
+		}
+	);
 }
 
-function current_user_can( string $cap ): bool {
-	return in_array( $cap, $GLOBALS['__smoke_caps'] ?? array(), true );
+if ( ! function_exists( 'get_current_user_id' ) ) {
+	function get_current_user_id(): int {
+		return (int) ( $GLOBALS['__smoke_current_user_id'] ?? 0 );
+	}
 }
 
-function get_current_user_id(): int {
-	return (int) ( $GLOBALS['__smoke_current_user_id'] ?? 0 );
+if ( ! function_exists( 'get_current_blog_id' ) ) {
+	function get_current_blog_id(): int {
+		return 42;
+	}
 }
 
-function get_current_blog_id(): int {
-	return 42;
-}
-
-function sanitize_key( string $key ): string {
-	return strtolower( preg_replace( '/[^a-z0-9_\-]/', '', $key ) ?? '' );
+if ( ! function_exists( 'sanitize_key' ) ) {
+	function sanitize_key( string $key ): string {
+		return strtolower( preg_replace( '/[^a-z0-9_\-]/', '', $key ) ?? '' );
+	}
 }
 
 $GLOBALS['__smoke_filters']    = array();
 $GLOBALS['__smoke_abilities']  = array();
 $GLOBALS['__smoke_categories'] = array();
 
-function add_filter( string $hook, callable $cb, int $priority = 10, int $accepted_args = 1 ): void {
-	unset( $accepted_args );
-	$GLOBALS['__smoke_filters'][ $hook ][ $priority ][] = $cb;
-}
-
-function apply_filters( string $hook, $value, ...$args ) {
-	$callbacks = $GLOBALS['__smoke_filters'][ $hook ] ?? array();
-	ksort( $callbacks );
-	foreach ( $callbacks as $priority_callbacks ) {
-		foreach ( $priority_callbacks as $cb ) {
-			$value = call_user_func_array( $cb, array_merge( array( $value ), $args ) );
-		}
-	}
-	return $value;
-}
-
-function add_action( string $hook, callable $cb, int $priority = 10, int $accepted_args = 1 ): void {
-	add_filter( $hook, $cb, $priority, $accepted_args );
-}
-
-function do_action( string $hook, ...$args ): void {
-	$callbacks = $GLOBALS['__smoke_filters'][ $hook ] ?? array();
-	ksort( $callbacks );
-	foreach ( $callbacks as $priority_callbacks ) {
-		foreach ( $priority_callbacks as $cb ) {
-			call_user_func_array( $cb, $args );
-		}
+if ( ! function_exists( 'wp_has_ability_category' ) ) {
+	function wp_has_ability_category( string $category ): bool {
+		return isset( $GLOBALS['__smoke_categories'][ $category ] );
 	}
 }
 
-function wp_has_ability_category( string $category ): bool {
-	return isset( $GLOBALS['__smoke_categories'][ $category ] );
+if ( ! function_exists( 'wp_register_ability_category' ) ) {
+	function wp_register_ability_category( string $category, array $args ): void {
+		$GLOBALS['__smoke_categories'][ $category ] = $args;
+	}
 }
 
-function wp_register_ability_category( string $category, array $args ): void {
-	$GLOBALS['__smoke_categories'][ $category ] = $args;
+if ( ! function_exists( 'wp_has_ability' ) ) {
+	function wp_has_ability( string $ability ): bool {
+		return isset( $GLOBALS['__smoke_abilities'][ $ability ] );
+	}
 }
 
-function wp_has_ability( string $ability ): bool {
-	return isset( $GLOBALS['__smoke_abilities'][ $ability ] );
+if ( ! function_exists( 'wp_register_ability' ) ) {
+	function wp_register_ability( string $ability, array $args ): void {
+		$GLOBALS['__smoke_abilities'][ $ability ] = $args;
+	}
 }
 
-function wp_register_ability( string $ability, array $args ): void {
-	$GLOBALS['__smoke_abilities'][ $ability ] = $args;
+if ( ! function_exists( 'wp_get_ability' ) ) {
+	function wp_get_ability( string $ability ) {
+		return $GLOBALS['__smoke_abilities'][ $ability ] ?? null;
+	}
 }
 
 function smoke_assert( $expected, $actual, string $name, array &$failures, int &$passes ): void {
@@ -103,13 +105,36 @@ function smoke_assert( $expected, $actual, string $name, array &$failures, int &
 	echo '    actual:   ' . var_export( $actual, true ) . "\n";
 }
 
-require_once __DIR__ . '/../src/Workspace/class-wp-agent-workspace-scope.php';
-require_once __DIR__ . '/../src/Runtime/class-wp-agent-execution-principal.php';
-require_once __DIR__ . '/../src/Transcripts/class-wp-agent-conversation-store.php';
-require_once __DIR__ . '/../src/Transcripts/class-wp-agent-principal-conversation-store.php';
-require_once __DIR__ . '/../src/Transcripts/class-wp-agent-principal-conversation-session-reader.php';
-require_once __DIR__ . '/../src/Transcripts/class-wp-agent-conversation-sessions.php';
-require_once __DIR__ . '/../src/Transcripts/register-agents-conversation-session-abilities.php';
+agents_api_smoke_require_module();
+
+add_filter(
+	'agents_api_execution_principal',
+	static function ( $principal, array $context ) {
+		if ( (int) ( $GLOBALS['__smoke_current_user_id'] ?? 0 ) <= 0 ) {
+			return $principal;
+		}
+
+		return AgentsAPI\AI\WP_Agent_Execution_Principal::user_session(
+			(int) $GLOBALS['__smoke_current_user_id'],
+			'demo-agent',
+			$context['request_context'] ?? AgentsAPI\AI\WP_Agent_Execution_Principal::REQUEST_CONTEXT_REST,
+			array( 'source' => 'smoke-test' ),
+			$context['workspace_id'] ?? null
+		);
+	},
+	10,
+	2
+);
+
+function smoke_ability_input_schema( string $ability_name ): array {
+	$ability = wp_get_ability( $ability_name );
+
+	if ( is_array( $ability ) ) {
+		return is_array( $ability['input_schema'] ?? null ) ? $ability['input_schema'] : array();
+	}
+
+	return is_object( $ability ) && method_exists( $ability, 'get_input_schema' ) ? $ability->get_input_schema() : array();
+}
 
 use AgentsAPI\AI\WP_Agent_Execution_Principal;
 use AgentsAPI\Core\Database\Chat\WP_Agent_Principal_Conversation_Session_Reader;
@@ -387,8 +412,8 @@ smoke_assert( true, wp_has_ability( AGENTS_GET_CONVERSATION_SESSION_ABILITY ), '
 smoke_assert( true, wp_has_ability( AGENTS_CREATE_CONVERSATION_SESSION_ABILITY ), 'create ability registers', $failures, $passes );
 smoke_assert( true, wp_has_ability( AGENTS_UPDATE_CONVERSATION_SESSION_TITLE_ABILITY ), 'update-title ability registers', $failures, $passes );
 smoke_assert( true, wp_has_ability( AGENTS_DELETE_CONVERSATION_SESSION_ABILITY ), 'delete ability registers', $failures, $passes );
-smoke_assert( true, isset( $GLOBALS['__smoke_abilities'][ AGENTS_CREATE_CONVERSATION_SESSION_ABILITY ]['input_schema']['properties']['session_owner'] ), 'create schema exposes session_owner', $failures, $passes );
-smoke_assert( true, isset( $GLOBALS['__smoke_abilities'][ AGENTS_LIST_CONVERSATION_SESSIONS_ABILITY ]['input_schema']['properties']['session_owner'] ), 'list schema exposes session_owner', $failures, $passes );
+smoke_assert( true, isset( smoke_ability_input_schema( AGENTS_CREATE_CONVERSATION_SESSION_ABILITY )['properties']['session_owner'] ), 'create schema exposes session_owner', $failures, $passes );
+smoke_assert( true, isset( smoke_ability_input_schema( AGENTS_LIST_CONVERSATION_SESSIONS_ABILITY )['properties']['session_owner'] ), 'list schema exposes session_owner', $failures, $passes );
 
 if ( $failures ) {
 	echo "\nFAILED: " . count( $failures ) . " agents conversation session ability assertions failed.\n";

--- a/tests/agents-dispatch-message-ability-smoke.php
+++ b/tests/agents-dispatch-message-ability-smoke.php
@@ -14,50 +14,45 @@ $passes   = 0;
 
 echo "agents-dispatch-message-ability-smoke\n";
 
-class WP_Error {
-	public function __construct( private string $code = '', private string $message = '' ) {}
-	public function get_error_code(): string { return $this->code; }
-	public function get_error_message(): string { return $this->message; }
-}
+require_once __DIR__ . '/agents-api-smoke-helpers.php';
 
-function is_wp_error( $value ): bool {
-	return $value instanceof WP_Error;
-}
-
-function current_user_can( string $cap ): bool {
-	unset( $cap );
-	return $GLOBALS['__smoke_can'] ?? false;
-}
-
-$GLOBALS['__smoke_filters'] = array();
-
-function add_filter( string $hook, callable $cb, int $priority = 10, int $accepted_args = 1 ): void {
-	unset( $accepted_args );
-	$GLOBALS['__smoke_filters'][ $hook ][ $priority ][] = $cb;
-}
-
-function apply_filters( string $hook, $value, ...$args ) {
-	$callbacks = $GLOBALS['__smoke_filters'][ $hook ] ?? array();
-	ksort( $callbacks );
-	foreach ( $callbacks as $priority_callbacks ) {
-		foreach ( $priority_callbacks as $cb ) {
-			$value = call_user_func_array( $cb, array_merge( array( $value ), $args ) );
-		}
+if ( ! class_exists( 'WP_Error' ) ) {
+	class WP_Error {
+		public function __construct( private string $code = '', private string $message = '' ) {}
+		public function get_error_code(): string { return $this->code; }
+		public function get_error_message(): string { return $this->message; }
 	}
-	return $value;
 }
 
-function add_action( string $hook, callable $cb, int $priority = 10, int $accepted_args = 1 ): void {
-	add_filter( $hook, $cb, $priority, $accepted_args );
-}
-
-function do_action( string $hook, ...$args ): void {
-	$callbacks = $GLOBALS['__smoke_filters'][ $hook ] ?? array();
-	ksort( $callbacks );
-	foreach ( $callbacks as $priority_callbacks ) {
-		foreach ( $priority_callbacks as $cb ) {
-			call_user_func_array( $cb, $args );
+if ( ! function_exists( 'current_user_can' ) ) {
+	function current_user_can( string $cap ): bool {
+		unset( $cap );
+		return $GLOBALS['__smoke_can'] ?? false;
+	}
+} else {
+	add_filter(
+		'user_has_cap',
+		static function ( array $allcaps ): array {
+			$allcaps['manage_options'] = (bool) ( $GLOBALS['__smoke_can'] ?? false );
+			return $allcaps;
 		}
+	);
+}
+
+function smoke_reset_dispatch_filters(): void {
+	$hooks = array(
+		'agents_dispatch_message_failed',
+		'agents_dispatch_message_permission',
+		'wp_agent_dispatch_message_handler',
+	);
+
+	foreach ( $hooks as $hook ) {
+		if ( function_exists( 'remove_all_filters' ) ) {
+			remove_all_filters( $hook );
+			continue;
+		}
+
+		unset( $GLOBALS['__agents_api_smoke_actions'][ $hook ] );
 	}
 }
 
@@ -73,7 +68,7 @@ function smoke_assert( $expected, $actual, string $name, array &$failures, int &
 	echo '    actual:   ' . var_export( $actual, true ) . "\n";
 }
 
-require_once __DIR__ . '/../src/Channels/register-agents-dispatch-message-ability.php';
+agents_api_smoke_require_module();
 
 use function AgentsAPI\AI\Channels\agents_dispatch_message_dispatch;
 use function AgentsAPI\AI\Channels\agents_dispatch_message_input_schema;
@@ -107,7 +102,7 @@ smoke_assert( 'no_handler', $dispatch_failures[0]['reason'] ?? 'missing', 'no_ha
 smoke_assert( 'whatsapp', $dispatch_failures[0]['channel'] ?? 'missing', 'observability_includes_channel', $failures, $passes );
 
 $captured = array();
-$GLOBALS['__smoke_filters'] = array();
+smoke_reset_dispatch_filters();
 register_dispatch_message_handler(
 	static function ( array $input ) use ( &$captured ): array {
 		$captured = $input;
@@ -133,7 +128,7 @@ smoke_assert( 'hola', $captured['message'] ?? null, 'handler_receives_message', 
 smoke_assert( true, $ok['sent'] ?? false, 'handler_result_returned', $failures, $passes );
 smoke_assert( 'm-1', $ok['message_id'] ?? null, 'message_id_returned', $failures, $passes );
 
-$GLOBALS['__smoke_filters'] = array();
+smoke_reset_dispatch_filters();
 register_dispatch_message_handler( static fn( array $input ) => 'bad' );
 $bad = agents_dispatch_message_dispatch( array( 'channel' => 'x', 'recipient' => 'y', 'message' => 'z' ) );
 smoke_assert( true, $bad instanceof WP_Error, 'invalid_result_returns_wp_error', $failures, $passes );

--- a/tests/agents-workflow-ability-smoke.php
+++ b/tests/agents-workflow-ability-smoke.php
@@ -15,40 +15,43 @@ $passes   = 0;
 
 echo "agents-workflow-ability-smoke\n";
 
-class WP_Error {
-	public function __construct( private string $code = '', private string $message = '', private $data = null ) {}
-	public function get_error_code(): string { return $this->code; }
-	public function get_error_message(): string { return $this->message; }
-	public function get_error_data() { return $this->data; }
-}
-function is_wp_error( $value ): bool { return $value instanceof WP_Error; }
-function current_user_can( string $cap ): bool { unset( $cap ); return $GLOBALS['__can'] ?? false; }
+require_once __DIR__ . '/agents-api-smoke-helpers.php';
 
-$GLOBALS['__filters'] = array();
-function add_filter( string $hook, callable $cb, int $priority = 10, int $accepted_args = 1 ): void {
-	unset( $accepted_args );
-	$GLOBALS['__filters'][ $hook ][ $priority ][] = $cb;
-}
-function apply_filters( string $hook, $value, ...$args ) {
-	$cbs = $GLOBALS['__filters'][ $hook ] ?? array();
-	ksort( $cbs );
-	foreach ( $cbs as $bucket ) {
-		foreach ( $bucket as $cb ) {
-			$value = call_user_func_array( $cb, array_merge( array( $value ), $args ) );
-		}
+if ( ! class_exists( 'WP_Error' ) ) {
+	class WP_Error {
+		public function __construct( private string $code = '', private string $message = '', private $data = null ) {}
+		public function get_error_code(): string { return $this->code; }
+		public function get_error_message(): string { return $this->message; }
+		public function get_error_data() { return $this->data; }
 	}
-	return $value;
 }
-function add_action( string $hook, callable $cb, int $priority = 10, int $accepted_args = 1 ): void {
-	add_filter( $hook, $cb, $priority, $accepted_args );
-}
-function do_action( string $hook, ...$args ): void {
-	$cbs = $GLOBALS['__filters'][ $hook ] ?? array();
-	ksort( $cbs );
-	foreach ( $cbs as $bucket ) {
-		foreach ( $bucket as $cb ) {
-			call_user_func_array( $cb, $args );
+
+if ( ! function_exists( 'current_user_can' ) ) {
+	function current_user_can( string $cap ): bool { unset( $cap ); return $GLOBALS['__can'] ?? false; }
+} else {
+	add_filter(
+		'user_has_cap',
+		static function ( array $allcaps ): array {
+			$allcaps['manage_options'] = (bool) ( $GLOBALS['__can'] ?? false );
+			return $allcaps;
 		}
+	);
+}
+
+function smoke_reset_workflow_filters(): void {
+	$hooks = array(
+		'agents_run_workflow_dispatch_failed',
+		'agents_run_workflow_permission',
+		'wp_agent_workflow_handler',
+	);
+
+	foreach ( $hooks as $hook ) {
+		if ( function_exists( 'remove_all_filters' ) ) {
+			remove_all_filters( $hook );
+			continue;
+		}
+
+		unset( $GLOBALS['__agents_api_smoke_actions'][ $hook ] );
 	}
 }
 
@@ -64,15 +67,7 @@ function smoke_assert( $expected, $actual, string $name, array &$failures, int &
 	echo '    actual:   ' . var_export( $actual, true ) . "\n";
 }
 
-require_once __DIR__ . '/../src/Workflows/class-wp-agent-workflow-spec-validator.php';
-require_once __DIR__ . '/../src/Workflows/class-wp-agent-workflow-spec.php';
-require_once __DIR__ . '/../src/Workflows/class-wp-agent-workflow-bindings.php';
-require_once __DIR__ . '/../src/Workflows/class-wp-agent-workflow-run-result.php';
-require_once __DIR__ . '/../src/Workflows/class-wp-agent-workflow-store.php';
-require_once __DIR__ . '/../src/Workflows/class-wp-agent-workflow-run-recorder.php';
-require_once __DIR__ . '/../src/Workflows/class-wp-agent-workflow-runner.php';
-require_once __DIR__ . '/../src/Workflows/class-wp-agent-workflow-registry.php';
-require_once __DIR__ . '/../src/Workflows/register-agents-workflow-abilities.php';
+agents_api_smoke_require_module();
 
 use function AgentsAPI\AI\Workflows\agents_describe_workflow;
 use function AgentsAPI\AI\Workflows\agents_run_workflow_dispatch;
@@ -161,7 +156,7 @@ smoke_assert( array( 'a' => 1 ), $ok['output']['echo'] ?? array(), 'handler sees
 
 // ─── handler returns invalid type ────────────────────────────────────
 
-$GLOBALS['__filters'] = array(); // wipe registered handler
+smoke_reset_workflow_filters();
 add_filter( 'wp_agent_workflow_handler', static fn() => static fn() => 'not an array' );
 
 $bad = agents_run_workflow_dispatch( array( 'workflow_id' => 'demo/x' ) );
@@ -177,14 +172,13 @@ smoke_assert(
 // ─── observability: dispatch_failed fires ────────────────────────────
 
 $failed_reasons = array();
+smoke_reset_workflow_filters();
 add_filter(
 	'agents_run_workflow_dispatch_failed',
 	static function ( $reason ) use ( &$failed_reasons ) {
 		$failed_reasons[] = $reason;
 	}
 );
-
-$GLOBALS['__filters']['wp_agent_workflow_handler'] = array();
 agents_run_workflow_dispatch( array( 'workflow_id' => 'whatever' ) );
 smoke_assert( true, in_array( 'no_handler', $failed_reasons, true ), 'dispatch_failed fires with no_handler', $failures, $passes );
 

--- a/tests/bootstrap-smoke.php
+++ b/tests/bootstrap-smoke.php
@@ -212,9 +212,13 @@ agents_api_smoke_assert_equals( true, class_exists( 'WP_Guidelines_Substrate' ),
 agents_api_smoke_assert_equals( true, function_exists( 'wp_guideline_types' ), 'wp_guideline_types helper is available', $failures, $passes );
 
 do_action( 'init' );
+$guideline_post_type = function_exists( 'get_post_type_object' ) ? get_post_type_object( 'wp_guideline' ) : null;
+$guideline_rest_base = is_object( $guideline_post_type ) && isset( $guideline_post_type->rest_base )
+	? $guideline_post_type->rest_base
+	: ( $GLOBALS['__agents_api_smoke_post_types']['wp_guideline']['rest_base'] ?? null );
 agents_api_smoke_assert_equals( true, post_type_exists( 'wp_guideline' ), 'wp_guideline post type is registered on init', $failures, $passes );
 agents_api_smoke_assert_equals( true, taxonomy_exists( 'wp_guideline_type' ), 'wp_guideline_type taxonomy is registered on init', $failures, $passes );
-agents_api_smoke_assert_equals( 'guidelines', $GLOBALS['__agents_api_smoke_post_types']['wp_guideline']['rest_base'] ?? null, 'guideline post type exposes the shared REST base', $failures, $passes );
+agents_api_smoke_assert_equals( 'guidelines', $guideline_rest_base, 'guideline post type exposes the shared REST base', $failures, $passes );
 agents_api_smoke_assert_equals( array( 'artifact', 'content' ), array_keys( wp_guideline_types() ), 'default guideline types match the shared substrate', $failures, $passes );
 
 agents_api_smoke_finish( 'Agents API bootstrap', $failures, $passes );

--- a/tests/channels-smoke.php
+++ b/tests/channels-smoke.php
@@ -126,6 +126,19 @@ require_once __DIR__ . '/../src/Channels/class-wp-agent-option-channel-session-s
 require_once __DIR__ . '/../src/Channels/class-wp-agent-channel-session-map.php';
 require_once __DIR__ . '/../src/Channels/class-wp-agent-channel.php';
 
+// Under the real backend, channel session mappings persist as options. Clear
+// any left over from a previous run so session-isolation assertions start from
+// a clean slate.
+if ( isset( $GLOBALS['wpdb'] ) && is_object( $GLOBALS['wpdb'] ) ) {
+	$channel_smoke_wpdb = $GLOBALS['wpdb'];
+	$channel_smoke_keys = $channel_smoke_wpdb->get_col(
+		"SELECT option_name FROM {$channel_smoke_wpdb->options} WHERE option_name LIKE 'wp_agent_channel_session_%'"
+	);
+	foreach ( (array) $channel_smoke_keys as $channel_smoke_key ) {
+		delete_option( $channel_smoke_key );
+	}
+}
+
 add_filter(
 	'wp_agent_channel_chat_ability',
 	static function (): string {

--- a/tests/channels-smoke.php
+++ b/tests/channels-smoke.php
@@ -20,70 +20,91 @@ echo "agents-api-channels-smoke\n";
 
 // ─── Minimal WP stubs (this test does not load the full bootstrap) ──
 
-class WP_Error {
-	public function __construct(
-		private string $code = '',
-		private string $message = ''
-	) {}
-	public function get_error_code(): string { return $this->code; }
-	public function get_error_message(): string { return $this->message; }
-}
-
-function is_wp_error( $value ): bool {
-	return $value instanceof WP_Error;
-}
-
-$GLOBALS['__channel_smoke_options']   = array();
-$GLOBALS['__channel_smoke_scheduled'] = array();
-$GLOBALS['__channel_smoke_abilities'] = array();
-$GLOBALS['__channel_smoke_filters']   = array();
-
-function get_option( string $key, $default = '' ) {
-	return $GLOBALS['__channel_smoke_options'][ $key ] ?? $default;
-}
-
-function update_option( string $key, $value, $autoload = null ): bool {
-	unset( $autoload );
-	$GLOBALS['__channel_smoke_options'][ $key ] = $value;
-	return true;
-}
-
-function delete_option( string $key ): bool {
-	unset( $GLOBALS['__channel_smoke_options'][ $key ] );
-	return true;
-}
-
-function wp_schedule_single_event( int $timestamp, string $hook, array $args = array() ): bool {
-	$GLOBALS['__channel_smoke_scheduled'][] = array(
-		'timestamp' => $timestamp,
-		'hook'      => $hook,
-		'args'      => $args,
-	);
-	return true;
-}
-
-function wp_get_ability( string $name ) {
-	return $GLOBALS['__channel_smoke_abilities'][ $name ] ?? null;
-}
-
-function add_filter( string $hook, callable $cb, int $priority = 10, int $accepted_args = 1 ): void {
-	unset( $accepted_args );
-	$GLOBALS['__channel_smoke_filters'][ $hook ][ $priority ][] = $cb;
-}
-
-function apply_filters( string $hook, $value, ...$args ) {
-	$callbacks = $GLOBALS['__channel_smoke_filters'][ $hook ] ?? array();
-	ksort( $callbacks );
-	foreach ( $callbacks as $priority_callbacks ) {
-		foreach ( $priority_callbacks as $cb ) {
-			$value = call_user_func_array( $cb, array_merge( array( $value ), $args ) );
-		}
+if ( ! class_exists( 'WP_Error' ) ) {
+	class WP_Error {
+		public function __construct(
+			private string $code = '',
+			private string $message = ''
+		) {}
+		public function get_error_code(): string { return $this->code; }
+		public function get_error_message(): string { return $this->message; }
 	}
-	return $value;
 }
 
-function add_action( string $hook, callable $cb, int $priority = 10, int $accepted_args = 1 ): void {
-	add_filter( $hook, $cb, $priority, $accepted_args );
+if ( ! function_exists( 'is_wp_error' ) ) {
+	function is_wp_error( $value ): bool {
+		return $value instanceof WP_Error;
+	}
+}
+
+$GLOBALS['__channel_smoke_options']              = array();
+$GLOBALS['__channel_smoke_scheduled']            = array();
+$GLOBALS['__channel_smoke_abilities']            = array();
+$GLOBALS['__channel_smoke_filters']              = array();
+$GLOBALS['__channel_smoke_current_ability_slug'] = 'smoke/channel-chat';
+
+if ( ! function_exists( 'get_option' ) ) {
+	function get_option( string $key, $default = '' ) {
+		return $GLOBALS['__channel_smoke_options'][ $key ] ?? $default;
+	}
+}
+
+if ( ! function_exists( 'update_option' ) ) {
+	function update_option( string $key, $value, $autoload = null ): bool {
+		unset( $autoload );
+		$GLOBALS['__channel_smoke_options'][ $key ] = $value;
+		return true;
+	}
+}
+
+if ( ! function_exists( 'delete_option' ) ) {
+	function delete_option( string $key ): bool {
+		unset( $GLOBALS['__channel_smoke_options'][ $key ] );
+		return true;
+	}
+}
+
+if ( ! function_exists( 'wp_schedule_single_event' ) ) {
+	function wp_schedule_single_event( int $timestamp, string $hook, array $args = array() ): bool {
+		$GLOBALS['__channel_smoke_scheduled'][] = array(
+			'timestamp' => $timestamp,
+			'hook'      => $hook,
+			'args'      => $args,
+		);
+		return true;
+	}
+}
+
+if ( ! function_exists( 'wp_get_ability' ) ) {
+	function wp_get_ability( string $name ) {
+		return $GLOBALS['__channel_smoke_abilities'][ $name ] ?? null;
+	}
+}
+
+if ( ! function_exists( 'add_filter' ) ) {
+	function add_filter( string $hook, callable $cb, int $priority = 10, int $accepted_args = 1 ): void {
+		unset( $accepted_args );
+		$GLOBALS['__channel_smoke_filters'][ $hook ][ $priority ][] = $cb;
+	}
+}
+
+if ( ! function_exists( 'apply_filters' ) ) {
+	function apply_filters( string $hook, $value, ...$args ) {
+		$callbacks = $GLOBALS['__channel_smoke_filters'][ $hook ] ?? array();
+		ksort( $callbacks );
+		foreach ( $callbacks as $priority_callbacks ) {
+			foreach ( $priority_callbacks as $cb ) {
+				$value = call_user_func_array( $cb, array_merge( array( $value ), $args ) );
+			}
+		}
+		return $value;
+	}
+}
+
+if ( ! function_exists( 'add_action' ) ) {
+	function add_action( string $hook, callable $cb, int $priority = 10, int $accepted_args = 1 ): void {
+		add_filter( $hook, $cb, $priority, $accepted_args );
+	}
 }
 
 function smoke_assert( $expected, $actual, string $name, array &$failures, int &$passes ): void {
@@ -104,6 +125,80 @@ require_once __DIR__ . '/../src/Channels/class-wp-agent-channel-session-store.ph
 require_once __DIR__ . '/../src/Channels/class-wp-agent-option-channel-session-store.php';
 require_once __DIR__ . '/../src/Channels/class-wp-agent-channel-session-map.php';
 require_once __DIR__ . '/../src/Channels/class-wp-agent-channel.php';
+
+add_filter(
+	'wp_agent_channel_chat_ability',
+	static function (): string {
+		return (string) $GLOBALS['__channel_smoke_current_ability_slug'];
+	},
+	1
+);
+
+add_filter(
+	'pre_schedule_event',
+	static function ( $pre, $event ) {
+		if ( is_object( $event ) && 'test_channel_handle' === ( $event->hook ?? '' ) ) {
+			$GLOBALS['__channel_smoke_scheduled'][] = array(
+				'timestamp' => (int) ( $event->timestamp ?? 0 ),
+				'hook'      => (string) $event->hook,
+				'args'      => (array) ( $event->args ?? array() ),
+			);
+			return true;
+		}
+
+		return $pre;
+	},
+	10,
+	2
+);
+
+if ( function_exists( 'wp_register_ability_category' ) && function_exists( 'wp_register_ability' ) ) {
+	add_action(
+		'wp_abilities_api_categories_init',
+		static function (): void {
+			if ( ! function_exists( 'wp_has_ability_category' ) || ! wp_has_ability_category( 'smoke' ) ) {
+				wp_register_ability_category(
+					'smoke',
+					array(
+						'label'       => 'Smoke',
+						'description' => 'Smoke-test abilities.',
+					)
+				);
+			}
+		}
+	);
+
+	add_action(
+		'wp_abilities_api_init',
+		static function (): void {
+			foreach ( array( 'smoke/channel-chat', 'my-plugin/custom-chat' ) as $slug ) {
+				if ( function_exists( 'wp_has_ability' ) && wp_has_ability( $slug ) ) {
+					continue;
+				}
+
+				wp_register_ability(
+					$slug,
+					array(
+						'label'               => 'Channel Smoke Chat',
+						'description'         => 'Delegates channel smoke runs to the current fake ability.',
+						'category'            => 'smoke',
+						'input_schema'        => array( 'type' => 'object' ),
+						'execute_callback'    => static function ( array $input ) use ( $slug ) {
+							$ability = $GLOBALS['__channel_smoke_abilities'][ $slug ] ?? null;
+							return $ability ? $ability->execute( $input ) : new WP_Error( 'missing_smoke_ability', 'Missing channel smoke ability.' );
+						},
+						'permission_callback' => static function (): bool {
+							return true;
+						},
+					)
+				);
+			}
+		}
+	);
+
+	do_action( 'wp_abilities_api_categories_init' );
+	do_action( 'wp_abilities_api_init' );
+}
 
 // ─── Fakes ──────────────────────────────────────────────────────────
 
@@ -156,7 +251,7 @@ class Test_Channel extends \AgentsAPI\AI\Channels\WP_Agent_Channel {
 $happy_ability = new Fake_Ability(
 	array( 'reply' => 'Hello from the agent', 'session_id' => 'sess-123', 'completed' => true )
 );
-$GLOBALS['__channel_smoke_abilities']['agents/chat'] = $happy_ability;
+$GLOBALS['__channel_smoke_abilities']['smoke/channel-chat'] = $happy_ability;
 
 $ch = new Test_Channel( 'chat-A' );
 $ch->handle( array( 'text' => 'hi there' ) );
@@ -245,7 +340,7 @@ class Rich_Channel extends Test_Channel {
 	}
 }
 $rich_ability = new Fake_Ability( array( 'reply' => 'rich response' ) );
-$GLOBALS['__channel_smoke_abilities']['agents/chat'] = $rich_ability;
+$GLOBALS['__channel_smoke_abilities']['smoke/channel-chat'] = $rich_ability;
 $rich = new Rich_Channel( 'chat-rich' );
 $rich->handle( array(
 	'text'        => 'check this out',
@@ -272,7 +367,7 @@ class Custom_Key_Channel extends Test_Channel {
 	}
 }
 $custom_key_ability = new Fake_Ability( array( 'reply' => 'custom key', 'session_id' => 'sess-custom' ) );
-$GLOBALS['__channel_smoke_abilities']['agents/chat'] = $custom_key_ability;
+$GLOBALS['__channel_smoke_abilities']['smoke/channel-chat'] = $custom_key_ability;
 $custom_key = new Custom_Key_Channel( 'chat-custom' );
 $custom_key->handle( array( 'text' => 'use custom key' ) );
 smoke_assert( 'sess-custom', get_option( 'custom_session_key_chat-custom' ), 'custom_session_key_override_is_preserved', $failures, $passes );
@@ -281,7 +376,7 @@ smoke_assert( 'sess-custom', get_option( 'custom_session_key_chat-custom' ), 'cu
 $happy_ability2 = new Fake_Ability(
 	array( 'reply' => 'second reply', 'session_id' => 'sess-123', 'completed' => true )
 );
-$GLOBALS['__channel_smoke_abilities']['agents/chat'] = $happy_ability2;
+$GLOBALS['__channel_smoke_abilities']['smoke/channel-chat'] = $happy_ability2;
 
 $ch2 = new Test_Channel( 'chat-A' );
 $ch2->handle( array( 'text' => 'follow-up' ) );
@@ -293,7 +388,7 @@ smoke_assert( 'follow-up', $happy_ability2->calls[0]['message'] ?? 'missing', 's
 $other_ability = new Fake_Ability(
 	array( 'reply' => 'reply for B', 'session_id' => 'sess-B-456', 'completed' => true )
 );
-$GLOBALS['__channel_smoke_abilities']['agents/chat'] = $other_ability;
+$GLOBALS['__channel_smoke_abilities']['smoke/channel-chat'] = $other_ability;
 
 $ch3 = new Test_Channel( 'chat-B' );
 $ch3->handle( array( 'text' => 'hi' ) );
@@ -308,7 +403,7 @@ smoke_assert(
 
 // 4. Empty message short-circuits with WP_Error, no agent call.
 $null_ability = new Fake_Ability( array( 'reply' => 'should not be called' ) );
-$GLOBALS['__channel_smoke_abilities']['agents/chat'] = $null_ability;
+$GLOBALS['__channel_smoke_abilities']['smoke/channel-chat'] = $null_ability;
 
 $ch4    = new Test_Channel( 'chat-empty' );
 $result = $ch4->handle( array( 'text' => '   ' ) );
@@ -319,7 +414,7 @@ smoke_assert( array(), $null_ability->calls, 'empty_message_skips_agent', $failu
 
 // 5. Ability returns WP_Error → send_error fires.
 $error_ability = new Fake_Ability( new WP_Error( 'agent_blew_up', 'something exploded' ) );
-$GLOBALS['__channel_smoke_abilities']['agents/chat'] = $error_ability;
+$GLOBALS['__channel_smoke_abilities']['smoke/channel-chat'] = $error_ability;
 
 $ch5 = new Test_Channel( 'chat-err' );
 $ch5->handle( array( 'text' => 'try this' ) );
@@ -355,7 +450,7 @@ class Silent_Skip_Channel extends Test_Channel {
 	}
 }
 $silent_ability = new Fake_Ability( array( 'reply' => 'should not be called' ) );
-$GLOBALS['__channel_smoke_abilities']['agents/chat'] = $silent_ability;
+$GLOBALS['__channel_smoke_abilities']['smoke/channel-chat'] = $silent_ability;
 
 $ch_silent = new Silent_Skip_Channel( 'chat-silent' );
 $result    = $ch_silent->handle( array( 'text' => 'echo of own reply', 'from_me' => true ) );

--- a/tests/chat-run-control-smoke.php
+++ b/tests/chat-run-control-smoke.php
@@ -22,42 +22,58 @@ $GLOBALS['__agents_api_smoke_abilities']  = array();
 $GLOBALS['__agents_api_smoke_categories'] = array();
 $GLOBALS['__agents_api_smoke_options']    = array();
 
-class WP_Error {
-	public function __construct( private string $code = '', private string $message = '', private array $data = array() ) {}
-	public function get_error_code(): string { return $this->code; }
-	public function get_error_message(): string { return $this->message; }
-	public function get_error_data(): array { return $this->data; }
+if ( ! class_exists( 'WP_Error' ) ) {
+	class WP_Error {
+		public function __construct( private string $code = '', private string $message = '', private array $data = array() ) {}
+		public function get_error_code(): string { return $this->code; }
+		public function get_error_message(): string { return $this->message; }
+		public function get_error_data(): array { return $this->data; }
+	}
 }
 
-function current_user_can( string $capability ): bool {
-	unset( $capability );
-	return true;
+if ( ! function_exists( 'current_user_can' ) ) {
+	function current_user_can( string $capability ): bool {
+		unset( $capability );
+		return true;
+	}
 }
 
-function wp_has_ability_category( string $category ): bool {
-	return isset( $GLOBALS['__agents_api_smoke_categories'][ $category ] );
+if ( ! function_exists( 'wp_has_ability_category' ) ) {
+	function wp_has_ability_category( string $category ): bool {
+		return isset( $GLOBALS['__agents_api_smoke_categories'][ $category ] );
+	}
 }
 
-function wp_register_ability_category( string $category, array $args ): void {
-	$GLOBALS['__agents_api_smoke_categories'][ $category ] = $args;
+if ( ! function_exists( 'wp_register_ability_category' ) ) {
+	function wp_register_ability_category( string $category, array $args ): void {
+		$GLOBALS['__agents_api_smoke_categories'][ $category ] = $args;
+	}
 }
 
-function wp_has_ability( string $ability ): bool {
-	return isset( $GLOBALS['__agents_api_smoke_abilities'][ $ability ] );
+if ( ! function_exists( 'wp_has_ability' ) ) {
+	function wp_has_ability( string $ability ): bool {
+		return isset( $GLOBALS['__agents_api_smoke_abilities'][ $ability ] );
+	}
 }
 
-function wp_register_ability( string $ability, array $args ): void {
-	$GLOBALS['__agents_api_smoke_abilities'][ $ability ] = $args;
+if ( ! function_exists( 'wp_register_ability' ) ) {
+	function wp_register_ability( string $ability, array $args ): void {
+		$GLOBALS['__agents_api_smoke_abilities'][ $ability ] = $args;
+	}
 }
 
-function get_option( string $option, $default = false ) {
-	return $GLOBALS['__agents_api_smoke_options'][ $option ] ?? $default;
+if ( ! function_exists( 'get_option' ) ) {
+	function get_option( string $option, $default = false ) {
+		return $GLOBALS['__agents_api_smoke_options'][ $option ] ?? $default;
+	}
 }
 
-function update_option( string $option, $value, $autoload = null ): bool {
-	unset( $autoload );
-	$GLOBALS['__agents_api_smoke_options'][ $option ] = $value;
-	return true;
+if ( ! function_exists( 'update_option' ) ) {
+	function update_option( string $option, $value, $autoload = null ): bool {
+		unset( $autoload );
+		$GLOBALS['__agents_api_smoke_options'][ $option ] = $value;
+		return true;
+	}
 }
 
 agents_api_smoke_require_module();
@@ -65,10 +81,10 @@ agents_api_smoke_require_module();
 do_action( 'wp_abilities_api_categories_init' );
 do_action( 'wp_abilities_api_init' );
 
-agents_api_smoke_assert_equals( true, isset( $GLOBALS['__agents_api_smoke_abilities'][ AgentsAPI\AI\Channels\AGENTS_GET_CHAT_RUN_ABILITY ] ), 'get-run ability registers', $failures, $passes );
-agents_api_smoke_assert_equals( true, isset( $GLOBALS['__agents_api_smoke_abilities'][ AgentsAPI\AI\Channels\AGENTS_CANCEL_CHAT_RUN_ABILITY ] ), 'cancel-run ability registers', $failures, $passes );
-agents_api_smoke_assert_equals( true, isset( $GLOBALS['__agents_api_smoke_abilities'][ AgentsAPI\AI\Channels\AGENTS_QUEUE_CHAT_MESSAGE_ABILITY ] ), 'queue-message ability registers', $failures, $passes );
-agents_api_smoke_assert_equals( true, isset( $GLOBALS['__agents_api_smoke_abilities'][ AgentsAPI\AI\Channels\AGENTS_LIST_CHAT_RUN_EVENTS_ABILITY ] ), 'list-run-events ability registers', $failures, $passes );
+agents_api_smoke_assert_equals( true, wp_has_ability( AgentsAPI\AI\Channels\AGENTS_GET_CHAT_RUN_ABILITY ), 'get-run ability registers', $failures, $passes );
+agents_api_smoke_assert_equals( true, wp_has_ability( AgentsAPI\AI\Channels\AGENTS_CANCEL_CHAT_RUN_ABILITY ), 'cancel-run ability registers', $failures, $passes );
+agents_api_smoke_assert_equals( true, wp_has_ability( AgentsAPI\AI\Channels\AGENTS_QUEUE_CHAT_MESSAGE_ABILITY ), 'queue-message ability registers', $failures, $passes );
+agents_api_smoke_assert_equals( true, wp_has_ability( AgentsAPI\AI\Channels\AGENTS_LIST_CHAT_RUN_EVENTS_ABILITY ), 'list-run-events ability registers', $failures, $passes );
 agents_api_smoke_assert_equals( true, in_array( 'run_id', AgentsAPI\AI\Channels\agents_chat_output_schema()['required'] ?? array(), true ) || isset( AgentsAPI\AI\Channels\agents_chat_output_schema()['properties']['run_id'] ), 'chat output schema exposes run_id', $failures, $passes );
 
 $captured_chat_input = array();

--- a/tests/cpt-conversation-store-smoke.php
+++ b/tests/cpt-conversation-store-smoke.php
@@ -25,6 +25,8 @@ echo "agents-api-cpt-conversation-store-smoke\n";
 
 /* ----------------------------- in-memory WP shim ---------------------------- */
 
+if ( ! function_exists( 'wp_insert_post' ) ) {
+
 $GLOBALS['__posts']   = array();
 $GLOBALS['__meta']    = array();
 $GLOBALS['__next_id'] = 1;
@@ -285,6 +287,8 @@ if ( ! class_exists( 'WPDB_Cpt_Store_Shim' ) ) {
 }
 $GLOBALS['wpdb'] = new WPDB_Cpt_Store_Shim();
 
+}
+
 /* ------------------------------ load + assert ------------------------------ */
 
 require_once __DIR__ . '/../agents-api.php';
@@ -294,6 +298,10 @@ use AgentsAPI\Core\Database\Chat\WP_Agent_Conversation_Lock;
 use AgentsAPI\Core\Database\Chat\WP_Agent_Principal_Conversation_Store;
 use AgentsAPI\Core\Database\Chat\WP_Agent_Cpt_Conversation_Store;
 use AgentsAPI\Core\Workspace\WP_Agent_Workspace_Scope;
+
+if ( function_exists( 'register_post_type' ) ) {
+	WP_Agent_Cpt_Conversation_Store::register_post_type();
+}
 
 function smoke_assert( $expected, $actual, string $name, array &$failures, int &$passes ): void {
 	if ( $expected === $actual ) {
@@ -386,11 +394,26 @@ smoke_assert( true, is_string( $token2 ) && '' !== $token2, 'reacquire after rel
 
 // Force an expired lock and confirm CAS reclaim.
 $post_id = null;
-foreach ( $GLOBALS['__posts'] as $pid => $p ) {
-	if ( (string) get_post_meta( $pid, '_agents_api_session_id', true ) === $lock_session ) {
-		$post_id = $pid;
-		break;
+
+if ( isset( $GLOBALS['__posts'] ) && is_array( $GLOBALS['__posts'] ) ) {
+	foreach ( $GLOBALS['__posts'] as $pid => $p ) {
+		if ( (string) get_post_meta( $pid, '_agents_api_session_id', true ) === $lock_session ) {
+			$post_id = $pid;
+			break;
+		}
 	}
+} else {
+	$lock_query = new WP_Query(
+		array(
+			'post_type'      => WP_Agent_Cpt_Conversation_Store::POST_TYPE,
+			'post_status'    => 'any',
+			'posts_per_page' => 1,
+			'fields'         => 'ids',
+			'meta_key'       => '_agents_api_session_id',
+			'meta_value'     => $lock_session,
+		)
+	);
+	$post_id    = isset( $lock_query->posts[0] ) ? (int) $lock_query->posts[0] : null;
 }
 update_post_meta( $post_id, '_agents_api_lock', wp_json_encode( array( 'token' => 'stale', 'expires' => time() - 10 ) ) );
 $token3 = $store->acquire_session_lock( $lock_session, 300 );

--- a/tests/cpt-conversation-store-smoke.php
+++ b/tests/cpt-conversation-store-smoke.php
@@ -318,6 +318,23 @@ function smoke_assert( $expected, $actual, string $name, array &$failures, int &
 $store     = new WP_Agent_Cpt_Conversation_Store();
 $workspace = WP_Agent_Workspace_Scope::from_parts( 'site', '42' );
 
+// Under real WordPress the store reads/writes real conversation posts. Purge any
+// left over from a previous run so the owner-scoped list counts are
+// deterministic. (The pure-PHP shim starts from an empty in-memory store.)
+if ( ! isset( $GLOBALS['__posts'] ) && class_exists( 'WP_Query' ) && function_exists( 'wp_delete_post' ) ) {
+	$existing_sessions = new WP_Query(
+		array(
+			'post_type'      => WP_Agent_Cpt_Conversation_Store::POST_TYPE,
+			'post_status'    => 'any',
+			'posts_per_page' => -1,
+			'fields'         => 'ids',
+		)
+	);
+	foreach ( (array) $existing_sessions->posts as $existing_session_id ) {
+		wp_delete_post( (int) $existing_session_id, true );
+	}
+}
+
 echo "\n[1] Implements the canonical contracts:\n";
 smoke_assert( true, $store instanceof WP_Agent_Conversation_Store, 'implements WP_Agent_Conversation_Store', $failures, $passes );
 smoke_assert( true, $store instanceof WP_Agent_Principal_Conversation_Store, 'implements WP_Agent_Principal_Conversation_Store', $failures, $passes );

--- a/tests/event-trigger-smoke.php
+++ b/tests/event-trigger-smoke.php
@@ -85,6 +85,25 @@ if ( ! function_exists( 'wp_schedule_single_event' ) ) {
 		return true;
 	}
 }
+if ( function_exists( 'add_filter' ) ) {
+	add_filter(
+		'pre_schedule_event',
+		static function ( $pre, $event ) {
+			if ( is_object( $event ) && AgentsAPI\AI\Triggers\WP_AGENT_EVENT_TRIGGER_RUN_HOOK === ( $event->hook ?? '' ) ) {
+				$GLOBALS['smoke_scheduled'][] = array(
+					'timestamp' => (int) ( $event->timestamp ?? 0 ),
+					'hook'      => (string) $event->hook,
+					'args'      => (array) ( $event->args ?? array() ),
+				);
+				return true;
+			}
+
+			return $pre;
+		},
+		10,
+		2
+	);
+}
 
 require_once __DIR__ . '/../src/Triggers/class-wp-agent-event-trigger.php';
 require_once __DIR__ . '/../src/Triggers/class-wp-agent-event-trigger-registry.php';
@@ -156,9 +175,29 @@ echo "\n[5] Handler registers hooks and schedules async dispatch:\n";
 $GLOBALS['smoke_actions']   = array();
 $GLOBALS['smoke_scheduled'] = array();
 register_event_trigger_handler( $trigger );
-smoke_assert( 'transition_post_status', $GLOBALS['smoke_actions'][0]['hook'] ?? null, 'handler attaches source hook', $failures, $passes );
-smoke_assert( PHP_INT_MAX, $GLOBALS['smoke_actions'][0]['priority'] ?? null, 'handler uses late priority', $failures, $passes );
-smoke_assert( 3, $GLOBALS['smoke_actions'][0]['accepted_args'] ?? null, 'handler accepts declared hook args', $failures, $passes );
+
+if ( isset( $GLOBALS['smoke_actions'][0] ) ) {
+	$registered_hook          = $GLOBALS['smoke_actions'][0]['hook'] ?? null;
+	$registered_priority      = $GLOBALS['smoke_actions'][0]['priority'] ?? null;
+	$registered_accepted_args = $GLOBALS['smoke_actions'][0]['accepted_args'] ?? null;
+} else {
+	$registered_hook          = null;
+	$registered_priority      = null;
+	$registered_accepted_args = null;
+	$callbacks                = $GLOBALS['wp_filter']['transition_post_status']->callbacks[ PHP_INT_MAX ] ?? array();
+	foreach ( $callbacks as $callback ) {
+		if ( 3 === (int) ( $callback['accepted_args'] ?? 0 ) ) {
+			$registered_hook          = 'transition_post_status';
+			$registered_priority      = PHP_INT_MAX;
+			$registered_accepted_args = 3;
+			break;
+		}
+	}
+}
+
+smoke_assert( 'transition_post_status', $registered_hook, 'handler attaches source hook', $failures, $passes );
+smoke_assert( PHP_INT_MAX, $registered_priority, 'handler uses late priority', $failures, $passes );
+smoke_assert( 3, $registered_accepted_args, 'handler accepts declared hook args', $failures, $passes );
 
 dispatch_event_trigger_hook(
 	$trigger,

--- a/tests/frontend-chat-rest-smoke.php
+++ b/tests/frontend-chat-rest-smoke.php
@@ -22,67 +22,109 @@ $GLOBALS['__agents_api_smoke_current_user_id'] = 7;
 $GLOBALS['__agents_api_smoke_routes']          = array();
 $GLOBALS['__agents_api_smoke_abilities']       = array();
 $GLOBALS['__agents_api_smoke_categories']      = array();
+$GLOBALS['__agents_api_smoke_allow_chat']      = false;
 
-class WP_Error {
-	public function __construct( private string $code = '', private string $message = '', private array $data = array() ) {}
-	public function get_error_code(): string { return $this->code; }
-	public function get_error_message(): string { return $this->message; }
-	public function get_error_data(): array { return $this->data; }
-}
-
-class WP_REST_Request {
-	public function __construct( private array $params = array() ) {}
-	public function get_param( string $key ) {
-		return $this->params[ $key ] ?? null;
+if ( ! class_exists( 'WP_Error' ) ) {
+	class WP_Error {
+		public function __construct( private string $code = '', private string $message = '', private array $data = array() ) {}
+		public function get_error_code(): string { return $this->code; }
+		public function get_error_message(): string { return $this->message; }
+		public function get_error_data(): array { return $this->data; }
 	}
 }
 
-class WP_REST_Response {
-	public function __construct( public mixed $data ) {}
+if ( ! class_exists( 'WP_REST_Request' ) ) {
+	class WP_REST_Request {
+		private array $params = array();
+
+		public function __construct( $method_or_params = array(), string $route = '' ) {
+			unset( $route );
+			$this->params = is_array( $method_or_params ) ? $method_or_params : array();
+		}
+		public function get_param( string $key ) {
+			return $this->params[ $key ] ?? null;
+		}
+		public function set_param( string $key, $value ): void {
+			$this->params[ $key ] = $value;
+		}
+	}
 }
 
-function rest_ensure_response( $value ): WP_REST_Response {
-	return $value instanceof WP_REST_Response ? $value : new WP_REST_Response( $value );
+if ( ! class_exists( 'WP_REST_Response' ) ) {
+	class WP_REST_Response {
+		public function __construct( public mixed $data ) {}
+		public function get_data() { return $this->data; }
+	}
 }
 
-function register_rest_route( string $namespace, string $route, array $args ): void {
-	$GLOBALS['__agents_api_smoke_routes'][ $namespace . $route ] = $args;
+if ( ! function_exists( 'rest_ensure_response' ) ) {
+	function rest_ensure_response( $value ): WP_REST_Response {
+		return $value instanceof WP_REST_Response ? $value : new WP_REST_Response( $value );
+	}
 }
 
-function get_current_user_id(): int {
-	return (int) $GLOBALS['__agents_api_smoke_current_user_id'];
+if ( ! function_exists( 'register_rest_route' ) ) {
+	function register_rest_route( string $namespace, string $route, array $args ): void {
+		$GLOBALS['__agents_api_smoke_routes'][ $namespace . $route ] = $args;
+	}
 }
 
-function current_user_can( string $capability ): bool {
-	unset( $capability );
-	return (bool) ( $GLOBALS['__agents_api_smoke_can_manage'] ?? false );
+if ( ! function_exists( 'get_current_user_id' ) ) {
+	function get_current_user_id(): int {
+		return (int) $GLOBALS['__agents_api_smoke_current_user_id'];
+	}
 }
 
-function wp_has_ability_category( string $category ): bool {
-	return isset( $GLOBALS['__agents_api_smoke_categories'][ $category ] );
+if ( ! function_exists( 'current_user_can' ) ) {
+	function current_user_can( string $capability ): bool {
+		unset( $capability );
+		return (bool) ( $GLOBALS['__agents_api_smoke_can_manage'] ?? false );
+	}
 }
 
-function wp_register_ability_category( string $category, array $args ): void {
-	$GLOBALS['__agents_api_smoke_categories'][ $category ] = $args;
+if ( ! function_exists( 'wp_has_ability_category' ) ) {
+	function wp_has_ability_category( string $category ): bool {
+		return isset( $GLOBALS['__agents_api_smoke_categories'][ $category ] );
+	}
 }
 
-function wp_has_ability( string $ability ): bool {
-	return isset( $GLOBALS['__agents_api_smoke_abilities'][ $ability ] );
+if ( ! function_exists( 'wp_register_ability_category' ) ) {
+	function wp_register_ability_category( string $category, array $args ): void {
+		$GLOBALS['__agents_api_smoke_categories'][ $category ] = $args;
+	}
 }
 
-function wp_register_ability( string $ability, array $args ): void {
-	$GLOBALS['__agents_api_smoke_abilities'][ $ability ] = $args;
+if ( ! function_exists( 'wp_has_ability' ) ) {
+	function wp_has_ability( string $ability ): bool {
+		return isset( $GLOBALS['__agents_api_smoke_abilities'][ $ability ] );
+	}
 }
 
-function wp_get_ability( string $name ) {
-	return $GLOBALS['__agents_api_smoke_abilities'][ $name ] ?? null;
+if ( ! function_exists( 'wp_register_ability' ) ) {
+	function wp_register_ability( string $ability, array $args ): void {
+		$GLOBALS['__agents_api_smoke_abilities'][ $ability ] = $args;
+	}
+}
+
+if ( ! function_exists( 'wp_get_ability' ) ) {
+	function wp_get_ability( string $name ) {
+		return $GLOBALS['__agents_api_smoke_abilities'][ $name ] ?? null;
+	}
+}
+
+function agents_api_smoke_rest_request( array $params ): WP_REST_Request {
+	$request = new WP_REST_Request( 'POST', '/agents-api/v1/chat' );
+	foreach ( $params as $key => $value ) {
+		$request->set_param( (string) $key, $value );
+	}
+	return $request;
 }
 
 agents_api_smoke_require_module();
 
-$grant = new WP_Agent_Access_Grant( 'support-agent', 7, WP_Agent_Access_Grant::ROLE_OPERATOR, 'site:42' );
+$grant = new WP_Agent_Access_Grant( 'support-agent', 0, WP_Agent_Access_Grant::ROLE_OPERATOR, 'site:42', null, null, null, array(), 'audience:public' );
 
-$access_store = new class( $grant ) implements WP_Agent_Access_Store {
+$access_store = new class( $grant ) implements WP_Agent_Access_Store, WP_Agent_Principal_Access_Store {
 	public function __construct( private WP_Agent_Access_Grant $grant ) {}
 	public function grant_access( WP_Agent_Access_Grant $grant ): WP_Agent_Access_Grant { $this->grant = $grant; return $grant; }
 	public function revoke_access( string $agent_id, int $user_id, ?string $workspace_id = null ): bool { return false; }
@@ -91,6 +133,13 @@ $access_store = new class( $grant ) implements WP_Agent_Access_Store {
 	}
 	public function get_agent_ids_for_user( int $user_id, ?string $minimum_role = null, ?string $workspace_id = null ): array { return array(); }
 	public function get_users_for_agent( string $agent_id, ?string $workspace_id = null ): array { return array(); }
+	public function get_access_for_principal( string $agent_id, AgentsAPI\AI\WP_Agent_Execution_Principal $principal, ?string $workspace_id = null ): ?WP_Agent_Access_Grant {
+		return $this->grant->agent_id === $agent_id && $this->grant->audience_id === $principal->audience_id && $this->grant->workspace_id === $workspace_id ? $this->grant : null;
+	}
+	public function get_agent_ids_for_principal( AgentsAPI\AI\WP_Agent_Execution_Principal $principal, ?string $minimum_role = null, ?string $workspace_id = null ): array {
+		unset( $minimum_role );
+		return $this->grant->audience_id === $principal->audience_id && $this->grant->workspace_id === $workspace_id ? array( $this->grant->agent_id ) : array();
+	}
 };
 
 $access_contexts = array();
@@ -101,12 +150,28 @@ add_filter(
 		return $store instanceof WP_Agent_Access_Store ? $store : $access_store;
 	}
 );
+add_filter(
+	'agents_chat_permission',
+	static function (): bool {
+		return (bool) $GLOBALS['__agents_api_smoke_allow_chat'];
+	}
+);
 
 do_action( 'rest_api_init' );
 
-agents_api_smoke_assert_equals( true, isset( $GLOBALS['__agents_api_smoke_routes']['agents-api/v1/chat'] ), 'chat REST route registers', $failures, $passes );
-agents_api_smoke_assert_equals( 'POST', $GLOBALS['__agents_api_smoke_routes']['agents-api/v1/chat']['methods'] ?? null, 'chat REST route uses POST', $failures, $passes );
-agents_api_smoke_assert_equals( true, isset( $GLOBALS['__agents_api_smoke_routes']['agents-api/v1/chat']['args']['attachments']['items'] ), 'chat REST args derive attachment schema', $failures, $passes );
+$chat_route = $GLOBALS['__agents_api_smoke_routes']['agents-api/v1/chat'] ?? null;
+if ( null === $chat_route && function_exists( 'rest_get_server' ) ) {
+	$routes     = rest_get_server()->get_routes();
+	$chat_route = $routes['/agents-api/v1/chat'][0] ?? null;
+}
+
+agents_api_smoke_assert_equals( true, is_array( $chat_route ), 'chat REST route registers', $failures, $passes );
+$route_methods = $chat_route['methods'] ?? null;
+if ( is_array( $route_methods ) ) {
+	$route_methods = isset( $route_methods['POST'] ) ? 'POST' : $route_methods;
+}
+agents_api_smoke_assert_equals( 'POST', $route_methods, 'chat REST route uses POST', $failures, $passes );
+agents_api_smoke_assert_equals( true, isset( $chat_route['args']['attachments']['items'] ), 'chat REST args derive attachment schema', $failures, $passes );
 
 $captured = array();
 $ability  = new class( $captured ) {
@@ -131,7 +196,19 @@ $ability  = new class( $captured ) {
 
 $GLOBALS['__agents_api_smoke_abilities'][ AgentsAPI\AI\Channels\AGENTS_CHAT_ABILITY ] = $ability;
 
-$request = new WP_REST_Request(
+add_filter(
+	'wp_agent_chat_handler',
+	static function ( $handler, array $input ) use ( $ability ) {
+		unset( $handler );
+		return static function () use ( $ability, $input ): array {
+			return $ability->execute( $input );
+		};
+	},
+	10,
+	2
+);
+
+$request = agents_api_smoke_rest_request(
 	array(
 		'agent'          => 'Support Agent',
 		'message'        => 'Hi there',
@@ -152,22 +229,26 @@ $request = new WP_REST_Request(
 $permission = AgentsAPI\AI\Channels\agents_frontend_chat_rest_permission( $request );
 agents_api_smoke_assert_equals( true, $permission, 'permission allows operator grant', $failures, $passes );
 
+$GLOBALS['__agents_api_smoke_allow_chat'] = true;
 $response = AgentsAPI\AI\Channels\agents_frontend_chat_rest_dispatch( $request );
+$GLOBALS['__agents_api_smoke_allow_chat'] = false;
+$response_data = $response instanceof WP_REST_Response && method_exists( $response, 'get_data' ) ? $response->get_data() : ( $response->data ?? null );
 agents_api_smoke_assert_equals( true, $response instanceof WP_REST_Response, 'dispatch returns REST response', $failures, $passes );
-agents_api_smoke_assert_equals( 'hello from adapter', $response->data['reply'] ?? null, 'dispatch returns ability reply', $failures, $passes );
-agents_api_smoke_assert_equals( 'https://example.test/rest-source', $response->data['metadata']['citations'][0]['url'] ?? null, 'dispatch preserves citation metadata', $failures, $passes );
-agents_api_smoke_assert_equals( 'rest-source-item-1', $response->data['metadata']['source_items'][0]['id'] ?? null, 'dispatch preserves caller-owned result metadata', $failures, $passes );
+agents_api_smoke_assert_equals( 'hello from adapter', $response_data['reply'] ?? null, 'dispatch returns ability reply', $failures, $passes );
+agents_api_smoke_assert_equals( 'https://example.test/rest-source', $response_data['metadata']['citations'][0]['url'] ?? null, 'dispatch preserves citation metadata', $failures, $passes );
+agents_api_smoke_assert_equals( 'rest-source-item-1', $response_data['metadata']['source_items'][0]['id'] ?? null, 'dispatch preserves caller-owned result metadata', $failures, $passes );
 agents_api_smoke_assert_equals( 'support-agent', $captured['agent'] ?? null, 'dispatch sanitizes agent slug', $failures, $passes );
 agents_api_smoke_assert_equals( 'Hi there', $captured['message'] ?? null, 'dispatch forwards message', $failures, $passes );
 agents_api_smoke_assert_equals( 'rest', $captured['client_context']['source'] ?? null, 'dispatch marks REST source', $failures, $passes );
 agents_api_smoke_assert_equals( 'block-chat', $captured['client_context']['client_name'] ?? null, 'dispatch preserves client name', $failures, $passes );
 agents_api_smoke_assert_equals( 'selected-material-123', $captured['client_context']['host_context']['opaque_id'] ?? null, 'dispatch preserves caller-owned context metadata', $failures, $passes );
 agents_api_smoke_assert_equals( array( 'current-item' ), $captured['client_context']['host_context']['hints'] ?? null, 'dispatch preserves nested caller-owned context metadata', $failures, $passes );
-agents_api_smoke_assert_equals( 'selected-material-123', $access_contexts[0]['client_context']['host_context']['opaque_id'] ?? null, 'access scope receives caller-owned context metadata', $failures, $passes );
-agents_api_smoke_assert_equals( array( 'current-item' ), $access_contexts[0]['request_metadata']['client_context']['host_context']['hints'] ?? null, 'access metadata receives nested caller-owned context metadata', $failures, $passes );
+$rest_access_scope = AgentsAPI\AI\Channels\agents_frontend_chat_rest_scope( $request );
+agents_api_smoke_assert_equals( 'selected-material-123', $rest_access_scope['client_context']['host_context']['opaque_id'] ?? null, 'access scope receives caller-owned context metadata', $failures, $passes );
+agents_api_smoke_assert_equals( array( 'current-item' ), $rest_access_scope['request_metadata']['client_context']['host_context']['hints'] ?? null, 'access metadata receives nested caller-owned context metadata', $failures, $passes );
 
 $blocked = AgentsAPI\AI\Channels\agents_frontend_chat_rest_permission(
-	new WP_REST_Request(
+	agents_api_smoke_rest_request(
 		array(
 			'agent'        => 'other-agent',
 			'message'      => 'Nope',
@@ -180,11 +261,11 @@ agents_api_smoke_assert_equals( 'agents_frontend_chat_forbidden', $blocked->get_
 
 add_filter( 'agents_frontend_chat_rest_permission', static fn() => true );
 $filtered = AgentsAPI\AI\Channels\agents_frontend_chat_rest_permission(
-	new WP_REST_Request( array( 'agent' => 'other-agent', 'message' => 'Allowed by host' ) )
+	agents_api_smoke_rest_request( array( 'agent' => 'other-agent', 'message' => 'Allowed by host' ) )
 );
 agents_api_smoke_assert_equals( true, $filtered, 'permission is filterable for hosts', $failures, $passes );
 
-$invalid = AgentsAPI\AI\Channels\agents_frontend_chat_rest_dispatch( new WP_REST_Request( array( 'agent' => '', 'message' => '' ) ) );
+$invalid = AgentsAPI\AI\Channels\agents_frontend_chat_rest_dispatch( agents_api_smoke_rest_request( array( 'agent' => '', 'message' => '' ) ) );
 agents_api_smoke_assert_equals( true, $invalid instanceof WP_Error, 'dispatch rejects empty input', $failures, $passes );
 agents_api_smoke_assert_equals( 'agents_frontend_chat_invalid_input', $invalid->get_error_code(), 'dispatch rejects empty input code', $failures, $passes );
 

--- a/tests/guidelines-substrate-smoke.php
+++ b/tests/guidelines-substrate-smoke.php
@@ -22,9 +22,39 @@ agents_api_smoke_require_module();
 echo "\n[1] Guideline substrate registers compatible storage primitives:\n";
 do_action( 'init' );
 
-$post_type_args = $GLOBALS['__agents_api_smoke_post_types']['wp_guideline'] ?? array();
-$taxonomy_entry = $GLOBALS['__agents_api_smoke_taxonomies']['wp_guideline_type'] ?? array();
-$taxonomy_args  = $taxonomy_entry['args'] ?? array();
+// Resolve the registered post-type / taxonomy configuration from either the
+// real WordPress registry (host backend) or the pure-PHP capture globals.
+$guideline_real_pt  = function_exists( 'get_post_type_object' ) ? get_post_type_object( 'wp_guideline' ) : null;
+$guideline_real_tax = function_exists( 'get_taxonomy' ) ? get_taxonomy( 'wp_guideline_type' ) : null;
+
+if ( is_object( $guideline_real_pt ) ) {
+	$post_type_args = array(
+		'public'          => $guideline_real_pt->public,
+		'show_in_rest'    => $guideline_real_pt->show_in_rest,
+		'rest_base'       => $guideline_real_pt->rest_base,
+		'capability_type' => $guideline_real_pt->capability_type,
+		'capabilities'    => array(
+			'read'              => $guideline_real_pt->cap->read ?? null,
+			'edit_posts'        => $guideline_real_pt->cap->edit_posts ?? null,
+			'read_private_posts' => $guideline_real_pt->cap->read_private_posts ?? null,
+		),
+	);
+} else {
+	$post_type_args = $GLOBALS['__agents_api_smoke_post_types']['wp_guideline'] ?? array();
+}
+
+if ( is_object( $guideline_real_tax ) ) {
+	$taxonomy_entry = array(
+		'object_type' => is_array( $guideline_real_tax->object_type ) ? ( $guideline_real_tax->object_type[0] ?? null ) : $guideline_real_tax->object_type,
+		'args'        => array(
+			'hierarchical' => $guideline_real_tax->hierarchical,
+			'show_in_rest' => $guideline_real_tax->show_in_rest,
+		),
+	);
+} else {
+	$taxonomy_entry = $GLOBALS['__agents_api_smoke_taxonomies']['wp_guideline_type'] ?? array();
+}
+$taxonomy_args = $taxonomy_entry['args'] ?? array();
 
 agents_api_smoke_assert_equals( true, post_type_exists( 'wp_guideline' ), 'wp_guideline post type exists', $failures, $passes );
 agents_api_smoke_assert_equals( false, $post_type_args['public'] ?? null, 'wp_guideline is non-public', $failures, $passes );
@@ -59,35 +89,67 @@ agents_api_smoke_assert_equals( true, (bool) term_exists( 'artifact', 'wp_guidel
 
 echo "\n[3] Guideline meta capabilities enforce memory and guidance boundaries:\n";
 
-$GLOBALS['__agents_api_smoke_posts'][200] = (object) array(
-	'ID'        => 200,
-	'post_type' => 'wp_guideline',
-);
-$GLOBALS['__agents_api_smoke_post_meta'][200] = array(
-	'_wp_guideline_scope'        => 'private_user_workspace_memory',
-	'_wp_guideline_user_id'      => '7',
-	'_wp_guideline_workspace_id' => 'workspace-a',
-);
+// Under real WordPress the meta-cap mapper reads real posts and post meta, so
+// create genuine wp_guideline posts; under pure-PHP fall back to the in-memory
+// post/meta fixtures. Either way the assertions exercise the real map_meta_cap
+// filter.
+$guideline_real_storage = function_exists( 'wp_insert_post' ) && function_exists( 'update_post_meta' );
 
-$GLOBALS['__agents_api_smoke_posts'][201] = (object) array(
-	'ID'        => 201,
-	'post_type' => 'wp_guideline',
-);
-$GLOBALS['__agents_api_smoke_post_meta'][201] = array(
-	'_wp_guideline_scope'        => 'workspace_shared_guidance',
-	'_wp_guideline_workspace_id' => 'workspace-a',
-);
+if ( $guideline_real_storage ) {
+	$private_guideline_id = (int) wp_insert_post(
+		array(
+			'post_type'   => 'wp_guideline',
+			'post_title'  => 'Private memory guideline',
+			'post_status' => 'publish',
+		)
+	);
+	update_post_meta( $private_guideline_id, '_wp_guideline_scope', 'private_user_workspace_memory' );
+	update_post_meta( $private_guideline_id, '_wp_guideline_user_id', '7' );
+	update_post_meta( $private_guideline_id, '_wp_guideline_workspace_id', 'workspace-a' );
+
+	$shared_guideline_id = (int) wp_insert_post(
+		array(
+			'post_type'   => 'wp_guideline',
+			'post_title'  => 'Shared guidance guideline',
+			'post_status' => 'publish',
+		)
+	);
+	update_post_meta( $shared_guideline_id, '_wp_guideline_scope', 'workspace_shared_guidance' );
+	update_post_meta( $shared_guideline_id, '_wp_guideline_workspace_id', 'workspace-a' );
+} else {
+	$private_guideline_id = 200;
+	$shared_guideline_id  = 201;
+
+	$GLOBALS['__agents_api_smoke_posts'][ $private_guideline_id ] = (object) array(
+		'ID'        => $private_guideline_id,
+		'post_type' => 'wp_guideline',
+	);
+	$GLOBALS['__agents_api_smoke_post_meta'][ $private_guideline_id ] = array(
+		'_wp_guideline_scope'        => 'private_user_workspace_memory',
+		'_wp_guideline_user_id'      => '7',
+		'_wp_guideline_workspace_id' => 'workspace-a',
+	);
+
+	$GLOBALS['__agents_api_smoke_posts'][ $shared_guideline_id ] = (object) array(
+		'ID'        => $shared_guideline_id,
+		'post_type' => 'wp_guideline',
+	);
+	$GLOBALS['__agents_api_smoke_post_meta'][ $shared_guideline_id ] = array(
+		'_wp_guideline_scope'        => 'workspace_shared_guidance',
+		'_wp_guideline_workspace_id' => 'workspace-a',
+	);
+}
 
 agents_api_smoke_assert_equals(
 	array( 'read' ),
-	apply_filters( 'map_meta_cap', array( 'read_private_posts' ), 'read_post', 7, array( 200 ) ),
+	apply_filters( 'map_meta_cap', array( 'read_private_posts' ), 'read_post', 7, array( $private_guideline_id ) ),
 	'private memory owner can read via explicit owner metadata',
 	$failures,
 	$passes
 );
 agents_api_smoke_assert_equals(
 	array( 'do_not_allow' ),
-	apply_filters( 'map_meta_cap', array( 'read_private_posts' ), 'read_post', 8, array( 200 ) ),
+	apply_filters( 'map_meta_cap', array( 'read_private_posts' ), 'read_post', 8, array( $private_guideline_id ) ),
 	'private memory non-owner is denied despite core private-post capability input',
 	$failures,
 	$passes
@@ -108,24 +170,29 @@ agents_api_smoke_assert_equals(
 );
 agents_api_smoke_assert_equals(
 	array( 'read_workspace_guidelines' ),
-	apply_filters( 'map_meta_cap', array(), 'read_post', 8, array( 201 ) ),
+	apply_filters( 'map_meta_cap', array(), 'read_post', 8, array( $shared_guideline_id ) ),
 	'workspace-shared guideline post reads use explicit guidance capability',
 	$failures,
 	$passes
 );
 agents_api_smoke_assert_equals(
 	array( 'promote_agent_memory' ),
-	apply_filters( 'map_meta_cap', array(), 'promote_agent_memory', 7, array( 200 ) ),
+	apply_filters( 'map_meta_cap', array(), 'promote_agent_memory', 7, array( $private_guideline_id ) ),
 	'private memory owner still needs explicit promotion capability',
 	$failures,
 	$passes
 );
 agents_api_smoke_assert_equals(
 	array( 'do_not_allow' ),
-	apply_filters( 'map_meta_cap', array(), 'promote_agent_memory', 8, array( 200 ) ),
+	apply_filters( 'map_meta_cap', array(), 'promote_agent_memory', 8, array( $private_guideline_id ) ),
 	'private memory non-owner cannot promote memory',
 	$failures,
 	$passes
 );
+
+if ( $guideline_real_storage ) {
+	wp_delete_post( $private_guideline_id, true );
+	wp_delete_post( $shared_guideline_id, true );
+}
 
 agents_api_smoke_finish( 'Agents API guideline substrate', $failures, $passes );

--- a/tests/pending-action-abilities-smoke.php
+++ b/tests/pending-action-abilities-smoke.php
@@ -16,13 +16,25 @@ echo "pending-action-abilities-smoke\n";
 
 require_once __DIR__ . '/agents-api-smoke-helpers.php';
 
-class WP_Error {
-	public function __construct( private string $code = '', private string $message = '', private $data = null ) {}
-	public function get_error_code(): string { return $this->code; }
-	public function get_error_message(): string { return $this->message; }
-	public function get_error_data() { return $this->data; }
+if ( ! class_exists( 'WP_Error' ) ) {
+	class WP_Error {
+		public function __construct( private string $code = '', private string $message = '', private $data = null ) {}
+		public function get_error_code(): string { return $this->code; }
+		public function get_error_message(): string { return $this->message; }
+		public function get_error_data() { return $this->data; }
+	}
 }
-function current_user_can( string $cap ): bool { unset( $cap ); return $GLOBALS['__can'] ?? false; }
+if ( ! function_exists( 'current_user_can' ) ) {
+	function current_user_can( string $cap ): bool { unset( $cap ); return $GLOBALS['__can'] ?? false; }
+} else {
+	add_filter(
+		'user_has_cap',
+		static function ( array $allcaps ): array {
+			$allcaps['manage_options'] = (bool) ( $GLOBALS['__can'] ?? false );
+			return $allcaps;
+		}
+	);
+}
 
 require_once __DIR__ . '/../src/Workspace/class-wp-agent-workspace-scope.php';
 require_once __DIR__ . '/../src/Approvals/class-wp-agent-pending-action-store.php';
@@ -132,7 +144,12 @@ $invalid_decision = agents_resolve_pending_action( array( 'action_id' => 'pa_123
 agents_api_smoke_assert_equals( true, $invalid_decision instanceof WP_Error, 'invalid decision returns WP_Error', $failures, $passes );
 agents_api_smoke_assert_equals( 'agents_pending_action_invalid_decision', $invalid_decision instanceof WP_Error ? $invalid_decision->get_error_code() : '', 'invalid decision error code', $failures, $passes );
 
-$GLOBALS['__agents_api_smoke_actions'] = array();
+if ( function_exists( 'remove_all_filters' ) ) {
+	remove_all_filters( 'wp_agent_pending_action_store' );
+	remove_all_filters( 'wp_agent_pending_action_resolver' );
+} else {
+	$GLOBALS['__agents_api_smoke_actions'] = array();
+}
 $no_store = agents_list_pending_actions( array() );
 agents_api_smoke_assert_equals( true, $no_store instanceof WP_Error, 'missing store returns WP_Error', $failures, $passes );
 agents_api_smoke_assert_equals( 'agents_pending_action_no_store', $no_store instanceof WP_Error ? $no_store->get_error_code() : '', 'missing store error code', $failures, $passes );

--- a/tests/registry-smoke.php
+++ b/tests/registry-smoke.php
@@ -19,6 +19,26 @@ echo "agents-api-registry-smoke\n";
 require_once __DIR__ . '/agents-api-smoke-helpers.php';
 agents_api_smoke_require_module();
 
+// Under real WordPress _doing_it_wrong() is native, so the duplicate-agent
+// notice is delivered through the doing_it_wrong_run action rather than the
+// pure-PHP shim. Capture it into the same log the assertions read, and silence
+// the would-be error so the smoke does not abort.
+if ( function_exists( 'add_action' ) && function_exists( 'remove_all_filters' ) ) {
+	add_action(
+		'doing_it_wrong_run',
+		static function ( $function_name, $message, $version ): void {
+			$GLOBALS['__agents_api_smoke_wrong'][] = array(
+				'function' => (string) $function_name,
+				'message'  => (string) $message,
+				'version'  => (string) $version,
+			);
+		},
+		10,
+		3
+	);
+	add_filter( 'doing_it_wrong_trigger_error', '__return_false' );
+}
+
 add_action(
 	'wp_agents_api_init',
 	static function () {

--- a/tests/remote-bridge-smoke.php
+++ b/tests/remote-bridge-smoke.php
@@ -24,18 +24,41 @@ $GLOBALS['__remote_bridge_connectors'] = array(
 	),
 );
 
-function get_option( string $key, $default = '' ) {
-	return $GLOBALS['__remote_bridge_options'][ $key ] ?? $default;
+if ( ! function_exists( 'get_option' ) ) {
+	function get_option( string $key, $default = '' ) {
+		return $GLOBALS['__remote_bridge_options'][ $key ] ?? $default;
+	}
 }
 
-function update_option( string $key, $value, $autoload = null ): bool {
-	unset( $autoload );
-	$GLOBALS['__remote_bridge_options'][ $key ] = $value;
-	return true;
+if ( ! function_exists( 'update_option' ) ) {
+	function update_option( string $key, $value, $autoload = null ): bool {
+		unset( $autoload );
+		$GLOBALS['__remote_bridge_options'][ $key ] = $value;
+		return true;
+	}
 }
 
-function wp_get_connector( string $id ): ?array {
-	return $GLOBALS['__remote_bridge_connectors'][ $id ] ?? null;
+// `wp_get_connector` may be supplied by the WordPress Connector Registry (real
+// backend) or be absent (pure-PHP). When the real registry is present, register
+// the test connector with it so wp_get_connector() resolves the metadata; when
+// it is absent, shim the lookup against the smoke fixture.
+if ( ! function_exists( 'wp_get_connector' ) ) {
+	function wp_get_connector( string $id ): ?array {
+		return $GLOBALS['__remote_bridge_connectors'][ $id ] ?? null;
+	}
+} elseif ( class_exists( 'WP_Connector_Registry' ) ) {
+	foreach ( $GLOBALS['__remote_bridge_connectors'] as $connector_id => $connector_args ) {
+		if ( ! WP_Connector_Registry::get_instance()->is_registered( $connector_id ) ) {
+			WP_Connector_Registry::get_instance()->register( $connector_id, $connector_args );
+		}
+	}
+}
+
+// Start from a clean bridge store so prior runs (real option persistence in the
+// host backend) do not leak queue/client state into this run.
+if ( function_exists( 'delete_option' ) ) {
+	delete_option( 'wp_agent_bridge_clients' );
+	delete_option( 'wp_agent_bridge_queue' );
 }
 
 function remote_bridge_assert( $expected, $actual, string $name, array &$failures, int &$passes ): void {

--- a/tests/routine-smoke.php
+++ b/tests/routine-smoke.php
@@ -73,6 +73,17 @@ if ( ! function_exists( 'do_action' ) ) {
 		// registry's lifecycle verbs assert on this from section 6 onwards.
 		$GLOBALS['smoke_dispatched'][] = array( 'hook' => $hook, 'arg' => $args[0] ?? null );
 	}
+} elseif ( function_exists( 'add_action' ) ) {
+	// Real WordPress: the lifecycle verbs fire real actions, so capture them
+	// with real listeners into the same dispatch log the assertions read.
+	foreach ( array( 'wp_agent_routine_paused', 'wp_agent_routine_resumed', 'wp_agent_routine_run_now_requested' ) as $routine_lifecycle_hook ) {
+		add_action(
+			$routine_lifecycle_hook,
+			static function ( $routine = null ) use ( $routine_lifecycle_hook ): void {
+				$GLOBALS['smoke_dispatched'][] = array( 'hook' => $routine_lifecycle_hook, 'arg' => $routine );
+			}
+		);
+	}
 }
 if ( ! function_exists( 'as_schedule_recurring_action' ) ) {
 	function as_schedule_recurring_action( int $start, int $interval, string $hook, array $args = array(), string $group = '' ): int {

--- a/tests/safe-execution-workspace-smoke.php
+++ b/tests/safe-execution-workspace-smoke.php
@@ -21,32 +21,87 @@ require_once __DIR__ . '/agents-api-smoke-helpers.php';
 $GLOBALS['__agents_api_smoke_abilities']  = array();
 $GLOBALS['__agents_api_smoke_categories'] = array();
 
-class WP_Error {
-	public function __construct( private string $code = '', private string $message = '', private array $data = array() ) {}
-	public function get_error_code(): string { return $this->code; }
-	public function get_error_message(): string { return $this->message; }
-	public function get_error_data(): array { return $this->data; }
+if ( ! class_exists( 'WP_Error' ) ) {
+	class WP_Error {
+		public function __construct( private string $code = '', private string $message = '', private array $data = array() ) {}
+		public function get_error_code(): string { return $this->code; }
+		public function get_error_message(): string { return $this->message; }
+		public function get_error_data(): array { return $this->data; }
+	}
 }
 
-function current_user_can( string $capability ): bool {
-	unset( $capability );
-	return true;
+if ( ! function_exists( 'current_user_can' ) ) {
+	function current_user_can( string $capability ): bool {
+		unset( $capability );
+		return true;
+	}
+} else {
+	add_filter(
+		'user_has_cap',
+		static function ( array $allcaps ): array {
+			$allcaps['manage_options'] = true;
+			return $allcaps;
+		}
+	);
 }
 
-function wp_has_ability_category( string $category ): bool {
-	return isset( $GLOBALS['__agents_api_smoke_categories'][ $category ] );
+if ( ! function_exists( 'wp_has_ability_category' ) ) {
+	function wp_has_ability_category( string $category ): bool {
+		return isset( $GLOBALS['__agents_api_smoke_categories'][ $category ] );
+	}
 }
 
-function wp_register_ability_category( string $category, array $args ): void {
-	$GLOBALS['__agents_api_smoke_categories'][ $category ] = $args;
+if ( ! function_exists( 'wp_register_ability_category' ) ) {
+	function wp_register_ability_category( string $category, array $args ): void {
+		$GLOBALS['__agents_api_smoke_categories'][ $category ] = $args;
+	}
 }
 
-function wp_has_ability( string $ability ): bool {
-	return isset( $GLOBALS['__agents_api_smoke_abilities'][ $ability ] );
+if ( ! function_exists( 'wp_has_ability' ) ) {
+	function wp_has_ability( string $ability ): bool {
+		return isset( $GLOBALS['__agents_api_smoke_abilities'][ $ability ] );
+	}
 }
 
-function wp_register_ability( string $ability, array $args ): void {
-	$GLOBALS['__agents_api_smoke_abilities'][ $ability ] = $args;
+if ( ! function_exists( 'wp_register_ability' ) ) {
+	function wp_register_ability( string $ability, array $args ): void {
+		$GLOBALS['__agents_api_smoke_abilities'][ $ability ] = $args;
+	}
+}
+
+/**
+ * Resolve whether an ability is registered, in either backend: the pure-PHP
+ * shim records into the smoke global; real WordPress records into the Abilities
+ * API registry.
+ */
+function agents_api_workspace_smoke_has_ability( string $ability ): bool {
+	if ( isset( $GLOBALS['__agents_api_smoke_abilities'][ $ability ] ) ) {
+		return true;
+	}
+
+	return function_exists( 'wp_get_ability' ) && null !== wp_get_ability( $ability );
+}
+
+/**
+ * Execute a registered ability in either backend.
+ *
+ * @param string $ability Ability slug.
+ * @param array  $input   Ability input payload.
+ * @return mixed Ability result.
+ */
+function agents_api_workspace_smoke_execute( string $ability, array $input ) {
+	if ( isset( $GLOBALS['__agents_api_smoke_abilities'][ $ability ]['execute_callback'] ) ) {
+		return call_user_func( $GLOBALS['__agents_api_smoke_abilities'][ $ability ]['execute_callback'], $input );
+	}
+
+	if ( function_exists( 'wp_get_ability' ) ) {
+		$resolved = wp_get_ability( $ability );
+		if ( null !== $resolved ) {
+			return $resolved->execute( $input );
+		}
+	}
+
+	return null;
 }
 
 function agents_api_workspace_smoke_rm( string $path ): void {
@@ -68,7 +123,7 @@ agents_api_smoke_require_module();
 
 $disabled_targets = AgentsAPI\AI\Tasks\agents_execution_targets();
 agents_api_smoke_assert_equals( array(), $disabled_targets, 'workspace target is disabled by default', $failures, $passes );
-agents_api_smoke_assert_equals( false, isset( $GLOBALS['__agents_api_smoke_abilities']['agents/workspace-prepare'] ), 'workspace abilities are not registered before opt-in', $failures, $passes );
+agents_api_smoke_assert_equals( false, agents_api_workspace_smoke_has_ability( 'agents/workspace-prepare' ), 'workspace abilities are not registered before opt-in', $failures, $passes );
 
 $root = sys_get_temp_dir() . '/agents-api-safe-workspace-' . bin2hex( random_bytes( 4 ) );
 mkdir( $root, 0755, true );
@@ -83,13 +138,13 @@ $targets = AgentsAPI\AI\Tasks\agents_execution_targets();
 agents_api_smoke_assert_equals( 'agents-api/safe-execution-workspace', $targets[0]['id'] ?? '', 'workspace target registers when opted in', $failures, $passes );
 agents_api_smoke_assert_equals( true, in_array( 'code.execution.safe-root', $targets[0]['capabilities'] ?? array(), true ), 'workspace target declares safe-root capability', $failures, $passes );
 agents_api_smoke_assert_equals( true, $targets[0]['metadata']['isolated_from_site'] ?? false, 'workspace target declares site isolation', $failures, $passes );
-agents_api_smoke_assert_equals( true, isset( $GLOBALS['__agents_api_smoke_abilities']['agents/workspace-prepare'] ), 'workspace prepare ability registers when opted in', $failures, $passes );
-agents_api_smoke_assert_equals( true, isset( $GLOBALS['__agents_api_smoke_abilities']['agents/workspace-write-file'] ), 'workspace write ability registers when opted in', $failures, $passes );
+agents_api_smoke_assert_equals( true, agents_api_workspace_smoke_has_ability( 'agents/workspace-prepare' ), 'workspace prepare ability registers when opted in', $failures, $passes );
+agents_api_smoke_assert_equals( true, agents_api_workspace_smoke_has_ability( 'agents/workspace-write-file' ), 'workspace write ability registers when opted in', $failures, $passes );
 
-$prepare = $GLOBALS['__agents_api_smoke_abilities']['agents/workspace-prepare']['execute_callback'];
-$write   = $GLOBALS['__agents_api_smoke_abilities']['agents/workspace-write-file']['execute_callback'];
-$read    = $GLOBALS['__agents_api_smoke_abilities']['agents/workspace-read-file']['execute_callback'];
-$list    = $GLOBALS['__agents_api_smoke_abilities']['agents/workspace-list']['execute_callback'];
+$prepare = static fn( array $input ) => agents_api_workspace_smoke_execute( 'agents/workspace-prepare', $input );
+$write   = static fn( array $input ) => agents_api_workspace_smoke_execute( 'agents/workspace-write-file', $input );
+$read    = static fn( array $input ) => agents_api_workspace_smoke_execute( 'agents/workspace-read-file', $input );
+$list    = static fn( array $input ) => agents_api_workspace_smoke_execute( 'agents/workspace-list', $input );
 
 $prepared = call_user_func( $prepare, array( 'handle' => 'site-generation' ) );
 agents_api_smoke_assert_equals( true, $prepared['success'] ?? false, 'prepare creates named workspace', $failures, $passes );
@@ -128,7 +183,9 @@ $traversal = call_user_func(
 agents_api_smoke_assert_equals( true, $traversal instanceof WP_Error, 'write rejects parent traversal', $failures, $passes );
 agents_api_smoke_assert_equals( false, file_exists( $root . '/escape.txt' ), 'traversal does not write outside workspace', $failures, $passes );
 
-add_filter( 'agents_api_safe_workspace_root', static fn(): string => dirname( __DIR__ ), 20 );
+// The site root itself is, by definition, "site-containing" in every backend —
+// using ABSPATH avoids assuming the plugin happens to live inside the site tree.
+add_filter( 'agents_api_safe_workspace_root', static fn(): string => rtrim( (string) ABSPATH, '/\\' ), 20 );
 
 $blocked_targets = AgentsAPI\AI\Tasks\agents_execution_targets();
 agents_api_smoke_assert_equals( array(), $blocked_targets, 'workspace target rejects site-containing root', $failures, $passes );

--- a/tests/task-execution-smoke.php
+++ b/tests/task-execution-smoke.php
@@ -22,42 +22,87 @@ $GLOBALS['__agents_api_smoke_abilities']  = array();
 $GLOBALS['__agents_api_smoke_categories'] = array();
 $GLOBALS['__agents_api_smoke_options']    = array();
 
-class WP_Error {
-	public function __construct( private string $code = '', private string $message = '', private array $data = array() ) {}
-	public function get_error_code(): string { return $this->code; }
-	public function get_error_message(): string { return $this->message; }
-	public function get_error_data(): array { return $this->data; }
+if ( ! class_exists( 'WP_Error' ) ) {
+	class WP_Error {
+		public function __construct( private string $code = '', private string $message = '', private array $data = array() ) {}
+		public function get_error_code(): string { return $this->code; }
+		public function get_error_message(): string { return $this->message; }
+		public function get_error_data(): array { return $this->data; }
+	}
 }
 
-function current_user_can( string $capability ): bool {
-	unset( $capability );
-	return true;
+if ( ! function_exists( 'current_user_can' ) ) {
+	function current_user_can( string $capability ): bool {
+		unset( $capability );
+		return true;
+	}
+} else {
+	add_filter(
+		'user_has_cap',
+		static function ( array $allcaps ): array {
+			$allcaps['manage_options'] = true;
+			return $allcaps;
+		}
+	);
 }
 
-function wp_has_ability_category( string $category ): bool {
-	return isset( $GLOBALS['__agents_api_smoke_categories'][ $category ] );
+if ( ! function_exists( 'wp_has_ability_category' ) ) {
+	function wp_has_ability_category( string $category ): bool {
+		return isset( $GLOBALS['__agents_api_smoke_categories'][ $category ] );
+	}
 }
 
-function wp_register_ability_category( string $category, array $args ): void {
-	$GLOBALS['__agents_api_smoke_categories'][ $category ] = $args;
+if ( ! function_exists( 'wp_register_ability_category' ) ) {
+	function wp_register_ability_category( string $category, array $args ): void {
+		$GLOBALS['__agents_api_smoke_categories'][ $category ] = $args;
+	}
 }
 
-function wp_has_ability( string $ability ): bool {
-	return isset( $GLOBALS['__agents_api_smoke_abilities'][ $ability ] );
+if ( ! function_exists( 'wp_has_ability' ) ) {
+	function wp_has_ability( string $ability ): bool {
+		return isset( $GLOBALS['__agents_api_smoke_abilities'][ $ability ] );
+	}
 }
 
-function wp_register_ability( string $ability, array $args ): void {
-	$GLOBALS['__agents_api_smoke_abilities'][ $ability ] = $args;
+if ( ! function_exists( 'wp_register_ability' ) ) {
+	function wp_register_ability( string $ability, array $args ): void {
+		$GLOBALS['__agents_api_smoke_abilities'][ $ability ] = $args;
+	}
 }
 
-function get_option( string $option, $default = false ) {
-	return $GLOBALS['__agents_api_smoke_options'][ $option ] ?? $default;
+if ( ! function_exists( 'get_option' ) ) {
+	function get_option( string $option, $default = false ) {
+		return $GLOBALS['__agents_api_smoke_options'][ $option ] ?? $default;
+	}
 }
 
-function update_option( string $option, $value, $autoload = null ): bool {
-	unset( $autoload );
-	$GLOBALS['__agents_api_smoke_options'][ $option ] = $value;
-	return true;
+if ( ! function_exists( 'update_option' ) ) {
+	function update_option( string $option, $value, $autoload = null ): bool {
+		unset( $autoload );
+		$GLOBALS['__agents_api_smoke_options'][ $option ] = $value;
+		return true;
+	}
+}
+
+/**
+ * Resolve a registered ability's output schema in either backend.
+ *
+ * @param string $ability Ability slug.
+ * @return array Output schema, or empty array when unavailable.
+ */
+function task_execution_smoke_output_schema( string $ability ): array {
+	if ( isset( $GLOBALS['__agents_api_smoke_abilities'][ $ability ]['output_schema'] ) ) {
+		return (array) $GLOBALS['__agents_api_smoke_abilities'][ $ability ]['output_schema'];
+	}
+
+	if ( function_exists( 'wp_get_ability' ) ) {
+		$resolved = wp_get_ability( $ability );
+		if ( null !== $resolved ) {
+			return (array) $resolved->get_output_schema();
+		}
+	}
+
+	return array();
 }
 
 agents_api_smoke_require_module();
@@ -65,10 +110,10 @@ agents_api_smoke_require_module();
 do_action( 'wp_abilities_api_categories_init' );
 do_action( 'wp_abilities_api_init' );
 
-agents_api_smoke_assert_equals( true, isset( $GLOBALS['__agents_api_smoke_abilities'][ AgentsAPI\AI\Tasks\AGENTS_RUN_TASK_ABILITY ] ), 'run-task ability registers', $failures, $passes );
-agents_api_smoke_assert_equals( true, isset( $GLOBALS['__agents_api_smoke_abilities'][ AgentsAPI\AI\Tasks\AGENTS_LIST_EXECUTION_TARGETS_ABILITY ] ), 'list-execution-targets ability registers', $failures, $passes );
-agents_api_smoke_assert_equals( true, isset( $GLOBALS['__agents_api_smoke_abilities'][ AgentsAPI\AI\Tasks\AGENTS_GET_TASK_RUN_ABILITY ] ), 'get-task-run ability registers', $failures, $passes );
-agents_api_smoke_assert_equals( true, isset( $GLOBALS['__agents_api_smoke_abilities'][ AgentsAPI\AI\Tasks\AGENTS_CANCEL_TASK_RUN_ABILITY ] ), 'cancel-task-run ability registers', $failures, $passes );
+agents_api_smoke_assert_equals( true, wp_has_ability( AgentsAPI\AI\Tasks\AGENTS_RUN_TASK_ABILITY ), 'run-task ability registers', $failures, $passes );
+agents_api_smoke_assert_equals( true, wp_has_ability( AgentsAPI\AI\Tasks\AGENTS_LIST_EXECUTION_TARGETS_ABILITY ), 'list-execution-targets ability registers', $failures, $passes );
+agents_api_smoke_assert_equals( true, wp_has_ability( AgentsAPI\AI\Tasks\AGENTS_GET_TASK_RUN_ABILITY ), 'get-task-run ability registers', $failures, $passes );
+agents_api_smoke_assert_equals( true, wp_has_ability( AgentsAPI\AI\Tasks\AGENTS_CANCEL_TASK_RUN_ABILITY ), 'cancel-task-run ability registers', $failures, $passes );
 
 $no_executor = AgentsAPI\AI\Tasks\agents_run_task(
 	array(
@@ -178,7 +223,7 @@ agents_api_smoke_assert_equals( 'fake-executor', $captured_target['id'] ?? null,
 agents_api_smoke_assert_equals( 'agents-api/task-result/v1', $result['schema'] ?? null, 'run-task returns result envelope schema', $failures, $passes );
 agents_api_smoke_assert_equals( 'succeeded', $result['status'] ?? null, 'run-task normalizes task result status', $failures, $passes );
 agents_api_smoke_assert_equals( 'fake-executor', $result['executor_id'] ?? null, 'run-task preserves executor id', $failures, $passes );
-agents_api_smoke_assert_equals( 'object', $GLOBALS['__agents_api_smoke_abilities'][ AgentsAPI\AI\Tasks\AGENTS_RUN_TASK_ABILITY ]['output_schema']['properties']['execution_metrics']['type'] ?? null, 'run-task result schema allows execution metrics', $failures, $passes );
+agents_api_smoke_assert_equals( 'object', task_execution_smoke_output_schema( AgentsAPI\AI\Tasks\AGENTS_RUN_TASK_ABILITY )['properties']['execution_metrics']['type'] ?? null, 'run-task result schema allows execution metrics', $failures, $passes );
 agents_api_smoke_assert_equals( 'agents-api/execution-metrics/v1', $result['execution_metrics']['schema'] ?? null, 'run-task normalizes execution metrics schema', $failures, $passes );
 agents_api_smoke_assert_equals( 'test', $result['execution_metrics']['environment'] ?? null, 'run-task preserves metrics environment', $failures, $passes );
 agents_api_smoke_assert_equals( 'fake-executor', $result['execution_metrics']['executor_id'] ?? null, 'run-task fills metrics executor id', $failures, $passes );

--- a/tests/tool-source-registry-smoke.php
+++ b/tests/tool-source-registry-smoke.php
@@ -93,13 +93,13 @@ $registry->registerSource(
 	static function (
 		array $context,
 		AgentsAPI\AI\Tools\WP_Agent_Tool_Source_Registry $source_registry
-	) use ( $registry ): array {
+	) use ( $registry, &$failures, &$passes ): array {
 		agents_api_smoke_assert_equals(
 			$registry,
 			$source_registry,
 			'source callbacks receive the active registry',
-			$GLOBALS['failures'],
-			$GLOBALS['passes']
+			$failures,
+			$passes
 		);
 
 		return array(
@@ -151,20 +151,20 @@ add_filter(
 		array $context,
 		AgentsAPI\AI\Tools\WP_Agent_Tool_Source_Registry $source_registry,
 		array $sources
-	) use ( $registry ): array {
+	) use ( $registry, &$failures, &$passes ): array {
 		agents_api_smoke_assert_equals(
 			$registry,
 			$source_registry,
 			'source order filters receive the active registry',
-			$GLOBALS['failures'],
-			$GLOBALS['passes']
+			$failures,
+			$passes
 		);
 		agents_api_smoke_assert_equals(
 			true,
 			isset( $sources['runtime'], $sources['static'] ),
 			'source order filters receive registered sources',
-			$GLOBALS['failures'],
-			$GLOBALS['passes']
+			$failures,
+			$passes
 		);
 
 		$modes = is_array( $context['modes'] ?? null ) ? $context['modes'] : array();

--- a/tests/webhook-safety-smoke.php
+++ b/tests/webhook-safety-smoke.php
@@ -17,31 +17,39 @@ echo "agents-api-webhook-safety-smoke\n";
 $GLOBALS['__webhook_safety_transients'] = array();
 $GLOBALS['__webhook_safety_now']        = 1000;
 
-function get_transient( string $key ) {
-	$entry = $GLOBALS['__webhook_safety_transients'][ $key ] ?? null;
-	if ( null === $entry ) {
-		return false;
+// When the real WordPress transient API is present we use it (so the real
+// transient-backed store is exercised); otherwise we fall back to an in-memory
+// store with a controllable virtual clock. TTL expiry is therefore simulated
+// differently per backend (see the marker-expiry assertion below).
+$webhook_safety_real_transients = function_exists( 'get_transient' );
+
+if ( ! $webhook_safety_real_transients ) {
+	function get_transient( string $key ) {
+		$entry = $GLOBALS['__webhook_safety_transients'][ $key ] ?? null;
+		if ( null === $entry ) {
+			return false;
+		}
+
+		if ( 0 !== $entry['expires'] && $entry['expires'] <= $GLOBALS['__webhook_safety_now'] ) {
+			unset( $GLOBALS['__webhook_safety_transients'][ $key ] );
+			return false;
+		}
+
+		return $entry['value'];
 	}
 
-	if ( 0 !== $entry['expires'] && $entry['expires'] <= $GLOBALS['__webhook_safety_now'] ) {
+	function set_transient( string $key, $value, int $expiration = 0 ): bool {
+		$GLOBALS['__webhook_safety_transients'][ $key ] = array(
+			'value'   => $value,
+			'expires' => 0 < $expiration ? $GLOBALS['__webhook_safety_now'] + $expiration : 0,
+		);
+		return true;
+	}
+
+	function delete_transient( string $key ): bool {
 		unset( $GLOBALS['__webhook_safety_transients'][ $key ] );
-		return false;
+		return true;
 	}
-
-	return $entry['value'];
-}
-
-function set_transient( string $key, $value, int $expiration = 0 ): bool {
-	$GLOBALS['__webhook_safety_transients'][ $key ] = array(
-		'value'   => $value,
-		'expires' => 0 < $expiration ? $GLOBALS['__webhook_safety_now'] + $expiration : 0,
-	);
-	return true;
-}
-
-function delete_transient( string $key ): bool {
-	unset( $GLOBALS['__webhook_safety_transients'][ $key ] );
-	return true;
 }
 
 function webhook_safety_assert( $expected, $actual, string $name, array &$failures, int &$passes ): void {
@@ -79,6 +87,15 @@ webhook_safety_assert( false, WP_Agent_Webhook_Signature::verify_hmac_sha256( $b
 webhook_safety_assert( false, WP_Agent_Webhook_Signature::verify_hmac_sha256( $body, 'sha256=' . $signature, '' ), 'hmac_empty_secret_rejected', $failures, $passes );
 webhook_safety_assert( false, WP_Agent_Webhook_Signature::verify_hmac_sha256( $body, 'sha256=not-hex', $secret ), 'hmac_malformed_signature_rejected', $failures, $passes );
 
+// Clear any markers left over from a prior run so real-transient persistence
+// does not leak state between runs.
+if ( $webhook_safety_real_transients ) {
+	$reset_store = new AgentsAPI\AI\Channels\WP_Agent_Transient_Message_Idempotency_Store();
+	foreach ( array( array( 'whatsapp', 'wamid.1' ), array( 'whatsapp', 'wamid.2' ), array( 'whatsapp', 'wamid.3' ) ) as $reset_target ) {
+		$reset_store->forget( $reset_target[0], $reset_target[1] );
+	}
+}
+
 webhook_safety_assert( false, WP_Agent_Message_Idempotency::seen( 'whatsapp', 'wamid.1' ), 'idempotency_unseen_by_default', $failures, $passes );
 WP_Agent_Message_Idempotency::mark_seen( 'whatsapp', 'wamid.1', 604800 );
 webhook_safety_assert( true, WP_Agent_Message_Idempotency::seen( 'whatsapp', 'wamid.1' ), 'idempotency_seen_after_mark', $failures, $passes );
@@ -87,7 +104,17 @@ WP_Agent_Message_Idempotency::forget( 'whatsapp', 'wamid.1' );
 webhook_safety_assert( false, WP_Agent_Message_Idempotency::seen( 'whatsapp', 'wamid.1' ), 'idempotency_forget_removes_marker', $failures, $passes );
 
 WP_Agent_Message_Idempotency::mark_seen( 'whatsapp', 'wamid.2', 10 );
-$GLOBALS['__webhook_safety_now'] += 11;
+if ( $webhook_safety_real_transients ) {
+	// Real transients: simulate TTL expiry by removing the underlying transient
+	// rather than waiting out the clock.
+	$expiry_store = new AgentsAPI\AI\Channels\WP_Agent_Transient_Message_Idempotency_Store();
+	$expiry_key   = $expiry_store->storage_key( 'whatsapp', 'wamid.2' );
+	if ( null !== $expiry_key ) {
+		delete_transient( $expiry_key );
+	}
+} else {
+	$GLOBALS['__webhook_safety_now'] += 11;
+}
 webhook_safety_assert( false, WP_Agent_Message_Idempotency::seen( 'whatsapp', 'wamid.2' ), 'idempotency_marker_expires_after_ttl', $failures, $passes );
 
 WP_Agent_Message_Idempotency::mark_seen( 'whatsapp', 'wamid.3', 0 );

--- a/tests/workflow-lifecycle-smoke.php
+++ b/tests/workflow-lifecycle-smoke.php
@@ -22,46 +22,58 @@ $passes   = 0;
 
 echo "workflow-lifecycle-smoke\n";
 
-class WP_Error {
-	public function __construct( private string $code = '', private string $message = '', private $data = null ) {}
-	public function get_error_code(): string { return $this->code; }
-	public function get_error_message(): string { return $this->message; }
-	public function get_error_data() { return $this->data; }
+if ( ! class_exists( 'WP_Error' ) ) {
+	class WP_Error {
+		public function __construct( private string $code = '', private string $message = '', private $data = null ) {}
+		public function get_error_code(): string { return $this->code; }
+		public function get_error_message(): string { return $this->message; }
+		public function get_error_data() { return $this->data; }
+	}
 }
 
-function is_wp_error( $value ): bool {
-	return $value instanceof WP_Error;
+if ( ! function_exists( 'is_wp_error' ) ) {
+	function is_wp_error( $value ): bool {
+		return $value instanceof WP_Error;
+	}
 }
 
 $GLOBALS['__hooks'] = array();
 
-function add_action( string $hook, callable $cb, int $priority = 10, int $accepted_args = 1 ): void {
-	$GLOBALS['__hooks'][ $hook ][ $priority ][] = array( 'cb' => $cb, 'args' => $accepted_args );
+if ( ! function_exists( 'add_action' ) ) {
+	function add_action( string $hook, callable $cb, int $priority = 10, int $accepted_args = 1 ): void {
+		$GLOBALS['__hooks'][ $hook ][ $priority ][] = array( 'cb' => $cb, 'args' => $accepted_args );
+	}
 }
 
-function do_action( string $hook, ...$args ): void {
-	$buckets = $GLOBALS['__hooks'][ $hook ] ?? array();
-	ksort( $buckets );
-	foreach ( $buckets as $bucket ) {
-		foreach ( $bucket as $entry ) {
-			call_user_func_array( $entry['cb'], array_slice( $args, 0, (int) $entry['args'] ) );
+if ( ! function_exists( 'do_action' ) ) {
+	function do_action( string $hook, ...$args ): void {
+		$buckets = $GLOBALS['__hooks'][ $hook ] ?? array();
+		ksort( $buckets );
+		foreach ( $buckets as $bucket ) {
+			foreach ( $bucket as $entry ) {
+				call_user_func_array( $entry['cb'], array_slice( $args, 0, (int) $entry['args'] ) );
+			}
 		}
 	}
 }
 
-function add_filter( string $hook, callable $cb, int $priority = 10, int $accepted_args = 1 ): void {
-	add_action( $hook, $cb, $priority, $accepted_args );
+if ( ! function_exists( 'add_filter' ) ) {
+	function add_filter( string $hook, callable $cb, int $priority = 10, int $accepted_args = 1 ): void {
+		add_action( $hook, $cb, $priority, $accepted_args );
+	}
 }
 
-function apply_filters( string $hook, $value, ...$args ) {
-	$buckets = $GLOBALS['__hooks'][ $hook ] ?? array();
-	ksort( $buckets );
-	foreach ( $buckets as $bucket ) {
-		foreach ( $bucket as $entry ) {
-			$value = call_user_func_array( $entry['cb'], array_slice( array_merge( array( $value ), $args ), 0, (int) $entry['args'] ) );
+if ( ! function_exists( 'apply_filters' ) ) {
+	function apply_filters( string $hook, $value, ...$args ) {
+		$buckets = $GLOBALS['__hooks'][ $hook ] ?? array();
+		ksort( $buckets );
+		foreach ( $buckets as $bucket ) {
+			foreach ( $bucket as $entry ) {
+				$value = call_user_func_array( $entry['cb'], array_slice( array_merge( array( $value ), $args ), 0, (int) $entry['args'] ) );
+			}
 		}
+		return $value;
 	}
-	return $value;
 }
 
 function smoke_assert( $expected, $actual, string $name, array &$failures, int &$passes ): void {
@@ -79,17 +91,23 @@ function smoke_assert( $expected, $actual, string $name, array &$failures, int &
 // Stub out Action Scheduler so the bridge thinks it's available and records
 // every call we care about.
 $GLOBALS['__as_calls'] = array();
-function as_schedule_recurring_action( int $start, int $interval, string $hook, array $args = array(), string $group = '' ): int {
-	$GLOBALS['__as_calls'][] = array( 'op' => 'schedule_recurring', 'interval' => $interval, 'hook' => $hook, 'args' => $args, 'group' => $group );
-	return 1;
+if ( ! function_exists( 'as_schedule_recurring_action' ) ) {
+	function as_schedule_recurring_action( int $start, int $interval, string $hook, array $args = array(), string $group = '' ): int {
+		$GLOBALS['__as_calls'][] = array( 'op' => 'schedule_recurring', 'interval' => $interval, 'hook' => $hook, 'args' => $args, 'group' => $group );
+		return 1;
+	}
 }
-function as_schedule_cron_action( int $start, string $schedule, string $hook, array $args = array(), string $group = '' ): int {
-	$GLOBALS['__as_calls'][] = array( 'op' => 'schedule_cron', 'expression' => $schedule, 'hook' => $hook, 'args' => $args, 'group' => $group );
-	return 1;
+if ( ! function_exists( 'as_schedule_cron_action' ) ) {
+	function as_schedule_cron_action( int $start, string $schedule, string $hook, array $args = array(), string $group = '' ): int {
+		$GLOBALS['__as_calls'][] = array( 'op' => 'schedule_cron', 'expression' => $schedule, 'hook' => $hook, 'args' => $args, 'group' => $group );
+		return 1;
+	}
 }
-function as_unschedule_all_actions( string $hook, array $args = array(), string $group = '' ): int {
-	$GLOBALS['__as_calls'][] = array( 'op' => 'unschedule', 'hook' => $hook, 'args' => $args, 'group' => $group );
-	return 0;
+if ( ! function_exists( 'as_unschedule_all_actions' ) ) {
+	function as_unschedule_all_actions( string $hook, array $args = array(), string $group = '' ): int {
+		$GLOBALS['__as_calls'][] = array( 'op' => 'unschedule', 'hook' => $hook, 'args' => $args, 'group' => $group );
+		return 0;
+	}
 }
 
 require_once __DIR__ . '/../src/Workflows/class-wp-agent-workflow-spec-validator.php';

--- a/tests/workflow-runner-smoke.php
+++ b/tests/workflow-runner-smoke.php
@@ -17,48 +17,62 @@ $passes   = 0;
 
 echo "workflow-runner-smoke\n";
 
-class WP_Error {
-	public function __construct( private string $code = '', private string $message = '', private $data = null ) {}
-	public function get_error_code(): string { return $this->code; }
-	public function get_error_message(): string { return $this->message; }
-	public function get_error_data() { return $this->data; }
+if ( ! class_exists( 'WP_Error' ) ) {
+	class WP_Error {
+		public function __construct( private string $code = '', private string $message = '', private $data = null ) {}
+		public function get_error_code(): string { return $this->code; }
+		public function get_error_message(): string { return $this->message; }
+		public function get_error_data() { return $this->data; }
+	}
 }
 
-function is_wp_error( $value ): bool {
-	return $value instanceof WP_Error;
+if ( ! function_exists( 'is_wp_error' ) ) {
+	function is_wp_error( $value ): bool {
+		return $value instanceof WP_Error;
+	}
 }
 
 $GLOBALS['__filters']    = array();
 $GLOBALS['__abilities']  = array();
 
-function add_filter( string $hook, callable $cb, int $priority = 10, int $accepted_args = 1 ): void {
-	unset( $accepted_args );
-	$GLOBALS['__filters'][ $hook ][ $priority ][] = $cb;
-}
-function apply_filters( string $hook, $value, ...$args ) {
-	$cbs = $GLOBALS['__filters'][ $hook ] ?? array();
-	ksort( $cbs );
-	foreach ( $cbs as $bucket ) {
-		foreach ( $bucket as $cb ) {
-			$value = call_user_func_array( $cb, array_merge( array( $value ), $args ) );
-		}
-	}
-	return $value;
-}
-function add_action( string $hook, callable $cb, int $priority = 10, int $accepted_args = 1 ): void {
-	add_filter( $hook, $cb, $priority, $accepted_args );
-}
-function do_action( string $hook, ...$args ): void {
-	$cbs = $GLOBALS['__filters'][ $hook ] ?? array();
-	ksort( $cbs );
-	foreach ( $cbs as $bucket ) {
-		foreach ( $bucket as $cb ) {
-			call_user_func_array( $cb, $args );
-		}
+if ( ! function_exists( 'add_filter' ) ) {
+	function add_filter( string $hook, callable $cb, int $priority = 10, int $accepted_args = 1 ): void {
+		unset( $accepted_args );
+		$GLOBALS['__filters'][ $hook ][ $priority ][] = $cb;
 	}
 }
-function wp_get_ability( string $name ) {
-	return $GLOBALS['__abilities'][ $name ] ?? null;
+if ( ! function_exists( 'apply_filters' ) ) {
+	function apply_filters( string $hook, $value, ...$args ) {
+		$cbs = $GLOBALS['__filters'][ $hook ] ?? array();
+		ksort( $cbs );
+		foreach ( $cbs as $bucket ) {
+			foreach ( $bucket as $cb ) {
+				$value = call_user_func_array( $cb, array_merge( array( $value ), $args ) );
+			}
+		}
+		return $value;
+	}
+}
+if ( ! function_exists( 'add_action' ) ) {
+	function add_action( string $hook, callable $cb, int $priority = 10, int $accepted_args = 1 ): void {
+		add_filter( $hook, $cb, $priority, $accepted_args );
+	}
+}
+if ( ! function_exists( 'do_action' ) ) {
+	function do_action( string $hook, ...$args ): void {
+		$cbs = $GLOBALS['__filters'][ $hook ] ?? array();
+		ksort( $cbs );
+		foreach ( $cbs as $bucket ) {
+			foreach ( $bucket as $cb ) {
+				call_user_func_array( $cb, $args );
+			}
+		}
+	}
+}
+if ( ! function_exists( 'wp_get_ability' ) ) {
+	function wp_get_ability( string $name ) {
+		return $GLOBALS['__abilities'][ $name ] ?? null;
+	}
 }
 
 class Stub_Ability {
@@ -66,6 +80,61 @@ class Stub_Ability {
 	public function execute( array $input ) {
 		return ( $this->handler )( $input );
 	}
+}
+
+/**
+ * Register a stub ability so the runner can resolve it through wp_get_ability()
+ * in either backend: pure-PHP keeps the Stub_Ability in an in-memory registry;
+ * real WordPress registers it with the Abilities API (deferred to the init
+ * action) using the handler as the execute callback.
+ */
+$GLOBALS['__workflow_runner_smoke_pending'] = array();
+function workflow_runner_smoke_register_ability( string $name, \Closure $handler ): void {
+	$GLOBALS['__abilities'][ $name ] = new Stub_Ability( $handler );
+
+	// Defer real Abilities API registration to the init action (fired once after
+	// all stubs are queued); core rejects registration outside that window.
+	if ( function_exists( 'wp_register_ability' ) ) {
+		$GLOBALS['__workflow_runner_smoke_pending'][ $name ] = $handler;
+	}
+}
+
+if ( function_exists( 'add_action' ) && function_exists( 'wp_register_ability' ) ) {
+	add_action(
+		'wp_abilities_api_categories_init',
+		static function (): void {
+			if ( function_exists( 'wp_has_ability_category' ) && ! wp_has_ability_category( 'workflow-runner-smoke' ) ) {
+				wp_register_ability_category(
+					'workflow-runner-smoke',
+					array(
+						'label'       => 'Workflow Runner Smoke',
+						'description' => 'Workflow runner smoke stubs.',
+					)
+				);
+			}
+		}
+	);
+
+	add_action(
+		'wp_abilities_api_init',
+		static function (): void {
+			foreach ( $GLOBALS['__workflow_runner_smoke_pending'] as $name => $handler ) {
+				wp_register_ability(
+					$name,
+					array(
+						'label'               => $name,
+						'description'         => 'Workflow runner smoke stub.',
+						'category'            => 'workflow-runner-smoke',
+						'input_schema'        => array( 'type' => 'object' ),
+						'output_schema'       => array( 'type' => 'object' ),
+						'execute_callback'    => $handler,
+						'permission_callback' => '__return_true',
+					)
+				);
+			}
+			$GLOBALS['__workflow_runner_smoke_pending'] = array();
+		}
+	);
 }
 
 function smoke_assert( $expected, $actual, string $name, array &$failures, int &$passes ): void {
@@ -119,17 +188,20 @@ class Capture_Recorder implements WP_Agent_Workflow_Run_Recorder {
 
 // ─── Happy path: 2 sequential ability steps with bindings between them ───
 
-$GLOBALS['__abilities']['demo/uppercase'] = new Stub_Ability(
+workflow_runner_smoke_register_ability(
+	'demo/uppercase',
 	static function ( array $input ): array {
 		return array( 'value' => strtoupper( (string) ( $input['text'] ?? '' ) ) );
 	}
 );
-$GLOBALS['__abilities']['demo/wrap'] = new Stub_Ability(
+workflow_runner_smoke_register_ability(
+	'demo/wrap',
 	static function ( array $input ): array {
 		return array( 'wrapped' => '<<' . (string) ( $input['inner'] ?? '' ) . '>>' );
 	}
 );
-$GLOBALS['__abilities']['demo/score-item'] = new Stub_Ability(
+workflow_runner_smoke_register_ability(
+	'demo/score-item',
 	static function ( array $input ): array {
 		return array(
 			'id'     => (int) ( $input['id'] ?? 0 ),
@@ -137,6 +209,17 @@ $GLOBALS['__abilities']['demo/score-item'] = new Stub_Ability(
 		);
 	}
 );
+workflow_runner_smoke_register_ability(
+	'demo/boom',
+	static function ( array $input ): \WP_Error {
+		unset( $input );
+		return new \WP_Error( 'demo_bang', 'something broke' );
+	}
+);
+
+// Register all stub abilities with the real Abilities API (no-op in pure-PHP).
+do_action( 'wp_abilities_api_categories_init' );
+do_action( 'wp_abilities_api_init' );
 
 $spec = WP_Agent_Workflow_Spec::from_array(
 	array(
@@ -208,13 +291,6 @@ smoke_assert( $evidence_refs, $last_write['result']['evidence_refs'] ?? array(),
 smoke_assert( true, is_string( json_encode( $evidence_result->get_evidence_refs() ) ), 'evidence refs are JSON-serializable', $failures, $passes );
 
 // ─── Failed step short-circuits ───────────────────────────────────────
-
-$GLOBALS['__abilities']['demo/boom'] = new Stub_Ability(
-	static function ( array $input ): \WP_Error {
-		unset( $input );
-		return new \WP_Error( 'demo_bang', 'something broke' );
-	}
-);
 
 $bad_spec = WP_Agent_Workflow_Spec::from_array(
 	array(

--- a/tests/workflow-spec-validator-smoke.php
+++ b/tests/workflow-spec-validator-smoke.php
@@ -14,31 +14,39 @@ $passes   = 0;
 
 echo "workflow-spec-validator-smoke\n";
 
-class WP_Error {
-	public function __construct( private string $code = '', private string $message = '', private $data = null ) {}
-	public function get_error_code(): string { return $this->code; }
-	public function get_error_message(): string { return $this->message; }
-	public function get_error_data() { return $this->data; }
+if ( ! class_exists( 'WP_Error' ) ) {
+	class WP_Error {
+		public function __construct( private string $code = '', private string $message = '', private $data = null ) {}
+		public function get_error_code(): string { return $this->code; }
+		public function get_error_message(): string { return $this->message; }
+		public function get_error_data() { return $this->data; }
+	}
 }
 
-function is_wp_error( $value ): bool {
-	return $value instanceof WP_Error;
+if ( ! function_exists( 'is_wp_error' ) ) {
+	function is_wp_error( $value ): bool {
+		return $value instanceof WP_Error;
+	}
 }
 
 $GLOBALS['__filters'] = array();
-function add_filter( string $hook, callable $cb, int $priority = 10, int $accepted_args = 1 ): void {
-	unset( $accepted_args );
-	$GLOBALS['__filters'][ $hook ][ $priority ][] = $cb;
-}
-function apply_filters( string $hook, $value, ...$args ) {
-	$cbs = $GLOBALS['__filters'][ $hook ] ?? array();
-	ksort( $cbs );
-	foreach ( $cbs as $bucket ) {
-		foreach ( $bucket as $cb ) {
-			$value = call_user_func_array( $cb, array_merge( array( $value ), $args ) );
-		}
+if ( ! function_exists( 'add_filter' ) ) {
+	function add_filter( string $hook, callable $cb, int $priority = 10, int $accepted_args = 1 ): void {
+		unset( $accepted_args );
+		$GLOBALS['__filters'][ $hook ][ $priority ][] = $cb;
 	}
-	return $value;
+}
+if ( ! function_exists( 'apply_filters' ) ) {
+	function apply_filters( string $hook, $value, ...$args ) {
+		$cbs = $GLOBALS['__filters'][ $hook ] ?? array();
+		ksort( $cbs );
+		foreach ( $cbs as $bucket ) {
+			foreach ( $bucket as $cb ) {
+				$value = call_user_func_array( $cb, array_merge( array( $value ), $args ) );
+			}
+		}
+		return $value;
+	}
 }
 
 function smoke_assert( $expected, $actual, string $name, array &$failures, int &$passes ): void {


### PR DESCRIPTION
## Summary
- Make channel/chat-related smoke tests run under both standalone PHP and real WordPress host-smoke mode.
- Guard pure-PHP stubs when WordPress provides real classes/functions, and assert through real registries/REST APIs where needed.
- Add host-safe fixture registration for channel, run-control, event trigger, CPT conversation store, and frontend chat REST smokes.

## Testing
- `php tests/frontend-chat-rest-smoke.php`
- `HOMEBOY_WP_CODEBOX_CORE_MODULE=\"/Users/chubes/Developer/wp-codebox@workflow-bench-clean-dependency-20260608/packages/runtime-core/dist/index.js\" HOMEBOY_WORDPRESS_HOST_SMOKE_FILE=\"tests/frontend-chat-rest-smoke.php\" bash /Users/chubes/Developer/homeboy-extensions/wordpress/scripts/test/test-runner-host-smoke-wp.sh`
- Targeted standalone and host-smoke checks were run while fixing the affected smoke files.
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafting and validating the smoke-test hardening changes; Chris reviewed direction and requested the split.