### PR TITLE
Redact tool parameters in loop surfaces

### DIFF
--- a/agents-api.php
+++ b/agents-api.php
@@ -120,6 +120,7 @@ require_once AGENTS_API_PATH . 'src/Transcripts/register-agents-conversation-ses
 require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-effective-agent-resolver.php';
 require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-compaction-item.php';
 require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-compaction-conservation.php';
+require_once AGENTS_API_PATH . 'src/Tools/class-wp-agent-tool-parameters.php';
 require_once AGENTS_API_PATH . 'src/Abilities/class-wp-agent-ability-dispatcher.php';
 require_once AGENTS_API_PATH . 'src/Tools/class-wp-agent-tool-declaration.php';
 require_once AGENTS_API_PATH . 'src/Tools/class-wp-agent-runtime-tool-policy.php';
@@ -165,7 +166,6 @@ require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-chat-run-control.php'
 require_once AGENTS_API_PATH . 'src/Tasks/class-wp-agent-task-run-control.php';
 require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-conversation-loop.php';
 require_once AGENTS_API_PATH . 'src/Tools/class-wp-agent-tool-call.php';
-require_once AGENTS_API_PATH . 'src/Tools/class-wp-agent-tool-parameters.php';
 require_once AGENTS_API_PATH . 'src/Tools/class-wp-agent-tool-result.php';
 require_once AGENTS_API_PATH . 'src/Tools/class-wp-agent-tool-executor.php';
 require_once AGENTS_API_PATH . 'src/Tools/class-wp-agent-ability-tool-executor.php';

--- a/src/Abilities/class-wp-agent-ability-dispatcher.php
+++ b/src/Abilities/class-wp-agent-ability-dispatcher.php
@@ -7,6 +7,8 @@
 
 namespace AgentsAPI\AI\Abilities;
 
