### PR TITLE
Tighten run-control permissions

### DIFF
--- a/src/Channels/register-agents-chat-run-control-abilities.php
+++ b/src/Channels/register-agents-chat-run-control-abilities.php
@@ -26,6 +26,7 @@ add_action(
 				'input_schema'     => agents_chat_run_events_input_schema(),
 				'output_schema'    => agents_chat_run_events_output_schema(),
 				'execute_callback' => __NAMESPACE__ . '\\agents_list_chat_run_events',
+				'permission'       => __NAMESPACE__ . '\\agents_chat_run_read_permission',
 				'annotations'      => array( 'idempotent' => true ),
 			),
 			AGENTS_GET_CHAT_RUN_ABILITY         => array(
@@ -34,6 +35,7 @@ add_action(
 				'input_schema'     => agents_chat_run_id_input_schema(),
 				'output_schema'    => agents_chat_run_output_schema(),
 				'execute_callback' => __NAMESPACE__ . '\\agents_get_chat_run',
+				'permission'       => __NAMESPACE__ . '\\agents_chat_run_read_permission',
 				'annotations'      => array( 'idempotent' => true ),
 			),
 			AGENTS_CANCEL_CHAT_RUN_ABILITY      => array(
@@ -42,6 +44,7 @@ add_action(
 				'input_schema'     => agents_chat_run_id_input_schema(),
 				'output_schema'    => agents_cancel_chat_run_output_schema(),
 				'execute_callback' => __NAMESPACE__ . '\\agents_cancel_chat_run',
+				'permission'       => __NAMESPACE__ . '\\agents_chat_run_cancel_permission',
 				'annotations'      => array(
 					'destructive' => true,
 					'idempotent'  => true,
@@ -53,6 +56,7 @@ add_action(
 				'input_schema'     => agents_queue_chat_message_input_schema(),
 				'output_schema'    => agents_queue_chat_message_output_schema(),
 				'execute_callback' => __NAMESPACE__ . '\\agents_queue_chat_message',
+				'permission'       => __NAMESPACE__ . '\\agents_chat_run_enqueue_permission',
 				'annotations'      => array(
 					'destructive' => true,
 					'idempotent'  => false,
@@ -74,7 +78,7 @@ add_action(
 					'input_schema'        => $args['input_schema'],
 					'output_schema'       => $args['output_schema'],
 					'execute_callback'    => $args['execute_callback'],
-					'permission_callback' => __NAMESPACE__ . '\\agents_chat_run_control_permission',
+					'permission_callback' => $args['permission'],
 					'meta'                => array(
 						'show_in_rest' => true,
 						'annotations'  => $args['annotations'],
@@ -197,7 +201,7 @@ function agents_queue_chat_message( array $input ) {
 /**
  * @param array<string, mixed> $input Ability input.
  */
-function agents_chat_run_control_permission( array $input ): bool {
+function agents_chat_run_read_permission( array $input ): bool {
 	$agent = sanitize_title( agents_chat_run_control_string( $input['agent'] ?? '' ) );
 	if ( '' !== $agent && class_exists( '\WP_Agent_Access' ) && class_exists( '\WP_Agent_Access_Grant' ) ) {
 		$allowed = \WP_Agent_Access::can_current_principal_access_agent(
@@ -209,7 +213,48 @@ function agents_chat_run_control_permission( array $input ): bool {
 		$allowed = function_exists( 'current_user_can' ) ? current_user_can( 'read' ) : false;
 	}
 
+	$allowed = (bool) apply_filters( 'agents_chat_run_read_permission', $allowed, $input );
 	return (bool) apply_filters( 'agents_chat_run_control_permission', $allowed, $input );
+}
+
+/** @param array<string, mixed> $input Ability input. */
+function agents_chat_run_enqueue_permission( array $input ): bool {
+	$allowed = agents_chat_run_write_permission( $input );
+	$allowed = (bool) apply_filters( 'agents_chat_run_enqueue_permission', $allowed, $input );
+	return (bool) apply_filters( 'agents_chat_run_control_permission', $allowed, $input );
+}
+
+/** @param array<string, mixed> $input Ability input. */
+function agents_chat_run_cancel_permission( array $input ): bool {
+	$allowed = agents_chat_run_write_permission( $input );
+	$allowed = (bool) apply_filters( 'agents_chat_run_cancel_permission', $allowed, $input );
+	return (bool) apply_filters( 'agents_chat_run_control_permission', $allowed, $input );
+}
+
+/** @param array<string, mixed> $input Ability input. */
+function agents_chat_run_write_permission( array $input ): bool {
+	$allowed = function_exists( 'current_user_can' ) ? current_user_can( 'manage_options' ) : false;
+	$agent = sanitize_title( agents_chat_run_control_string( $input['agent'] ?? '' ) );
+	if ( '' !== $agent && class_exists( '\WP_Agent_Access' ) && class_exists( '\WP_Agent_Access_Grant' ) ) {
+		$allowed = $allowed || \WP_Agent_Access::can_current_principal_access_agent(
+			$agent,
+			\WP_Agent_Access_Grant::ROLE_OPERATOR,
+			agents_chat_run_control_request_scope( $input )
+		);
+	}
+
+	return $allowed || agents_chat_run_current_user_owns_session( $input );
+}
+
+/** @param array<string, mixed> $input Ability input. */
+function agents_chat_run_current_user_owns_session( array $input ): bool {
+	$owner = is_array( $input['session_owner'] ?? null ) ? agents_chat_run_control_string_keyed_array( $input['session_owner'] ) : array();
+	if ( 'user' !== agents_chat_run_control_string( $owner['type'] ?? '' ) ) {
+		return false;
+	}
+
+	$user_id = function_exists( 'get_current_user_id' ) ? (int) get_current_user_id() : 0;
+	return $user_id > 0 && (string) $user_id === agents_chat_run_control_string( $owner['key'] ?? '' );
 }
 
 /**

--- a/src/Channels/register-agents-chat-run-control-abilities.php
+++ b/src/Channels/register-agents-chat-run-control-abilities.php
@@ -234,7 +234,7 @@ function agents_chat_run_cancel_permission( array $input ): bool {
 /** @param array<string, mixed> $input Ability input. */
 function agents_chat_run_write_permission( array $input ): bool {
 	$allowed = function_exists( 'current_user_can' ) ? current_user_can( 'manage_options' ) : false;
-	$agent = sanitize_title( agents_chat_run_control_string( $input['agent'] ?? '' ) );
+	$agent   = sanitize_title( agents_chat_run_control_string( $input['agent'] ?? '' ) );
 	if ( '' !== $agent && class_exists( '\WP_Agent_Access' ) && class_exists( '\WP_Agent_Access_Grant' ) ) {
 		$allowed = $allowed || \WP_Agent_Access::can_current_principal_access_agent(
 			$agent,
@@ -254,7 +254,7 @@ function agents_chat_run_current_user_owns_session( array $input ): bool {
 	}
 
 	$user_id = function_exists( 'get_current_user_id' ) ? (int) get_current_user_id() : 0;
-	return $user_id > 0 && (string) $user_id === agents_chat_run_control_string( $owner['key'] ?? '' );
+	return 0 < $user_id && agents_chat_run_control_string( $owner['key'] ?? '' ) === (string) $user_id;
 }
 
 /**

--- a/src/Tasks/register-agents-task-abilities.php
+++ b/src/Tasks/register-agents-task-abilities.php
@@ -41,6 +41,7 @@ add_action(
 				'input_schema'     => agents_task_input_schema(),
 				'output_schema'    => agents_task_result_schema(),
 				'execute_callback' => __NAMESPACE__ . '\\agents_run_task',
+				'permission'       => __NAMESPACE__ . '\\agents_run_task_permission',
 				'annotations'      => array(
 					'destructive' => true,
 					'idempotent'  => false,
@@ -52,6 +53,7 @@ add_action(
 				'input_schema'     => agents_list_execution_targets_input_schema(),
 				'output_schema'    => agents_list_execution_targets_output_schema(),
 				'execute_callback' => __NAMESPACE__ . '\\agents_list_execution_targets',
+				'permission'       => __NAMESPACE__ . '\\agents_task_read_permission',
 				'annotations'      => array( 'idempotent' => true ),
 			),
 			AGENTS_GET_TASK_RUN_ABILITY           => array(
@@ -60,6 +62,7 @@ add_action(
 				'input_schema'     => agents_task_run_id_input_schema(),
 				'output_schema'    => agents_task_result_schema(),
 				'execute_callback' => __NAMESPACE__ . '\\agents_get_task_run',
+				'permission'       => __NAMESPACE__ . '\\agents_task_read_permission',
 				'annotations'      => array( 'idempotent' => true ),
 			),
 			AGENTS_CANCEL_TASK_RUN_ABILITY        => array(
@@ -68,6 +71,7 @@ add_action(
 				'input_schema'     => agents_task_run_id_input_schema(),
 				'output_schema'    => agents_cancel_task_run_output_schema(),
 				'execute_callback' => __NAMESPACE__ . '\\agents_cancel_task_run',
+				'permission'       => __NAMESPACE__ . '\\agents_cancel_task_run_permission',
 				'annotations'      => array(
 					'destructive' => true,
 					'idempotent'  => true,
@@ -89,7 +93,7 @@ add_action(
 					'input_schema'        => $args['input_schema'],
 					'output_schema'       => $args['output_schema'],
 					'execute_callback'    => $args['execute_callback'],
-					'permission_callback' => __NAMESPACE__ . '\\agents_task_permission',
+					'permission_callback' => $args['permission'],
 					'meta'                => array(
 						'show_in_rest' => true,
 						'annotations'  => $args['annotations'],
@@ -443,9 +447,41 @@ function agents_task_normalize_run_control_result( $result, string $error_code )
 /**
  * @param array<string,mixed> $input Ability input.
  */
-function agents_task_permission( array $input ): bool {
+function agents_task_read_permission( array $input ): bool {
 	$allowed = function_exists( 'current_user_can' ) ? current_user_can( 'read' ) : false;
+	$allowed = (bool) apply_filters( 'agents_task_read_permission', $allowed, $input );
 	return (bool) apply_filters( 'agents_task_permission', $allowed, $input );
+}
+
+/** @param array<string,mixed> $input Ability input. */
+function agents_run_task_permission( array $input ): bool {
+	$allowed = agents_task_write_permission( $input );
+	$allowed = (bool) apply_filters( 'agents_run_task_permission', $allowed, $input );
+	return (bool) apply_filters( 'agents_task_permission', $allowed, $input );
+}
+
+/** @param array<string,mixed> $input Ability input. */
+function agents_cancel_task_run_permission( array $input ): bool {
+	$allowed = agents_task_write_permission( $input );
+	$allowed = (bool) apply_filters( 'agents_cancel_task_run_permission', $allowed, $input );
+	return (bool) apply_filters( 'agents_task_permission', $allowed, $input );
+}
+
+/** @param array<string,mixed> $input Ability input. */
+function agents_task_write_permission( array $input ): bool {
+	$allowed = function_exists( 'current_user_can' ) ? current_user_can( 'manage_options' ) : false;
+	return $allowed || agents_task_current_user_owns_session( $input );
+}
+
+/** @param array<string,mixed> $input Ability input. */
+function agents_task_current_user_owns_session( array $input ): bool {
+	$owner = is_array( $input['session_owner'] ?? null ) ? agents_task_string_keyed_array( $input['session_owner'] ) : array();
+	if ( 'user' !== agents_task_string( $owner['type'] ?? '' ) ) {
+		return false;
+	}
+
+	$user_id = function_exists( 'get_current_user_id' ) ? (int) get_current_user_id() : 0;
+	return $user_id > 0 && (string) $user_id === agents_task_string( $owner['key'] ?? '' );
 }
 
 function agents_task_optional_string( mixed $value ): ?string {
@@ -508,6 +544,7 @@ function agents_task_input_schema(): array {
 			'instructions'   => array( 'type' => 'string' ),
 			'session_id'     => array( 'type' => array( 'string', 'null' ) ),
 			'run_id'         => array( 'type' => array( 'string', 'null' ) ),
+			'session_owner'  => agents_task_session_owner_schema(),
 			'placement'      => agents_task_placement_schema(),
 			'client_context' => array( 'type' => 'object' ),
 			'metadata'       => array( 'type' => 'object' ),
@@ -645,6 +682,18 @@ function agents_task_run_id_input_schema(): array {
 		'properties' => array(
 			'session_id' => array( 'type' => 'string' ),
 			'run_id'     => array( 'type' => 'string' ),
+			'session_owner' => agents_task_session_owner_schema(),
+		),
+	);
+}
+
+/** @return array<string,mixed> */
+function agents_task_session_owner_schema(): array {
+	return array(
+		'type'       => array( 'object', 'null' ),
+		'properties' => array(
+			'type' => array( 'type' => 'string' ),
+			'key'  => array( 'type' => 'string' ),
 		),
 	);
 }

--- a/src/Tasks/register-agents-task-abilities.php
+++ b/src/Tasks/register-agents-task-abilities.php
@@ -481,7 +481,7 @@ function agents_task_current_user_owns_session( array $input ): bool {
 	}
 
 	$user_id = function_exists( 'get_current_user_id' ) ? (int) get_current_user_id() : 0;
-	return $user_id > 0 && (string) $user_id === agents_task_string( $owner['key'] ?? '' );
+	return 0 < $user_id && agents_task_string( $owner['key'] ?? '' ) === (string) $user_id;
 }
 
 function agents_task_optional_string( mixed $value ): ?string {
@@ -680,8 +680,8 @@ function agents_task_run_id_input_schema(): array {
 		'type'       => 'object',
 		'required'   => array( 'session_id', 'run_id' ),
 		'properties' => array(
-			'session_id' => array( 'type' => 'string' ),
-			'run_id'     => array( 'type' => 'string' ),
+			'session_id'    => array( 'type' => 'string' ),
+			'run_id'        => array( 'type' => 'string' ),
 			'session_owner' => agents_task_session_owner_schema(),
 		),
 	);

--- a/tests/chat-run-control-smoke.php
+++ b/tests/chat-run-control-smoke.php
@@ -88,9 +88,9 @@ do_action( 'wp_abilities_api_init' );
 
 $GLOBALS['__agents_api_smoke_caps']    = array( 'read' => true );
 $GLOBALS['__agents_api_smoke_user_id'] = 123;
-$chat_read_permission                  = $GLOBALS['__agents_api_smoke_abilities'][ AgentsAPI\AI\Channels\AGENTS_GET_CHAT_RUN_ABILITY ]['permission_callback'];
-$chat_cancel_permission                = $GLOBALS['__agents_api_smoke_abilities'][ AgentsAPI\AI\Channels\AGENTS_CANCEL_CHAT_RUN_ABILITY ]['permission_callback'];
-$chat_queue_permission                 = $GLOBALS['__agents_api_smoke_abilities'][ AgentsAPI\AI\Channels\AGENTS_QUEUE_CHAT_MESSAGE_ABILITY ]['permission_callback'];
+$chat_read_permission                  = 'AgentsAPI\AI\Channels\agents_chat_run_read_permission';
+$chat_cancel_permission                = 'AgentsAPI\AI\Channels\agents_chat_run_cancel_permission';
+$chat_queue_permission                 = 'AgentsAPI\AI\Channels\agents_chat_run_enqueue_permission';
 
 agents_api_smoke_assert_equals( true, call_user_func( $chat_read_permission, array( 'session_id' => 'session-1', 'run_id' => 'run-1' ) ), 'read-only user can read chat run status', $failures, $passes );
 agents_api_smoke_assert_equals( false, call_user_func( $chat_cancel_permission, array( 'session_id' => 'session-1', 'run_id' => 'run-1' ) ), 'read-only user cannot cancel chat run by id alone', $failures, $passes );

--- a/tests/chat-run-control-smoke.php
+++ b/tests/chat-run-control-smoke.php
@@ -33,8 +33,13 @@ if ( ! class_exists( 'WP_Error' ) ) {
 
 if ( ! function_exists( 'current_user_can' ) ) {
 	function current_user_can( string $capability ): bool {
-		unset( $capability );
-		return true;
+		return ! empty( $GLOBALS['__agents_api_smoke_caps'][ $capability ] );
+	}
+}
+
+if ( ! function_exists( 'get_current_user_id' ) ) {
+	function get_current_user_id(): int {
+		return (int) ( $GLOBALS['__agents_api_smoke_user_id'] ?? 0 );
 	}
 }
 
@@ -80,6 +85,21 @@ agents_api_smoke_require_module();
 
 do_action( 'wp_abilities_api_categories_init' );
 do_action( 'wp_abilities_api_init' );
+
+$GLOBALS['__agents_api_smoke_caps']    = array( 'read' => true );
+$GLOBALS['__agents_api_smoke_user_id'] = 123;
+$chat_read_permission                  = $GLOBALS['__agents_api_smoke_abilities'][ AgentsAPI\AI\Channels\AGENTS_GET_CHAT_RUN_ABILITY ]['permission_callback'];
+$chat_cancel_permission                = $GLOBALS['__agents_api_smoke_abilities'][ AgentsAPI\AI\Channels\AGENTS_CANCEL_CHAT_RUN_ABILITY ]['permission_callback'];
+$chat_queue_permission                 = $GLOBALS['__agents_api_smoke_abilities'][ AgentsAPI\AI\Channels\AGENTS_QUEUE_CHAT_MESSAGE_ABILITY ]['permission_callback'];
+
+agents_api_smoke_assert_equals( true, call_user_func( $chat_read_permission, array( 'session_id' => 'session-1', 'run_id' => 'run-1' ) ), 'read-only user can read chat run status', $failures, $passes );
+agents_api_smoke_assert_equals( false, call_user_func( $chat_cancel_permission, array( 'session_id' => 'session-1', 'run_id' => 'run-1' ) ), 'read-only user cannot cancel chat run by id alone', $failures, $passes );
+agents_api_smoke_assert_equals( false, call_user_func( $chat_queue_permission, array( 'agent' => 'demo-agent', 'session_id' => 'session-1', 'message' => 'Next' ) ), 'read-only user cannot queue chat message by session id alone', $failures, $passes );
+agents_api_smoke_assert_equals( true, call_user_func( $chat_cancel_permission, array( 'session_id' => 'session-1', 'run_id' => 'run-1', 'session_owner' => array( 'type' => 'user', 'key' => '123' ) ) ), 'session owner can cancel chat run', $failures, $passes );
+agents_api_smoke_assert_equals( true, call_user_func( $chat_queue_permission, array( 'agent' => 'demo-agent', 'session_id' => 'session-1', 'message' => 'Next', 'session_owner' => array( 'type' => 'user', 'key' => '123' ) ) ), 'session owner can queue chat message', $failures, $passes );
+$GLOBALS['__agents_api_smoke_caps']['manage_options'] = true;
+agents_api_smoke_assert_equals( true, call_user_func( $chat_cancel_permission, array( 'session_id' => 'session-1', 'run_id' => 'run-1' ) ), 'manager can cancel chat run without owner claim', $failures, $passes );
+agents_api_smoke_assert_equals( true, call_user_func( $chat_queue_permission, array( 'agent' => 'demo-agent', 'session_id' => 'session-1', 'message' => 'Next' ) ), 'manager can queue chat message without owner claim', $failures, $passes );
 
 agents_api_smoke_assert_equals( true, wp_has_ability( AgentsAPI\AI\Channels\AGENTS_GET_CHAT_RUN_ABILITY ), 'get-run ability registers', $failures, $passes );
 agents_api_smoke_assert_equals( true, wp_has_ability( AgentsAPI\AI\Channels\AGENTS_CANCEL_CHAT_RUN_ABILITY ), 'cancel-run ability registers', $failures, $passes );

--- a/tests/task-execution-smoke.php
+++ b/tests/task-execution-smoke.php
@@ -117,9 +117,9 @@ do_action( 'wp_abilities_api_init' );
 
 $GLOBALS['__agents_api_smoke_caps']    = array( 'read' => true );
 $GLOBALS['__agents_api_smoke_user_id'] = 123;
-$task_read_permission                  = $GLOBALS['__agents_api_smoke_abilities'][ AgentsAPI\AI\Tasks\AGENTS_GET_TASK_RUN_ABILITY ]['permission_callback'];
-$task_run_permission                   = $GLOBALS['__agents_api_smoke_abilities'][ AgentsAPI\AI\Tasks\AGENTS_RUN_TASK_ABILITY ]['permission_callback'];
-$task_cancel_permission                = $GLOBALS['__agents_api_smoke_abilities'][ AgentsAPI\AI\Tasks\AGENTS_CANCEL_TASK_RUN_ABILITY ]['permission_callback'];
+$task_read_permission                  = 'AgentsAPI\AI\Tasks\agents_task_read_permission';
+$task_run_permission                   = 'AgentsAPI\AI\Tasks\agents_run_task_permission';
+$task_cancel_permission                = 'AgentsAPI\AI\Tasks\agents_cancel_task_run_permission';
 
 agents_api_smoke_assert_equals( true, call_user_func( $task_read_permission, array( 'session_id' => 'task-session-1', 'run_id' => 'task-run-1' ) ), 'read-only user can read task run status', $failures, $passes );
 agents_api_smoke_assert_equals( false, call_user_func( $task_run_permission, array( 'task' => array( 'id' => 'task-1' ), 'session_id' => 'task-session-1', 'run_id' => 'task-run-1' ) ), 'read-only user cannot queue task run by id alone', $failures, $passes );

--- a/tests/task-execution-smoke.php
+++ b/tests/task-execution-smoke.php
@@ -33,8 +33,7 @@ if ( ! class_exists( 'WP_Error' ) ) {
 
 if ( ! function_exists( 'current_user_can' ) ) {
 	function current_user_can( string $capability ): bool {
-		unset( $capability );
-		return true;
+		return ! empty( $GLOBALS['__agents_api_smoke_caps'][ $capability ] );
 	}
 } else {
 	add_filter(
@@ -44,6 +43,12 @@ if ( ! function_exists( 'current_user_can' ) ) {
 			return $allcaps;
 		}
 	);
+}
+
+if ( ! function_exists( 'get_current_user_id' ) ) {
+	function get_current_user_id(): int {
+		return (int) ( $GLOBALS['__agents_api_smoke_user_id'] ?? 0 );
+	}
 }
 
 if ( ! function_exists( 'wp_has_ability_category' ) ) {
@@ -109,6 +114,21 @@ agents_api_smoke_require_module();
 
 do_action( 'wp_abilities_api_categories_init' );
 do_action( 'wp_abilities_api_init' );
+
+$GLOBALS['__agents_api_smoke_caps']    = array( 'read' => true );
+$GLOBALS['__agents_api_smoke_user_id'] = 123;
+$task_read_permission                  = $GLOBALS['__agents_api_smoke_abilities'][ AgentsAPI\AI\Tasks\AGENTS_GET_TASK_RUN_ABILITY ]['permission_callback'];
+$task_run_permission                   = $GLOBALS['__agents_api_smoke_abilities'][ AgentsAPI\AI\Tasks\AGENTS_RUN_TASK_ABILITY ]['permission_callback'];
+$task_cancel_permission                = $GLOBALS['__agents_api_smoke_abilities'][ AgentsAPI\AI\Tasks\AGENTS_CANCEL_TASK_RUN_ABILITY ]['permission_callback'];
+
+agents_api_smoke_assert_equals( true, call_user_func( $task_read_permission, array( 'session_id' => 'task-session-1', 'run_id' => 'task-run-1' ) ), 'read-only user can read task run status', $failures, $passes );
+agents_api_smoke_assert_equals( false, call_user_func( $task_run_permission, array( 'task' => array( 'id' => 'task-1' ), 'session_id' => 'task-session-1', 'run_id' => 'task-run-1' ) ), 'read-only user cannot queue task run by id alone', $failures, $passes );
+agents_api_smoke_assert_equals( false, call_user_func( $task_cancel_permission, array( 'session_id' => 'task-session-1', 'run_id' => 'task-run-1' ) ), 'read-only user cannot cancel task run by id alone', $failures, $passes );
+agents_api_smoke_assert_equals( true, call_user_func( $task_run_permission, array( 'task' => array( 'id' => 'task-1' ), 'session_id' => 'task-session-1', 'run_id' => 'task-run-1', 'session_owner' => array( 'type' => 'user', 'key' => '123' ) ) ), 'session owner can queue task run', $failures, $passes );
+agents_api_smoke_assert_equals( true, call_user_func( $task_cancel_permission, array( 'session_id' => 'task-session-1', 'run_id' => 'task-run-1', 'session_owner' => array( 'type' => 'user', 'key' => '123' ) ) ), 'session owner can cancel task run', $failures, $passes );
+$GLOBALS['__agents_api_smoke_caps']['manage_options'] = true;
+agents_api_smoke_assert_equals( true, call_user_func( $task_run_permission, array( 'task' => array( 'id' => 'task-1' ), 'session_id' => 'task-session-1', 'run_id' => 'task-run-1' ) ), 'manager can queue task run without owner claim', $failures, $passes );
+agents_api_smoke_assert_equals( true, call_user_func( $task_cancel_permission, array( 'session_id' => 'task-session-1', 'run_id' => 'task-run-1' ) ), 'manager can cancel task run without owner claim', $failures, $passes );
 
 agents_api_smoke_assert_equals( true, wp_has_ability( AgentsAPI\AI\Tasks\AGENTS_RUN_TASK_ABILITY ), 'run-task ability registers', $failures, $passes );
 agents_api_smoke_assert_equals( true, wp_has_ability( AgentsAPI\AI\Tasks\AGENTS_LIST_EXECUTION_TARGETS_ABILITY ), 'list-execution-targets ability registers', $failures, $passes );


### PR DESCRIPTION
## Summary
- split chat run-control and task execution permissions into read/status vs enqueue/run vs cancel callbacks
- keep existing host-level filters while adding action-specific permission filters
- require manage_options, agent operator access for chat, or matching session_owner before destructive enqueue/cancel/run actions
- cover read-only denial and manager/owner allowance in chat and task smoke tests

## Testing
- php tests/chat-run-control-smoke.php
- php tests/task-execution-smoke.php
- composer test
- composer phpstan

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** implementation and tests drafted by coding agent for Chris to review