### PR TITLE
Fix runtime package helper late registration

### DIFF
--- a/src/Abilities/functions-ability-dispatch.php
+++ b/src/Abilities/functions-ability-dispatch.php
@@ -44,6 +44,10 @@ if ( ! function_exists( 'wp_agent_run_runtime_package' ) ) {
 		$ability_name     = defined( 'AgentsAPI\\AI\\AGENTS_RUN_RUNTIME_PACKAGE_ABILITY' )
 			? constant( 'AgentsAPI\\AI\\AGENTS_RUN_RUNTIME_PACKAGE_ABILITY' )
 			: 'agents/run-runtime-package';
+		if ( function_exists( 'AgentsAPI\\AI\\agents_register_runtime_package_run_abilities' ) ) {
+			AgentsAPI\AI\agents_register_runtime_package_run_abilities();
+		}
+
 		$normalize_result = static function ( mixed $result ) {
 			if ( $result instanceof WP_Error ) {
 				return $result;

--- a/tests/runtime-package-run-contract-smoke.php
+++ b/tests/runtime-package-run-contract-smoke.php
@@ -236,6 +236,19 @@ $late_dispatch = $late_ability instanceof WP_Ability ? $late_ability->execute(
 ) : null;
 agents_api_smoke_assert_equals( false, is_wp_error( $late_dispatch ), 'late-resolved ability executes through the canonical ability object', $failures, $passes );
 agents_api_smoke_assert_equals( 'late-load', is_array( $late_dispatch ) ? $late_dispatch['result']['workflow_id'] ?? '' : '', 'late-resolved ability uses the runtime package handler filter', $failures, $passes );
+
+if ( $registry instanceof WP_Abilities_Registry ) {
+	$registry->reset_registered_for_smoke();
+}
+
+$helper_dispatch = wp_agent_run_runtime_package(
+	array(
+		'package'  => array( 'slug' => 'site-builder' ),
+		'workflow' => array( 'id' => 'helper-late-load' ),
+	)
+);
+agents_api_smoke_assert_equals( false, is_wp_error( $helper_dispatch ), 'runtime package helper resolves the ability after abilities init already fired', $failures, $passes );
+agents_api_smoke_assert_equals( 'helper-late-load', is_array( $helper_dispatch ) ? $helper_dispatch['result']['workflow_id'] ?? '' : '', 'runtime package helper dispatches through the canonical ability', $failures, $passes );
 $GLOBALS['__agents_api_smoke_actions']['wp_agent_runtime_package_run_handler'] = array();
 
 echo "\n[1] Request validates package and workflow selectors:\n";


### PR DESCRIPTION
## Summary
- Ensure wp_agent_run_runtime_package() attempts to register the canonical runtime package abilities before reading the Abilities API registry.
- Add regression coverage for the helper path after wp_abilities_api_init has already fired.

## Testing
- php -l src/Abilities/functions-ability-dispatch.php
- php tests/runtime-package-run-contract-smoke.php
- composer smoke

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Root-cause investigation, code change, regression test, and verification.