### PR TITLE
Disable PHPUnit result cache

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit cacheResult="false" colors="true">
+	<testsuites>
+		<testsuite name="Unit">
+			<directory>tests/Unit</directory>
+		</testsuite>
+	</testsuites>
+</phpunit>


### PR DESCRIPTION
## Summary
- Add a minimal PHPUnit config for the existing unit suite.
- Disable PHPUnit result caching so release/test runs do not create the PHPUnit result cache in the plugin checkout.

## Testing
- homeboy test agents-api
- homeboy lint agents-api

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosed release test artifact issue, added PHPUnit config, verified and prepared PR.