### PR TITLE
Clarify memory source registry contract

### DIFF
--- a/docs/auth-consent-context-memory.md
+++ b/docs/auth-consent-context-memory.md
@@ -130,7 +130,9 @@ Products should persist consent decision arrays beside memory writes, transcript
 
 ## Memory and context source registry
 
-`WP_Agent_Memory_Registry` registers memory/context sources without assuming those sources are files. Its normalized metadata includes:
+`WP_Agent_Memory_Registry` is the canonical generic registry for memory/context sources. Hosts and adapters register source availability here, then project the normalized metadata into their own filesystem, database, retrieval, or runtime layers. The registry is portable source truth; memory stores and host adapters remain responsible for persistence and physical paths.
+
+The registry does not assume sources are files. Its normalized metadata includes:
 
 | Field | Purpose |
 | --- | --- |
@@ -141,11 +143,13 @@ Products should persist consent decision arrays beside memory writes, transcript
 | `modes` | Eligible runtime modes, or `all`. |
 | `retrieval_policy` | `always`, `on_intent`, `on_tool_need`, `manual`, or `never`. |
 | `composable`, `context_slug` | Whether this source contributes to composable context. |
-| `convention_path` | Optional adapter hint such as `AGENTS.md`; not storage identity. |
-| `external_projection_target` | Optional adapter projection hint. |
+| `convention_path` | Optional adapter hint such as `AGENTS.md`; not source identity or storage identity. |
+| `external_projection_target` | Optional adapter projection hint, such as a guideline id or host-owned destination. |
 | `label`, `description`, `meta` | Display and extension metadata. |
 
-`agents_api_memory_sources` lets extensions register sources lazily when sources are first resolved.
+`agents_api_memory_sources` lets extensions register sources lazily when sources are first resolved. Hook callbacks should call `WP_Agent_Memory_Registry::register()`; the hook argument is an inspection snapshot, not a mutable source of truth.
+
+Filesystem-backed systems can use `convention_path` to map a registered source to a relative file and `external_projection_target` to map it to another host concept. They should avoid maintaining a second source registry with independent layer, mode, editability, or retrieval-policy truth.
 
 `WP_Agent_Context_Section_Registry` composes ordered context sections. `WP_Agent_Composable_Context` carries assembled context output.
 

--- a/src/Context/class-wp-agent-memory-registry.php
+++ b/src/Context/class-wp-agent-memory-registry.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Generic agent memory/context source registry.
+ * Canonical generic agent memory/context source registry.
  *
  * @package AgentsAPI
  */
