### PR TITLE
Fix product-boundary lint alignment

### DIFF
--- a/src/Registry/register-agent-runtime-bundle-importer.php
+++ b/src/Registry/register-agent-runtime-bundle-importer.php
@@ -226,8 +226,8 @@ add_filter(
 			$registry->unregister( $slug );
 		}
 
-		$config = is_array( $agent['agent_config'] ?? null ) ? $agent['agent_config'] : array();
-		$meta   = is_array( $agent['meta'] ?? null ) ? $agent['meta'] : array();
+		$config         = is_array( $agent['agent_config'] ?? null ) ? $agent['agent_config'] : array();
+		$meta           = is_array( $agent['meta'] ?? null ) ? $agent['meta'] : array();
 		$source_type    = $string_value( $bundle['source_type'] ?? null, $spec['source_type'] ?? null, 'runtime-agent-package' );
 		$source_package = $string_value( $bundle['source_package'] ?? null, $spec['source_package'] ?? null, $bundle['package_slug'] ?? null, $spec['package_slug'] ?? null, $bundle['bundle_slug'] ?? null );
 		$source_version = $string_value( $bundle['source_version'] ?? null, $spec['source_version'] ?? null, $bundle['package_version'] ?? null, $spec['package_version'] ?? null, $bundle['bundle_version'] ?? null );

--- a/src/Runtime/class-wp-agent-run-control.php
+++ b/src/Runtime/class-wp-agent-run-control.php
@@ -262,5 +262,4 @@ class WP_Agent_Run_Control {
 	private static function int_value( mixed $value ): int {
 		return is_int( $value ) || is_float( $value ) || is_string( $value ) || is_bool( $value ) ? (int) $value : 0;
 	}
-
 }


### PR DESCRIPTION
## Summary
- Align runtime bundle importer assignments for PHPCS.
- Remove the extra class-closing separator flagged by PHPCS in run control.

## Testing
- composer smoke
- homeboy lint
- php tests/runtime-agent-bundle-importer-smoke.php
- php tests/chat-run-control-smoke.php

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** fixed Agents API boundary cleanup lint alignment