+use AgentsAPI\AI\Tools\WP_Agent_Tool_Parameters;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -17,7 +19,7 @@ class WP_Agent_Ability_Dispatcher {
 	/**
 	 * Redacted placeholder used for sensitive parameter values.
 	 */
-	public const REDACTED_VALUE = '[redacted]';
+	public const REDACTED_VALUE = WP_Agent_Tool_Parameters::REDACTED_VALUE;
 
 	/**
 	 * Dispatch an ability through WordPress core's WP_Ability::execute().
@@ -56,10 +58,15 @@ class WP_Agent_Ability_Dispatcher {
 	 */
 	public static function redacted_parameters( string $ability_name, array $parameters ): array {
 		$ability = function_exists( 'wp_get_ability' ) ? wp_get_ability( trim( $ability_name ) ) : null;
-		$paths   = $ability instanceof \WP_Ability ? self::sensitive_parameter_paths( $ability ) : array();
+		$schema  = $ability instanceof \WP_Ability ? $ability->get_input_schema() : array();
+		$meta    = array();
 
-		$redacted = self::redact_value( $parameters, '', $paths );
-		return is_array( $redacted ) ? self::string_keyed_array( $redacted ) : array();
+		if ( $ability instanceof \WP_Ability && method_exists( $ability, 'get_meta_item' ) ) {
+			$meta['sensitive_parameters']  = $ability->get_meta_item( 'sensitive_parameters', array() );
+			$meta['parameter_sensitivity'] = $ability->get_meta_item( 'parameter_sensitivity', array() );
+		}
+
+		return WP_Agent_Tool_Parameters::redactedParameters( $parameters, array_merge( $meta, $schema ) );
 	}
 
 	/**
@@ -69,156 +76,12 @@ class WP_Agent_Ability_Dispatcher {
 	 * @return array<string,bool> Dot paths keyed to true.
 	 */
 	public static function sensitive_parameter_paths( \WP_Ability $ability ): array {
-		$paths = array();
-
+		$definition = $ability->get_input_schema();
 		if ( method_exists( $ability, 'get_meta_item' ) ) {
-			self::add_meta_paths( $paths, $ability->get_meta_item( 'sensitive_parameters', array() ) );
-			self::add_meta_paths( $paths, $ability->get_meta_item( 'parameter_sensitivity', array() ) );
+			$definition['sensitive_parameters']  = $ability->get_meta_item( 'sensitive_parameters', array() );
+			$definition['parameter_sensitivity'] = $ability->get_meta_item( 'parameter_sensitivity', array() );
 		}
 
-		self::collect_schema_paths( $ability->get_input_schema(), '', $paths );
-
-		return $paths;
-	}
-
-	/**
-	 * Add explicit meta-defined paths.
-	 *
-	 * @param array<string,bool> $paths Existing path map.
-	 * @param mixed              $value Meta value.
-	 */
-	private static function add_meta_paths( array &$paths, $value ): void {
-		if ( ! is_array( $value ) ) {
-			return;
-		}
-
-		foreach ( $value as $key => $item ) {
-			if ( is_string( $item ) && '' !== trim( $item ) ) {
-				$paths[ trim( $item ) ] = true;
-				continue;
-			}
-
-			if ( is_string( $key ) && true === $item && '' !== trim( $key ) ) {
-				$paths[ trim( $key ) ] = true;
-			}
-		}
-	}
-
-	/**
-	 * Collect sensitive paths from JSON schema property annotations.
-	 *
-	 * @param array<mixed>        $schema JSON-schema fragment.
-	 * @param string              $path   Current dot path.
-	 * @param array<string,bool>  $paths  Sensitive path map.
-	 */
-	private static function collect_schema_paths( array $schema, string $path, array &$paths ): void {
-		if ( self::schema_marks_sensitive( $schema ) && '' !== $path ) {
-			$paths[ $path ] = true;
-		}
-
-		$properties = $schema['properties'] ?? array();
-		if ( is_array( $properties ) ) {
-			foreach ( $properties as $name => $property_schema ) {
-				if ( ! is_string( $name ) || ! is_array( $property_schema ) ) {
-					continue;
-				}
-
-				self::collect_schema_paths( $property_schema, '' === $path ? $name : $path . '.' . $name, $paths );
-			}
-		}
-
-		$items = $schema['items'] ?? null;
-		if ( is_array( $items ) ) {
-			self::collect_schema_paths( $items, '' === $path ? '*' : $path . '.*', $paths );
-		}
-	}
-
-	/**
-	 * Determine whether a schema node marks its value as sensitive.
-	 *
-	 * @param array<mixed> $schema JSON-schema fragment.
-	 * @return bool
-	 */
-	private static function schema_marks_sensitive( array $schema ): bool {
-		foreach ( array( 'sensitive', 'x-sensitive', 'secret', 'writeOnly' ) as $key ) {
-			if ( true === ( $schema[ $key ] ?? false ) ) {
-				return true;
-			}
-		}
-
-		return isset( $schema['format'] ) && 'password' === $schema['format'];
-	}
-
-	/**
-	 * Redact sensitive values in nested data.
-	 *
-	 * @param mixed              $value Value to redact.
-	 * @param string             $path  Current dot path.
-	 * @param array<string,bool> $paths Sensitive path map.
-	 * @return mixed Redacted value.
-	 */
-	private static function redact_value( $value, string $path, array $paths ) {
-		$key = self::last_path_segment( $path );
-		if ( '' !== $path && ( isset( $paths[ $path ] ) || self::sensitive_key( $key ) ) ) {
-			return self::REDACTED_VALUE;
-		}
-
-		if ( ! is_array( $value ) ) {
-			return $value;
-		}
-
-		$redacted = array();
-		foreach ( $value as $item_key => $item_value ) {
-			$segment   = is_string( $item_key ) ? $item_key : '*';
-			$next_path = '' === $path ? $segment : $path . '.' . $segment;
-			if ( ! isset( $paths[ $next_path ] ) && '*' !== $segment ) {
-				$wildcard_path = '' === $path ? '*' : $path . '.*';
-				if ( isset( $paths[ $wildcard_path ] ) ) {
-					$next_path = $wildcard_path;
-				}
-			}
-
-			$redacted[ $item_key ] = self::redact_value( $item_value, $next_path, $paths );
-		}
-
-		return $redacted;
-	}
-
-	/**
-	 * Check a parameter key against conservative sensitive-name patterns.
-	 *
-	 * @param string $key Parameter key.
-	 * @return bool
-	 */
-	private static function sensitive_key( string $key ): bool {
-		return '' !== $key && 1 === preg_match( '/(api[_-]?key|authorization|cookie|credential|nonce|password|secret|token)/i', $key );
-	}
-
-	/**
-	 * Return the final segment from a dot path.
-	 *
-	 * @param string $path Dot path.
-	 * @return string Segment.
-	 */
-	private static function last_path_segment( string $path ): string {
-		$parts = explode( '.', $path );
-		return (string) end( $parts );
-	}
-
-	/**
-	 * Keep only string-keyed top-level parameters.
-	 *
-	 * @param array<array-key,mixed> $value Raw array.
-	 * @return array<string,mixed>
-	 */
-	private static function string_keyed_array( array $value ): array {
-		$result = array();
-		foreach ( $value as $key => $item ) {
-			if ( is_string( $key ) ) {
-				$result[ $key ] = $item;
-			}
-		}
-
-		return $result;
+		return WP_Agent_Tool_Parameters::sensitiveParameterPaths( $definition );
 	}
 }

