### PR TITLE
Centralize agent ability dispatch

### DIFF
--- a/agents-api.php
+++ b/agents-api.php
@@ -118,6 +118,7 @@ require_once AGENTS_API_PATH . 'src/Transcripts/register-agents-conversation-ses
 require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-effective-agent-resolver.php';
 require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-compaction-item.php';
 require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-compaction-conservation.php';
+require_once AGENTS_API_PATH . 'src/Abilities/class-wp-agent-ability-dispatcher.php';
 require_once AGENTS_API_PATH . 'src/Tools/class-wp-agent-tool-declaration.php';
 require_once AGENTS_API_PATH . 'src/Tools/class-wp-agent-runtime-tool-policy.php';
 require_once AGENTS_API_PATH . 'src/Tools/class-wp-agent-action-policy.php';

--- a/src/Abilities/class-wp-agent-ability-dispatcher.php
+++ b/src/Abilities/class-wp-agent-ability-dispatcher.php
@@ -1,0 +1,224 @@
+<?php
+/**
+ * Shared agent-side ability dispatcher.
+ *
+ * @package AgentsAPI
+ */
+
+namespace AgentsAPI\AI\Abilities;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Resolves Abilities API abilities and invokes core WP_Ability::execute().
+ */
+class WP_Agent_Ability_Dispatcher {
+
+	/**
+	 * Redacted placeholder used for sensitive parameter values.
+	 */
+	public const REDACTED_VALUE = '[redacted]';
+
+	/**
+	 * Dispatch an ability through WordPress core's WP_Ability::execute().
+	 *
+	 * @param string       $ability_name Registered ability name.
+	 * @param array<mixed> $parameters   Ability parameters.
+	 * @return mixed|\WP_Error Ability result, or a WP_Error before dispatch.
+	 */
+	public static function dispatch( string $ability_name, array $parameters = array() ) {
+		$ability_name = trim( $ability_name );
+		if ( '' === $ability_name ) {
+			return new \WP_Error( 'ability_name_missing', 'Ability name is required.' );
+		}
+
+		if ( ! function_exists( 'wp_get_ability' ) ) {
+			return new \WP_Error( 'abilities_api_missing', 'Abilities API is not loaded; cannot dispatch ability.' );
+		}
+
+		$ability = wp_get_ability( $ability_name );
+		if ( ! $ability instanceof \WP_Ability ) {
+			return new \WP_Error( 'ability_not_found', 'Ability is not registered.', array( 'ability_name' => $ability_name ) );
+		}
+
+		return $ability->execute( $parameters );
+	}
+
+	/**
+	 * Return ability parameters with sensitive values redacted.
+	 *
+	 * Sensitivity is detected from explicit ability metadata and JSON-schema
+	 * annotations, then backed by a conservative key-name fallback.
+	 *
+	 * @param string       $ability_name Registered ability name.
+	 * @param array<mixed> $parameters   Raw ability parameters.
+	 * @return array<string,mixed> Redacted parameters.
+	 */
+	public static function redacted_parameters( string $ability_name, array $parameters ): array {
+		$ability = function_exists( 'wp_get_ability' ) ? wp_get_ability( trim( $ability_name ) ) : null;
+		$paths   = $ability instanceof \WP_Ability ? self::sensitive_parameter_paths( $ability ) : array();
+
+		$redacted = self::redact_value( $parameters, '', $paths );
+		return is_array( $redacted ) ? self::string_keyed_array( $redacted ) : array();
+	}
+
+	/**
+	 * Resolve sensitive parameter paths declared by an ability.
+	 *
+	 * @param \WP_Ability $ability Ability object.
+	 * @return array<string,bool> Dot paths keyed to true.
+	 */
+	public static function sensitive_parameter_paths( \WP_Ability $ability ): array {
+		$paths = array();
+
+		if ( method_exists( $ability, 'get_meta_item' ) ) {
+			self::add_meta_paths( $paths, $ability->get_meta_item( 'sensitive_parameters', array() ) );
+			self::add_meta_paths( $paths, $ability->get_meta_item( 'parameter_sensitivity', array() ) );
+		}
+
+		self::collect_schema_paths( $ability->get_input_schema(), '', $paths );
+
+		return $paths;
+	}
+
+	/**
+	 * Add explicit meta-defined paths.
+	 *
+	 * @param array<string,bool> $paths Existing path map.
+	 * @param mixed              $value Meta value.
+	 */
+	private static function add_meta_paths( array &$paths, $value ): void {
+		if ( ! is_array( $value ) ) {
+			return;
+		}
+
+		foreach ( $value as $key => $item ) {
+			if ( is_string( $item ) && '' !== trim( $item ) ) {
+				$paths[ trim( $item ) ] = true;
+				continue;
+			}
+
+			if ( is_string( $key ) && true === $item && '' !== trim( $key ) ) {
+				$paths[ trim( $key ) ] = true;
+			}
+		}
+	}
+
+	/**
+	 * Collect sensitive paths from JSON schema property annotations.
+	 *
+	 * @param array<mixed>        $schema JSON-schema fragment.
+	 * @param string              $path   Current dot path.
+	 * @param array<string,bool>  $paths  Sensitive path map.
+	 */
+	private static function collect_schema_paths( array $schema, string $path, array &$paths ): void {
+		if ( self::schema_marks_sensitive( $schema ) && '' !== $path ) {
+			$paths[ $path ] = true;
+		}
+
+		$properties = $schema['properties'] ?? array();
+		if ( is_array( $properties ) ) {
+			foreach ( $properties as $name => $property_schema ) {
+				if ( ! is_string( $name ) || ! is_array( $property_schema ) ) {
+					continue;
+				}
+
+				self::collect_schema_paths( $property_schema, '' === $path ? $name : $path . '.' . $name, $paths );
+			}
+		}
+
+		$items = $schema['items'] ?? null;
+		if ( is_array( $items ) ) {
+			self::collect_schema_paths( $items, '' === $path ? '*' : $path . '.*', $paths );
+		}
+	}
+
+	/**
+	 * Determine whether a schema node marks its value as sensitive.
+	 *
+	 * @param array<mixed> $schema JSON-schema fragment.
+	 * @return bool
+	 */
+	private static function schema_marks_sensitive( array $schema ): bool {
+		foreach ( array( 'sensitive', 'x-sensitive', 'secret', 'writeOnly' ) as $key ) {
+			if ( true === ( $schema[ $key ] ?? false ) ) {
+				return true;
+			}
+		}
+
+		return isset( $schema['format'] ) && 'password' === $schema['format'];
+	}
+
+	/**
+	 * Redact sensitive values in nested data.
+	 *
+	 * @param mixed              $value Value to redact.
+	 * @param string             $path  Current dot path.
+	 * @param array<string,bool> $paths Sensitive path map.
+	 * @return mixed Redacted value.
+	 */
+	private static function redact_value( $value, string $path, array $paths ) {
+		$key = self::last_path_segment( $path );
+		if ( '' !== $path && ( isset( $paths[ $path ] ) || self::sensitive_key( $key ) ) ) {
+			return self::REDACTED_VALUE;
+		}
+
+		if ( ! is_array( $value ) ) {
+			return $value;
+		}
+
+		$redacted = array();
+		foreach ( $value as $item_key => $item_value ) {
+			$segment  = is_string( $item_key ) ? $item_key : '*';
+			$next_path = '' === $path ? $segment : $path . '.' . $segment;
+			if ( ! isset( $paths[ $next_path ] ) && '*' !== $segment ) {
+				$wildcard_path = '' === $path ? '*' : $path . '.*';
+				if ( isset( $paths[ $wildcard_path ] ) ) {
+					$next_path = $wildcard_path;
+				}
+			}
+
+			$redacted[ $item_key ] = self::redact_value( $item_value, $next_path, $paths );
+		}
+
+		return $redacted;
+	}
+
+	/**
+	 * Check a parameter key against conservative sensitive-name patterns.
+	 *
+	 * @param string $key Parameter key.
+	 * @return bool
+	 */
+	private static function sensitive_key( string $key ): bool {
+		return '' !== $key && 1 === preg_match( '/(api[_-]?key|authorization|cookie|credential|nonce|password|secret|token)/i', $key );
+	}
+
+	/**
+	 * Return the final segment from a dot path.
+	 *
+	 * @param string $path Dot path.
+	 * @return string Segment.
+	 */
+	private static function last_path_segment( string $path ): string {
+		$parts = explode( '.', $path );
+		return (string) end( $parts );
+	}
+
+	/**
+	 * Keep only string-keyed top-level parameters.
+	 *
+	 * @param array<array-key,mixed> $value Raw array.
+	 * @return array<string,mixed>
+	 */
+	private static function string_keyed_array( array $value ): array {
+		$result = array();
+		foreach ( $value as $key => $item ) {
+			if ( is_string( $key ) ) {
+				$result[ $key ] = $item;
+			}
+		}
+
+		return $result;
+	}
+}

