### PR TITLE
Extract generic response and input primitives

### DIFF
--- a/agents-api.php
+++ b/agents-api.php
@@ -73,6 +73,8 @@ require_once AGENTS_API_PATH . 'src/Auth/class-wp-agent-authorization-policy.php
 require_once AGENTS_API_PATH . 'src/Auth/class-wp-agent-token-authenticator.php';
 require_once AGENTS_API_PATH . 'src/Auth/class-wp-agent-wordpress-authorization-policy.php';
 require_once AGENTS_API_PATH . 'src/Auth/register-agent-access-abilities.php';
+require_once AGENTS_API_PATH . 'src/Runtime/functions-input-normalization.php';
+require_once AGENTS_API_PATH . 'src/Runtime/functions-sse-response.php';
 require_once AGENTS_API_PATH . 'src/Context/class-wp-agent-context-injection-policy.php';
 require_once AGENTS_API_PATH . 'src/Context/class-wp-agent-memory-layer.php';
 require_once AGENTS_API_PATH . 'src/Context/class-wp-agent-memory-registry.php';

--- a/composer.json
+++ b/composer.json
@@ -89,6 +89,7 @@
       "php tests/task-execution-smoke.php",
       "php tests/frontend-chat-rest-smoke.php",
       "php tests/agents-chat-jsonrpc-route-smoke.php",
+      "php tests/response-and-input-primitives-smoke.php",
       "php tests/agents-dispatch-message-ability-smoke.php",
       "php tests/webhook-safety-smoke.php",
       "php tests/remote-bridge-smoke.php",

