### PR TITLE
Reuse workflow handlers in nested foreach

### DIFF
--- a/src/Workflows/class-wp-agent-workflow-runner.php
+++ b/src/Workflows/class-wp-agent-workflow-runner.php
@@ -340,7 +340,10 @@ class WP_Agent_Workflow_Runner {
 		$as                = '' !== $as_value ? $as_value : 'item';
 		$index_as          = '' !== $index_as_value ? $index_as_value : 'index';
 		$continue_on_error = ! empty( $step['continue_on_error'] );
-		$handlers          = self::default_step_handlers();
+		$handlers          = is_array( $context['_workflow_step_handlers'] ?? null )
+			? $context['_workflow_step_handlers']
+			: self::default_step_handlers();
+		/** @var array<string,mixed> $handlers */
 		$executor          = new WP_Agent_Workflow_Step_Executor( $handlers );
 		$iterations        = array();
 

--- a/src/Workflows/class-wp-agent-workflow-step-executor.php
+++ b/src/Workflows/class-wp-agent-workflow-step-executor.php
@@ -52,7 +52,9 @@ class WP_Agent_Workflow_Step_Executor {
 		$resolved      = 'foreach' === $type
 			? self::expand_foreach_outer_step( $step, $context_array )
 			: WP_Agent_Workflow_Bindings::expand( $step, $context_array );
-		$step_output   = call_user_func( $handler, $resolved, $context_array );
+		$handler_context                            = $context_array;
+		$handler_context['_workflow_step_handlers'] = $this->handlers;
+		$step_output                                = call_user_func( $handler, $resolved, $handler_context );
 
 		if ( is_wp_error( $step_output ) ) {
 			$record['status']   = WP_Agent_Workflow_Run_Result::STATUS_FAILED;

--- a/tests/workflow-runner-smoke.php
+++ b/tests/workflow-runner-smoke.php
@@ -486,5 +486,54 @@ smoke_assert( 2, $result8->get_output()['last']['count'] ?? 0, 'foreach reports 
 smoke_assert( 10, $result8->get_output()['last']['iterations'][0]['last']['id'] ?? 0, 'foreach first iteration receives scoped item', $failures, $passes );
 smoke_assert( 1, $result8->get_output()['last']['iterations'][1]['last']['points'] ?? 0, 'foreach second iteration receives scoped item', $failures, $passes );
 
+// ─── foreach reuses constructor-injected handlers for nested steps ────
+
+add_filter( 'wp_agent_workflow_known_step_types', static fn( $types ) => array_merge( (array) $types, array( 'custom_nested' ) ) );
+
+$custom_foreach_spec = WP_Agent_Workflow_Spec::from_array(
+	array(
+		'id'    => 'demo/foreach-custom-handler',
+		'inputs' => array(
+			'items' => array( 'type' => 'array', 'required' => true ),
+		),
+		'steps' => array(
+			array(
+				'id'    => 'custom_each',
+				'type'  => 'foreach',
+				'items' => '${inputs.items}',
+				'as'    => 'item',
+				'steps' => array(
+					array(
+						'id'     => 'custom',
+						'type'   => 'custom_nested',
+						'prefix' => 'item',
+						'value'  => '${vars.item.id}',
+					),
+				),
+			),
+		),
+	)
+);
+
+$custom_result = ( new WP_Agent_Workflow_Runner(
+	null,
+	array(
+		'custom_nested' => static function ( array $step, array $context ): array {
+			unset( $context );
+			return array( 'label' => (string) ( $step['prefix'] ?? '' ) . '-' . (string) ( $step['value'] ?? '' ) );
+		},
+	)
+) )->run(
+	$custom_foreach_spec,
+	array(
+		'items' => array(
+			array( 'id' => 42 ),
+		),
+	)
+);
+
+smoke_assert( WP_Agent_Workflow_Run_Result::STATUS_SUCCEEDED, $custom_result->get_status(), 'foreach nested custom handler run succeeds', $failures, $passes );
+smoke_assert( 'item-42', $custom_result->get_output()['last']['iterations'][0]['last']['label'] ?? '', 'foreach nested step uses constructor-injected handler', $failures, $passes );
+
 echo "Passed: {$passes}, Failed: " . count( $failures ) . "\n";
 exit( count( $failures ) > 0 ? 1 : 0 );


### PR DESCRIPTION
## Summary
- Pass the active workflow step handler map through handler context during step execution.
- Make default foreach execution reuse that active handler map for nested steps instead of rebuilding filtered defaults.
- Add smoke coverage for a constructor-injected custom handler inside a nested foreach body.

## Testing
- php tests/workflow-runner-smoke.php
- composer test
- composer phpstan

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** implemented and tested nested workflow handler context propagation.