### PR TITLE
Fix release lint formatting

### DIFF
--- a/src/Abilities/functions-ability-dispatch.php
+++ b/src/Abilities/functions-ability-dispatch.php
@@ -41,7 +41,7 @@ if ( ! function_exists( 'wp_agent_run_runtime_package' ) ) {
 	 * @return array<string,mixed>|WP_Error Runtime package result or dispatch error.
 	 */
 	function wp_agent_run_runtime_package( array $input ) {
-		$ability_name = defined( 'AgentsAPI\\AI\\AGENTS_RUN_RUNTIME_PACKAGE_ABILITY' )
+		$ability_name     = defined( 'AgentsAPI\\AI\\AGENTS_RUN_RUNTIME_PACKAGE_ABILITY' )
 			? constant( 'AgentsAPI\\AI\\AGENTS_RUN_RUNTIME_PACKAGE_ABILITY' )
 			: 'agents/run-runtime-package';
 		$normalize_result = static function ( mixed $result ) {

--- a/src/Runtime/class-wp-agent-conversation-loop.php
+++ b/src/Runtime/class-wp-agent-conversation-loop.php
@@ -182,9 +182,9 @@ class WP_Agent_Conversation_Loop {
 				$turn_context['turn'] = $turn;
 				$interrupt            = self::check_runtime_cancellation( $run_id, $lock_session_id, $turn_context, $on_event );
 				if ( null !== $interrupt ) {
-					$messages[]   = $interrupt['message'];
-					$events[]     = self::interrupt_event( $interrupt );
-					$interrupted  = $interrupt['metadata'];
+					$messages[]  = $interrupt['message'];
+					$events[]    = self::interrupt_event( $interrupt );
+					$interrupted = $interrupt['metadata'];
 					break;
 				}
 
@@ -247,9 +247,9 @@ class WP_Agent_Conversation_Loop {
 
 				$interrupt = self::check_runtime_cancellation( $run_id, $lock_session_id, $turn_context, $on_event );
 				if ( null !== $interrupt ) {
-					$messages[]   = $interrupt['message'];
-					$events[]     = self::interrupt_event( $interrupt );
-					$interrupted  = $interrupt['metadata'];
+					$messages[]  = $interrupt['message'];
+					$events[]    = self::interrupt_event( $interrupt );
+					$interrupted = $interrupt['metadata'];
 					break;
 				}
 
@@ -308,9 +308,9 @@ class WP_Agent_Conversation_Loop {
 				if ( null !== $tool_executor && $mediation_enabled && isset( $result['tool_calls'] ) && is_array( $result['tool_calls'] ) ) {
 					$interrupt = self::check_runtime_cancellation( $run_id, $lock_session_id, $turn_context, $on_event );
 					if ( null !== $interrupt ) {
-						$messages[]   = $interrupt['message'];
-						$events[]     = self::interrupt_event( $interrupt );
-						$interrupted  = $interrupt['metadata'];
+						$messages[]  = $interrupt['message'];
+						$events[]    = self::interrupt_event( $interrupt );
+						$interrupted = $interrupt['metadata'];
 						break;
 					}
 
@@ -346,9 +346,9 @@ class WP_Agent_Conversation_Loop {
 					$stalled               = self::check_spin_detector( $spin_detector, $mediation_result['spin_signatures'], $turn_context, $on_event );
 					$interrupt             = self::check_runtime_cancellation( $run_id, $lock_session_id, $turn_context, $on_event );
 					if ( null !== $interrupt ) {
-						$messages[]   = $interrupt['message'];
-						$events[]     = self::interrupt_event( $interrupt );
-						$interrupted  = $interrupt['metadata'];
+						$messages[]  = $interrupt['message'];
+						$events[]    = self::interrupt_event( $interrupt );
+						$interrupted = $interrupt['metadata'];
 						break;
 					}
 				} else {

--- a/src/Runtime/class-wp-agent-run-control.php
+++ b/src/Runtime/class-wp-agent-run-control.php
@@ -419,8 +419,8 @@ class WP_Agent_Run_Control {
 	 * @return array{runs:array<string,array<string,mixed>>,queues:array<string,array<int,array<string,mixed>>>,events:array<string,array<int,array<string,mixed>>>}
 	 */
 	private static function record_event_in_state( array $state, string $run_id, string $type, array $metadata = array() ): array {
-		$events         = array_values( $state['events'][ $run_id ] ?? array() );
-		$events[]       = array(
+		$events                     = array_values( $state['events'][ $run_id ] ?? array() );
+		$events[]                   = array(
 			'id'         => $run_id . ':' . count( $events ),
 			'type'       => $type,
 			'created_at' => self::now(),

--- a/src/Runtime/class-wp-agent-runtime-package-run-request.php
+++ b/src/Runtime/class-wp-agent-runtime-package-run-request.php
@@ -55,7 +55,7 @@ final class WP_Agent_Runtime_Package_Run_Request {
 			);
 		}
 
-		$workflow_id  = self::string_value( $workflow['id'] ?? '' );
+		$workflow_id   = self::string_value( $workflow['id'] ?? '' );
 		$workflow_spec = self::array_value( $workflow['spec'] ?? array() );
 		if ( '' === $workflow_id && empty( $workflow_spec ) ) {
 			return new \WP_Error(

--- a/src/Runtime/register-runtime-package-run-ability.php
+++ b/src/Runtime/register-runtime-package-run-ability.php
@@ -13,11 +13,11 @@ require_once __DIR__ . '/interface-wp-agent-run-control-store.php';
 require_once __DIR__ . '/class-wp-agent-option-run-control-store.php';
 require_once __DIR__ . '/class-wp-agent-run-control.php';
 
-const AGENTS_RUN_RUNTIME_PACKAGE_ABILITY               = 'agents/run-runtime-package';
-const AGENTS_GET_RUNTIME_PACKAGE_RUN_ABILITY           = 'agents/get-runtime-package-run';
-const AGENTS_CANCEL_RUNTIME_PACKAGE_RUN_ABILITY        = 'agents/cancel-runtime-package-run';
-const AGENTS_LIST_RUNTIME_PACKAGE_RUN_EVENTS_ABILITY   = 'agents/list-runtime-package-run-events';
-const AGENTS_RUNTIME_PACKAGE_RUN_CONTROL_STORE         = 'agents_api_runtime_package_run_control';
+const AGENTS_RUN_RUNTIME_PACKAGE_ABILITY             = 'agents/run-runtime-package';
+const AGENTS_GET_RUNTIME_PACKAGE_RUN_ABILITY         = 'agents/get-runtime-package-run';
+const AGENTS_CANCEL_RUNTIME_PACKAGE_RUN_ABILITY      = 'agents/cancel-runtime-package-run';
+const AGENTS_LIST_RUNTIME_PACKAGE_RUN_EVENTS_ABILITY = 'agents/list-runtime-package-run-events';
+const AGENTS_RUNTIME_PACKAGE_RUN_CONTROL_STORE       = 'agents_api_runtime_package_run_control';
 
 add_action(
 	'wp_abilities_api_categories_init',
@@ -345,11 +345,11 @@ function agents_runtime_package_run_id_input_schema(): array {
 
 /** @return array<string,mixed> */
 function agents_runtime_package_run_events_input_schema(): array {
-	$schema                  = agents_runtime_package_run_id_input_schema();
-	$properties              = is_array( $schema['properties'] ?? null ) ? $schema['properties'] : array();
-	$properties['cursor']    = array( 'type' => 'string' );
-	$properties['limit']     = array( 'type' => 'integer' );
-	$schema['properties']    = $properties;
+	$schema               = agents_runtime_package_run_id_input_schema();
+	$properties           = is_array( $schema['properties'] ?? null ) ? $schema['properties'] : array();
+	$properties['cursor'] = array( 'type' => 'string' );
+	$properties['limit']  = array( 'type' => 'integer' );
+	$schema['properties'] = $properties;
 	return $schema;
 }
 
@@ -380,20 +380,20 @@ function agents_runtime_package_run_control_output_schema( bool $include_cancell
 
 /** @return array<string,mixed> */
 function agents_runtime_package_run_events_output_schema(): array {
-	$schema                  = agents_runtime_package_run_control_output_schema();
-	$required                = is_array( $schema['required'] ?? null ) ? array_values( $schema['required'] ) : array();
-	$properties              = is_array( $schema['properties'] ?? null ) ? $schema['properties'] : array();
-	$required[]              = 'events';
-	$required[]              = 'cursor';
-	$required[]              = 'has_more';
-	$properties['events']    = array(
+	$schema                 = agents_runtime_package_run_control_output_schema();
+	$required               = is_array( $schema['required'] ?? null ) ? array_values( $schema['required'] ) : array();
+	$properties             = is_array( $schema['properties'] ?? null ) ? $schema['properties'] : array();
+	$required[]             = 'events';
+	$required[]             = 'cursor';
+	$required[]             = 'has_more';
+	$properties['events']   = array(
 		'type'  => 'array',
 		'items' => array( 'type' => 'object' ),
 	);
-	$properties['cursor']    = array( 'type' => 'string' );
-	$properties['has_more']  = array( 'type' => 'boolean' );
-	$schema['required']      = $required;
-	$schema['properties']    = $properties;
+	$properties['cursor']   = array( 'type' => 'string' );
+	$properties['has_more'] = array( 'type' => 'boolean' );
+	$schema['required']     = $required;
+	$schema['properties']   = $properties;
 	return $schema;
 }
 

--- a/src/Runtime/register-runtime-tool-lifecycle-abilities.php
+++ b/src/Runtime/register-runtime-tool-lifecycle-abilities.php
@@ -343,8 +343,8 @@ function agents_runtime_tool_required_string( array $input, string $field ) {
  * @return array<string, mixed>
  */
 function agents_runtime_tool_normalize_stored_request( array $request ): array {
-	$status     = is_string( $request['status'] ?? null ) && '' !== trim( $request['status'] ) ? trim( $request['status'] ) : WP_Agent_Runtime_Tool_Request::STATUS_PENDING;
-	$normalized = WP_Agent_Runtime_Tool_Request::normalize( $request );
+	$status               = is_string( $request['status'] ?? null ) && '' !== trim( $request['status'] ) ? trim( $request['status'] ) : WP_Agent_Runtime_Tool_Request::STATUS_PENDING;
+	$normalized           = WP_Agent_Runtime_Tool_Request::normalize( $request );
 	$normalized['status'] = $status;
 
 	if ( isset( $request['result'] ) && is_array( $request['result'] ) ) {

--- a/src/Tasks/class-wp-agent-task-run-control.php
+++ b/src/Tasks/class-wp-agent-task-run-control.php
@@ -118,11 +118,11 @@ class WP_Agent_Task_Run_Control {
 				'error'         => self::map_value( $normalized['error'] ?? array() ),
 				'cancellation'  => self::map_value( $normalized['cancellation'] ?? array() ),
 				'metadata'      => self::map_value( $normalized['metadata'] ?? array() ) + array(
-					'session_id'         => $normalized['session_id'],
-					'executor_id'        => $normalized['executor_id'],
-					'execution_metrics'  => $normalized['execution_metrics'],
-					'diagnostics'        => $normalized['diagnostics'],
-					'events'             => $normalized['events'],
+					'session_id'        => $normalized['session_id'],
+					'executor_id'       => $normalized['executor_id'],
+					'execution_metrics' => $normalized['execution_metrics'],
+					'diagnostics'       => $normalized['diagnostics'],
+					'events'            => $normalized['events'],
 				),
 			)
 		);

--- a/src/Workflows/class-wp-agent-workflow-run-result.php
+++ b/src/Workflows/class-wp-agent-workflow-run-result.php
@@ -192,7 +192,10 @@ final class WP_Agent_Workflow_Run_Result {
 					'ended_at'   => $this->ended_at,
 				),
 				'error'         => $this->error,
-				'metadata'      => $this->metadata + array( 'steps' => $this->steps, 'inputs' => $this->inputs ),
+				'metadata'      => $this->metadata + array(
+					'steps'  => $this->steps,
+					'inputs' => $this->inputs,
+				),
 			)
 		);
 	}

--- a/src/Workflows/register-agents-workflow-abilities.php
+++ b/src/Workflows/register-agents-workflow-abilities.php
@@ -21,11 +21,11 @@ namespace AgentsAPI\AI\Workflows;
 
 defined( 'ABSPATH' ) || exit;
 
-const AGENTS_RUN_WORKFLOW_ABILITY      = 'agents/run-workflow';
-const AGENTS_VALIDATE_WORKFLOW_ABILITY = 'agents/validate-workflow';
-const AGENTS_DESCRIBE_WORKFLOW_ABILITY = 'agents/describe-workflow';
-const AGENTS_GET_WORKFLOW_RUN_ABILITY  = 'agents/get-workflow-run';
-const AGENTS_CANCEL_WORKFLOW_RUN_ABILITY = 'agents/cancel-workflow-run';
+const AGENTS_RUN_WORKFLOW_ABILITY             = 'agents/run-workflow';
+const AGENTS_VALIDATE_WORKFLOW_ABILITY        = 'agents/validate-workflow';
+const AGENTS_DESCRIBE_WORKFLOW_ABILITY        = 'agents/describe-workflow';
+const AGENTS_GET_WORKFLOW_RUN_ABILITY         = 'agents/get-workflow-run';
+const AGENTS_CANCEL_WORKFLOW_RUN_ABILITY      = 'agents/cancel-workflow-run';
 const AGENTS_LIST_WORKFLOW_RUN_EVENTS_ABILITY = 'agents/list-workflow-run-events';
 
 add_action(
@@ -524,11 +524,11 @@ function agents_workflow_run_id_input_schema(): array {
 
 /** @return array<string,mixed> */
 function agents_workflow_run_events_input_schema(): array {
-	$schema                 = agents_workflow_run_id_input_schema();
-	$properties             = is_array( $schema['properties'] ?? null ) ? $schema['properties'] : array();
-	$properties['cursor']   = array( 'type' => 'string' );
-	$properties['limit']    = array( 'type' => 'integer' );
-	$schema['properties']   = $properties;
+	$schema               = agents_workflow_run_id_input_schema();
+	$properties           = is_array( $schema['properties'] ?? null ) ? $schema['properties'] : array();
+	$properties['cursor'] = array( 'type' => 'string' );
+	$properties['limit']  = array( 'type' => 'integer' );
+	$schema['properties'] = $properties;
 	return $schema;
 }
 


### PR DESCRIPTION
## Summary
- Fix PHPCS formatting issues blocking the Homeboy release lint gate.
- Keep changes limited to spacing/alignment and array formatting.

## Testing
- Running PHP linting...
PHP compatibility target: 8.1-
Validating with PHPCS...
PHPCS linting passed

No JavaScript files found, skipping ESLint.

Running PHPStan static analysis...
PHPStan PHP version target: 8.1 (80100)

PHPStan analysis passed

Linting passed
{
  "success": true,
  "data": {
    "component": "agents-api",
    "exit_code": 0,
    "findings": [],
    "hints": [
      "For targeted linting: --file <path>, --glob <pattern>, --changed-only, or --changed-since <ref>",
      "Full options: homeboy docs commands/lint",
      "Save lint baseline: homeboy lint agents-api --baseline"
    ],
    "passed": true,
    "phase": {
      "exit_code": 0,
      "phase": "lint",
      "status": "passed",
      "summary": "lint phase passed with no findings"
    },
    "producer_summaries": [
      {
        "finding_count": 0,
        "metadata": {
          "exit_code": 0,
          "source_sidecar": "lint-producers",
          "source_sidecar_path": "/home/chubes/.config/homeboy/runtime/tmp/homeboy-run-e42f8c87-b271-4ecb-ad62-20edd9daaa45-1782164269632111741/lint-producers.json"
        },
        "source": {
          "kind": "sidecar",
          "label": "lint-producers",
          "path": "/home/chubes/.config/homeboy/runtime/tmp/homeboy-run-e42f8c87-b271-4ecb-ad62-20edd9daaa45-1782164269632111741/lint-producers.json"
        },
        "status": "passed",
        "step": "phpcs",
        "tool": "phpcs"
      },
      {
        "finding_count": 0,
        "metadata": {
          "exit_code": 0,
          "source_sidecar": "lint-producers",
          "source_sidecar_path": "/home/chubes/.config/homeboy/runtime/tmp/homeboy-run-e42f8c87-b271-4ecb-ad62-20edd9daaa45-1782164269632111741/lint-producers.json"
        },
        "source": {
          "kind": "sidecar",
          "label": "lint-producers",
          "path": "/home/chubes/.config/homeboy/runtime/tmp/homeboy-run-e42f8c87-b271-4ecb-ad62-20edd9daaa45-1782164269632111741/lint-producers.json"
        },
        "status": "passed",
        "step": "eslint",
        "tool": "eslint"
      },
      {
        "finding_count": 0,
        "metadata": {
          "exit_code": 0,
          "phpstan_component_config": "/home/chubes/Developer/_lab_workspaces/agents-api-fix-homeboy-lint-release-0-4-28ba9cff2340-382a5fe8-8274-4471-8916-8eb4f331a29c-1782164261957668000/phpstan.neon.dist",
          "phpstan_config": "/home/chubes/Developer/.tmp/phpstan-dependencies.AMlG8i.neon",
          "phpstan_config_source": "component-local",
          "phpstan_level": "config",
          "phpstan_level_source": "component-local",
          "source_sidecar": "lint-producers",
          "source_sidecar_path": "/home/chubes/.config/homeboy/runtime/tmp/homeboy-run-e42f8c87-b271-4ecb-ad62-20edd9daaa45-1782164269632111741/lint-producers.json"
        },
        "source": {
          "kind": "sidecar",
          "label": "lint-producers",
          "path": "/home/chubes/.config/homeboy/runtime/tmp/homeboy-run-e42f8c87-b271-4ecb-ad62-20edd9daaa45-1782164269632111741/lint-producers.json"
        },
        "status": "passed",
        "step": "phpstan",
        "tool": "phpstan"
      }
    ],
    "status": "passed"
  }
}

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Applied release lint cleanup, verification, and PR preparation.