--- a/src/Channels/register-agents-chat-jsonrpc-route.php
+++ b/src/Channels/register-agents-chat-jsonrpc-route.php
@@ -107,7 +107,7 @@ function register_chat_stream_handler( callable $handler, int $priority = 10 ): 
  * @param \WP_REST_Request $request REST request.
  */
 function agents_chat_jsonrpc_permission( \WP_REST_Request $request ): bool|\WP_Error {
-	$agent = sanitize_title( agents_chat_jsonrpc_string( $request->get_param( 'agent_id' ) ) );
+	$agent = sanitize_title( \AgentsAPI\AI\agents_api_scalar_to_string( $request->get_param( 'agent_id' ) ) );
 	if ( '' === $agent ) {
 		return new \WP_Error(
 			'agents_chat_jsonrpc_forbidden',
@@ -155,7 +155,7 @@ function agents_chat_jsonrpc_permission( \WP_REST_Request $request ): bool|\WP_E
  * @return \WP_REST_Response
  */
 function agents_chat_jsonrpc_dispatch( \WP_REST_Request $request ): \WP_REST_Response {
-	$agent  = sanitize_title( agents_chat_jsonrpc_string( $request->get_param( 'agent_id' ) ) );
+	$agent  = sanitize_title( \AgentsAPI\AI\agents_api_scalar_to_string( $request->get_param( 'agent_id' ) ) );
 	$body   = $request->get_json_params();
 	$rpc_id = agents_chat_jsonrpc_request_id( $body );
 	$method = isset( $body['method'] ) && is_string( $body['method'] ) ? $body['method'] : '';
@@ -215,7 +215,7 @@ function agents_chat_jsonrpc_run_sync( array $input ) {
 		return $result;
 	}
 
-	return agents_chat_jsonrpc_string_keyed_array( is_array( $result ) ? $result : array() );
+	return \AgentsAPI\AI\agents_api_string_keyed_array( is_array( $result ) ? $result : array() );
 }
 
 /**
@@ -232,9 +232,9 @@ function agents_chat_jsonrpc_run_sync( array $input ) {
  * @return void
  */
 function agents_chat_jsonrpc_stream( $rpc_id, array $input ): void {
-	agents_chat_jsonrpc_open_sse_stream();
+	\AgentsAPI\AI\agents_api_open_sse_response();
 
-	$task_id = agents_chat_jsonrpc_string( $input['run_id'] ?? null );
+	$task_id = \AgentsAPI\AI\agents_api_scalar_to_string( $input['run_id'] ?? null );
 	if ( '' === $task_id ) {
 		$task_id         = WP_Agent_Chat_Run_Control::generate_run_id();
 		$input['run_id'] = $task_id;
@@ -247,8 +247,8 @@ function agents_chat_jsonrpc_stream( $rpc_id, array $input ): void {
 		 * @param array<string,mixed> $delta Canonical delta emitted by the runtime.
 		 */
 		$emit = static function ( array $delta ) use ( $task_id ): void {
-			agents_chat_jsonrpc_send_sse_frame(
-				agents_chat_jsonrpc_delta_frame( $task_id, agents_chat_jsonrpc_string_keyed_array( $delta ) )
+			\AgentsAPI\AI\agents_api_emit_sse_json_frame(
+				agents_chat_jsonrpc_delta_frame( $task_id, \AgentsAPI\AI\agents_api_string_keyed_array( $delta ) )
 			);
 		};
 
@@ -259,18 +259,18 @@ function agents_chat_jsonrpc_stream( $rpc_id, array $input ): void {
 	}
 
 	if ( is_wp_error( $output ) ) {
-		agents_chat_jsonrpc_send_sse_frame(
+		\AgentsAPI\AI\agents_api_emit_sse_json_frame(
 			agents_chat_jsonrpc_error_frame( $rpc_id, AGENTS_CHAT_JSONRPC_ERR_INTERNAL, $output->get_error_message() )
 		);
 		return;
 	}
 
-	$output = agents_chat_jsonrpc_string_keyed_array( is_array( $output ) ? $output : array() );
-	if ( '' === agents_chat_jsonrpc_string( $output['run_id'] ?? null ) ) {
+	$output = \AgentsAPI\AI\agents_api_string_keyed_array( is_array( $output ) ? $output : array() );
+	if ( '' === \AgentsAPI\AI\agents_api_scalar_to_string( $output['run_id'] ?? null ) ) {
 		$output['run_id'] = $task_id;
 	}
 
-	agents_chat_jsonrpc_send_sse_frame(
+	\AgentsAPI\AI\agents_api_emit_sse_json_frame(
 		agents_chat_jsonrpc_result_frame( $rpc_id, agents_chat_jsonrpc_task_from_output( $output ) )
 	);
 }
@@ -293,8 +293,8 @@ function agents_chat_jsonrpc_input_from_params( array $params, string $agent ) {
 		return new \WP_Error( 'agents_chat_jsonrpc_invalid_params', 'params.message must contain non-empty text.' );
 	}
 
-	$session_id = agents_chat_jsonrpc_string( $params['sessionId'] ?? null );
-	$run_id     = agents_chat_jsonrpc_string( $params['id'] ?? null );
+	$session_id = \AgentsAPI\AI\agents_api_scalar_to_string( $params['sessionId'] ?? null );
+	$run_id     = \AgentsAPI\AI\agents_api_scalar_to_string( $params['id'] ?? null );
 
 	$client_context = array(
 		'source'      => 'jsonrpc',
@@ -323,7 +323,7 @@ function agents_chat_jsonrpc_input_from_params( array $params, string $agent ) {
 	/** @var mixed $filtered Hosts may return invalid values from this filter. */
 	$filtered = apply_filters( 'agents_chat_jsonrpc_input', $input, $params, $agent );
 
-	return is_array( $filtered ) ? agents_chat_jsonrpc_string_keyed_array( $filtered ) : $input;
+	return is_array( $filtered ) ? \AgentsAPI\AI\agents_api_string_keyed_array( $filtered ) : $input;
 }
 
 /**
@@ -333,9 +333,9 @@ function agents_chat_jsonrpc_input_from_params( array $params, string $agent ) {
  * @return array<string,mixed> Task.
  */
 function agents_chat_jsonrpc_task_from_output( array $output ): array {
-	$run_id     = agents_chat_jsonrpc_string( $output['run_id'] ?? null );
-	$session_id = agents_chat_jsonrpc_string( $output['session_id'] ?? null );
-	$reply      = agents_chat_jsonrpc_string( $output['reply'] ?? null );
+	$run_id     = \AgentsAPI\AI\agents_api_scalar_to_string( $output['run_id'] ?? null );
+	$session_id = \AgentsAPI\AI\agents_api_scalar_to_string( $output['session_id'] ?? null );
+	$reply      = \AgentsAPI\AI\agents_api_scalar_to_string( $output['reply'] ?? null );
 
 	// `completed` defaults to true when absent (mirrors run-control in agents_chat_dispatch).
 	$completed = ! array_key_exists( 'completed', $output ) || ! empty( $output['completed'] );
@@ -443,31 +443,31 @@ function agents_chat_jsonrpc_delta_frame( string $task_id, array $delta ): array
  * @return array<string,mixed> Wire StreamDelta.
  */
 function agents_chat_jsonrpc_delta_to_wire( array $delta ): array {
-	$type = agents_chat_jsonrpc_string( $delta['type'] ?? null );
+	$type = \AgentsAPI\AI\agents_api_scalar_to_string( $delta['type'] ?? null );
 
 	if ( 'tool_call' === $type ) {
 		return array(
 			'deltaType'     => 'tool_name',
-			'content'       => agents_chat_jsonrpc_string( $delta['tool_name'] ?? null ),
-			'toolCallId'    => agents_chat_jsonrpc_string( $delta['tool_call_id'] ?? null ),
-			'toolCallName'  => agents_chat_jsonrpc_string( $delta['tool_name'] ?? null ),
-			'toolCallIndex' => agents_chat_jsonrpc_int( $delta['index'] ?? null ),
+			'content'       => \AgentsAPI\AI\agents_api_scalar_to_string( $delta['tool_name'] ?? null ),
+			'toolCallId'    => \AgentsAPI\AI\agents_api_scalar_to_string( $delta['tool_call_id'] ?? null ),
+			'toolCallName'  => \AgentsAPI\AI\agents_api_scalar_to_string( $delta['tool_name'] ?? null ),
+			'toolCallIndex' => \AgentsAPI\AI\agents_api_numeric_to_int( $delta['index'] ?? null ),
 		);
 	}
 
 	if ( 'tool_argument' === $type ) {
 		return array(
 			'deltaType'     => 'tool_argument',
-			'content'       => agents_chat_jsonrpc_string( $delta['text'] ?? null ),
-			'toolCallId'    => agents_chat_jsonrpc_string( $delta['tool_call_id'] ?? null ),
-			'toolCallIndex' => agents_chat_jsonrpc_int( $delta['index'] ?? null ),
+			'content'       => \AgentsAPI\AI\agents_api_scalar_to_string( $delta['text'] ?? null ),
+			'toolCallId'    => \AgentsAPI\AI\agents_api_scalar_to_string( $delta['tool_call_id'] ?? null ),
+			'toolCallIndex' => \AgentsAPI\AI\agents_api_numeric_to_int( $delta['index'] ?? null ),
 		);
 	}
 
 	// Default: content delta.
 	return array(
 		'deltaType' => 'content',
-		'content'   => agents_chat_jsonrpc_string( $delta['text'] ?? ( $delta['content'] ?? null ) ),
+		'content'   => \AgentsAPI\AI\agents_api_scalar_to_string( $delta['text'] ?? ( $delta['content'] ?? null ) ),
 	);
 }
 
@@ -489,7 +489,7 @@ function agents_chat_jsonrpc_extract_text( array $message ): string {
 		if ( 'context' === ( $part['contentType'] ?? null ) ) {
 			continue;
 		}
-		$texts[] = agents_chat_jsonrpc_string( $part['text'] ?? null );
+		$texts[] = \AgentsAPI\AI\agents_api_scalar_to_string( $part['text'] ?? null );
 	}
 
 	return trim( implode( '', $texts ) );
@@ -510,7 +510,7 @@ function agents_chat_jsonrpc_attachments( array $message ): array {
 			continue;
 		}
 		$file          = isset( $part['file'] ) && is_array( $part['file'] ) ? $part['file'] : array();
-		$attachments[] = agents_chat_jsonrpc_string_keyed_array( $file );
+		$attachments[] = \AgentsAPI\AI\agents_api_string_keyed_array( $file );
 	}
 
 	return $attachments;
@@ -545,77 +545,8 @@ function agents_chat_jsonrpc_scope( \WP_REST_Request $request ): array {
 		)
 	);
 	$scope['request_metadata'] = array(
-		'rest_route' => AGENTS_CHAT_JSONRPC_NAMESPACE . '/agent/' . sanitize_title( agents_chat_jsonrpc_string( $request->get_param( 'agent_id' ) ) ),
+		'rest_route' => AGENTS_CHAT_JSONRPC_NAMESPACE . '/agent/' . sanitize_title( \AgentsAPI\AI\agents_api_scalar_to_string( $request->get_param( 'agent_id' ) ) ),
 	);
 
 	return $scope;
-}
-
-/**
- * Open an SSE response: send headers and disable output buffering/compression.
- *
- * @return void
- */
-function agents_chat_jsonrpc_open_sse_stream(): void {
-	if ( ! headers_sent() ) {
-		header( 'Content-Type: text/event-stream; charset=utf-8' );
-		header( 'Cache-Control: no-cache, no-store, must-revalidate' );
-		header( 'Connection: keep-alive' );
-		header( 'X-Accel-Buffering: no' ); // Disable nginx proxy buffering.
-	}
-
-	// Discard any output buffering so frames flush immediately.
-	while ( ob_get_level() > 0 ) {
-		ob_end_flush();
-	}
-}
-
-/**
- * Write one SSE `data:` frame and flush.
- *
- * @param array<string,mixed> $frame JSON-RPC frame.
- * @return void
- */
-function agents_chat_jsonrpc_send_sse_frame( array $frame ): void {
-	echo 'data: ' . wp_json_encode( $frame ) . "\n\n"; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- SSE payload is JSON, not HTML.
-	flush();
-}
-
-/**
- * Coerce a value to string only when it is safely representable as text.
- *
- * @param mixed $value Value to normalize.
- */
-function agents_chat_jsonrpc_string( $value ): string {
-	if ( is_scalar( $value ) || $value instanceof \Stringable ) {
-		return (string) $value;
-	}
-
-	return '';
-}
-
-/**
- * Coerce a value to int only when it is numeric, defaulting to 0.
- *
- * @param mixed $value Value to normalize.
- */
-function agents_chat_jsonrpc_int( $value ): int {
-	return is_numeric( $value ) ? (int) $value : 0;
-}
-
-/**
- * Keep only string-keyed entries for canonical associative arrays.
- *
- * @param array<mixed> $value Input array.
- * @return array<string,mixed>
- */
-function agents_chat_jsonrpc_string_keyed_array( array $value ): array {
-	$result = array();
-	foreach ( $value as $key => $item ) {
-		if ( is_string( $key ) ) {
-			$result[ $key ] = $item;
-		}
-	}
-
-	return $result;
 }

--- a/src/Channels/register-frontend-chat-rest-route.php
+++ b/src/Channels/register-frontend-chat-rest-route.php
@@ -69,7 +69,7 @@ function agents_frontend_chat_rest_permission( \WP_REST_Request $request ): bool
 		return $input;
 	}
 
-	$agent   = agents_frontend_chat_rest_string_value( $input['agent'] ?? null );
+	$agent   = \AgentsAPI\AI\agents_api_scalar_to_string( $input['agent'] ?? null );
 	$allowed = '' !== $agent && agents_chat_permission( $input );
 
 	if ( ! $allowed && '' !== $agent ) {
@@ -115,14 +115,14 @@ function agents_frontend_chat_rest_input( \WP_REST_Request $request ) {
 			return $cached;
 		}
 		if ( is_array( $cached ) ) {
-			return agents_frontend_chat_rest_string_key_array( $cached );
+			return \AgentsAPI\AI\agents_api_string_keyed_array( $cached );
 		}
 	}
 
 	$client_context = $request->get_param( 'client_context' );
-	$client_context = is_array( $client_context ) ? agents_frontend_chat_rest_string_key_array( $client_context ) : array();
+	$client_context = is_array( $client_context ) ? \AgentsAPI\AI\agents_api_string_keyed_array( $client_context ) : array();
 	$session_id     = $request->get_param( 'session_id' );
-	$client_name    = agents_frontend_chat_rest_string_value( $client_context['client_name'] ?? null );
+	$client_name    = \AgentsAPI\AI\agents_api_scalar_to_string( $client_context['client_name'] ?? null );
 	$client_context = array_merge(
 		$client_context,
 		array(
@@ -133,9 +133,9 @@ function agents_frontend_chat_rest_input( \WP_REST_Request $request ) {
 
 	$attachments = $request->get_param( 'attachments' );
 	$input       = array(
-		'agent'          => sanitize_title( agents_frontend_chat_rest_string_value( $request->get_param( 'agent' ) ) ),
-		'message'        => agents_frontend_chat_rest_string_value( $request->get_param( 'message' ) ),
-		'session_id'     => null !== $session_id ? agents_frontend_chat_rest_string_value( $session_id ) : null,
+		'agent'          => sanitize_title( \AgentsAPI\AI\agents_api_scalar_to_string( $request->get_param( 'agent' ) ) ),
+		'message'        => \AgentsAPI\AI\agents_api_scalar_to_string( $request->get_param( 'message' ) ),
+		'session_id'     => null !== $session_id ? \AgentsAPI\AI\agents_api_scalar_to_string( $session_id ) : null,
 		'attachments'    => is_array( $attachments ) ? $attachments : array(),
 		'client_context' => $client_context,
 	);
@@ -157,9 +157,9 @@ function agents_frontend_chat_rest_input( \WP_REST_Request $request ) {
 
 		return $cache[ $request ];
 	}
-	$input = agents_frontend_chat_rest_string_key_array( $filtered_input );
+	$input = \AgentsAPI\AI\agents_api_string_keyed_array( $filtered_input );
 
-	if ( '' === agents_frontend_chat_rest_string_value( $input['agent'] ?? null ) || '' === trim( agents_frontend_chat_rest_string_value( $input['message'] ?? null ) ) ) {
+	if ( '' === \AgentsAPI\AI\agents_api_scalar_to_string( $input['agent'] ?? null ) || '' === trim( \AgentsAPI\AI\agents_api_scalar_to_string( $input['message'] ?? null ) ) ) {
 		$cache[ $request ] = new \WP_Error(
 			'agents_frontend_chat_invalid_input',
 			'The frontend chat REST request requires a non-empty agent and message.',
@@ -174,36 +174,6 @@ function agents_frontend_chat_rest_input( \WP_REST_Request $request ) {
 }
 
 /**
- * Return a string only for values that can safely be represented as text.
- *
- * @param mixed $value Value to normalize.
- */
-function agents_frontend_chat_rest_string_value( $value ): string {
-	if ( is_scalar( $value ) || $value instanceof \Stringable ) {
-		return (string) $value;
-	}
-
-	return '';
-}
-
-/**
- * Keep only string-keyed entries for canonical associative input arrays.
- *
- * @param array<mixed> $value Input array.
- * @return array<string,mixed>
- */
-function agents_frontend_chat_rest_string_key_array( array $value ): array {
-	$result = array();
-	foreach ( $value as $key => $item ) {
-		if ( is_string( $key ) ) {
-			$result[ $key ] = $item;
-		}
-	}
-
-	return $result;
-}
-
-/**
  * Build request context for principal/access helpers.
  *
  * @param \WP_REST_Request $request REST request.
@@ -211,7 +181,7 @@ function agents_frontend_chat_rest_string_key_array( array $value ): array {
  */
 function agents_frontend_chat_rest_scope( \WP_REST_Request $request ): array {
 	$client_context            = $request->get_param( 'client_context' );
-	$client_context            = is_array( $client_context ) ? agents_frontend_chat_rest_string_key_array( $client_context ) : array();
+	$client_context            = is_array( $client_context ) ? \AgentsAPI\AI\agents_api_string_keyed_array( $client_context ) : array();
 	$scope                     = \AgentsAPI\AI\Auth\agents_access_request_scope(
 		array(
 			'workspace_id' => $request->get_param( 'workspace_id' ),
@@ -282,7 +252,7 @@ function agents_frontend_chat_rest_schema_property( array $properties, string $n
 		return $fallback;
 	}
 
-	return agents_frontend_chat_rest_string_key_array( $property );
+	return \AgentsAPI\AI\agents_api_string_keyed_array( $property );
 }
 
 /**

--- a/src/Runtime/functions-input-normalization.php
+++ b/src/Runtime/functions-input-normalization.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Generic input normalization helpers.
+ *
+ * @package AgentsAPI
+ */
+
+namespace AgentsAPI\AI;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Return a string only for values that can safely be represented as text.
+ *
+ * @param mixed $value Value to normalize.
+ */
+function agents_api_scalar_to_string( $value ): string {
+	if ( is_scalar( $value ) || $value instanceof \Stringable ) {
+		return (string) $value;
+	}
+
+	return '';
+}
+
+/**
+ * Coerce a value to int only when it is numeric, defaulting to 0.
+ *
+ * @param mixed $value Value to normalize.
+ */
+function agents_api_numeric_to_int( $value ): int {
+	return is_numeric( $value ) ? (int) $value : 0;
+}
+
+/**
+ * Keep only string-keyed entries for canonical associative arrays.
+ *
+ * @param array<mixed> $value Input array.
+ * @return array<string,mixed>
+ */
+function agents_api_string_keyed_array( array $value ): array {
+	$result = array();
+	foreach ( $value as $key => $item ) {
+		if ( is_string( $key ) ) {
+			$result[ $key ] = $item;
+		}
+	}
+
+	return $result;
+}

--- a/src/Runtime/functions-sse-response.php
+++ b/src/Runtime/functions-sse-response.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Generic Server-Sent Events response helpers.
+ *
+ * @package AgentsAPI
+ */
+
+namespace AgentsAPI\AI;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Open an SSE response: send headers and disable output buffering/compression.
+ *
+ * @return void
+ */
+function agents_api_open_sse_response(): void {
+	if ( ! headers_sent() ) {
+		header( 'Content-Type: text/event-stream; charset=utf-8' );
+		header( 'Cache-Control: no-cache, no-store, must-revalidate' );
+		header( 'Connection: keep-alive' );
+		header( 'X-Accel-Buffering: no' );
+	}
+
+	while ( ob_get_level() > 0 ) {
+		ob_end_flush();
+	}
+}
+
+/**
+ * Write one JSON SSE `data:` frame and flush it to the client.
+ *
+ * @param array<string,mixed> $frame JSON-serializable frame.
+ * @return void
+ */
+function agents_api_emit_sse_json_frame( array $frame ): void {
+	echo 'data: ' . wp_json_encode( $frame ) . "\n\n"; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- SSE payload is JSON, not HTML.
+	flush();
+}

--- a/tests/response-and-input-primitives-smoke.php
+++ b/tests/response-and-input-primitives-smoke.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Pure-PHP smoke test for generic input and SSE response primitives.
+ *
+ * Run with: php tests/response-and-input-primitives-smoke.php
+ *
+ * @package AgentsAPI\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+$failures = array();
+$passes   = 0;
+
+echo "response-and-input-primitives-smoke\n";
+
+require_once __DIR__ . '/agents-api-smoke-helpers.php';
+
+agents_api_smoke_require_module();
+
+use function AgentsAPI\AI\agents_api_emit_sse_json_frame;
+use function AgentsAPI\AI\agents_api_numeric_to_int;
+use function AgentsAPI\AI\agents_api_scalar_to_string;
+use function AgentsAPI\AI\agents_api_string_keyed_array;
+
+$stringable = new class() {
+	public function __toString(): string {
+		return 'stringable-value';
+	}
+};
+
+agents_api_smoke_assert_equals( 'text', agents_api_scalar_to_string( 'text' ), 'scalar string passes through', $failures, $passes );
+agents_api_smoke_assert_equals( '123', agents_api_scalar_to_string( 123 ), 'scalar int converts to string', $failures, $passes );
+agents_api_smoke_assert_equals( 'stringable-value', agents_api_scalar_to_string( $stringable ), 'Stringable converts to string', $failures, $passes );
+agents_api_smoke_assert_equals( '', agents_api_scalar_to_string( array( 'not text' ) ), 'array normalizes to empty string', $failures, $passes );
+agents_api_smoke_assert_equals( '', agents_api_scalar_to_string( new stdClass() ), 'non-stringable object normalizes to empty string', $failures, $passes );
+
+agents_api_smoke_assert_equals( 42, agents_api_numeric_to_int( '42' ), 'numeric string converts to int', $failures, $passes );
+agents_api_smoke_assert_equals( 0, agents_api_numeric_to_int( 'abc' ), 'non-numeric value converts to zero', $failures, $passes );
+
+$normalized = agents_api_string_keyed_array(
+	array(
+		'alpha' => 1,
+		0       => 'drop',
+		'beta'  => 2,
+	)
+);
+agents_api_smoke_assert_equals( array( 'alpha' => 1, 'beta' => 2 ), $normalized, 'string-keyed array drops numeric keys', $failures, $passes );
+
+ob_start();
+agents_api_emit_sse_json_frame( array( 'ok' => true, 'message' => 'hello' ) );
+$sse = ob_get_clean();
+
+agents_api_smoke_assert_equals( "data: {\"ok\":true,\"message\":\"hello\"}\n\n", $sse, 'SSE emitter writes one JSON data frame', $failures, $passes );
+
+agents_api_smoke_finish( 'generic response/input primitives', $failures, $passes );


### PR DESCRIPTION
## Summary
- Extract reusable scalar/int/string-keyed input normalization helpers into runtime functions.
- Extract generic SSE response open/JSON frame emission helpers out of the JSON-RPC route.
- Update JSON-RPC and frontend REST adapters to use the shared helpers, and add primitive contract coverage.

## Tests
- php tests/agents-chat-jsonrpc-route-smoke.php
- php tests/frontend-chat-rest-smoke.php
- php tests/response-and-input-primitives-smoke.php
- composer test
- composer phpstan

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted and verified the primitive extraction, adapter updates, and smoke test coverage; Chris remains responsible for review and merge.