### PR TITLE
Add provider-safe tool aliases

### DIFF
--- a/src/Tools/class-wp-agent-tool-declaration.php
+++ b/src/Tools/class-wp-agent-tool-declaration.php
@@ -115,6 +115,11 @@ class WP_Agent_Tool_Declaration {
 			'scope'       => self::SCOPE_RUN,
 		);
 
+		$provider_safe_name = self::providerSafeName( $name );
+		if ( $provider_safe_name !== $name ) {
+			$normalized['provider_safe_name'] = $provider_safe_name;
+		}
+
 		$runtime = self::normalizeRuntimeMetadata( $declaration['runtime'] ?? array() );
 		if ( ! empty( $runtime ) ) {
 			$normalized['runtime'] = $runtime;
@@ -191,6 +196,11 @@ class WP_Agent_Tool_Declaration {
 			'executor'    => self::EXECUTOR_HOST,
 			'scope'       => self::SCOPE_RUN,
 		);
+
+		$provider_safe_name = self::providerSafeName( $name );
+		if ( $provider_safe_name !== $name ) {
+			$normalized['provider_safe_name'] = $provider_safe_name;
+		}
 
 		$runtime = self::normalizeRuntimeMetadata( $declaration['runtime'] ?? array() );
 		if ( ! empty( $runtime ) ) {
@@ -474,6 +484,58 @@ class WP_Agent_Tool_Declaration {
 	 */
 	public static function namespacedName( string $source, string $tool_slug ): string {
 		return $source . '/' . $tool_slug;
+	}
+
+	/**
+	 * Build a provider-safe alias for a canonical tool name.
+	 *
+	 * Some provider APIs reject namespaced names containing `/`. The alias is not
+	 * canonical; it is a transport-safe identifier that callers can map back to the
+	 * normalized declaration before executing a tool.
+	 *
+	 * @param string $name Canonical tool name.
+	 * @return string Provider-safe tool alias.
+	 */
+	public static function providerSafeName( string $name ): string {
+		$alias = preg_replace( '/[^A-Za-z0-9_]+/', '__', trim( $name ) );
+		$alias = is_string( $alias ) ? trim( $alias, '_' ) : '';
+		if ( '' === $alias ) {
+			return 'tool';
+		}
+
+		return 1 === preg_match( '/^[A-Za-z]/', $alias ) ? $alias : 'tool_' . $alias;
+	}
+
+	/**
+	 * Resolve a provider-emitted tool name to the canonical declaration name.
+	 *
+	 * @param string       $tool_name Tool name from the provider or caller.
+	 * @param array<mixed> $available_tools Normalized tool declarations keyed by canonical name.
+	 * @return string Canonical tool name when found, otherwise the original name.
+	 */
+	public static function canonicalNameForProviderToolName( string $tool_name, array $available_tools ): string {
+		if ( isset( $available_tools[ $tool_name ] ) && is_array( $available_tools[ $tool_name ] ) ) {
+			return $tool_name;
+		}
+
+		foreach ( $available_tools as $canonical_name => $tool_definition ) {
+			if ( ! is_string( $canonical_name ) || ! is_array( $tool_definition ) ) {
+				continue;
+			}
+
+			$aliases = array( $tool_definition['provider_safe_name'] ?? self::providerSafeName( $canonical_name ) );
+			if ( is_array( $tool_definition['provider_aliases'] ?? null ) ) {
+				$aliases = array_merge( $aliases, $tool_definition['provider_aliases'] );
+			}
+
+			foreach ( $aliases as $alias ) {
+				if ( is_string( $alias ) && $tool_name === $alias ) {
+					return $canonical_name;
+				}
+			}
+		}
+
+		return $tool_name;
 	}
 
 	/**

--- a/src/Tools/class-wp-agent-tool-execution-core.php
+++ b/src/Tools/class-wp-agent-tool-execution-core.php
@@ -26,11 +26,13 @@ class WP_Agent_Tool_Execution_Core {
 	 * @return array<string, mixed> Prepared call or normalized error result.
 	 */
 	public function prepareWP_Agent_Tool_Call( string $tool_name, array $tool_parameters, array $available_tools, array $context = array() ): array {
+		$provider_tool_name = $tool_name;
+		$tool_name          = WP_Agent_Tool_Declaration::canonicalNameForProviderToolName( $tool_name, $available_tools );
 		$tool_definition = $available_tools[ $tool_name ] ?? null;
 		if ( ! is_array( $tool_definition ) ) {
 			return array_merge(
 				array( 'ready' => false ),
-				WP_Agent_Tool_Result::error( $tool_name, "Tool '{$tool_name}' not found", array( 'error_type' => 'tool_not_found' ) )
+				WP_Agent_Tool_Result::error( $provider_tool_name, "Tool '{$provider_tool_name}' not found", array( 'error_type' => 'tool_not_found' ) )
 			);
 		}
 
@@ -57,7 +59,8 @@ class WP_Agent_Tool_Execution_Core {
 			'tool_name'  => $tool_name,
 			'parameters' => $parameters,
 			'metadata'   => array(
-				'source' => $tool_definition['source'] ?? WP_Agent_Tool_Declaration::sourceFromName( $tool_name ),
+				'source'             => $tool_definition['source'] ?? WP_Agent_Tool_Declaration::sourceFromName( $tool_name ),
+				'provider_tool_name' => $provider_tool_name,
 			),
 		);
 

--- a/tests/ability-tool-executor-smoke.php
+++ b/tests/ability-tool-executor-smoke.php
@@ -171,11 +171,12 @@ $core     = new AgentsAPI\AI\Tools\WP_Agent_Tool_Execution_Core();
 echo "\n[1] Ability executor invokes mapped abilities through the generic tool core:\n";
 $tools = array(
 	'host/search' => array(
-		'name'       => 'host/search',
-		'source'     => 'ability',
-		'executor'   => AgentsAPI\AI\Tools\WP_Agent_Tool_Declaration::EXECUTOR_HOST,
-		'ability'    => 'local/search-posts',
-		'parameters' => array(
+		'name'        => 'host/search',
+		'source'      => 'ability',
+		'description' => 'Search posts through the host runtime.',
+		'executor'    => AgentsAPI\AI\Tools\WP_Agent_Tool_Declaration::EXECUTOR_HOST,
+		'ability'     => 'local/search-posts',
+		'parameters'  => array(
 			'type'       => 'object',
 			'required'   => array( 'query' ),
 			'properties' => array(
@@ -199,6 +200,22 @@ agents_api_smoke_assert_equals( 'host/search', $result['tool_name'] ?? '', 'resu
 agents_api_smoke_assert_equals( 'local/search-posts', $result['metadata']['ability_name'] ?? '', 'result records invoked ability name', $failures, $passes );
 agents_api_smoke_assert_equals( 'agents api', $result['result']['query'] ?? '', 'ability receives prepared tool parameters', $failures, $passes );
 agents_api_smoke_assert_equals( 10, $result['result']['limit'] ?? null, 'ability result payload is preserved', $failures, $passes );
+
+echo "\n[1b] Provider-safe tool aliases resolve back to canonical tool declarations:\n";
+$normalized_tool = AgentsAPI\AI\Tools\WP_Agent_Tool_Declaration::normalizeForConversationRequest( $tools['host/search'] );
+$alias_tools     = array( 'host/search' => $normalized_tool );
+$alias_result    = $core->executeTool(
+	(string) $normalized_tool['provider_safe_name'],
+	array( 'query' => 'safe alias' ),
+	$alias_tools,
+	$executor,
+	array( 'tool_call_id' => 'call-ability-alias-1' )
+);
+
+agents_api_smoke_assert_equals( 'host__search', $normalized_tool['provider_safe_name'] ?? '', 'namespaced tool has provider-safe alias', $failures, $passes );
+agents_api_smoke_assert_equals( true, $alias_result['success'] ?? false, 'provider-safe alias executes canonical tool', $failures, $passes );
+agents_api_smoke_assert_equals( 'host/search', $alias_result['tool_name'] ?? '', 'alias result reports canonical tool name', $failures, $passes );
+agents_api_smoke_assert_equals( 'safe alias', $alias_result['result']['query'] ?? '', 'alias execution preserves parameters', $failures, $passes );
 
 echo "\n[2] Ability executor reports registered ability failures without throwing:\n";
 $error_result = $executor->executeWP_Agent_Tool_Call(


### PR DESCRIPTION
## Summary
- add provider-safe aliases to normalized tool declarations for providers that reject namespaced tool names
- resolve provider-emitted aliases back to canonical tool declarations before execution
- cover alias execution through the ability tool executor smoke test

## Tests
- `php tests/ability-tool-executor-smoke.php`
- `php -l src/Tools/class-wp-agent-tool-declaration.php`
- `php -l src/Tools/class-wp-agent-tool-execution-core.php`
- `php -l tests/ability-tool-executor-smoke.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the minimal alias primitive, smoke coverage, and PR text; Chris remains responsible for review and validation.