### PR TITLE
Add deterministic tool parameter bindings

### DIFF
--- a/src/Tools/class-wp-agent-tool-declaration.php
+++ b/src/Tools/class-wp-agent-tool-declaration.php
@@ -125,7 +125,7 @@ class WP_Agent_Tool_Declaration {
 			$normalized['runtime'] = $runtime;
 		}
 
-		$normalized = array_merge( $normalized, self::normalizeExtensionFields( $declaration ) );
+		$normalized = array_merge( $normalized, self::normalizeExtensionFields( $declaration ), self::normalizeParameterBindingFields( $declaration ) );
 
 		return $normalized;
 	}
@@ -207,7 +207,7 @@ class WP_Agent_Tool_Declaration {
 			$normalized['runtime'] = $runtime;
 		}
 
-		$normalized = array_merge( $normalized, self::normalizeExtensionFields( $declaration ) );
+		$normalized = array_merge( $normalized, self::normalizeExtensionFields( $declaration ), self::normalizeParameterBindingFields( $declaration ) );
 
 		return $normalized;
 	}
@@ -268,6 +268,8 @@ class WP_Agent_Tool_Declaration {
 			$errors[] = 'runtime';
 		}
 
+		$errors = array_merge( $errors, self::validateParameterBindingFields( $declaration ) );
+
 		return array_values( array_unique( $errors ) );
 	}
 
@@ -321,6 +323,8 @@ class WP_Agent_Tool_Declaration {
 		if ( isset( $declaration['runtime'] ) && ! is_array( $declaration['runtime'] ) ) {
 			$errors[] = 'runtime';
 		}
+
+		$errors = array_merge( $errors, self::validateParameterBindingFields( $declaration ) );
 
 		return array_values( array_unique( $errors ) );
 	}