--- a/src/Abilities/class-wp-agent-ability-dispatcher.php
+++ b/src/Abilities/class-wp-agent-ability-dispatcher.php
@@ -169,7 +169,7 @@ class WP_Agent_Ability_Dispatcher {
 
 		$redacted = array();
 		foreach ( $value as $item_key => $item_value ) {
-			$segment  = is_string( $item_key ) ? $item_key : '*';
+			$segment   = is_string( $item_key ) ? $item_key : '*';
 			$next_path = '' === $path ? $segment : $path . '.' . $segment;
 			if ( ! isset( $paths[ $next_path ] ) && '*' !== $segment ) {
 				$wildcard_path = '' === $path ? '*' : $path . '.*';

--- a/src/Tools/class-wp-agent-ability-tool-executor.php
+++ b/src/Tools/class-wp-agent-ability-tool-executor.php
@@ -7,6 +7,8 @@
 
 namespace AgentsAPI\AI\Tools;
 
+use AgentsAPI\AI\Abilities\WP_Agent_Ability_Dispatcher;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -31,6 +33,7 @@ class WP_Agent_Ability_Tool_Executor implements WP_Agent_Tool_Executor {
 
 		$tool_call    = WP_Agent_Tool_Call::normalize( $tool_call );
 		$tool_name    = is_string( $tool_call['tool_name'] ?? null ) ? $tool_call['tool_name'] : '';
+		$parameters   = isset( $tool_call['parameters'] ) && is_array( $tool_call['parameters'] ) ? $tool_call['parameters'] : array();
 		$ability_name = $this->ability_name( $tool_call, $tool_definition );
 
 		if ( '' === $ability_name ) {
@@ -41,38 +44,17 @@ class WP_Agent_Ability_Tool_Executor implements WP_Agent_Tool_Executor {
 			);
 		}
 
-		if ( ! function_exists( 'wp_get_ability' ) ) {
-			return WP_Agent_Tool_Result::error(
-				$tool_name,
-				'WordPress Abilities API is not available.',
-				array(
-					'ability_name' => $ability_name,
-					'error_type'   => 'abilities_api_unavailable',
-				)
-			);
-		}
-
-		$ability = wp_get_ability( $ability_name );
-		if ( ! $ability instanceof \WP_Ability ) {
-			return WP_Agent_Tool_Result::error(
-				$tool_name,
-				'Ability is not registered.',
-				array(
-					'ability_name' => $ability_name,
-					'error_type'   => 'ability_not_found',
-				)
-			);
-		}
-
-		$result = $ability->execute( $tool_call['parameters'] );
+		$result = WP_Agent_Ability_Dispatcher::dispatch( $ability_name, $parameters );
 		if ( function_exists( 'is_wp_error' ) && is_wp_error( $result ) ) {
 			return WP_Agent_Tool_Result::error(
 				$tool_name,
 				$this->wp_error_message( $result ),
 				array(
-					'ability_name' => $ability_name,
-					'error_code'   => $result->get_error_code(),
-					'error_type'   => 'ability_error',
+					'ability_name'        => $ability_name,
+					'error_code'          => $result->get_error_code(),
+					'error_type'          => $this->error_type( $result ),
+					'parameters'          => WP_Agent_Ability_Dispatcher::redacted_parameters( $ability_name, $parameters ),
+					'parameters_redacted' => true,
 				)
 			);
 		}
@@ -80,7 +62,11 @@ class WP_Agent_Ability_Tool_Executor implements WP_Agent_Tool_Executor {
 		return WP_Agent_Tool_Result::success(
 			$tool_name,
 			$result,
-			array( 'ability_name' => $ability_name )
+			array(
+				'ability_name'        => $ability_name,
+				'parameters'          => WP_Agent_Ability_Dispatcher::redacted_parameters( $ability_name, $parameters ),
+				'parameters_redacted' => true,
+			)
 		);
 	}
 
@@ -125,5 +111,22 @@ class WP_Agent_Ability_Tool_Executor implements WP_Agent_Tool_Executor {
 		}
 
 		return 'Ability execution failed.';
+	}
+
+	/**
+	 * Normalize dispatcher/core WP_Error codes to executor error types.
+	 *
+	 * @param mixed $error WP_Error-like value.
+	 * @return string Error type.
+	 */
+	private function error_type( $error ): string {
+		$code = is_object( $error ) && method_exists( $error, 'get_error_code' ) ? $error->get_error_code() : '';
+
+		return match ( $code ) {
+			'abilities_api_missing' => 'abilities_api_unavailable',
+			'ability_not_found'     => 'ability_not_found',
+			'ability_name_missing'  => 'ability_name_missing',
+			default                 => 'ability_error',
+		};
 	}
 }

--- a/src/Tools/register-agent-ability-meta-abilities.php
+++ b/src/Tools/register-agent-ability-meta-abilities.php
@@ -7,6 +7,8 @@
 
 namespace AgentsAPI\AI\Tools;
 
+use AgentsAPI\AI\Abilities\WP_Agent_Ability_Dispatcher;
+
 defined( 'ABSPATH' ) || exit;
 
 const AGENTS_ABILITY_SEARCH_ABILITY = 'agents/ability-search';
@@ -131,19 +133,19 @@ function agents_ability_call( array $input ) {
 		return new \WP_Error( 'agents_ability_call_recursion', 'agents/ability-call cannot call itself.' );
 	}
 
-	$ability = wp_get_ability( $name );
-	if ( ! $ability instanceof \WP_Ability ) {
+	$result = WP_Agent_Ability_Dispatcher::dispatch( $name, $parameters );
+	if ( is_wp_error( $result ) && 'ability_not_found' === $result->get_error_code() ) {
 		return new \WP_Error( 'agents_ability_call_not_found', 'Ability is not registered.' );
 	}
-
-	$result = $ability->execute( $parameters );
 	if ( is_wp_error( $result ) ) {
 		return $result;
 	}
 
 	return array(
-		'name'   => $name,
-		'result' => $result,
+		'name'                => $name,
+		'parameters'          => WP_Agent_Ability_Dispatcher::redacted_parameters( $name, $parameters ),
+		'parameters_redacted' => true,
+		'result'              => $result,
 	);
 }
 
@@ -385,8 +387,13 @@ function agents_ability_call_output_schema(): array {
 		'type'       => 'object',
 		'required'   => array( 'name', 'result' ),
 		'properties' => array(
-			'name'   => array( 'type' => 'string' ),
-			'result' => array( 'type' => array( 'object', 'array', 'string', 'number', 'boolean', 'null' ) ),
+			'name'                => array( 'type' => 'string' ),
+			'parameters'          => array(
+				'type'        => 'object',
+				'description' => 'Target ability parameters with sensitive values redacted.',
+			),
+			'parameters_redacted' => array( 'type' => 'boolean' ),
+			'result'              => array( 'type' => array( 'object', 'array', 'string', 'number', 'boolean', 'null' ) ),
 		),
 	);
 }

--- a/src/Workflows/class-wp-agent-workflow-runner.php
+++ b/src/Workflows/class-wp-agent-workflow-runner.php
@@ -343,8 +343,8 @@ class WP_Agent_Workflow_Runner {
 	public static function default_ability_handler( array $step, array $context ) {
 		unset( $context );
 		$ability_name = self::string_value( $step['ability'] ?? null );
-		$args   = (array) ( $step['args'] ?? array() );
-		$result = WP_Agent_Ability_Dispatcher::dispatch( $ability_name, $args );
+		$args         = (array) ( $step['args'] ?? array() );
+		$result       = WP_Agent_Ability_Dispatcher::dispatch( $ability_name, $args );
 		if ( is_wp_error( $result ) && 'ability_not_found' === $result->get_error_code() ) {
 			return new \WP_Error(
 				'unknown_ability',

--- a/src/Workflows/class-wp-agent-workflow-runner.php
+++ b/src/Workflows/class-wp-agent-workflow-runner.php
@@ -39,6 +39,7 @@
 
 namespace AgentsAPI\AI\Workflows;
 
+use AgentsAPI\AI\Abilities\WP_Agent_Ability_Dispatcher;
 use WP_Error;
 
 defined( 'ABSPATH' ) || exit;
@@ -341,22 +342,15 @@ class WP_Agent_Workflow_Runner {
 	 */
 	public static function default_ability_handler( array $step, array $context ) {
 		unset( $context );
-		if ( ! function_exists( 'wp_get_ability' ) ) {
-			return new \WP_Error(
-				'abilities_api_missing',
-				'Abilities API is not loaded; cannot dispatch ability step.'
-			);
-		}
 		$ability_name = self::string_value( $step['ability'] ?? null );
-		$ability      = wp_get_ability( $ability_name );
-		if ( null === $ability ) {
+		$args   = (array) ( $step['args'] ?? array() );
+		$result = WP_Agent_Ability_Dispatcher::dispatch( $ability_name, $args );
+		if ( is_wp_error( $result ) && 'ability_not_found' === $result->get_error_code() ) {
 			return new \WP_Error(
 				'unknown_ability',
 				sprintf( 'no ability registered as `%s`', $ability_name )
 			);
 		}
-		$args   = (array) ( $step['args'] ?? array() );
-		$result = $ability->execute( $args );
 		if ( is_wp_error( $result ) ) {
 			return $result;
 		}

--- a/tests/ability-meta-abilities-smoke.php
+++ b/tests/ability-meta-abilities-smoke.php
@@ -157,6 +157,9 @@ add_action(
 				'permission_callback' => static function (): bool {
 					return true;
 				},
+				'meta'                => array(
+					'sensitive_parameters' => array( 'token' ),
+				),
 			)
 		);
 
@@ -206,11 +209,16 @@ echo "\n[3] ability-call dispatches through the registered target ability:\n";
 $call = AgentsAPI\AI\Tools\agents_ability_call(
 	array(
 		'name'       => 'demo/weather-forecast',
-		'parameters' => array( 'city' => 'Portland' ),
+		'parameters' => array(
+			'city'  => 'Portland',
+			'token' => 'secret-token',
+		),
 	)
 );
 agents_api_smoke_assert_equals( 'demo/weather-forecast', $call['name'] ?? '', 'ability-call returns target ability name', $failures, $passes );
 agents_api_smoke_assert_equals( 'sunny in Portland', $call['result']['forecast'] ?? '', 'ability-call returns target result', $failures, $passes );
+agents_api_smoke_assert_equals( '[redacted]', $call['parameters']['token'] ?? '', 'ability-call redacts sensitive parameters in its response envelope', $failures, $passes );
+agents_api_smoke_assert_equals( true, $call['parameters_redacted'] ?? false, 'ability-call marks response parameters redacted', $failures, $passes );
 
 $missing = AgentsAPI\AI\Tools\agents_ability_call( array( 'name' => 'demo/missing' ) );
 agents_api_smoke_assert_equals( true, $missing instanceof WP_Error, 'missing ability returns WP_Error', $failures, $passes );

--- a/tests/ability-tool-executor-smoke.php
+++ b/tests/ability-tool-executor-smoke.php
@@ -46,6 +46,23 @@ if ( ! class_exists( 'WP_Ability' ) ) {
 			return $this->name;
 		}
 
+		public function get_input_schema(): array {
+			return array(
+				'type'       => 'object',
+				'properties' => array(
+					'api_key' => array( 'type' => 'string' ),
+					'token'   => array(
+						'type'        => 'string',
+						'x-sensitive' => true,
+					),
+				),
+			);
+		}
+
+		public function get_meta_item( string $key, $default = null ) {
+			return $default;
+		}
+
 		public function execute( $input = null ) {
 			return call_user_func( $this->callback, $input );
 		}
@@ -189,7 +206,11 @@ $tools = array(
 
 $result = $core->executeTool(
 	'host/search',
-	array( 'query' => 'agents api' ),
+	array(
+		'query'   => 'agents api',
+		'api_key' => 'secret-key',
+		'token'   => 'secret-token',
+	),
 	$tools,
 	$executor,
 	array( 'tool_call_id' => 'call-ability-1' )
@@ -200,6 +221,9 @@ agents_api_smoke_assert_equals( 'host/search', $result['tool_name'] ?? '', 'resu
 agents_api_smoke_assert_equals( 'local/search-posts', $result['metadata']['ability_name'] ?? '', 'result records invoked ability name', $failures, $passes );
 agents_api_smoke_assert_equals( 'agents api', $result['result']['query'] ?? '', 'ability receives prepared tool parameters', $failures, $passes );
 agents_api_smoke_assert_equals( 10, $result['result']['limit'] ?? null, 'ability result payload is preserved', $failures, $passes );
+agents_api_smoke_assert_equals( '[redacted]', $result['metadata']['parameters']['api_key'] ?? '', 'ability executor redacts sensitive key-name parameters', $failures, $passes );
+agents_api_smoke_assert_equals( '[redacted]', $result['metadata']['parameters']['token'] ?? '', 'ability executor redacts schema-sensitive parameters', $failures, $passes );
+agents_api_smoke_assert_equals( true, $result['metadata']['parameters_redacted'] ?? false, 'ability executor marks metadata parameters redacted', $failures, $passes );
 
 echo "\n[1b] Provider-safe tool aliases resolve back to canonical tool declarations:\n";
 $normalized_tool = AgentsAPI\AI\Tools\WP_Agent_Tool_Declaration::normalizeForConversationRequest( $tools['host/search'] );

--- a/tests/workflow-runner-smoke.php
+++ b/tests/workflow-runner-smoke.php
@@ -32,6 +32,19 @@ if ( ! function_exists( 'is_wp_error' ) ) {
 	}
 }
 
+if ( ! class_exists( 'WP_Ability' ) ) {
+	class WP_Ability {
+		public function __construct( private string $name, private array $args ) {}
+		public function get_name(): string { return $this->name; }
+		public function get_input_schema(): array { return isset( $this->args['input_schema'] ) && is_array( $this->args['input_schema'] ) ? $this->args['input_schema'] : array(); }
+		public function get_meta_item( string $key, $default = null ) { return $this->args['meta'][ $key ] ?? $default; }
+		public function execute( $input = null ) {
+			$callback = $this->args['execute_callback'] ?? null;
+			return is_callable( $callback ) ? call_user_func( $callback, is_array( $input ) ? $input : array() ) : null;
+		}
+	}
+}
+
 $GLOBALS['__filters']    = array();
 $GLOBALS['__abilities']  = array();
 
@@ -75,13 +88,6 @@ if ( ! function_exists( 'wp_get_ability' ) ) {
 	}
 }
 
-class Stub_Ability {
-	public function __construct( private \Closure $handler ) {}
-	public function execute( array $input ) {
-		return ( $this->handler )( $input );
-	}
-}
-
 /**
  * Register a stub ability so the runner can resolve it through wp_get_ability()
  * in either backend: pure-PHP keeps the Stub_Ability in an in-memory registry;
@@ -90,7 +96,13 @@ class Stub_Ability {
  */
 $GLOBALS['__workflow_runner_smoke_pending'] = array();
 function workflow_runner_smoke_register_ability( string $name, \Closure $handler ): void {
-	$GLOBALS['__abilities'][ $name ] = new Stub_Ability( $handler );
+	$GLOBALS['__abilities'][ $name ] = new WP_Ability(
+		$name,
+		array(
+			'input_schema'     => array( 'type' => 'object' ),
+			'execute_callback' => $handler,
+		)
+	);
 
 	// Defer real Abilities API registration to the init action (fired once after
 	// all stubs are queued); core rejects registration outside that window.
@@ -155,6 +167,7 @@ require_once __DIR__ . '/../src/Workflows/class-wp-agent-workflow-spec.php';
 require_once __DIR__ . '/../src/Workflows/class-wp-agent-workflow-run-result.php';
 require_once __DIR__ . '/../src/Workflows/class-wp-agent-workflow-store.php';
 require_once __DIR__ . '/../src/Workflows/class-wp-agent-workflow-run-recorder.php';
+require_once __DIR__ . '/../src/Abilities/class-wp-agent-ability-dispatcher.php';
 require_once __DIR__ . '/../src/Workflows/class-wp-agent-workflow-runner.php';
 
 use AgentsAPI\AI\Workflows\WP_Agent_Workflow_Run_Recorder;


### PR DESCRIPTION
## Summary
- Add a shared agent-side ability dispatcher that resolves registered abilities and invokes WordPress core `WP_Ability::execute()`.
- Add explicit ability parameter redaction helpers using ability meta, input-schema sensitivity annotations, and conservative sensitive-key fallback.
- Migrate ability-backed tool execution, `agents/ability-call`, and workflow ability steps to use the shared dispatcher.
- Extend smoke coverage for redacted ability parameters and core-shaped ability stubs.

## Testing
- `php tests/ability-tool-executor-smoke.php`
- `php tests/ability-meta-abilities-smoke.php`
- `php tests/workflow-runner-smoke.php`
- `composer phpstan`
- `composer smoke`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the dispatcher, migrated call sites, added smoke coverage, and ran verification. Submitted through the normal PR workflow, where the submitter remains responsible for the change.
