### PR TITLE
Add ability-backed tool executor

### DIFF
--- a/agents-api.php
+++ b/agents-api.php
@@ -165,6 +165,7 @@ require_once AGENTS_API_PATH . 'src/Tools/class-wp-agent-tool-call.php';
 require_once AGENTS_API_PATH . 'src/Tools/class-wp-agent-tool-parameters.php';
 require_once AGENTS_API_PATH . 'src/Tools/class-wp-agent-tool-result.php';
 require_once AGENTS_API_PATH . 'src/Tools/class-wp-agent-tool-executor.php';
+require_once AGENTS_API_PATH . 'src/Tools/class-wp-agent-ability-tool-executor.php';
 require_once AGENTS_API_PATH . 'src/Tools/class-wp-agent-tool-execution-core.php';
 require_once AGENTS_API_PATH . 'src/Tools/class-wp-agent-tool-source-registry.php';
 require_once AGENTS_API_PATH . 'src/Context/class-wp-agent-context-authority-tier.php';

--- a/composer.json
+++ b/composer.json
@@ -75,6 +75,7 @@
       "php tests/context-registry-smoke.php",
       "php tests/conversation-loop-smoke.php",
       "php tests/provider-turn-adapter-smoke.php",
+      "php tests/ability-tool-executor-smoke.php",
       "php tests/conversation-loop-tool-execution-smoke.php",
       "php tests/conversation-loop-completion-policy-smoke.php",
       "php tests/conversation-loop-transcript-persister-smoke.php",

--- a/src/Tools/class-wp-agent-ability-tool-executor.php
+++ b/src/Tools/class-wp-agent-ability-tool-executor.php
@@ -1,0 +1,129 @@
+<?php
+/**
+ * Ability-backed tool executor.
+ *
+ * @package AgentsAPI
+ */
+
+namespace AgentsAPI\AI\Tools;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Executes host-owned tool calls through the WordPress Abilities API.
+ */
+class WP_Agent_Ability_Tool_Executor implements WP_Agent_Tool_Executor {
+
+	/**
+	 * Execute a prepared tool call by invoking its mapped ability.
+	 *
+	 * Tool declarations may specify `ability` or `ability_name` when the model-facing
+	 * tool name differs from the registered ability name. Otherwise the tool name is
+	 * used directly as the ability name.
+	 *
+	 * @param array<mixed> $tool_call       Normalized prepared tool call.
+	 * @param array<mixed> $tool_definition Tool declaration selected for the call.
+	 * @param array<mixed> $context         Host runtime context for this invocation.
+	 * @return array<mixed> Normalized tool execution result.
+	 */
+	public function executeWP_Agent_Tool_Call( array $tool_call, array $tool_definition, array $context = array() ): array {
+		unset( $context );
+
+		$tool_call    = WP_Agent_Tool_Call::normalize( $tool_call );
+		$tool_name    = is_string( $tool_call['tool_name'] ?? null ) ? $tool_call['tool_name'] : '';
+		$ability_name = $this->ability_name( $tool_call, $tool_definition );
+
+		if ( '' === $ability_name ) {
+			return WP_Agent_Tool_Result::error(
+				$tool_name,
+				'Tool declaration does not identify an ability.',
+				array( 'error_type' => 'ability_name_missing' )
+			);
+		}
+
+		if ( ! function_exists( 'wp_get_ability' ) ) {
+			return WP_Agent_Tool_Result::error(
+				$tool_name,
+				'WordPress Abilities API is not available.',
+				array(
+					'ability_name' => $ability_name,
+					'error_type'   => 'abilities_api_unavailable',
+				)
+			);
+		}
+
+		$ability = wp_get_ability( $ability_name );
+		if ( ! $ability instanceof \WP_Ability ) {
+			return WP_Agent_Tool_Result::error(
+				$tool_name,
+				'Ability is not registered.',
+				array(
+					'ability_name' => $ability_name,
+					'error_type'   => 'ability_not_found',
+				)
+			);
+		}
+
+		$result = $ability->execute( $tool_call['parameters'] );
+		if ( function_exists( 'is_wp_error' ) && is_wp_error( $result ) ) {
+			return WP_Agent_Tool_Result::error(
+				$tool_name,
+				$this->wp_error_message( $result ),
+				array(
+					'ability_name' => $ability_name,
+					'error_code'   => $result->get_error_code(),
+					'error_type'   => 'ability_error',
+				)
+			);
+		}
+
+		return WP_Agent_Tool_Result::success(
+			$tool_name,
+			$result,
+			array( 'ability_name' => $ability_name )
+		);
+	}
+
+	/**
+	 * Resolve the registered ability name for a tool call.
+	 *
+	 * @param array<mixed> $tool_call       Normalized prepared tool call.
+	 * @param array<mixed> $tool_definition Tool declaration selected for the call.
+	 * @return string Ability name.
+	 */
+	private function ability_name( array $tool_call, array $tool_definition ): string {
+		$metadata = isset( $tool_call['metadata'] ) && is_array( $tool_call['metadata'] ) ? $tool_call['metadata'] : array();
+
+		$candidates = array(
+			$tool_definition['ability'] ?? null,
+			$tool_definition['ability_name'] ?? null,
+			$metadata['ability_name'] ?? null,
+			$tool_call['tool_name'] ?? null,
+		);
+
+		foreach ( $candidates as $candidate ) {
+			if ( is_string( $candidate ) && '' !== trim( $candidate ) ) {
+				return trim( $candidate );
+			}
+		}
+
+		return '';
+	}
+
+	/**
+	 * Return a human-readable WP_Error message without requiring full WP stubs.
+	 *
+	 * @param mixed $error WP_Error-like value.
+	 * @return string Error message.
+	 */
+	private function wp_error_message( $error ): string {
+		if ( is_object( $error ) && method_exists( $error, 'get_error_message' ) ) {
+			$message = $error->get_error_message();
+			if ( is_string( $message ) && '' !== $message ) {
+				return $message;
+			}
+		}
+
+		return 'Ability execution failed.';
+	}
+}