@@ -10,6 +10,11 @@ defined( 'ABSPATH' ) || exit;
 if ( ! class_exists( 'WP_Agent_Memory_Registry' ) ) {
 	/**
 	 * Registers memory and context sources without prescribing storage shape.
+	 *
+	 * Hosts and adapters should register their available sources here, then map the
+	 * normalized metadata to their own storage, filesystem, retrieval, or projection
+	 * layers. The registry is the portable source contract; persistence remains the
+	 * responsibility of memory stores or host-owned adapters.
 	 */
 	final class WP_Agent_Memory_Registry {
 
@@ -32,8 +37,12 @@ if ( ! class_exists( 'WP_Agent_Memory_Registry' ) ) {
 		/**
 		 * Register a memory or context source.
 		 *
-		 * @param string $source_id Source identifier, e.g. `workspace/instructions`.
-		 * @param array<mixed>  $args      Registration metadata.
+		 * @param string       $source_id Source identifier, e.g. `workspace/instructions`.
+		 * @param array<mixed> $args      Registration metadata. Adapter hints such as
+		 *                                `convention_path` and
+		 *                                `external_projection_target` describe how a host
+		 *                                may project the source; they are not source
+		 *                                identity and do not imply file-backed storage.
 		 * @return array<string, mixed>|null Normalized source metadata, or null on invalid ID.
 		 */
 		public static function register( string $source_id, array $args = array() ): ?array {
@@ -186,6 +195,15 @@ if ( ! class_exists( 'WP_Agent_Memory_Registry' ) ) {
 		private static function get_resolved(): array {
 			if ( ! self::$hooks_fired ) {
 				if ( function_exists( 'do_action' ) ) {
+					/**
+					 * Fires before memory/context sources are resolved.
+					 *
+					 * Extensions should call {@see WP_Agent_Memory_Registry::register()} from
+					 * this hook to add sources lazily. The hook argument is a snapshot for
+					 * inspection, not a mutable source of truth.
+					 *
+					 * @param array<string, array<string, mixed>> $sources Registered source snapshot.
+					 */
 					do_action( 'agents_api_memory_sources', self::$sources );
 				}
 				self::$hooks_fired = true;

--- a/tests/context-registry-smoke.php
+++ b/tests/context-registry-smoke.php
@@ -50,6 +50,25 @@ $manual_source = WP_Agent_Memory_Registry::register(
 	)
 );
 
+add_action(
+	'agents_api_memory_sources',
+	static function ( array $sources ): void {
+		$sources['local-only/mutation'] = array( 'id' => 'local-only/mutation' );
+
+		WP_Agent_Memory_Registry::register(
+			'shared/runtime-briefing',
+			array(
+				'layer'                      => 'shared',
+				'priority'                   => 30,
+				'modes'                      => array( 'chat' ),
+				'retrieval_policy'           => 'on_intent',
+				'convention_path'            => '/contexts/runtime.md',
+				'external_projection_target' => 'guideline:runtime-briefing',
+			)
+		);
+	}
+);
+
 agents_api_smoke_assert_equals( 'workspace', $workspace_source['layer'] ?? null, 'workspace is the generic layer vocabulary', $failures, $passes );
 agents_api_smoke_assert_equals( false, $workspace_source['editable'] ?? null, 'composable sources are not hand editable', $failures, $passes );
 agents_api_smoke_assert_equals( 'AGENTS.md', $workspace_source['convention_path'] ?? null, 'convention path is metadata, not identity', $failures, $passes );
@@ -57,7 +76,11 @@ agents_api_smoke_assert_equals( 'manual', $manual_source['retrieval_policy'] ?? 
 agents_api_smoke_assert_equals( array( 'always', 'on_intent', 'on_tool_need', 'manual', 'never' ), WP_Agent_Context_Injection_Policy::values(), 'policy vocabulary covers accepted values', $failures, $passes );
 
 $all_sources = WP_Agent_Memory_Registry::get_all();
-agents_api_smoke_assert_equals( array( 'workspace/instructions', 'user/project-notes' ), array_keys( $all_sources ), 'sources sort by priority', $failures, $passes );
+agents_api_smoke_assert_equals( array( 'workspace/instructions', 'shared/runtime-briefing', 'user/project-notes' ), array_keys( $all_sources ), 'sources sort by priority', $failures, $passes );
+agents_api_smoke_assert_equals( false, isset( $all_sources['local-only/mutation'] ), 'hook snapshot mutation does not become source truth', $failures, $passes );
+agents_api_smoke_assert_equals( 1, did_action( 'agents_api_memory_sources' ), 'lazy source hook fires once during resolution', $failures, $passes );
+agents_api_smoke_assert_equals( 'contexts/runtime.md', $all_sources['shared/runtime-briefing']['convention_path'] ?? null, 'filesystem paths are adapter hints', $failures, $passes );
+agents_api_smoke_assert_equals( 'guideline:runtime-briefing', $all_sources['shared/runtime-briefing']['external_projection_target'] ?? null, 'external projections are adapter hints', $failures, $passes );
 agents_api_smoke_assert_equals( array( 'workspace/instructions' ), array_keys( WP_Agent_Memory_Registry::get_by_layer( 'workspace' ) ), 'sources filter by layer', $failures, $passes );
 agents_api_smoke_assert_equals( array( 'workspace/instructions' ), array_keys( WP_Agent_Memory_Registry::get_always_injected( 'pipeline' ) ), 'always-injected sources filter by mode and policy', $failures, $passes );
 agents_api_smoke_assert_equals( array( 'workspace/instructions' ), array_keys( WP_Agent_Memory_Registry::get_composable() ), 'composable sources are discoverable', $failures, $passes );


### PR DESCRIPTION
## Summary
- Clarifies `WP_Agent_Memory_Registry` as the canonical generic memory/context source registry contract.
- Documents that filesystem paths and external projection targets are adapter hints, not independent source identity.
- Extends the context registry smoke test to cover lazy source registration through `agents_api_memory_sources` and adapter projection metadata.

## Testing
- `php tests/context-registry-smoke.php`
- `composer smoke`
- `composer phpstan`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the contract clarification, smoke test coverage, and PR description; Chris remains responsible for review and merge.
