### PR TITLE
Remove product-specific runtime bundle metadata

### DIFF
--- a/src/Registry/register-agent-runtime-bundle-importer.php
+++ b/src/Registry/register-agent-runtime-bundle-importer.php
@@ -228,12 +228,14 @@ add_filter(
 
 		$config = is_array( $agent['agent_config'] ?? null ) ? $agent['agent_config'] : array();
 		$meta   = is_array( $agent['meta'] ?? null ) ? $agent['meta'] : array();
-		if ( is_array( $config['datamachine_bundle'] ?? null ) ) {
+		$bundle_slug    = $string_value( $bundle['bundle_slug'] ?? null );
+		$bundle_version = $string_value( $bundle['bundle_version'] ?? null );
+		if ( '' !== $bundle_slug || '' !== $bundle_version ) {
 			$meta = array_merge(
 				array(
 					'source_type'    => 'runtime-agent-bundle',
-					'source_package' => $string_value( $config['datamachine_bundle']['bundle_slug'] ?? null, $bundle['bundle_slug'] ?? null ),
-					'source_version' => $string_value( $config['datamachine_bundle']['bundle_version'] ?? null, $bundle['bundle_version'] ?? null ),
+					'source_package' => $bundle_slug,
+					'source_version' => $bundle_version,
 				),
 				$meta
 			);

--- a/tests/runtime-agent-bundle-importer-smoke.php
+++ b/tests/runtime-agent-bundle-importer-smoke.php
@@ -54,11 +54,7 @@ $bundle = array(
 		'agent_slug'   => 'studio-web-static-site-generator',
 		'agent_name'   => 'Static Site Generator',
 		'agent_config' => array(
-			'studio_web'         => array( 'prompt' => 'Cook a site.' ),
-			'datamachine_bundle' => array(
-				'bundle_slug'    => 'studio-web-static-site-generator',
-				'bundle_version' => '1.2.3',
-			),
+			'studio_web' => array( 'prompt' => 'Cook a site.' ),
 		),
 	),
 );


### PR DESCRIPTION
## Summary
- Remove the Data Machine-specific runtime bundle config key from the generic runtime bundle importer.
- Populate generic runtime bundle provenance from top-level bundle_slug and bundle_version instead.
- Keep Agents API core-safe: no Homeboy/Data Machine/Codebox production vocabulary and no storage/table changes.

## Verification
- php tests/runtime-agent-bundle-importer-smoke.php
- php tests/bootstrap-smoke.php
- php -l src/Registry/register-agent-runtime-bundle-importer.php
- git diff --check

## Notes
- Local composer phpstan could not run in this skip-bootstrap worktree because phpstan is not installed; CI should run the full composer checks.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Auditing boundary vocabulary, drafting the metadata cleanup, and running local verification; Chris remains responsible for review and merge.