--- a/src/Runtime/class-wp-agent-conversation-loop.php
+++ b/src/Runtime/class-wp-agent-conversation-loop.php
@@ -599,7 +599,7 @@ class WP_Agent_Conversation_Loop {
 			// metadata/payload, but generic transcripts receive only the redacted
 			// parameter envelope; in-process mediators and executors still receive raw
 			// parameters explicitly through their private context.
-			$messages[] = WP_Agent_Message::toolCall(
+			$messages[]        = WP_Agent_Message::toolCall(
 				'',
 				$tool_name,
 				$parameter_exposure['parameters'],
@@ -610,8 +610,8 @@ class WP_Agent_Conversation_Loop {
 					'parameters_redacted' => true,
 				)
 			);
-			$mediator_complete            = false;
-			$mediation_context            = array(
+			$mediator_complete = false;
+			$mediation_context = array(
 				'messages'               => $messages,
 				'raw_tool_call'          => $raw_call,
 				'prepared_tool_call'     => ! empty( $prepared['ready'] ) ? $prepared_tool_call : null,
@@ -624,7 +624,7 @@ class WP_Agent_Conversation_Loop {
 				'prior_tool_results'     => array_merge( $prior_tool_results, $tool_execution_results ),
 				'prior_mediated_results' => $tool_execution_results,
 			);
-			$mediator_decision            = self::pre_tool_mediation_decision(
+			$mediator_decision = self::pre_tool_mediation_decision(
 				$pre_tool_mediator,
 				$mediation_context
 			);

--- a/src/Runtime/class-wp-agent-conversation-loop.php
+++ b/src/Runtime/class-wp-agent-conversation-loop.php
@@ -10,8 +10,9 @@ namespace AgentsAPI\AI;
 use AgentsAPI\AI\Tools\WP_Agent_Tool_Call;
 use AgentsAPI\AI\Tools\WP_Agent_Tool_Declaration;
 use AgentsAPI\AI\Tools\WP_Agent_Tool_Execution_Core;
-use AgentsAPI\AI\Tools\WP_Agent_Tool_Result;
 use AgentsAPI\AI\Tools\WP_Agent_Tool_Executor;
+use AgentsAPI\AI\Tools\WP_Agent_Tool_Parameters;
+use AgentsAPI\AI\Tools\WP_Agent_Tool_Result;
 use AgentsAPI\Core\Database\Chat\WP_Agent_Conversation_Lock;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -569,33 +570,6 @@ class WP_Agent_Conversation_Loop {
 
 			$spin_signatures[] = new WP_Agent_Spin_Signature( $tool_name, $parameters_for_policy );
 
-			self::emit_event( $on_event, 'tool_call', array(
-				'turn'         => $turn,
-				'tool_name'    => $tool_name,
-				'tool_call_id' => $tool_call_id,
-				'parameters'   => $parameters,
-			) );
-			$tool_events[] = self::tool_event( 'tool_call', $tool_name, $tool_call_id, $turn, array( 'status' => 'called' ) );
-
-			// Add tool-call message to transcript. The structured info
-			// (tool_name + parameters) lives in metadata; `content` is
-			// intentionally empty so adapters that flatten the transcript
-			// to provider text don't end up echoing the human-readable
-			// "Calling X" debug string back to the model. When the model
-			// sees "Calling foo" as a previous assistant text turn, it
-			// pattern-matches and starts emitting that literal string as
-			// text instead of issuing real function-calls — a sneaky
-			// failure mode on long multi-tool conversations (Gemini Flash
-			// in particular). Adapters that want a user-facing label can
-			// derive it from `metadata.tool_name`.
-			$messages[] = WP_Agent_Message::toolCall(
-				'',
-				$tool_name,
-				$parameters,
-				$turn,
-				array( 'tool_call_id' => $tool_call_id )
-			);
-
 			// Prepare through WP_Agent_Tool_Execution_Core so callers can mediate
 			// with the same normalized tool-call shape the executor would receive.
 			$tool_context                 = $turn_context;
@@ -609,6 +583,33 @@ class WP_Agent_Conversation_Loop {
 			$prepared_tool_call           = self::array_or_empty( $prepared['tool_call'] ?? null );
 			$prepared_tool_def            = isset( $prepared['tool_def'] ) && is_array( $prepared['tool_def'] ) ? $prepared['tool_def'] : array();
 			$tool_definition              = self::associative_array_or_null( $prepared['tool_def'] ?? ( $declarations[ $tool_name ] ?? null ) );
+			$parameter_exposure           = self::tool_parameter_exposure( $parameters_for_policy, $tool_definition );
+
+			self::emit_event( $on_event, 'tool_call', array_merge(
+				array(
+					'turn'         => $turn,
+					'tool_name'    => $tool_name,
+					'tool_call_id' => $tool_call_id,
+				),
+				$parameter_exposure
+			) );
+			$tool_events[] = self::tool_event( 'tool_call', $tool_name, $tool_call_id, $turn, array_merge( array( 'status' => 'called' ), $parameter_exposure ) );
+
+			// Add tool-call message to transcript. The structured info lives in
+			// metadata/payload, but generic transcripts receive only the redacted
+			// parameter envelope; in-process mediators and executors still receive raw
+			// parameters explicitly through their private context.
+			$messages[] = WP_Agent_Message::toolCall(
+				'',
+				$tool_name,
+				$parameter_exposure['parameters'],
+				$turn,
+				array(
+					'tool_call_id'        => $tool_call_id,
+					'parameters_sha256'   => $parameter_exposure['parameters_sha256'],
+					'parameters_redacted' => true,
+				)
+			);
 			$mediator_complete            = false;
 			$mediation_context            = array(
 				'messages'               => $messages,
@@ -762,11 +763,13 @@ class WP_Agent_Conversation_Loop {
 
 			// Build the tool_execution_results entry.
 			$execution_result = array(
-				'tool_name'    => $tool_name,
-				'tool_call_id' => $tool_call_id,
-				'result'       => $exec_result,
-				'parameters'   => $parameters,
-				'turn_count'   => $turn,
+				'tool_name'           => $tool_name,
+				'tool_call_id'        => $tool_call_id,
+				'result'              => $exec_result,
+				'parameters'          => $parameter_exposure['parameters'],
+				'parameters_sha256'   => $parameter_exposure['parameters_sha256'],
+				'parameters_redacted' => true,
+				'turn_count'          => $turn,
 			);
 
 			$runtime = isset( $exec_result['runtime'] ) && is_array( $exec_result['runtime'] ) ? $exec_result['runtime'] : array();
@@ -784,7 +787,7 @@ class WP_Agent_Conversation_Loop {
 					'tool_declaration'  => $tool_definition,
 					'result'            => $exec_result,
 					'success'           => (bool) ( $exec_result['success'] ?? false ),
-					'parameters_sha256' => self::stable_sha256( $parameters_for_policy ),
+					'parameters_sha256' => $parameter_exposure['parameters_sha256'],
 				)
 			);
 			if ( ! empty( $diagnostics ) ) {
@@ -1849,9 +1852,9 @@ class WP_Agent_Conversation_Loop {
 	 * @return array<string, mixed> Audit event.
 	 */
 	private static function tool_audit_event( string $tool_name, string $tool_call_id, array $parameters, array $result, ?array $tool_definition, array $context, int $turn ): array {
-		$safe_parameters = self::redact_tool_audit_parameters( $parameters, $tool_name, $tool_definition, $context );
-		$metadata        = isset( $result['metadata'] ) && is_array( $result['metadata'] ) ? $result['metadata'] : array();
-		$error_type      = isset( $metadata['error_type'] ) && is_string( $metadata['error_type'] ) ? $metadata['error_type'] : '';
+		$parameter_exposure = self::tool_parameter_exposure( $parameters, $tool_definition, $tool_name, $context );
+		$metadata           = isset( $result['metadata'] ) && is_array( $result['metadata'] ) ? $result['metadata'] : array();
+		$error_type         = isset( $metadata['error_type'] ) && is_string( $metadata['error_type'] ) ? $metadata['error_type'] : '';
 
 		$audit_event = array(
 			'schema_version'      => 1,
@@ -1860,7 +1863,7 @@ class WP_Agent_Conversation_Loop {
 			'tool_name'           => $tool_name,
 			'tool_call_id'        => $tool_call_id,
 			'tool_source'         => is_array( $tool_definition ) && is_string( $tool_definition['source'] ?? null ) ? $tool_definition['source'] : '',
-			'parameters_sha256'   => self::stable_sha256( $safe_parameters ),
+			'parameters_sha256'   => $parameter_exposure['parameters_sha256'],
 			'parameters_redacted' => true,
 			'success'             => (bool) ( $result['success'] ?? false ),
 			'result_status'       => ! empty( $result['success'] ) ? 'success' : 'error',
@@ -1887,8 +1890,7 @@ class WP_Agent_Conversation_Loop {
 	 * @return array<string, mixed> Redacted parameters.
 	 */
 	private static function redact_tool_audit_parameters( array $parameters, string $tool_name, ?array $tool_definition, array $context ): array {
-		$redacted = self::redact_sensitive_values( $parameters );
-		$redacted = is_array( $redacted ) ? self::normalize_assoc_array( $redacted ) : array();
+		$redacted = WP_Agent_Tool_Parameters::redactedParameters( $parameters, is_array( $tool_definition ) ? $tool_definition : array() );
 
 		if ( function_exists( 'apply_filters' ) ) {
 			try {
@@ -1917,26 +1919,22 @@ class WP_Agent_Conversation_Loop {
 	}
 
 	/**
-	 * Redact obviously sensitive scalar fields in nested parameter arrays.
+	 * Build the generic observer-safe parameter envelope used by loop surfaces.
 	 *
-	 * @param mixed $value Value to redact.
-	 * @param string $key Current key.
-	 * @return mixed Redacted value.
+	 * @param array<string, mixed>      $parameters      Raw tool-call parameters.
+	 * @param array<string, mixed>|null $tool_definition Tool declaration, when available.
+	 * @param string                    $tool_name       Tool identifier for filters.
+	 * @param array<string, mixed>      $context         Turn context for filters.
+	 * @return array{parameters: array<string, mixed>, parameters_sha256: string, parameters_redacted: bool}
 	 */
-	private static function redact_sensitive_values( $value, string $key = '' ) {
-		if ( is_array( $value ) ) {
-			$redacted = array();
-			foreach ( $value as $item_key => $item_value ) {
-				$redacted[ $item_key ] = self::redact_sensitive_values( $item_value, is_string( $item_key ) ? $item_key : '' );
-			}
-			return $redacted;
-		}
+	private static function tool_parameter_exposure( array $parameters, ?array $tool_definition, string $tool_name = '', array $context = array() ): array {
+		$safe_parameters = self::redact_tool_audit_parameters( $parameters, $tool_name, $tool_definition, $context );
 
-		if ( '' !== $key && preg_match( '/(api[_-]?key|authorization|cookie|credential|nonce|password|secret|token)/i', $key ) ) {
-			return '[redacted]';
-		}
-
-		return $value;
+		return array(
+			'parameters'          => $safe_parameters,
+			'parameters_sha256'   => self::stable_sha256( $safe_parameters ),
+			'parameters_redacted' => true,
+		);
 	}
 
 	/**

--- a/src/Tools/class-wp-agent-tool-parameters.php
+++ b/src/Tools/class-wp-agent-tool-parameters.php
@@ -15,6 +15,11 @@ defined( 'ABSPATH' ) || exit;
 class WP_Agent_Tool_Parameters {
 
 	/**
+	 * Redacted placeholder used for sensitive parameter values.
+	 */
+	public const REDACTED_VALUE = '[redacted]';
+
+	/**
 	 * Merge declared client-context bindings with runtime tool parameters.
 	 *
 	 * Caller-supplied parameters always win. Values from `$context` are only
@@ -115,6 +120,60 @@ class WP_Agent_Tool_Parameters {
 	}
 
 	/**
+	 * Build a generic observer-safe exposure envelope for tool parameters.
+	 *
+	 * @param array<mixed> $tool_parameters Raw tool-call parameters.
+	 * @param array<mixed> $tool_definition Normalized tool declaration.
+	 * @return array{parameters: array<string, mixed>, parameters_sha256: string, parameters_redacted: bool}
+	 */
+	public static function exposureEnvelope( array $tool_parameters, array $tool_definition = array() ): array {
+		$parameters = self::redactedParameters( $tool_parameters, $tool_definition );
+
+		return array(
+			'parameters'          => $parameters,
+			'parameters_sha256'   => self::stableSha256( $parameters ),
+			'parameters_redacted' => true,
+		);
+	}
+
+	/**
+	 * Return tool parameters with sensitive values redacted.
+	 *
+	 * Sensitivity is detected from explicit declaration metadata and JSON-schema
+	 * annotations, then backed by a conservative key-name fallback.
+	 *
+	 * @param array<mixed> $tool_parameters Raw tool-call parameters.
+	 * @param array<mixed> $tool_definition Normalized tool declaration or schema.
+	 * @return array<string,mixed> Redacted parameters.
+	 */
+	public static function redactedParameters( array $tool_parameters, array $tool_definition = array() ): array {
+		$paths      = self::sensitiveParameterPaths( $tool_definition );
+		$redacted   = self::redactValue( $tool_parameters, '', $paths );
+		$normalized = is_array( $redacted ) ? self::stringKeyedArray( $redacted ) : array();
+
+		return self::normalizeArrayKeys( $normalized );
+	}
+
+	/**
+	 * Resolve sensitive parameter paths from a tool declaration or JSON schema.
+	 *
+	 * @param array<mixed> $tool_definition Normalized tool declaration or schema.
+	 * @return array<string,bool> Dot paths keyed to true.
+	 */
+	public static function sensitiveParameterPaths( array $tool_definition ): array {
+		$paths = array();
+		self::addSensitivePaths( $paths, $tool_definition['sensitive_parameters'] ?? array() );
+		self::addSensitivePaths( $paths, $tool_definition['parameter_sensitivity'] ?? array() );
+
+		$schema = isset( $tool_definition['parameters'] ) && is_array( $tool_definition['parameters'] )
+			? $tool_definition['parameters']
+			: $tool_definition;
+		self::collectSchemaPaths( $schema, '', $paths );
+
+		return $paths;
+	}
+
+	/**
 	 * Extract required parameter names from known declaration shapes.
 	 *
 	 * @param array<mixed> $tool_definition Normalized tool declaration.
@@ -145,5 +204,196 @@ class WP_Agent_Tool_Parameters {
 		}
 
 		return array_values( array_unique( $required ) );
+	}
+
+	/**
+	 * Add explicit meta-defined sensitive paths.
+	 *
+	 * @param array<string,bool> $paths Existing path map.
+	 * @param mixed              $value Meta value.
+	 */
+	private static function addSensitivePaths( array &$paths, $value ): void {
+		if ( ! is_array( $value ) ) {
+			return;
+		}
+
+		foreach ( $value as $key => $item ) {
+			if ( is_string( $item ) && '' !== trim( $item ) ) {
+				$paths[ trim( $item ) ] = true;
+				continue;
+			}
+
+			if ( is_string( $key ) && true === $item && '' !== trim( $key ) ) {
+				$paths[ trim( $key ) ] = true;
+			}
+		}
+	}
+
+	/**
+	 * Collect sensitive paths from JSON schema property annotations.
+	 *
+	 * @param array<mixed>       $schema JSON-schema fragment.
+	 * @param string             $path   Current dot path.
+	 * @param array<string,bool> $paths  Sensitive path map.
+	 */
+	private static function collectSchemaPaths( array $schema, string $path, array &$paths ): void {
+		if ( self::schemaMarksSensitive( $schema ) && '' !== $path ) {
+			$paths[ $path ] = true;
+		}
+
+		$properties = $schema['properties'] ?? array();
+		if ( is_array( $properties ) ) {
+			foreach ( $properties as $name => $property_schema ) {
+				if ( ! is_string( $name ) || ! is_array( $property_schema ) ) {
+					continue;
+				}
+
+				self::collectSchemaPaths( $property_schema, '' === $path ? $name : $path . '.' . $name, $paths );
+			}
+		}
+
+		$items = $schema['items'] ?? null;
+		if ( is_array( $items ) ) {
+			self::collectSchemaPaths( $items, '' === $path ? '*' : $path . '.*', $paths );
+		}
+	}
+
+	/**
+	 * Determine whether a schema node marks its value as sensitive.
+	 *
+	 * @param array<mixed> $schema JSON-schema fragment.
+	 * @return bool
+	 */
+	private static function schemaMarksSensitive( array $schema ): bool {
+		foreach ( array( 'sensitive', 'x-sensitive', 'secret', 'writeOnly' ) as $key ) {
+			if ( true === ( $schema[ $key ] ?? false ) ) {
+				return true;
+			}
+		}
+
+		return isset( $schema['format'] ) && 'password' === $schema['format'];
+	}
+
+	/**
+	 * Redact sensitive values in nested data.
+	 *
+	 * @param mixed              $value Value to redact.
+	 * @param string             $path  Current dot path.
+	 * @param array<string,bool> $paths Sensitive path map.
+	 * @return mixed Redacted value.
+	 */
+	private static function redactValue( $value, string $path, array $paths ) {
+		$key = self::lastPathSegment( $path );
+		if ( '' !== $path && ( isset( $paths[ $path ] ) || self::sensitiveKey( $key ) ) ) {
+			return self::REDACTED_VALUE;
+		}
+
+		if ( ! is_array( $value ) ) {
+			return $value;
+		}
+
+		$redacted = array();
+		foreach ( $value as $item_key => $item_value ) {
+			$segment   = is_string( $item_key ) ? $item_key : '*';
+			$next_path = '' === $path ? $segment : $path . '.' . $segment;
+			if ( ! isset( $paths[ $next_path ] ) && '*' !== $segment ) {
+				$wildcard_path = '' === $path ? '*' : $path . '.*';
+				if ( isset( $paths[ $wildcard_path ] ) ) {
+					$next_path = $wildcard_path;
+				}
+			}
+
+			$redacted[ $item_key ] = self::redactValue( $item_value, $next_path, $paths );
+		}
+
+		return $redacted;
+	}
+
+	/**
+	 * Check a parameter key against conservative sensitive-name patterns.
+	 *
+	 * @param string $key Parameter key.
+	 * @return bool
+	 */
+	private static function sensitiveKey( string $key ): bool {
+		return '' !== $key && 1 === preg_match( '/(api[_-]?key|authorization|auth[_-]?token|bearer|cookie|credential|nonce|password|private[_-]?key|secret|session[_-]?id|token)/i', $key );
+	}
+
+	/**
+	 * Return the final segment from a dot path.
+	 *
+	 * @param string $path Dot path.
+	 * @return string Segment.
+	 */
+	private static function lastPathSegment( string $path ): string {
+		$parts = explode( '.', $path );
+		return (string) end( $parts );
+	}
+
+	/**
+	 * Keep only string-keyed top-level parameters.
+	 *
+	 * @param array<array-key,mixed> $value Raw array.
+	 * @return array<string,mixed>
+	 */
+	private static function stringKeyedArray( array $value ): array {
+		$result = array();
+		foreach ( $value as $key => $item ) {
+			if ( is_string( $key ) ) {
+				$result[ $key ] = $item;
+			}
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Hash data after recursively sorting array keys for deterministic output.
+	 *
+	 * @param mixed $data Data to hash.
+	 * @return string sha256-prefixed hash.
+	 */
+	private static function stableSha256( $data ): string {
+		$normalized = self::normalizeArrayKeys( $data );
+		$json       = wp_json_encode( $normalized );
+
+		if ( ! is_string( $json ) ) {
+			$json = serialize( $normalized );
+		}
+
+		return 'sha256:' . hash( 'sha256', $json );
+	}
+
+	/**
+	 * Recursively sort associative array keys for deterministic hashing.
+	 *
+	 * @param mixed $data Data to normalize.
+	 * @return mixed Normalized data.
+	 */
+	private static function normalizeArrayKeys( $data ) {
+		if ( ! is_array( $data ) ) {
+			return $data;
+		}
+
+		$normalized = array();
+		foreach ( $data as $key => $value ) {
+			$normalized[ $key ] = self::normalizeArrayKeys( $value );
+		}
+
+		if ( self::isAssoc( $normalized ) ) {
+			ksort( $normalized );
+		}
+
+		return $normalized;
+	}
+
+	/**
+	 * Determine whether an array has non-sequential keys.
+	 *
+	 * @param array<mixed> $value Array to inspect.
+	 * @return bool
+	 */
+	private static function isAssoc( array $value ): bool {
+		return array_keys( $value ) !== range( 0, count( $value ) - 1 );
 	}
 }

--- a/src/Tools/class-wp-agent-tool-parameters.php
+++ b/src/Tools/class-wp-agent-tool-parameters.php
@@ -147,11 +147,12 @@ class WP_Agent_Tool_Parameters {
 	 * @return array<string,mixed> Redacted parameters.
 	 */
 	public static function redactedParameters( array $tool_parameters, array $tool_definition = array() ): array {
-		$paths      = self::sensitiveParameterPaths( $tool_definition );
-		$redacted   = self::redactValue( $tool_parameters, '', $paths );
-		$normalized = is_array( $redacted ) ? self::stringKeyedArray( $redacted ) : array();
+		$paths           = self::sensitiveParameterPaths( $tool_definition );
+		$redacted        = self::redactValue( $tool_parameters, '', $paths );
+		$normalized      = is_array( $redacted ) ? self::stringKeyedArray( $redacted ) : array();
+		$normalized_keys = self::normalizeArrayKeys( $normalized );
 
-		return self::normalizeArrayKeys( $normalized );
+		return is_array( $normalized_keys ) ? self::stringKeyedArray( $normalized_keys ) : array();
 	}
 
 	/**

--- a/tests/conversation-loop-tool-execution-smoke.php
+++ b/tests/conversation-loop-tool-execution-smoke.php
@@ -47,7 +47,18 @@ $tools = array(
 			'type'       => 'object',
 			'required'   => array( 'text' ),
 			'properties' => array(
-				'text' => array( 'type' => 'string' ),
+				'text'       => array( 'type' => 'string' ),
+				'profile'    => array(
+					'type'        => 'object',
+					'properties'  => array(
+						'username' => array( 'type' => 'string' ),
+						'password' => array(
+							'type'        => 'string',
+							'x-sensitive' => true,
+						),
+					),
+				),
+				'session_id' => array( 'type' => 'string' ),
 			),
 		),
 		'executor'    => 'client',
@@ -61,6 +72,7 @@ $tools = array(
 
 echo "\n[1] Loop mediates tool calls through WP_Agent_Tool_Execution_Core when tool_executor is provided:\n";
 $executor->executed = array();
+$captured_events    = array();
 
 $result = AgentsAPI\AI\WP_Agent_Conversation_Loop::run(
 	array( array( 'role' => 'user', 'content' => 'summarize this' ) ),
@@ -69,19 +81,32 @@ $result = AgentsAPI\AI\WP_Agent_Conversation_Loop::run(
 		return array(
 			'messages'   => $messages,
 			'content'    => 'I will summarize that for you.',
-				'tool_calls' => array(
-					array(
-						'id'         => 'call_123',
-						'name'       => 'client/summarize',
-						'parameters' => array( 'text' => 'hello world' ),
+			'tool_calls' => array(
+				array(
+					'id'         => 'call_123',
+					'name'       => 'client/summarize',
+					'parameters' => array(
+						'text'       => 'hello world',
+						'profile'    => array(
+							'username' => 'chef',
+							'password' => 'mise-en-place',
+						),
+						'session_id' => 'session-secret',
 					),
 				),
+			),
 		);
 	},
 	array(
 		'max_turns'         => 1,
 		'tool_executor'     => $executor,
 		'tool_declarations' => $tools,
+		'on_event'          => static function ( string $event, array $payload ) use ( &$captured_events ): void {
+			$captured_events[] = array(
+				'event'   => $event,
+				'payload' => $payload,
+			);
+		},
 	)
 );
 
@@ -91,9 +116,14 @@ $result = AgentsAPI\AI\WP_Agent_Conversation_Loop::run(
 	agents_api_smoke_assert_equals( 'client/summarize', $executor->executed[0]['tool_name'], 'tool executor received correct tool name', $failures, $passes );
 	agents_api_smoke_assert_equals( 'call_123', $executor->executed[0]['id'] ?? '', 'tool executor received provider tool call id', $failures, $passes );
 	agents_api_smoke_assert_equals( 'call_123', $executor->executed[0]['metadata']['tool_call_id'] ?? '', 'tool executor received provider tool call id in metadata', $failures, $passes );
+	agents_api_smoke_assert_equals( 'mise-en-place', $executor->executed[0]['parameters']['profile']['password'] ?? '', 'tool executor receives raw schema-sensitive parameters through explicit in-process call', $failures, $passes );
 	agents_api_smoke_assert_equals( 1, count( $result['tool_execution_results'] ), 'result contains one tool execution result', $failures, $passes );
 	agents_api_smoke_assert_equals( 'client/summarize', $result['tool_execution_results'][0]['tool_name'], 'tool execution result has correct tool name', $failures, $passes );
 	agents_api_smoke_assert_equals( 'call_123', $result['tool_execution_results'][0]['tool_call_id'] ?? '', 'tool execution result preserves provider tool call id', $failures, $passes );
+	agents_api_smoke_assert_equals( '[redacted]', $result['tool_execution_results'][0]['parameters']['profile']['password'] ?? '', 'tool execution result redacts schema-sensitive parameter paths', $failures, $passes );
+	agents_api_smoke_assert_equals( '[redacted]', $result['tool_execution_results'][0]['parameters']['session_id'] ?? '', 'tool execution result redacts non-obvious sensitive names', $failures, $passes );
+	agents_api_smoke_assert_equals( true, str_starts_with( $result['tool_execution_results'][0]['parameters_sha256'] ?? '', 'sha256:' ), 'tool execution result carries parameter hash', $failures, $passes );
+	agents_api_smoke_assert_equals( true, $result['tool_execution_results'][0]['parameters_redacted'] ?? false, 'tool execution result marks parameters redacted', $failures, $passes );
 	agents_api_smoke_assert_equals( 'HELLO WORLD', $result['tool_execution_results'][0]['result']['result']['summary'], 'tool execution result carries executor payload', $failures, $passes );
 	agents_api_smoke_assert_equals( 'repeatable', $result['tool_execution_results'][0]['runtime']['duplicate_policy'] ?? '', 'tool execution result exposes duplicate policy runtime metadata', $failures, $passes );
 	agents_api_smoke_assert_equals( 'progress', $result['tool_execution_results'][0]['result']['runtime']['completion_signal'] ?? '', 'tool result preserves completion signal runtime metadata', $failures, $passes );
@@ -106,7 +136,17 @@ agents_api_smoke_assert_equals( true, $result['tool_audit_events'][0]['success']
 agents_api_smoke_assert_equals( true, str_starts_with( $result['tool_audit_events'][0]['parameters_sha256'], 'sha256:' ), 'tool audit event hashes parameters', $failures, $passes );
 agents_api_smoke_assert_equals( true, ! array_key_exists( 'parameters', $result['tool_audit_events'][0] ), 'tool audit event omits raw parameters', $failures, $passes );
 agents_api_smoke_assert_equals( array( 'tool_call', 'tool_result' ), array_column( $result['tool_events'], 'type' ), 'result contains canonical tool call/result events', $failures, $passes );
+agents_api_smoke_assert_equals( '[redacted]', $result['tool_events'][0]['metadata']['parameters']['profile']['password'] ?? '', 'canonical tool-call event redacts schema-sensitive parameters', $failures, $passes );
 agents_api_smoke_assert_equals( 'success', $result['tool_events'][1]['status'] ?? '', 'tool result event records status', $failures, $passes );
+$captured_tool_call_events = array_values(
+	array_filter(
+		$captured_events,
+		static function ( array $event ): bool {
+			return 'tool_call' === ( $event['event'] ?? '' );
+		}
+	)
+);
+agents_api_smoke_assert_equals( '[redacted]', $captured_tool_call_events[0]['payload']['parameters']['profile']['password'] ?? '', 'observer tool_call event redacts schema-sensitive parameters', $failures, $passes );
 
 // Messages should contain: user, assistant text, tool_call, tool_result.
 $message_count = count( $result['messages'] );
@@ -131,7 +171,9 @@ $tool_call_messages = array_values(
 	)
 );
 agents_api_smoke_assert_equals( 'call_123', $tool_call_messages[0]['metadata']['tool_call_id'] ?? '', 'tool call metadata preserves provider tool call id', $failures, $passes );
-agents_api_smoke_assert_equals( array( 'text' => 'hello world' ), $tool_call_messages[0]['payload']['parameters'] ?? array(), 'tool call payload preserves provider parameters for runtime replay', $failures, $passes );
+agents_api_smoke_assert_equals( '[redacted]', $tool_call_messages[0]['payload']['parameters']['profile']['password'] ?? '', 'tool call transcript redacts schema-sensitive parameter paths', $failures, $passes );
+agents_api_smoke_assert_equals( '[redacted]', $tool_call_messages[0]['payload']['parameters']['session_id'] ?? '', 'tool call transcript redacts sensitive-name fallback paths', $failures, $passes );
+agents_api_smoke_assert_equals( true, str_starts_with( $tool_call_messages[0]['metadata']['parameters_sha256'] ?? '', 'sha256:' ), 'tool call transcript carries parameter hash', $failures, $passes );
 
 echo "\n[Pre-tool mediator proceed/reject/replace decisions (#260):\n";
 


### PR DESCRIPTION
## Summary
- centralizes schema-aware tool parameter redaction/hash envelope helpers in WP_Agent_Tool_Parameters
- applies the redacted parameter envelope to conversation loop tool_call events, canonical tool events, tool_execution_results, transcripts, and audit hashes
- keeps raw parameters available only to explicit in-process mediator/executor contexts

## Testing
- php tests/conversation-loop-tool-execution-smoke.php
- php -l agents-api.php && php -l src/Tools/class-wp-agent-tool-parameters.php && php -l src/Abilities/class-wp-agent-ability-dispatcher.php && php -l src/Runtime/class-wp-agent-conversation-loop.php && php -l tests/conversation-loop-tool-execution-smoke.php
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the implementation, targeted smoke-test updates, and verification commands for Chris to review.