--- a/tests/ability-tool-executor-smoke.php
+++ b/tests/ability-tool-executor-smoke.php
@@ -99,6 +99,10 @@ function agents_api_smoke_ability_args( string $name, callable $callback ): arra
 		'category'            => 'agents-api-smoke',
 		'execute_callback'    => $callback,
 		'permission_callback' => '__return_true',
+		'input_schema'        => array(
+			'type'                 => 'object',
+			'additionalProperties' => true,
+		),
 	);
 }
 

--- a/tests/ability-tool-executor-smoke.php
+++ b/tests/ability-tool-executor-smoke.php
@@ -85,6 +85,59 @@ function agents_api_smoke_create_ability( string $name, callable $callback ): WP
 	return new WP_Ability( $name, $callback );
 }
 
+/**
+ * Build runtime ability arguments for the WordPress Abilities API.
+ *
+ * @param string   $name     Ability name.
+ * @param callable $callback Ability execution callback.
+ * @return array<string, mixed> Ability registration arguments.
+ */
+function agents_api_smoke_ability_args( string $name, callable $callback ): array {
+	return array(
+		'label'               => $name,
+		'description'         => 'Smoke test ability.',
+		'category'            => 'agents-api-smoke',
+		'execute_callback'    => $callback,
+		'permission_callback' => '__return_true',
+	);
+}
+
+/**
+ * Register smoke abilities through the loaded runtime when available.
+ *
+ * @param array<string, callable> $definitions Ability callbacks keyed by ability name.
+ */
+function agents_api_smoke_register_abilities( array $definitions ): void {
+	if ( class_exists( 'WP_Abilities_Registry' ) && class_exists( 'WP_Ability_Categories_Registry' ) ) {
+		$category_registry = WP_Ability_Categories_Registry::get_instance();
+		if ( null !== $category_registry && ! $category_registry->is_registered( 'agents-api-smoke' ) ) {
+			$category_registry->register(
+				'agents-api-smoke',
+				array(
+					'label'       => 'Agents API smoke',
+					'description' => 'Smoke test abilities.',
+				)
+			);
+		}
+
+		$ability_registry = WP_Abilities_Registry::get_instance();
+		if ( null !== $ability_registry ) {
+			foreach ( $definitions as $name => $callback ) {
+				if ( ! $ability_registry->is_registered( $name ) ) {
+					$ability_registry->register( $name, agents_api_smoke_ability_args( $name, $callback ) );
+				}
+			}
+
+			return;
+		}
+	}
+
+	$GLOBALS['__agents_api_smoke_abilities'] = array();
+	foreach ( $definitions as $name => $callback ) {
+		$GLOBALS['__agents_api_smoke_abilities'][ $name ] = agents_api_smoke_create_ability( $name, $callback );
+	}
+}
+
 $failures = array();
 $passes   = 0;
 
@@ -93,22 +146,19 @@ echo "agents-api-ability-tool-executor-smoke\n";
 require_once __DIR__ . '/agents-api-smoke-helpers.php';
 agents_api_smoke_require_module();
 
