### PR TITLE
Channels: per-agent routing for register_chat_handler()

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -82,6 +82,7 @@
       "php tests/conversation-loop-smoke.php",
       "php tests/provider-turn-adapter-smoke.php",
       "php tests/default-provider-turn-adapter-smoke.php",
+      "php tests/agents-chat-ability-smoke.php",
       "php tests/default-agents-chat-handler-smoke.php",
       "php tests/tool-observability-smoke.php",
       "php tests/ability-tool-executor-smoke.php",

--- a/docs/external-clients.md
+++ b/docs/external-clients.md
@@ -174,6 +174,9 @@ streaming handlers are consumer territory (the same boundary as `agents/chat`).
 add_filter( 'agents_api_enable_default_conversation_store', '__return_true' );
 
 // 2. A runtime: register a chat handler (sync) and/or a stream handler (tokens).
+//    Pass an agent slug as the 3rd arg to scope the handler to one agent so
+//    multiple consumer plugins can coexist on the same site without colliding:
+//    register_chat_handler( $my_sync_handler, 10, 'my-agent-slug' );
 AgentsAPI\AI\Channels\register_chat_handler( $my_sync_handler );
 AgentsAPI\AI\Channels\register_chat_stream_handler( $my_stream_handler );
 

--- a/src/Channels/register-agents-chat-ability.php
+++ b/src/Channels/register-agents-chat-ability.php
@@ -623,19 +623,29 @@ function agents_chat_output_schema(): array {
  * Equivalent to `add_filter( 'wp_agent_chat_handler', ... )` but reads more
  * intentionally at the call site.
  *
+ * Pass an `$agent_slug` to scope the handler to a single agent: it then claims
+ * only turns whose `agent` matches and passes every other agent through to later
+ * handlers, so multiple consumer plugins can register runtimes on the same site
+ * without colliding. Without it (the default), the handler claims any turn not
+ * already handled — the original behavior, fine for a single-consumer site.
+ *
  * @since 0.103.0
  *
- * @param callable $handler  Receives the canonical input array, returns the
- *                           canonical output array or WP_Error.
- * @param int      $priority Filter priority. Default 10.
+ * @param callable    $handler    Receives the canonical input array, returns the
+ *                                canonical output array or WP_Error.
+ * @param int         $priority   Filter priority. Default 10.
+ * @param string|null $agent_slug Optional agent slug to scope this handler to. When
+ *                                set, non-matching agents are passed through.
  */
-function register_chat_handler( callable $handler, int $priority = 10 ): void {
+function register_chat_handler( callable $handler, int $priority = 10, ?string $agent_slug = null ): void {
 	add_filter(
 		'wp_agent_chat_handler',
-		static function ( $existing, array $input ) use ( $handler ) {
-			unset( $input );
+		static function ( $existing, array $input ) use ( $handler, $agent_slug ) {
 			if ( null !== $existing ) {
-				return $existing;
+				return $existing; // An earlier handler already claimed this turn.
+			}
+			if ( null !== $agent_slug && ( $input['agent'] ?? null ) !== $agent_slug ) {
+				return $existing; // Scoped handler: not our agent, pass through.
 			}
 			return $handler;
 		},

--- a/tests/agents-chat-ability-smoke.php
+++ b/tests/agents-chat-ability-smoke.php
@@ -234,12 +234,13 @@ register_chat_handler(
 	10,
 	'beta'
 );
+AgentsAPI\AI\Channels\WP_Agent_Default_Chat_Handler::register();
 $alpha = agents_chat_dispatch( array( 'agent' => 'alpha', 'message' => 'hi' ) );
 $beta  = agents_chat_dispatch( array( 'agent' => 'beta', 'message' => 'hi' ) );
 $gamma = agents_chat_dispatch( array( 'agent' => 'gamma', 'message' => 'hi' ) );
 smoke_assert( 'from-alpha', $alpha['reply'] ?? null, 'scoped_handler_claims_its_agent', $failures, $passes );
 smoke_assert( 'from-beta', $beta['reply'] ?? null, 'second_scoped_handler_coexists', $failures, $passes );
-smoke_assert( true, $gamma instanceof WP_Error, 'unmatched_agent_passes_through_to_no_handler', $failures, $passes );
+smoke_assert( 'agents_chat_registry_unavailable', $gamma instanceof WP_Error ? $gamma->get_error_code() : '', 'unmatched_agent_reaches_native_fallback', $failures, $passes );
 
 // ─── Done ───────────────────────────────────────────────────────────
 

--- a/tests/agents-chat-ability-smoke.php
+++ b/tests/agents-chat-ability-smoke.php
@@ -220,6 +220,27 @@ $invalid_principal_result = agents_chat_dispatch( array( 'agent' => 'runtime-loc
 smoke_assert( true, $invalid_principal_result instanceof WP_Error, 'invalid_principal_returns_wp_error', $failures, $passes );
 smoke_assert( 'agents_chat_invalid_principal', $invalid_principal_result->get_error_code(), 'invalid_principal_error_code', $failures, $passes );
 
+// 10. Per-agent handler routing: scoped handlers coexist and pass through.
+// Clear earlier handlers (including the unscoped runtime handler above and the
+// default fallback runtime) so only the scoped handlers below are registered.
+smoke_reset_chat_filters();
+register_chat_handler(
+	static fn( array $i ) => array( 'session_id' => 'sa', 'reply' => 'from-alpha', 'completed' => true ),
+	10,
+	'alpha'
+);
+register_chat_handler(
+	static fn( array $i ) => array( 'session_id' => 'sb', 'reply' => 'from-beta', 'completed' => true ),
+	10,
+	'beta'
+);
+$alpha = agents_chat_dispatch( array( 'agent' => 'alpha', 'message' => 'hi' ) );
+$beta  = agents_chat_dispatch( array( 'agent' => 'beta', 'message' => 'hi' ) );
+$gamma = agents_chat_dispatch( array( 'agent' => 'gamma', 'message' => 'hi' ) );
+smoke_assert( 'from-alpha', $alpha['reply'] ?? null, 'scoped_handler_claims_its_agent', $failures, $passes );
+smoke_assert( 'from-beta', $beta['reply'] ?? null, 'second_scoped_handler_coexists', $failures, $passes );
+smoke_assert( true, $gamma instanceof WP_Error, 'unmatched_agent_passes_through_to_no_handler', $failures, $passes );
+
 // ─── Done ───────────────────────────────────────────────────────────
 
 if ( $failures ) {


### PR DESCRIPTION
## Problem

`register_chat_handler()` registers a `wp_agent_chat_handler` filter whose closure claims **every** turn not already handled — it `unset($input)` and ignores the `agent` slug:

```php
static function ( $existing, array $input ) use ( $handler ) {
    unset( $input );
    if ( null !== $existing ) { return $existing; }
    return $handler;
}
```

So on a site with **two consumer plugins**, the first registration (by priority/order) wins for *all* agents, and the second consumer's agent never reaches its runtime. The only workaround today is to skip the helper and hand-roll a slug-checking `add_filter( 'wp_agent_chat_handler', … )` — which is exactly the boilerplate this helper exists to remove.

Since #380 this matters even on a **single-consumer** site: `WP_Agent_Default_Chat_Handler` registers unscoped at `FALLBACK_PRIORITY = 1000`, so the intended composition is "consumer runtime for its agents, native default runtime for the rest". But an unscoped consumer handler at priority 10 shadows the default for *every* agent. Slug scoping is the missing piece that lets a consumer claim only its own agents and let everything else fall through to the default runtime.

## Change

Add an optional `$agent_slug` parameter. When set, the handler claims only turns whose `agent` matches and passes every other agent through to later handlers, so multiple runtimes coexist:

```php
register_chat_handler( $handler, 10, 'my-agent-slug' );
```

Default (`null`) preserves the original "claim anything unhandled" behavior — **backward compatible**.

## Tests

`tests/agents-chat-ability-smoke.php` gains a routing case: two slug-scoped handlers each claim their own agent, and an unmatched agent passes through to the `no_handler` path (53 assertions pass).

While rebasing I noticed the file itself is never run by `composer test` — it isn't in the `smoke` script chain, so CI has not been executing it. Second commit wires it in next to the other chat runtime smokes. (It passes standalone on current `main`.)

Full suite + PHPStan pass locally.

## Notes

- Rebased onto current `main` (post-v0.5.1); the new smoke section uses `smoke_reset_chat_filters()` so it isolates from the default fallback runtime.
- Docs (`docs/external-clients.md`) updated to show the scoped form.
- A fuller alternative would be a slug→handler registry with dispatcher-side routing; this PR is the minimal, additive step that unblocks multi-consumer sites today.

Motivating consumer (an "agent-served site" example built on agents-api + wp-ai-client): https://github.com/lezama/agent-served-site

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Claude Opus 4.8 and Claude Fable 5); OpenCode (openai/gpt-5.6-sol)
- **Used for:** Miguel used Claude Code for the original implementation; Chris and OpenCode added native fallback integration coverage and verified the PR.