@@ -400,6 +404,9 @@ class WP_Agent_Tool_Declaration {
 			if ( ! is_string( $key ) || isset( self::CANONICAL_FIELDS[ $key ] ) ) {
 				continue;
 			}
+			if ( 'parameter_bindings' === $key || 'parameter_defaults' === $key ) {
+				continue;
+			}
 
 			$normalized_value = self::normalizeRuntimeMetadataValue( $value );
 			if ( null !== $normalized_value ) {
@@ -408,6 +415,53 @@ class WP_Agent_Tool_Declaration {
 		}
 
 		return $extensions;
+	}
+
+	/**
+	 * Validate parameter binding/default metadata.
+	 *
+	 * @param array<mixed> $declaration Raw declaration.
+	 * @return string[] Machine-readable invalid field names.
+	 */
+	private static function validateParameterBindingFields( array $declaration ): array {
+		$errors = array();
+
+		try {
+			WP_Agent_Tool_Parameters::normalizeParameterBindings( $declaration );
+		} catch ( \InvalidArgumentException $error ) {
+			unset( $error );
+			$errors[] = array_key_exists( 'parameter_bindings', $declaration ) ? 'parameter_bindings' : 'client_context_bindings';
+		}
+
+		try {
+			WP_Agent_Tool_Parameters::normalizeParameterDefaults( $declaration );
+		} catch ( \InvalidArgumentException $error ) {
+			unset( $error );
+			$errors[] = 'parameter_defaults';
+		}
+
+		return $errors;
+	}
+
+	/**
+	 * Normalize validated parameter binding/default metadata.
+	 *
+	 * @param array<mixed> $declaration Raw declaration.
+	 * @return array<string,mixed> Normalized parameter metadata.
+	 */
+	private static function normalizeParameterBindingFields( array $declaration ): array {
+		$fields   = array();
+		$bindings = WP_Agent_Tool_Parameters::normalizeParameterBindings( $declaration );
+		if ( ! empty( $bindings ) ) {
+			$fields['parameter_bindings'] = $bindings;
+		}
+
+		$defaults = WP_Agent_Tool_Parameters::normalizeParameterDefaults( $declaration );
+		if ( ! empty( $defaults ) ) {
+			$fields['parameter_defaults'] = $defaults;
+		}
+
+		return $fields;
 	}
 
 	/**

--- a/src/Tools/class-wp-agent-tool-parameters.php
+++ b/src/Tools/class-wp-agent-tool-parameters.php
@@ -15,6 +15,16 @@ defined( 'ABSPATH' ) || exit;
 class WP_Agent_Tool_Parameters {
 
 	/**
+	 * Context roots a tool declaration may explicitly bind from.
+	 */
+	private const ALLOWED_CONTEXT_SOURCES = array(
+		'context'         => true,
+		'client_context'  => true,
+		'caller_context'  => true,
+		'runtime_context' => true,
+	);
+
+	/**
 	 * Redacted placeholder used for sensitive parameter values.
 	 */
 	public const REDACTED_VALUE = '[redacted]';
@@ -46,11 +56,19 @@ class WP_Agent_Tool_Parameters {
 	public static function buildParameters( array $tool_parameters, array $context = array(), array $tool_definition = array() ): array {
 		$parameters = array();
 
-		foreach ( self::clientContextBindings( $tool_definition ) as $parameter_name => $context_key ) {
-			if ( ! array_key_exists( $context_key, $context ) ) {
+		foreach ( self::parameterDefaults( $tool_definition ) as $parameter_name => $value ) {
+			$parameters[ $parameter_name ] = $value;
+		}
+
+		foreach ( self::parameterBindings( $tool_definition ) as $parameter_name => $binding ) {
+			$resolved = self::resolveBindingValue( $binding, $context );
+			if ( ! $resolved['found'] ) {
+				if ( array_key_exists( 'default', $binding ) ) {
+					$parameters[ $parameter_name ] = $binding['default'];
+				}
 				continue;
 			}
-			$value = $context[ $context_key ];
+			$value = $resolved['value'];
 			if ( '' === $value || null === $value ) {
 				continue;
 			}
@@ -65,31 +83,214 @@ class WP_Agent_Tool_Parameters {
 	}
 
 	/**
-	 * Normalize the tool's `client_context_bindings` declaration into a
-	 * `parameter_name => context_key` map. Skips malformed entries silently
-	 * — the declaration is best-effort metadata, not validated input.
+	 * Normalize explicit parameter bindings, including legacy client-context bindings.
 	 *
 	 * @param array<mixed> $tool_definition Normalized tool declaration.
-	 * @return array<string, string>
+	 * @return array<string, array{source: string, path: string, sensitive?: bool, default?: mixed}>
 	 */
-	private static function clientContextBindings( array $tool_definition ): array {
-		$bindings = $tool_definition['client_context_bindings'] ?? array();
-		if ( ! is_array( $bindings ) ) {
-			return array();
+	public static function normalizeParameterBindings( array $tool_definition ): array {
+		$normalized = array();
+
+		if ( array_key_exists( 'client_context_bindings', $tool_definition ) ) {
+			$bindings = $tool_definition['client_context_bindings'];
+			if ( ! is_array( $bindings ) ) {
+				throw new \InvalidArgumentException( 'invalid_parameter_bindings: client_context_bindings' );
+			}
+
+			foreach ( $bindings as $parameter_name => $context_key ) {
+				if ( is_int( $parameter_name ) && is_string( $context_key ) && '' !== trim( $context_key ) ) {
+					$normalized[ $context_key ] = array(
+						'source' => 'context',
+						'path'   => trim( $context_key ),
+					);
+					continue;
+				}
+
+				if ( is_string( $parameter_name ) && '' !== trim( $parameter_name ) && is_string( $context_key ) && '' !== trim( $context_key ) ) {
+					$normalized[ trim( $parameter_name ) ] = array(
+						'source' => 'context',
+						'path'   => trim( $context_key ),
+					);
+					continue;
+				}
+
+				throw new \InvalidArgumentException( 'invalid_parameter_bindings: client_context_bindings' );
+			}
 		}
 
-		$normalized = array();
-		foreach ( $bindings as $parameter_name => $context_key ) {
-			if ( is_int( $parameter_name ) && is_string( $context_key ) && '' !== $context_key ) {
-				$normalized[ $context_key ] = $context_key;
-				continue;
+		if ( ! array_key_exists( 'parameter_bindings', $tool_definition ) ) {
+			return $normalized;
+		}
+
+		$bindings = $tool_definition['parameter_bindings'];
+		if ( ! is_array( $bindings ) ) {
+			throw new \InvalidArgumentException( 'invalid_parameter_bindings: parameter_bindings' );
+		}
+
+		foreach ( $bindings as $parameter_name => $binding ) {
+			if ( ! is_string( $parameter_name ) || '' === trim( $parameter_name ) ) {
+				throw new \InvalidArgumentException( 'invalid_parameter_bindings: parameter_bindings' );
 			}
-			if ( is_string( $parameter_name ) && '' !== $parameter_name && is_string( $context_key ) && '' !== $context_key ) {
-				$normalized[ $parameter_name ] = $context_key;
-			}
+
+			$normalized[ trim( $parameter_name ) ] = self::normalizeParameterBinding( $binding );
 		}
 
 		return $normalized;
+	}
+
+	/**
+	 * Normalize top-level parameter defaults.
+	 *
+	 * @param array<mixed> $tool_definition Normalized tool declaration.
+	 * @return array<string,mixed>
+	 */
+	public static function normalizeParameterDefaults( array $tool_definition ): array {
+		if ( ! array_key_exists( 'parameter_defaults', $tool_definition ) ) {
+			return array();
+		}
+
+		$defaults = $tool_definition['parameter_defaults'];
+		if ( ! is_array( $defaults ) ) {
+			throw new \InvalidArgumentException( 'invalid_parameter_bindings: parameter_defaults' );
+		}
+
+		$normalized = array();
+		foreach ( $defaults as $parameter_name => $value ) {
+			if ( ! is_string( $parameter_name ) || '' === trim( $parameter_name ) || ! self::isJsonFriendlyValue( $value ) ) {
+				throw new \InvalidArgumentException( 'invalid_parameter_bindings: parameter_defaults' );
+			}
+
+			$normalized[ trim( $parameter_name ) ] = $value;
+		}
+
+		return $normalized;
+	}
+
+	/**
+	 * Normalize parameter bindings from a declaration that has already been validated.
+	 *
+	 * @param array<mixed> $tool_definition Normalized tool declaration.
+	 * @return array<string, array{source: string, path: string, sensitive?: bool, default?: mixed}>
+	 */
+	private static function parameterBindings( array $tool_definition ): array {
+		try {
+			return self::normalizeParameterBindings( $tool_definition );
+		} catch ( \InvalidArgumentException $error ) {
+			unset( $error );
+			return array();
+		}
+	}
+
+	/**
+	 * Normalize parameter defaults from a declaration that has already been validated.
+	 *
+	 * @param array<mixed> $tool_definition Normalized tool declaration.
+	 * @return array<string,mixed>
+	 */
+	private static function parameterDefaults( array $tool_definition ): array {
+		try {
+			return self::normalizeParameterDefaults( $tool_definition );
+		} catch ( \InvalidArgumentException $error ) {
+			unset( $error );
+			return array();
+		}
+	}
+
+	/**
+	 * Normalize one parameter binding declaration.
+	 *
+	 * @param mixed $binding Raw binding declaration.
+	 * @return array{source: string, path: string, sensitive?: bool, default?: mixed}
+	 */
+	private static function normalizeParameterBinding( $binding ): array {
+		if ( is_string( $binding ) ) {
+			return self::normalizeBindingSourcePath( $binding );
+		}
+
+		if ( ! is_array( $binding ) ) {
+			throw new \InvalidArgumentException( 'invalid_parameter_bindings: parameter_bindings' );
+		}
+
+		$source = $binding['source'] ?? '';
+		$path   = $binding['path'] ?? '';
+		if ( ! is_string( $source ) || ! is_string( $path ) || '' === trim( $path ) || ! isset( self::ALLOWED_CONTEXT_SOURCES[ $source ] ) ) {
+			throw new \InvalidArgumentException( 'invalid_parameter_bindings: parameter_bindings' );
+		}
+
+		$normalized = array(
+			'source' => $source,
+			'path'   => trim( $path ),
+		);
+
+		if ( array_key_exists( 'sensitive', $binding ) ) {
+			if ( ! is_bool( $binding['sensitive'] ) ) {
+				throw new \InvalidArgumentException( 'invalid_parameter_bindings: parameter_bindings' );
+			}
+			if ( $binding['sensitive'] ) {
+				$normalized['sensitive'] = true;
+			}
+		}
+
+		if ( array_key_exists( 'default', $binding ) ) {
+			if ( ! self::isJsonFriendlyValue( $binding['default'] ) ) {
+				throw new \InvalidArgumentException( 'invalid_parameter_bindings: parameter_bindings' );
+			}
+			$normalized['default'] = $binding['default'];
+		}
+
+		return $normalized;
+	}
+
+	/**
+	 * Normalize the compact `source.dot.path` binding form.
+	 *
+	 * @param string $binding Binding expression.
+	 * @return array{source: string, path: string}
+	 */
+	private static function normalizeBindingSourcePath( string $binding ): array {
+		$binding = trim( $binding );
+		$parts   = explode( '.', $binding, 2 );
+		if ( 2 !== count( $parts ) || ! isset( self::ALLOWED_CONTEXT_SOURCES[ $parts[0] ] ) || '' === trim( $parts[1] ) ) {
+			throw new \InvalidArgumentException( 'invalid_parameter_bindings: parameter_bindings' );
+		}
+
+		return array(
+			'source' => $parts[0],
+			'path'   => trim( $parts[1] ),
+		);
+	}
+
+	/**
+	 * Resolve a binding value from runtime context.
+	 *
+	 * @param array{source: string, path: string} $binding Binding declaration.
+	 * @param array<mixed>                       $context Runtime context.
+	 * @return array{found: bool, value: mixed}
+	 */
+	private static function resolveBindingValue( array $binding, array $context ): array {
+		$source = $binding['source'];
+		$value  = 'context' === $source ? $context : ( $context[ $source ] ?? null );
+		if ( ! is_array( $value ) ) {
+			return array(
+				'found' => false,
+				'value' => null,
+			);
+		}
+
+		foreach ( explode( '.', $binding['path'] ) as $segment ) {
+			if ( '' === $segment || ! is_array( $value ) || ! array_key_exists( $segment, $value ) ) {
+				return array(
+					'found' => false,
+					'value' => null,
+				);
+			}
+			$value = $value[ $segment ];
+		}
+
+		return array(
+			'found' => true,
+			'value' => $value,
+		);
 	}
 
 	/**
@@ -165,6 +366,11 @@ class WP_Agent_Tool_Parameters {
 		$paths = array();
 		self::addSensitivePaths( $paths, $tool_definition['sensitive_parameters'] ?? array() );
 		self::addSensitivePaths( $paths, $tool_definition['parameter_sensitivity'] ?? array() );
+		foreach ( self::parameterBindings( $tool_definition ) as $parameter_name => $binding ) {
+			if ( ! empty( $binding['sensitive'] ) ) {
+				$paths[ $parameter_name ] = true;
+			}
+		}
 
 		$schema = isset( $tool_definition['parameters'] ) && is_array( $tool_definition['parameters'] )
 			? $tool_definition['parameters']
@@ -329,6 +535,30 @@ class WP_Agent_Tool_Parameters {
 	private static function lastPathSegment( string $path ): string {
 		$parts = explode( '.', $path );
 		return (string) end( $parts );
+	}
+
+	/**
+	 * Determine whether a value can be safely carried in JSON-friendly metadata.
+	 *
+	 * @param mixed $value Value to inspect.
+	 * @return bool
+	 */
+	private static function isJsonFriendlyValue( $value ): bool {
+		if ( null === $value || is_string( $value ) || is_int( $value ) || is_float( $value ) || is_bool( $value ) ) {
+			return true;
+		}
+
+		if ( ! is_array( $value ) ) {
+			return false;
+		}
+
+		foreach ( $value as $item ) {
+			if ( ! self::isJsonFriendlyValue( $item ) ) {
+				return false;
+			}
+		}
+
+		return true;
 	}
 
 	/**

--- a/tests/tool-runtime-smoke.php
+++ b/tests/tool-runtime-smoke.php
@@ -78,6 +78,7 @@ agents_api_smoke_assert_equals( 'host', $server_declaration['executor'], 'server
 agents_api_smoke_assert_equals( 'run', $server_declaration['scope'], 'server declaration defaults to run scope', $failures, $passes );
 agents_api_smoke_assert_equals( array(), $server_declaration['parameters'], 'server declaration defaults missing parameters to an array', $failures, $passes );
 agents_api_smoke_assert_equals( array( 'query' => 'search_query' ), $server_declaration['client_context_bindings'] ?? null, 'server declaration preserves generic execution extension fields', $failures, $passes );
+agents_api_smoke_assert_equals( array( 'source' => 'context', 'path' => 'search_query' ), $server_declaration['parameter_bindings']['query'] ?? null, 'legacy client context bindings normalize into parameter bindings', $failures, $passes );
 agents_api_smoke_assert_equals( 'control_plane', $server_declaration['runtime']['capability_scope'] ?? '', 'server declaration preserves product-neutral runtime metadata', $failures, $passes );
 
 $host_declaration = AgentsAPI\AI\Tools\WP_Agent_Tool_Declaration::normalizeForConversationRequest(
@@ -230,6 +231,82 @@ $renamed = AgentsAPI\AI\Tools\WP_Agent_Tool_Parameters::buildParameters(
 );
 agents_api_smoke_assert_equals( 'whatsapp:+1', $renamed['user_phone'] ?? null, 'binding can rename context_key → parameter_name', $failures, $passes );
 agents_api_smoke_assert_equals( false, array_key_exists( 'sender_id', $renamed ), 'rename binding does not also expose the source key', $failures, $passes );
+
+$dot_path_definition = AgentsAPI\AI\Tools\WP_Agent_Tool_Declaration::normalizeForServer(
+	array(
+		'name'               => 'ability/inspect_selection',
+		'source'             => 'abilities',
+		'description'        => 'Inspect selected client state.',
+		'parameter_bindings' => array(
+			'post_id' => 'client_context.selection.post_id',
+		),
+	)
+);
+$dot_path_parameters = AgentsAPI\AI\Tools\WP_Agent_Tool_Parameters::buildParameters(
+	array(),
+	array(
+		'client_context' => array(
+			'selection' => array(
+				'post_id' => 42,
+			),
+		),
+	),
+	$dot_path_definition
+);
+agents_api_smoke_assert_equals( 42, $dot_path_parameters['post_id'] ?? null, 'parameter bindings read values from allowed dot-path context sources', $failures, $passes );
+
+$default_definition = array(
+	'parameter_defaults' => array( 'query' => 'top-level-default' ),
+	'parameter_bindings' => array(
+		'query' => array(
+			'source'  => 'client_context',
+			'path'    => 'search.query',
+			'default' => 'binding-default',
+		),
+	),
+);
+$defaulted = AgentsAPI\AI\Tools\WP_Agent_Tool_Parameters::buildParameters( array(), array(), $default_definition );
+agents_api_smoke_assert_equals( 'binding-default', $defaulted['query'] ?? null, 'binding defaults override top-level parameter defaults', $failures, $passes );
+$default_context = AgentsAPI\AI\Tools\WP_Agent_Tool_Parameters::buildParameters(
+	array(),
+	array( 'client_context' => array( 'search' => array( 'query' => 'bound-context' ) ) ),
+	$default_definition
+);
+agents_api_smoke_assert_equals( 'bound-context', $default_context['query'] ?? null, 'context bindings override defaults', $failures, $passes );
+$default_explicit = AgentsAPI\AI\Tools\WP_Agent_Tool_Parameters::buildParameters(
+	array( 'query' => 'explicit' ),
+	array( 'client_context' => array( 'search' => array( 'query' => 'bound-context' ) ) ),
+	$default_definition
+);
+agents_api_smoke_assert_equals( 'explicit', $default_explicit['query'] ?? null, 'explicit runtime parameters override bindings and defaults', $failures, $passes );
+
+$malformed_rejected = false;
+try {
+	AgentsAPI\AI\Tools\WP_Agent_Tool_Declaration::normalizeForServer(
+		array(
+			'name'               => 'ability/bad_binding',
+			'source'             => 'abilities',
+			'description'        => 'Bad binding.',
+			'parameter_bindings' => array(
+				'query' => array( 'source' => 'ambient', 'path' => 'query' ),
+			),
+		)
+	);
+} catch ( InvalidArgumentException $error ) {
+	$malformed_rejected = false !== strpos( $error->getMessage(), 'parameter_bindings' );
+}
+agents_api_smoke_assert_equals( true, $malformed_rejected, 'malformed parameter bindings are rejected with field-scoped errors', $failures, $passes );
+
+$sensitive_definition = array(
+	'parameter_bindings' => array(
+		'api_key' => array(
+			'source'    => 'client_context',
+			'path'      => 'secrets.api_key',
+			'sensitive' => true,
+		),
+	),
+);
+agents_api_smoke_assert_equals( array( 'api_key' => AgentsAPI\AI\Tools\WP_Agent_Tool_Parameters::REDACTED_VALUE ), AgentsAPI\AI\Tools\WP_Agent_Tool_Parameters::redactedParameters( array( 'api_key' => 'secret' ), $sensitive_definition ), 'sensitive parameter binding metadata participates in redaction', $failures, $passes );
 
 $undeclared = AgentsAPI\AI\Tools\WP_Agent_Tool_Parameters::buildParameters(
 	array(),


### PR DESCRIPTION
## Summary
- add validated parameter_bindings and parameter_defaults metadata for tool declarations
- normalize legacy client_context_bindings into parameter_bindings while preserving compatibility
- resolve parameters with deterministic precedence: defaults, binding defaults, bound context, explicit tool parameters
- support allowed context roots, dot-path lookups, malformed mapping rejection, and sensitive binding redaction metadata

## Testing
- php tests/tool-runtime-smoke.php
- php tests/tool-policy-contracts-smoke.php
- php -l src/Tools/class-wp-agent-tool-parameters.php
- php -l src/Tools/class-wp-agent-tool-declaration.php
- php -l tests/tool-runtime-smoke.php
- composer run phpstan

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the implementation, smoke coverage, and verification commands for Chris to review.