-$GLOBALS['__agents_api_smoke_abilities'] = array(
-	'local/search-posts' => agents_api_smoke_create_ability(
-		'local/search-posts',
-		static function ( array $input ): array {
+
+agents_api_smoke_register_abilities(
+	array(
+		'local/search-posts' => static function ( array $input ): array {
 			return array(
 				'query' => $input['query'] ?? '',
 				'limit' => $input['limit'] ?? 10,
 			);
-		}
-	),
-	'local/fail'         => agents_api_smoke_create_ability(
-		'local/fail',
-		static function (): WP_Error {
+		},
+		'local/fail'         => static function (): WP_Error {
 			return new WP_Error( 'local_failed', 'The local ability failed.' );
-		}
-	),
+		},
+	)
 );
 
 $executor = new AgentsAPI\AI\Tools\WP_Agent_Ability_Tool_Executor();

--- a/tests/ability-tool-executor-smoke.php
+++ b/tests/ability-tool-executor-smoke.php
@@ -1,0 +1,148 @@
+<?php
+/**
+ * Pure-PHP smoke test for ability-backed tool execution.
+ *
+ * Run with: php tests/ability-tool-executor-smoke.php
+ *
+ * @package AgentsAPI\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+if ( ! class_exists( 'WP_Error' ) ) {
+	class WP_Error {
+		private string $code;
+		private string $message;
+
+		public function __construct( string $code, string $message ) {
+			$this->code    = $code;
+			$this->message = $message;
+		}
+
+		public function get_error_code(): string {
+			return $this->code;
+		}
+
+		public function get_error_message(): string {
+			return $this->message;
+		}
+	}
+}
+
+if ( ! class_exists( 'WP_Ability' ) ) {
+	class WP_Ability {
+		private string $name;
+		/** @var callable */
+		private $callback;
+
+		public function __construct( string $name, callable $callback ) {
+			$this->name     = $name;
+			$this->callback = $callback;
+		}
+
+		public function get_name(): string {
+			return $this->name;
+		}
+
+		public function execute( $input = null ) {
+			return call_user_func( $this->callback, $input );
+		}
+	}
+}
+
+if ( ! function_exists( 'wp_get_ability' ) ) {
+	function wp_get_ability( string $name ): ?WP_Ability {
+		return $GLOBALS['__agents_api_smoke_abilities'][ $name ] ?? null;
+	}
+}
+
+$failures = array();
+$passes   = 0;
+
+echo "agents-api-ability-tool-executor-smoke\n";
+
+require_once __DIR__ . '/agents-api-smoke-helpers.php';
+agents_api_smoke_require_module();
+
+$GLOBALS['__agents_api_smoke_abilities'] = array(
+	'local/search-posts' => new WP_Ability(
+		'local/search-posts',
+		static function ( array $input ): array {
+			return array(
+				'query' => $input['query'] ?? '',
+				'limit' => $input['limit'] ?? 10,
+			);
+		}
+	),
+	'local/fail'         => new WP_Ability(
+		'local/fail',
+		static function (): WP_Error {
+			return new WP_Error( 'local_failed', 'The local ability failed.' );
+		}
+	),
+);
+
+$executor = new AgentsAPI\AI\Tools\WP_Agent_Ability_Tool_Executor();
+$core     = new AgentsAPI\AI\Tools\WP_Agent_Tool_Execution_Core();
+
+echo "\n[1] Ability executor invokes mapped abilities through the generic tool core:\n";
+$tools = array(
+	'host/search' => array(
+		'name'       => 'host/search',
+		'source'     => 'ability',
+		'executor'   => AgentsAPI\AI\Tools\WP_Agent_Tool_Declaration::EXECUTOR_HOST,
+		'ability'    => 'local/search-posts',
+		'parameters' => array(
+			'type'       => 'object',
+			'required'   => array( 'query' ),
+			'properties' => array(
+				'query' => array( 'type' => 'string' ),
+				'limit' => array( 'type' => 'integer' ),
+			),
+		),
+	),
+);
+
+$result = $core->executeTool(
+	'host/search',
+	array( 'query' => 'agents api' ),
+	$tools,
+	$executor,
+	array( 'tool_call_id' => 'call-ability-1' )
+);
+
+agents_api_smoke_assert_equals( true, $result['success'] ?? false, 'ability-backed tool execution succeeds', $failures, $passes );
+agents_api_smoke_assert_equals( 'host/search', $result['tool_name'] ?? '', 'result keeps model-facing tool name', $failures, $passes );
+agents_api_smoke_assert_equals( 'local/search-posts', $result['metadata']['ability_name'] ?? '', 'result records invoked ability name', $failures, $passes );
+agents_api_smoke_assert_equals( 'agents api', $result['result']['query'] ?? '', 'ability receives prepared tool parameters', $failures, $passes );
+agents_api_smoke_assert_equals( 10, $result['result']['limit'] ?? null, 'ability result payload is preserved', $failures, $passes );
+
+echo "\n[2] Ability executor reports registered ability failures without throwing:\n";
+$error_result = $executor->executeWP_Agent_Tool_Call(
+	array(
+		'tool_name'  => 'host/fail',
+		'parameters' => array(),
+	),
+	array( 'ability_name' => 'local/fail' )
+);
+
+agents_api_smoke_assert_equals( false, $error_result['success'] ?? true, 'ability WP_Error becomes failed tool result', $failures, $passes );
+agents_api_smoke_assert_equals( 'The local ability failed.', $error_result['error'] ?? '', 'ability error message is preserved', $failures, $passes );
+agents_api_smoke_assert_equals( 'local_failed', $error_result['metadata']['error_code'] ?? '', 'ability error code is preserved', $failures, $passes );
+agents_api_smoke_assert_equals( 'ability_error', $error_result['metadata']['error_type'] ?? '', 'ability error type is stable', $failures, $passes );
+
+echo "\n[3] Missing ability names produce stable tool errors:\n";
+$missing_result = $executor->executeWP_Agent_Tool_Call(
+	array(
+		'tool_name'  => 'missing/ability',
+		'parameters' => array(),
+	),
+	array()
+);
+
+agents_api_smoke_assert_equals( false, $missing_result['success'] ?? true, 'missing ability returns failed tool result', $failures, $passes );
+agents_api_smoke_assert_equals( 'ability_not_found', $missing_result['metadata']['error_type'] ?? '', 'missing ability error type is stable', $failures, $passes );
+
+agents_api_smoke_finish( 'ability tool executor smoke', $failures, $passes );

--- a/tests/ability-tool-executor-smoke.php
+++ b/tests/ability-tool-executor-smoke.php
@@ -58,6 +58,33 @@ if ( ! function_exists( 'wp_get_ability' ) ) {
 	}
 }
 
+/**
+ * Create an ability using the loaded runtime contract or the local smoke stub.
+ *
+ * @param string   $name     Ability name.
+ * @param callable $callback Ability execution callback.
+ * @return WP_Ability Ability instance.
+ */
+function agents_api_smoke_create_ability( string $name, callable $callback ): WP_Ability {
+	$constructor = new ReflectionMethod( WP_Ability::class, '__construct' );
+	$parameters  = $constructor->getParameters();
+
+	if ( isset( $parameters[1] ) && $parameters[1]->hasType() && 'array' === (string) $parameters[1]->getType() ) {
+		return new WP_Ability(
+			$name,
+			array(
+				'label'               => $name,
+				'description'         => 'Smoke test ability.',
+				'category'            => 'agents-api-smoke',
+				'execute_callback'    => $callback,
+				'permission_callback' => '__return_true',
+			)
+		);
+	}
+
+	return new WP_Ability( $name, $callback );
+}
+
 $failures = array();
 $passes   = 0;
 
@@ -67,7 +94,7 @@ require_once __DIR__ . '/agents-api-smoke-helpers.php';
 agents_api_smoke_require_module();
 
 $GLOBALS['__agents_api_smoke_abilities'] = array(
-	'local/search-posts' => new WP_Ability(
+	'local/search-posts' => agents_api_smoke_create_ability(
 		'local/search-posts',
 		static function ( array $input ): array {
 			return array(
@@ -76,7 +103,7 @@ $GLOBALS['__agents_api_smoke_abilities'] = array(
 			);
 		}
 	),
-	'local/fail'         => new WP_Ability(
+	'local/fail'         => agents_api_smoke_create_ability(
 		'local/fail',
 		static function (): WP_Error {
 			return new WP_Error( 'local_failed', 'The local ability failed.' );


### PR DESCRIPTION
## Summary
- Add a generic WP_Agent_Ability_Tool_Executor that implements the existing tool executor interface by invoking WordPress abilities.
- Support explicit ability mappings with ability or ability_name, falling back to the model-facing tool name.
- Add a pure-PHP smoke test covering success, WP_Error handling, and missing ability behavior.

## Verification
- php tests/ability-tool-executor-smoke.php
- composer smoke
- composer phpstan

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the implementation, smoke coverage, and PR description; Chris remains responsible for review and testing.