### PR TITLE
feat: ship default provider-turn adapter and run_conversation facade

### DIFF
--- a/agents-api.php
+++ b/agents-api.php
@@ -178,6 +178,7 @@ require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-conversation-result.p
 require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-chat-run-control.php';
 require_once AGENTS_API_PATH . 'src/Tasks/class-wp-agent-task-run-control.php';
 require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-conversation-loop.php';
+require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-default-provider-turn-adapter.php';
 require_once AGENTS_API_PATH . 'src/Tools/class-wp-agent-tool-call.php';
 require_once AGENTS_API_PATH . 'src/Tools/class-wp-agent-tool-result.php';
 require_once AGENTS_API_PATH . 'src/Tools/class-wp-agent-tool-executor.php';

--- a/composer.json
+++ b/composer.json
@@ -76,6 +76,7 @@
       "php tests/context-registry-smoke.php",
       "php tests/conversation-loop-smoke.php",
       "php tests/provider-turn-adapter-smoke.php",
+      "php tests/default-provider-turn-adapter-smoke.php",
       "php tests/ability-tool-executor-smoke.php",
       "php tests/tool-mediation-runner-smoke.php",
       "php tests/conversation-loop-tool-execution-smoke.php",

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -12,3 +12,6 @@ parameters:
 		- stubs/class-wp-filter-sentinel.php
 		- stubs/abilities-api-functions.php
 		- stubs/action-scheduler-functions.php
+		- stubs/wp-ai-client-functions.php
+		- stubs/class-wp-ai-client-prompt-builder.php
+		- stubs/wp-ai-client-dtos.php

--- a/src/Runtime/class-wp-agent-conversation-loop.php
+++ b/src/Runtime/class-wp-agent-conversation-loop.php
@@ -512,6 +512,60 @@ class WP_Agent_Conversation_Loop {
 	}
 
 	/**
+	 * One-call conversation convenience that supplies the default adapter.
+	 *
+	 * Fulfills the {@see WP_Agent_Conversation_Runner} contract intent: a caller
+	 * provides messages, tool declarations, and a provider/model, and the loop
+	 * runs end-to-end through {@see WP_Agent_Default_Provider_Turn_Adapter}
+	 * without the caller hand-building a turn runner.
+	 *
+	 * The adapter is supplied through the mediated path (as `provider_turn_adapter`),
+	 * so when a `tool_executor` is provided the loop executes tools and assembles
+	 * the canonical envelopes itself — the adapter never executes tools.
+	 *
+	 * Recognized `$options` keys (all optional):
+	 *
+	 * - `system_prompt` (string): Default system instruction for the adapter.
+	 * - `temperature` (float) / `max_tokens` (int): Forwarded to the adapter.
+	 * - `prompt_input_provider` (callable): Pluggable prompt-input strategy.
+	 * - `tool_executor` (WP_Agent_Tool_Executor): Enables mediated tool execution.
+	 * - `completion_policy`, `max_turns`, `context`, `should_continue`, and any
+	 *   other {@see WP_Agent_Conversation_Loop::run()} option are passed through.
+	 *
+	 * @param array<int, array<string, mixed>>    $messages          Initial transcript messages.
+	 * @param array<mixed>                        $tool_declarations Tool declarations keyed by name.
+	 * @param string                              $provider_id       Provider identifier.
+	 * @param string                              $model_id          Model identifier.
+	 * @param array<string, mixed>                $options           Loop and adapter options.
+	 * @return array<string, mixed> Normalized conversation result.
+	 */
+	public static function run_conversation( array $messages, array $tool_declarations, string $provider_id, string $model_id, array $options = array() ): array {
+		$system_prompt = is_string( $options['system_prompt'] ?? null ) ? $options['system_prompt'] : '';
+
+		$adapter_options = array();
+		foreach ( array( 'temperature', 'max_tokens', 'prompt_input_provider' ) as $adapter_key ) {
+			if ( array_key_exists( $adapter_key, $options ) ) {
+				$adapter_options[ $adapter_key ] = $options[ $adapter_key ];
+			}
+		}
+
+		$adapter = new WP_Agent_Default_Provider_Turn_Adapter( $provider_id, $model_id, $system_prompt, $adapter_options );
+
+		$loop_options                          = $options;
+		$loop_options['provider_turn_adapter'] = $adapter;
+		$loop_options['tool_declarations']     = $tool_declarations;
+		unset( $loop_options['temperature'], $loop_options['max_tokens'], $loop_options['prompt_input_provider'], $loop_options['system_prompt'] );
+
+		if ( '' !== $system_prompt ) {
+			$context                  = self::normalize_assoc_array( $loop_options['context'] ?? array() );
+			$context['system_prompt'] = $context['system_prompt'] ?? $system_prompt;
+			$loop_options['context']  = $context;
+		}
+
+		return self::run( $messages, null, $loop_options );
+	}
+
+	/**
 	 * Mediate tool calls extracted from the turn runner result.
 	 *
 	 * Handles the tool-call → validate → execute → message assembly cycle.

--- a/src/Runtime/class-wp-agent-default-provider-turn-adapter.php
+++ b/src/Runtime/class-wp-agent-default-provider-turn-adapter.php
@@ -1,0 +1,537 @@
+<?php
+/**
+ * Default provider-turn adapter.
+ *
+ * @package AgentsAPI
+ */
+
+namespace AgentsAPI\AI;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Reference provider-turn adapter that dispatches one model turn through the
+ * upstream wp-ai-client prompt builder.
+ *
+ * This is the first concrete implementation of {@see WP_Agent_Provider_Turn_Adapter}.
+ * It owns only the generic turn: map canonical agent messages and tool
+ * declarations into the wp-ai-client builder, dispatch via
+ * `generate_text_result()`, then normalize the assistant text, tool calls, and
+ * token usage into the shape {@see WP_Agent_Provider_Turn_Result::normalize()}
+ * expects. The conversation loop keeps ownership of continuation, mediated tool
+ * execution, transcript events, and stop conditions.
+ *
+ * The adapter consumes the UPSTREAM wp-ai-client builder reached through the
+ * `wp_ai_client_prompt()` entrypoint. It deliberately does NOT introduce a new
+ * prompt-builder abstraction — the only generic work it adds is the mapping
+ * step into that existing builder.
+ *
+ * Prompt assembly is the one genuinely consumer-variable concern, so the
+ * adapter exposes a single injectable "prompt-input provider" strategy. The
+ * default is identity (pass the request's system prompt + messages straight
+ * through). A consumer with its own directive-composition layer can inject a
+ * callable that transforms `(system_prompt, messages, context)` into
+ * `(system_prompt, messages)` before the builder is populated, without
+ * replacing the dispatch, extraction, or normalization the adapter provides.
+ */
+// phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Turn-dispatch exceptions are caught by the conversation loop and returned as structured arrays, never rendered.
+class WP_Agent_Default_Provider_Turn_Adapter implements WP_Agent_Provider_Turn_Adapter {
+
+	/** @var string Provider identifier passed to the wp-ai-client builder. */
+	private string $provider_id;
+
+	/** @var string Model identifier passed to the wp-ai-client builder. */
+	private string $model_id;
+
+	/** @var string Default system prompt applied when the request omits one. */
+	private string $system_prompt;
+
+	/** @var array<string, mixed> Dispatch options (temperature, max_tokens). */
+	private array $options;
+
+	/** @var callable|null Injectable prompt-input strategy, defaulting to identity. */
+	private $prompt_input_provider;
+
+	/**
+	 * @param string                $provider_id   Provider identifier (for example `openai`).
+	 * @param string                $model_id      Model identifier.
+	 * @param string                $system_prompt Default system prompt.
+	 * @param array<string, mixed>  $options       Dispatch options. Recognized keys:
+	 *                                              `temperature` (float), `max_tokens` (int),
+	 *                                              `prompt_input_provider` (callable). Only keys
+	 *                                              the wp-ai-client builder supports are wired.
+	 */
+	public function __construct( string $provider_id, string $model_id, string $system_prompt = '', array $options = array() ) {
+		$this->provider_id   = $provider_id;
+		$this->model_id      = $model_id;
+		$this->system_prompt = $system_prompt;
+
+		$prompt_input_provider = $options['prompt_input_provider'] ?? null;
+		unset( $options['prompt_input_provider'] );
+		$this->options = $options;
+
+		$this->prompt_input_provider = is_callable( $prompt_input_provider ) ? $prompt_input_provider : null;
+	}
+
+	/**
+	 * Set the pluggable prompt-input provider.
+	 *
+	 * The provider receives `(string $system_prompt, array $messages, array $context)`
+	 * and must return either `[ $system_prompt, $messages ]` or
+	 * `[ 'system_prompt' => ..., 'messages' => ... ]`. Passing `null` restores the
+	 * identity (pass-through) default.
+	 *
+	 * @param callable|null $prompt_input_provider Prompt-input strategy.
+	 * @return self
+	 */
+	public function set_prompt_input_provider( ?callable $prompt_input_provider ): self {
+		$this->prompt_input_provider = $prompt_input_provider;
+		return $this;
+	}
+
+	/**
+	 * Run one provider turn through the upstream wp-ai-client builder.
+	 *
+	 * @param WP_Agent_Provider_Turn_Request $request Provider-turn request.
+	 * @return array<string, mixed> Normalized provider-turn result.
+	 */
+	public function run_turn( WP_Agent_Provider_Turn_Request $request ): array {
+		if ( ! function_exists( 'wp_ai_client_prompt' ) ) {
+			throw new \RuntimeException( 'wp-ai-client is unavailable: wp_ai_client_prompt() is not defined.' );
+		}
+
+		$resolved      = $this->resolve_prompt_input( $request );
+		$system_prompt = $resolved['system_prompt'];
+		$messages      = $resolved['messages'];
+
+		$provider_id = $this->resolve_provider_id( $request );
+		$model_id    = $this->resolve_model_id( $request );
+
+		$prompt_context = self::split_prompt_context( $messages );
+
+		$builder = wp_ai_client_prompt();
+
+		if ( ! empty( $prompt_context['prompt_parts'] ) ) {
+			$builder = $builder->with_message_parts( ...$prompt_context['prompt_parts'] );
+		}
+
+		if ( '' !== $provider_id ) {
+			$builder = $builder->using_provider( $provider_id );
+		}
+
+		if ( '' !== $model_id ) {
+			$builder = $builder->using_model( $model_id );
+		}
+
+		if ( '' !== $system_prompt ) {
+			$builder = $builder->using_system_instruction( $system_prompt );
+		}
+
+		if ( isset( $this->options['temperature'] ) && is_numeric( $this->options['temperature'] ) ) {
+			$builder = $builder->using_temperature( (float) $this->options['temperature'] );
+		}
+
+		if ( isset( $this->options['max_tokens'] ) && is_numeric( $this->options['max_tokens'] ) ) {
+			$builder = $builder->using_max_tokens( (int) $this->options['max_tokens'] );
+		}
+
+		if ( ! empty( $prompt_context['history'] ) ) {
+			$builder = $builder->with_history( ...$prompt_context['history'] );
+		}
+
+		$function_declarations = self::function_declarations( $request->toolDeclarations() );
+		if ( ! empty( $function_declarations ) ) {
+			$builder = $builder->using_function_declarations( ...$function_declarations );
+		}
+
+		$result = $builder->generate_text_result();
+
+		if ( function_exists( 'is_wp_error' ) && is_wp_error( $result ) ) {
+			throw new \RuntimeException( 'wp-ai-client request failed: ' . $result->get_error_message() );
+		}
+
+		return array(
+			'content'          => self::result_text( $result ),
+			'tool_calls'       => WP_Agent_Provider_Turn_Result::extract_tool_calls( $result ),
+			'usage'            => self::result_usage( $result ),
+			'request_metadata' => array(
+				'provider_id' => $provider_id,
+				'model_id'    => $model_id,
+			),
+		);
+	}
+
+	/**
+	 * Resolve the system prompt + message set handed to the wp-ai-client builder.
+	 *
+	 * Default behavior is identity: the request's system prompt and messages are
+	 * used as-is. When a prompt-input provider is injected, it owns the transform.
+	 *
+	 * @param WP_Agent_Provider_Turn_Request $request Provider-turn request.
+	 * @return array{system_prompt:string,messages:array<int,array<string,mixed>>}
+	 */
+	private function resolve_prompt_input( WP_Agent_Provider_Turn_Request $request ): array {
+		$system_prompt = $this->request_system_prompt( $request );
+		$messages      = $request->messages();
+
+		if ( null === $this->prompt_input_provider ) {
+			return array(
+				'system_prompt' => $system_prompt,
+				'messages'      => $messages,
+			);
+		}
+
+		$produced = call_user_func( $this->prompt_input_provider, $system_prompt, $messages, $request->context() );
+
+		if ( is_array( $produced ) ) {
+			if ( array_key_exists( 'system_prompt', $produced ) || array_key_exists( 'messages', $produced ) ) {
+				$system_prompt = is_string( $produced['system_prompt'] ?? null ) ? $produced['system_prompt'] : $system_prompt;
+				$messages      = is_array( $produced['messages'] ?? null ) ? $produced['messages'] : $messages;
+			} elseif ( array_is_list( $produced ) ) {
+				$system_prompt = is_string( $produced[0] ?? null ) ? $produced[0] : $system_prompt;
+				$messages      = is_array( $produced[1] ?? null ) ? $produced[1] : $messages;
+			}
+		}
+
+		return array(
+			'system_prompt' => $system_prompt,
+			'messages'      => WP_Agent_Message::normalize_many( $messages ),
+		);
+	}
+
+	/**
+	 * Resolve the request system prompt, falling back to the constructed default.
+	 *
+	 * @param WP_Agent_Provider_Turn_Request $request Provider-turn request.
+	 * @return string
+	 */
+	private function request_system_prompt( WP_Agent_Provider_Turn_Request $request ): string {
+		$context = $request->context();
+		$runtime = $request->runtime();
+		foreach ( array( $context['system_prompt'] ?? null, $runtime['system_prompt'] ?? null ) as $candidate ) {
+			if ( is_string( $candidate ) && '' !== $candidate ) {
+				return $candidate;
+			}
+		}
+
+		return $this->system_prompt;
+	}
+
+	/**
+	 * Resolve the provider id from request metadata or the constructor default.
+	 *
+	 * @param WP_Agent_Provider_Turn_Request $request Provider-turn request.
+	 * @return string
+	 */
+	private function resolve_provider_id( WP_Agent_Provider_Turn_Request $request ): string {
+		$model = $request->model();
+		$value = $model['provider_id'] ?? null;
+
+		return is_string( $value ) && '' !== $value ? $value : $this->provider_id;
+	}
+
+	/**
+	 * Resolve the model id from request metadata or the constructor default.
+	 *
+	 * @param WP_Agent_Provider_Turn_Request $request Provider-turn request.
+	 * @return string
+	 */
+	private function resolve_model_id( WP_Agent_Provider_Turn_Request $request ): string {
+		$model = $request->model();
+		$value = $model['model_id'] ?? null;
+
+		return is_string( $value ) && '' !== $value ? $value : $this->model_id;
+	}
+
+	/**
+	 * Split canonical messages into the wp-ai-client current prompt + history.
+	 *
+	 * wp-ai-client expects the current user turn supplied through the builder
+	 * (here via `with_message_parts()`) and earlier turns through
+	 * `with_history()`. The latest user message becomes the current prompt; all
+	 * other messages become history.
+	 *
+	 * @param array<int, mixed> $messages Canonical messages.
+	 * @return array{prompt_parts:array<int,object>,history:array<int,object>}
+	 */
+	private static function split_prompt_context( array $messages ): array {
+		$prompt_index = null;
+		$prompt_parts = array();
+
+		foreach ( $messages as $index => $message ) {
+			if ( ! is_array( $message ) ) {
+				continue;
+			}
+
+			if ( 'user' !== ( $message['role'] ?? '' ) ) {
+				continue;
+			}
+
+			$candidate_parts = self::message_parts( $message );
+			if ( ! empty( $candidate_parts ) ) {
+				$prompt_index = $index;
+				$prompt_parts = $candidate_parts;
+			}
+		}
+
+		$history = array();
+		foreach ( $messages as $index => $message ) {
+			if ( $index === $prompt_index || ! is_array( $message ) ) {
+				continue;
+			}
+
+			$history_message = self::history_message( $message );
+			if ( null !== $history_message ) {
+				$history[] = $history_message;
+			}
+		}
+
+		return array(
+			'prompt_parts' => $prompt_parts,
+			'history'      => $history,
+		);
+	}
+
+	/**
+	 * Convert a canonical message envelope into a wp-ai-client history Message DTO.
+	 *
+	 * @param array<mixed> $message Canonical message envelope.
+	 * @return object|null wp-ai-client Message DTO, or null when unmappable.
+	 */
+	private static function history_message( array $message ): ?object {
+		$role  = is_string( $message['role'] ?? null ) ? $message['role'] : '';
+		$parts = self::message_parts( $message );
+		if ( empty( $parts ) ) {
+			return null;
+		}
+
+		if ( ( 'assistant' === $role || 'model' === $role ) && class_exists( \WordPress\AiClient\Messages\DTO\ModelMessage::class ) ) {
+			return new \WordPress\AiClient\Messages\DTO\ModelMessage( $parts );
+		}
+
+		if ( class_exists( \WordPress\AiClient\Messages\DTO\UserMessage::class ) ) {
+			return new \WordPress\AiClient\Messages\DTO\UserMessage( $parts );
+		}
+
+		return null;
+	}
+
+	/**
+	 * Convert a canonical message envelope into wp-ai-client MessagePart objects.
+	 *
+	 * Handles plain text plus the canonical tool-call and tool-result envelopes
+	 * so multi-turn tool transcripts replay correctly. Unmappable shapes yield an
+	 * empty list and are skipped by callers.
+	 *
+	 * @param array<mixed> $message Canonical message envelope.
+	 * @return array<int, object> wp-ai-client MessagePart objects.
+	 */
+	private static function message_parts( array $message ): array {
+		if ( ! class_exists( \WordPress\AiClient\Messages\DTO\MessagePart::class ) ) {
+			return array();
+		}
+
+		try {
+			$envelope = WP_Agent_Message::normalize( $message );
+		} catch ( \Throwable $error ) {
+			unset( $error );
+			return self::text_parts( $message['content'] ?? '' );
+		}
+
+		$type     = is_string( $envelope['type'] ?? null ) ? $envelope['type'] : WP_Agent_Message::TYPE_TEXT;
+		$payload  = is_array( $envelope['payload'] ?? null ) ? $envelope['payload'] : array();
+		$metadata = is_array( $envelope['metadata'] ?? null ) ? $envelope['metadata'] : array();
+
+		if ( WP_Agent_Message::TYPE_TOOL_CALL === $type ) {
+			$tool_name = is_string( $payload['tool_name'] ?? null ) ? $payload['tool_name'] : '';
+			$call_id   = self::tool_call_id( $metadata, $payload );
+			if ( ( '' === $tool_name && '' === $call_id ) || ! class_exists( \WordPress\AiClient\Tools\DTO\FunctionCall::class ) ) {
+				return array();
+			}
+
+			$parameters = is_array( $payload['parameters'] ?? null ) ? $payload['parameters'] : array();
+
+			return array(
+				new \WordPress\AiClient\Messages\DTO\MessagePart(
+					new \WordPress\AiClient\Tools\DTO\FunctionCall(
+						'' !== $call_id ? $call_id : null,
+						'' !== $tool_name ? $tool_name : null,
+						$parameters
+					)
+				),
+			);
+		}
+
+		if ( WP_Agent_Message::TYPE_TOOL_RESULT === $type ) {
+			$tool_name = is_string( $payload['tool_name'] ?? null ) ? $payload['tool_name'] : '';
+			$call_id   = self::tool_call_id( $metadata, $payload );
+			if ( ( '' === $tool_name && '' === $call_id ) || ! class_exists( \WordPress\AiClient\Tools\DTO\FunctionResponse::class ) ) {
+				return array();
+			}
+
+			return array(
+				new \WordPress\AiClient\Messages\DTO\MessagePart(
+					new \WordPress\AiClient\Tools\DTO\FunctionResponse(
+						'' !== $call_id ? $call_id : null,
+						'' !== $tool_name ? $tool_name : null,
+						$payload
+					)
+				),
+			);
+		}
+
+		return self::text_parts( $envelope['content'] ?? '' );
+	}
+
+	/**
+	 * Build text-only wp-ai-client MessagePart objects from message content.
+	 *
+	 * @param mixed $content Message content (string or list of blocks).
+	 * @return array<int, object>
+	 */
+	private static function text_parts( $content ): array {
+		if ( ! class_exists( \WordPress\AiClient\Messages\DTO\MessagePart::class ) ) {
+			return array();
+		}
+
+		if ( is_string( $content ) ) {
+			return '' !== $content ? array( new \WordPress\AiClient\Messages\DTO\MessagePart( $content ) ) : array();
+		}
+
+		if ( ! is_array( $content ) ) {
+			return array();
+		}
+
+		$parts = array();
+		foreach ( $content as $part ) {
+			if ( is_string( $part ) && '' !== $part ) {
+				$parts[] = new \WordPress\AiClient\Messages\DTO\MessagePart( $part );
+				continue;
+			}
+
+			if ( ! is_array( $part ) ) {
+				continue;
+			}
+
+			$text = $part['text'] ?? $part['content'] ?? null;
+			if ( is_string( $text ) && '' !== $text ) {
+				$parts[] = new \WordPress\AiClient\Messages\DTO\MessagePart( $text );
+			}
+		}
+
+		return $parts;
+	}
+
+	/**
+	 * Resolve the provider tool-call id from envelope metadata or payload.
+	 *
+	 * @param array<mixed> $metadata Envelope metadata.
+	 * @param array<mixed> $payload  Envelope payload.
+	 * @return string
+	 */
+	private static function tool_call_id( array $metadata, array $payload ): string {
+		foreach ( array( $metadata['tool_call_id'] ?? null, $payload['tool_call_id'] ?? null ) as $candidate ) {
+			if ( is_string( $candidate ) && '' !== $candidate ) {
+				return $candidate;
+			}
+		}
+
+		return '';
+	}
+
+	/**
+	 * Convert normalized tool declarations into wp-ai-client FunctionDeclaration objects.
+	 *
+	 * @param array<string, array<string, mixed>> $tool_declarations Tool declarations keyed by name.
+	 * @return array<int, object>
+	 */
+	private static function function_declarations( array $tool_declarations ): array {
+		if ( ! class_exists( \WordPress\AiClient\Tools\DTO\FunctionDeclaration::class ) ) {
+			return array();
+		}
+
+		$declarations = array();
+		foreach ( $tool_declarations as $name => $tool ) {
+			$tool_name = is_string( $tool['name'] ?? null ) && '' !== $tool['name'] ? $tool['name'] : (string) $name;
+			if ( '' === $tool_name ) {
+				continue;
+			}
+
+			$description = is_string( $tool['description'] ?? null ) ? $tool['description'] : '';
+			$parameters  = is_array( $tool['parameters'] ?? null ) ? $tool['parameters'] : array();
+
+			$declarations[] = new \WordPress\AiClient\Tools\DTO\FunctionDeclaration(
+				$tool_name,
+				$description,
+				$parameters
+			);
+		}
+
+		return $declarations;
+	}
+
+	/**
+	 * Extract assistant text from a wp-ai-client result.
+	 *
+	 * @param mixed $result wp-ai-client GenerativeAiResult.
+	 * @return string
+	 */
+	private static function result_text( $result ): string {
+		if ( is_object( $result ) && method_exists( $result, 'toText' ) ) {
+			try {
+				$text = $result->toText();
+
+				return is_string( $text ) ? $text : '';
+			} catch ( \Throwable $error ) {
+				// Results without text content (tool-only turns) throw; treat as empty.
+				if ( false !== strpos( $error->getMessage(), 'No text content found' ) ) {
+					return '';
+				}
+
+				throw $error;
+			}
+		}
+
+		return '';
+	}
+
+	/**
+	 * Normalize token usage from a wp-ai-client result.
+	 *
+	 * @param mixed $result wp-ai-client GenerativeAiResult.
+	 * @return array{prompt_tokens:int,completion_tokens:int,total_tokens:int}
+	 */
+	private static function result_usage( $result ): array {
+		$usage = array(
+			'prompt_tokens'     => 0,
+			'completion_tokens' => 0,
+			'total_tokens'      => 0,
+		);
+
+		if ( ! is_object( $result ) || ! method_exists( $result, 'getTokenUsage' ) ) {
+			return $usage;
+		}
+
+		$token_usage = $result->getTokenUsage();
+		if ( ! is_object( $token_usage ) ) {
+			return $usage;
+		}
+
+		if ( method_exists( $token_usage, 'getPromptTokens' ) ) {
+			$prompt_tokens          = $token_usage->getPromptTokens();
+			$usage['prompt_tokens'] = is_numeric( $prompt_tokens ) ? (int) $prompt_tokens : 0;
+		}
+
+		if ( method_exists( $token_usage, 'getCompletionTokens' ) ) {
+			$completion_tokens          = $token_usage->getCompletionTokens();
+			$usage['completion_tokens'] = is_numeric( $completion_tokens ) ? (int) $completion_tokens : 0;
+		}
+
+		if ( method_exists( $token_usage, 'getTotalTokens' ) ) {
+			$total_tokens          = $token_usage->getTotalTokens();
+			$usage['total_tokens'] = is_numeric( $total_tokens ) ? (int) $total_tokens : 0;
+		}
+
+		return $usage;
+	}
+}

--- a/stubs/class-wp-ai-client-prompt-builder.php
+++ b/stubs/class-wp-ai-client-prompt-builder.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * PHPStan class stub for the WordPress core wp-ai-client prompt builder facade.
+ *
+ * agents-api has no hard dependency on wp-ai-client. This stub exists only so
+ * the static analyzer can type the snake-case fluent builder the default
+ * provider-turn adapter drives behind `function_exists()` guards. It mirrors
+ * the real WordPress core facade (wp-includes/ai-client) but is never loaded at
+ * runtime.
+ *
+ * @see https://github.com/WordPress/wordpress-develop wp-includes/ai-client/class-wp-ai-client-prompt-builder.php
+ */
+
+/**
+ * Snake-case fluent prompt builder facade (WP core wp-includes/ai-client).
+ */
+class WP_AI_Client_Prompt_Builder {
+
+	public function with_message_parts( object ...$parts ): self {
+		unset( $parts );
+		return $this;
+	}
+
+	public function using_provider( string $provider ): self {
+		unset( $provider );
+		return $this;
+	}
+
+	public function using_model( string $model ): self {
+		unset( $model );
+		return $this;
+	}
+
+	public function using_system_instruction( string $system_instruction ): self {
+		unset( $system_instruction );
+		return $this;
+	}
+
+	public function using_temperature( float $temperature ): self {
+		unset( $temperature );
+		return $this;
+	}
+
+	public function using_max_tokens( int $max_tokens ): self {
+		unset( $max_tokens );
+		return $this;
+	}
+
+	public function with_history( object ...$messages ): self {
+		unset( $messages );
+		return $this;
+	}
+
+	public function using_function_declarations( object ...$function_declarations ): self {
+		unset( $function_declarations );
+		return $this;
+	}
+
+	/**
+	 * @return object|\WP_Error wp-ai-client GenerativeAiResult or a WP_Error on failure.
+	 */
+	public function generate_text_result() {
+		return new \stdClass();
+	}
+}

--- a/stubs/wp-ai-client-dtos.php
+++ b/stubs/wp-ai-client-dtos.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * PHPStan class stubs for the php-ai-client DTO surface the default
+ * provider-turn adapter consumes.
+ *
+ * agents-api has no hard dependency on wp-ai-client. These stubs exist only so
+ * the static analyzer can type the generic message/tool mapping the adapter
+ * performs behind `class_exists()` guards. They mirror the real php-ai-client
+ * DTOs but are never loaded at runtime. The builder facade stub lives in its
+ * own file (class-wp-ai-client-prompt-builder.php) because it is in the global
+ * namespace.
+ *
+ * @see https://github.com/WordPress/php-ai-client
+ */
+
+// phpcs:disable Generic.Files.OneObjectStructurePerFile.MultipleFound -- Grouped stub file.
+
+namespace WordPress\AiClient\Messages\DTO {
+
+	class MessagePart {
+		/**
+		 * @param mixed $value Part value.
+		 */
+		public function __construct( $value ) {
+			unset( $value );
+		}
+	}
+
+	class UserMessage {
+		/**
+		 * @param array<int, object> $parts Message parts.
+		 */
+		public function __construct( array $parts ) {
+			unset( $parts );
+		}
+	}
+
+	class ModelMessage {
+		/**
+		 * @param array<int, object> $parts Message parts.
+		 */
+		public function __construct( array $parts ) {
+			unset( $parts );
+		}
+	}
+}
+
+namespace WordPress\AiClient\Tools\DTO {
+
+	class FunctionCall {
+		/**
+		 * @param string|null          $id   Call id.
+		 * @param string|null          $name Tool name.
+		 * @param array<mixed> $args Call arguments.
+		 */
+		public function __construct( ?string $id, ?string $name, array $args ) {
+			unset( $id, $name, $args );
+		}
+	}
+
+	class FunctionResponse {
+		/**
+		 * @param string|null          $id      Call id.
+		 * @param string|null          $name    Tool name.
+		 * @param array<mixed> $payload Response payload.
+		 */
+		public function __construct( ?string $id, ?string $name, array $payload ) {
+			unset( $id, $name, $payload );
+		}
+	}
+
+	class FunctionDeclaration {
+		/**
+		 * @param string               $name        Function name.
+		 * @param string               $description Function description.
+		 * @param array<mixed> $parameters  JSON-schema parameters.
+		 */
+		public function __construct( string $name, string $description, array $parameters ) {
+			unset( $name, $description, $parameters );
+		}
+	}
+}

--- a/stubs/wp-ai-client-functions.php
+++ b/stubs/wp-ai-client-functions.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * PHPStan function stub for the WordPress core wp-ai-client entrypoint.
+ *
+ * agents-api has no hard dependency on wp-ai-client; the default provider-turn
+ * adapter reaches it only behind `function_exists()`/`class_exists()` guards at
+ * runtime. This stub gives the static analyzer a type for the builder so the
+ * generic mapping/dispatch logic can be checked at level max. It is a companion
+ * to wp-ai-client-dtos.php, which carries the DTO class stubs (phpcs requires a
+ * file to contain either OO structures or function declarations, not both).
+ *
+ * @see https://github.com/WordPress/wordpress-develop wp-includes/ai-client.php
+ */
+
+/**
+ * @param mixed $prompt Optional initial prompt content.
+ */
+function wp_ai_client_prompt( $prompt = null ): WP_AI_Client_Prompt_Builder {
+	unset( $prompt );
+	return new WP_AI_Client_Prompt_Builder();
+}

--- a/tests/default-provider-turn-adapter-smoke.php
+++ b/tests/default-provider-turn-adapter-smoke.php
@@ -1,0 +1,431 @@
+<?php
+/**
+ * Pure-PHP smoke test for the default provider-turn adapter and run_conversation facade.
+ *
+ * Run with: php tests/default-provider-turn-adapter-smoke.php
+ *
+ * @package AgentsAPI\Tests
+ */
+
+/*
+ * Minimal wp-ai-client doubles. The adapter reaches the upstream builder through
+ * class_exists() guards and the wp_ai_client_prompt() entrypoint, so the smoke
+ * stands in fakes that record builder calls and return a GenerativeAiResult-shaped
+ * object the already-shipped extraction/normalization helpers understand.
+ *
+ * This file uses bracketed namespace blocks so the wp-ai-client DTO doubles can
+ * live under their real namespaces alongside the global test code.
+ */
+// phpcs:disable Generic.Files.OneObjectStructurePerFile.MultipleFound, Squiz.Commenting, Generic.Commenting
+
+namespace WordPress\AiClient\Messages\DTO {
+	if ( ! class_exists( __NAMESPACE__ . '\\MessagePart' ) ) {
+		class MessagePart {
+			public $value;
+			public function __construct( $value ) {
+				$this->value = $value;
+			}
+		}
+	}
+	if ( ! class_exists( __NAMESPACE__ . '\\UserMessage' ) ) {
+		class UserMessage {
+			public array $parts;
+			public function __construct( array $parts ) {
+				$this->parts = $parts;
+			}
+		}
+	}
+	if ( ! class_exists( __NAMESPACE__ . '\\ModelMessage' ) ) {
+		class ModelMessage {
+			public array $parts;
+			public function __construct( array $parts ) {
+				$this->parts = $parts;
+			}
+		}
+	}
+}
+
+namespace WordPress\AiClient\Tools\DTO {
+	if ( ! class_exists( __NAMESPACE__ . '\\FunctionCall' ) ) {
+		class FunctionCall {
+			public $id;
+			public $name;
+			public $args;
+			public function __construct( $id, $name, $args ) {
+				$this->id   = $id;
+				$this->name = $name;
+				$this->args = $args;
+			}
+		}
+	}
+	if ( ! class_exists( __NAMESPACE__ . '\\FunctionResponse' ) ) {
+		class FunctionResponse {
+			public $id;
+			public $name;
+			public $payload;
+			public function __construct( $id, $name, $payload ) {
+				$this->id      = $id;
+				$this->name    = $name;
+				$this->payload = $payload;
+			}
+		}
+	}
+	if ( ! class_exists( __NAMESPACE__ . '\\FunctionDeclaration' ) ) {
+		class FunctionDeclaration {
+			public string $name;
+			public string $description;
+			public array $parameters;
+			public function __construct( string $name, string $description, array $parameters ) {
+				$this->name        = $name;
+				$this->description  = $description;
+				$this->parameters   = $parameters;
+			}
+		}
+	}
+}
+
+namespace {
+
+	if ( ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', __DIR__ . '/' );
+	}
+
+	$failures = array();
+	$passes   = 0;
+
+	echo "agents-api-default-provider-turn-adapter-smoke\n";
+
+	require_once __DIR__ . '/agents-api-smoke-helpers.php';
+	require_once __DIR__ . '/../agents-api.php';
+
+	/**
+	 * Shared recorder so assertions can inspect what the adapter handed the builder.
+	 *
+	 * @var array<string, mixed> $GLOBALS['__adapter_smoke']
+	 */
+	$GLOBALS['__adapter_smoke'] = array();
+
+	/** Fake GenerativeAiResult exposing the surface the substrate reads. */
+	class Agents_API_Fake_Token_Usage {
+		public function __construct( private int $prompt, private int $completion, private int $total ) {}
+		public function getPromptTokens(): int {
+			return $this->prompt;
+		}
+		public function getCompletionTokens(): int {
+			return $this->completion;
+		}
+		public function getTotalTokens(): int {
+			return $this->total;
+		}
+	}
+
+	class Agents_API_Fake_Function_Call {
+		public function __construct( private string $name, private string $args, private string $id ) {}
+		public function getName(): string {
+			return $this->name;
+		}
+		public function getArgs(): string {
+			return $this->args;
+		}
+		public function getId(): string {
+			return $this->id;
+		}
+	}
+
+	class Agents_API_Fake_Part {
+		public function __construct( private ?Agents_API_Fake_Function_Call $call, private string $text ) {}
+		public function getFunctionCall(): ?Agents_API_Fake_Function_Call {
+			return $this->call;
+		}
+		public function getText(): string {
+			return $this->text;
+		}
+	}
+
+	class Agents_API_Fake_Message {
+		/** @param array<int, Agents_API_Fake_Part> $parts */
+		public function __construct( private array $parts ) {}
+		public function getParts(): array {
+			return $this->parts;
+		}
+	}
+
+	class Agents_API_Fake_Candidate {
+		public function __construct( private Agents_API_Fake_Message $message ) {}
+		public function getMessage(): Agents_API_Fake_Message {
+			return $this->message;
+		}
+	}
+
+	class Agents_API_Fake_Generative_Result {
+		/** @param array<int, Agents_API_Fake_Candidate> $candidates */
+		public function __construct( private string $text, private array $candidates, private Agents_API_Fake_Token_Usage $usage ) {}
+		public function toText(): string {
+			if ( '' === $this->text ) {
+				throw new \RuntimeException( 'No text content found in result.' );
+			}
+			return $this->text;
+		}
+		public function getCandidates(): array {
+			return $this->candidates;
+		}
+		public function getTokenUsage(): Agents_API_Fake_Token_Usage {
+			return $this->usage;
+		}
+	}
+
+	/** Fake builder recording the fluent calls the adapter makes. */
+	class Agents_API_Fake_Prompt_Builder {
+		public function with_message_parts( ...$parts ): self {
+			$GLOBALS['__adapter_smoke']['prompt_parts'] = $parts;
+			return $this;
+		}
+		public function using_provider( string $provider ): self {
+			$GLOBALS['__adapter_smoke']['provider'] = $provider;
+			return $this;
+		}
+		public function using_model( string $model ): self {
+			$GLOBALS['__adapter_smoke']['model'] = $model;
+			return $this;
+		}
+		public function using_system_instruction( string $system ): self {
+			$GLOBALS['__adapter_smoke']['system'] = $system;
+			return $this;
+		}
+		public function using_temperature( float $temperature ): self {
+			$GLOBALS['__adapter_smoke']['temperature'] = $temperature;
+			return $this;
+		}
+		public function using_max_tokens( int $max_tokens ): self {
+			$GLOBALS['__adapter_smoke']['max_tokens'] = $max_tokens;
+			return $this;
+		}
+		public function with_history( ...$history ): self {
+			$GLOBALS['__adapter_smoke']['history'] = $history;
+			return $this;
+		}
+		public function using_function_declarations( ...$declarations ): self {
+			$GLOBALS['__adapter_smoke']['declarations'] = $declarations;
+			return $this;
+		}
+		public function generate_text_result() {
+			if ( isset( $GLOBALS['__adapter_smoke']['select_next'] ) && is_callable( $GLOBALS['__adapter_smoke']['select_next'] ) ) {
+				return call_user_func( $GLOBALS['__adapter_smoke']['select_next'] );
+			}
+			return $GLOBALS['__adapter_smoke']['next_result'];
+		}
+	}
+
+	if ( ! function_exists( 'wp_ai_client_prompt' ) ) {
+		function wp_ai_client_prompt( $prompt = null ): Agents_API_Fake_Prompt_Builder {
+			unset( $prompt );
+			return new Agents_API_Fake_Prompt_Builder();
+		}
+	}
+
+	if ( ! class_exists( 'WP_Error' ) ) {
+		class WP_Error {
+			public function __construct( private string $code = '', private string $message = '' ) {}
+			public function get_error_code(): string {
+				return $this->code;
+			}
+			public function get_error_message(): string {
+				return $this->message;
+			}
+		}
+	}
+
+	$make_result = static function ( string $text, array $tool_calls, array $usage ): Agents_API_Fake_Generative_Result {
+		$parts = array();
+		foreach ( $tool_calls as $call ) {
+			$parts[] = new Agents_API_Fake_Part(
+				new Agents_API_Fake_Function_Call( $call['name'], json_encode( $call['parameters'] ), $call['id'] ),
+				''
+			);
+		}
+		if ( '' !== $text ) {
+			$parts[] = new Agents_API_Fake_Part( null, $text );
+		}
+		return new Agents_API_Fake_Generative_Result(
+			$text,
+			array( new Agents_API_Fake_Candidate( new Agents_API_Fake_Message( $parts ) ) ),
+			new Agents_API_Fake_Token_Usage( $usage[0], $usage[1], $usage[2] )
+		);
+	};
+
+	echo "\n[1] run_turn() returns a normalized result from a mocked wp-ai-client dispatch:\n";
+	$GLOBALS['__adapter_smoke']             = array();
+	$GLOBALS['__adapter_smoke']['next_result'] = $make_result(
+		'Final answer.',
+		array( array( 'name' => 'client/lookup', 'parameters' => array( 'query' => 'alpha' ), 'id' => 'call-1' ) ),
+		array( 5, 7, 12 )
+	);
+
+	$adapter = new AgentsAPI\AI\WP_Agent_Default_Provider_Turn_Adapter( 'fake-provider', 'fake-model', 'You are a test agent.' );
+	$request = new AgentsAPI\AI\WP_Agent_Provider_Turn_Request(
+		array(
+			array( 'role' => 'user', 'content' => 'earlier turn' ),
+			array( 'role' => 'assistant', 'content' => 'earlier answer' ),
+			array( 'role' => 'user', 'content' => 'look up alpha' ),
+		),
+		array(
+			'client/lookup' => array(
+				'name'        => 'client/lookup',
+				'source'      => 'client',
+				'description' => 'Look up one value.',
+				'parameters'  => array(
+					'type'       => 'object',
+					'required'   => array( 'query' ),
+					'properties' => array( 'query' => array( 'type' => 'string' ) ),
+				),
+				'executor'    => 'client',
+				'scope'       => 'run',
+			),
+		),
+		array( 'provider_id' => 'fake-provider', 'model_id' => 'fake-model' )
+	);
+
+	$raw    = $adapter->run_turn( $request );
+	$result = AgentsAPI\AI\WP_Agent_Provider_Turn_Result::normalize( $raw );
+
+	agents_api_smoke_assert_equals( 'Final answer.', $result['content'], 'run_turn surfaces assistant text', $failures, $passes );
+	agents_api_smoke_assert_equals( 'client/lookup', $result['tool_calls'][0]['name'] ?? '', 'run_turn extracts tool calls via shipped extractor', $failures, $passes );
+	agents_api_smoke_assert_equals( 'alpha', $result['tool_calls'][0]['parameters']['query'] ?? '', 'run_turn decodes tool-call arguments', $failures, $passes );
+	agents_api_smoke_assert_equals( 12, $result['usage']['total_tokens'], 'run_turn normalizes token usage', $failures, $passes );
+	agents_api_smoke_assert_equals( 'fake-provider', $GLOBALS['__adapter_smoke']['provider'] ?? '', 'run_turn passes provider id to the builder', $failures, $passes );
+	agents_api_smoke_assert_equals( 'fake-model', $GLOBALS['__adapter_smoke']['model'] ?? '', 'run_turn passes model id to the builder', $failures, $passes );
+	agents_api_smoke_assert_equals( 'You are a test agent.', $GLOBALS['__adapter_smoke']['system'] ?? '', 'run_turn passes default system prompt to the builder', $failures, $passes );
+	agents_api_smoke_assert_equals( 1, count( $GLOBALS['__adapter_smoke']['prompt_parts'] ?? array() ), 'run_turn sends the latest user turn as the current prompt', $failures, $passes );
+	agents_api_smoke_assert_equals( 2, count( $GLOBALS['__adapter_smoke']['history'] ?? array() ), 'run_turn sends earlier turns as history', $failures, $passes );
+	agents_api_smoke_assert_equals( 1, count( $GLOBALS['__adapter_smoke']['declarations'] ?? array() ), 'run_turn maps tool declarations to function declarations', $failures, $passes );
+	agents_api_smoke_assert_equals( 'client/lookup', $GLOBALS['__adapter_smoke']['declarations'][0]->name ?? '', 'function declaration carries the logical tool name', $failures, $passes );
+
+	echo "\n[2] Prompt-input seam defaults to identity and applies an override:\n";
+	$GLOBALS['__adapter_smoke']                = array();
+	$GLOBALS['__adapter_smoke']['next_result'] = $make_result( 'ok', array(), array( 1, 1, 2 ) );
+
+	$identity_adapter = new AgentsAPI\AI\WP_Agent_Default_Provider_Turn_Adapter( 'fake-provider', 'fake-model', 'identity-system' );
+	$identity_adapter->run_turn(
+		new AgentsAPI\AI\WP_Agent_Provider_Turn_Request(
+			array( array( 'role' => 'user', 'content' => 'hello' ) )
+		)
+	);
+	agents_api_smoke_assert_equals( 'identity-system', $GLOBALS['__adapter_smoke']['system'] ?? '', 'identity seam passes the request/default system prompt through', $failures, $passes );
+
+	$GLOBALS['__adapter_smoke']                = array();
+	$GLOBALS['__adapter_smoke']['next_result'] = $make_result( 'ok', array(), array( 1, 1, 2 ) );
+	$seam_called                               = array();
+	$override_adapter                          = new AgentsAPI\AI\WP_Agent_Default_Provider_Turn_Adapter(
+		'fake-provider',
+		'fake-model',
+		'base-system',
+		array(
+			'prompt_input_provider' => static function ( string $system_prompt, array $messages, array $context ) use ( &$seam_called ): array {
+				$seam_called[] = array( $system_prompt, count( $messages ), $context );
+				return array(
+					'system_prompt' => 'composed-system',
+					'messages'      => array( array( 'role' => 'user', 'content' => 'composed prompt' ) ),
+				);
+			},
+		)
+	);
+	$override_adapter->run_turn(
+		new AgentsAPI\AI\WP_Agent_Provider_Turn_Request(
+			array( array( 'role' => 'user', 'content' => 'original prompt' ) ),
+			array(),
+			array(),
+			array(),
+			array( 'turn' => 1 )
+		)
+	);
+	agents_api_smoke_assert_equals( 'composed-system', $GLOBALS['__adapter_smoke']['system'] ?? '', 'prompt-input override replaces the system prompt before dispatch', $failures, $passes );
+	agents_api_smoke_assert_equals( 'base-system', $seam_called[0][0] ?? '', 'prompt-input override receives the request/default system prompt', $failures, $passes );
+	agents_api_smoke_assert_equals( 1, $seam_called[0][1] ?? 0, 'prompt-input override receives the request messages', $failures, $passes );
+
+	echo "\n[3] run_turn() converts a wp-ai-client failure into a thrown RuntimeException:\n";
+	$GLOBALS['__adapter_smoke']                = array();
+	$GLOBALS['__adapter_smoke']['next_result'] = new WP_Error( 'wp_ai_client_text_exception', 'provider exploded' );
+	$threw                                     = false;
+	try {
+		$adapter->run_turn(
+			new AgentsAPI\AI\WP_Agent_Provider_Turn_Request(
+				array( array( 'role' => 'user', 'content' => 'fail please' ) )
+			)
+		);
+	} catch ( \RuntimeException $error ) {
+		$threw = false !== strpos( $error->getMessage(), 'provider exploded' );
+	}
+	agents_api_smoke_assert_equals( true, $threw, 'run_turn throws on a WP_Error dispatch result', $failures, $passes );
+
+	echo "\n[4] run_conversation() drives the loop end-to-end through the default adapter:\n";
+	$turn = 0;
+	$GLOBALS['__adapter_smoke'] = array();
+
+	$executor = new class() implements AgentsAPI\AI\Tools\WP_Agent_Tool_Executor {
+		/** @var array<int, array<string, mixed>> Executed tool calls. */
+		public array $executed = array();
+		public function executeWP_Agent_Tool_Call( array $tool_call, array $tool_definition, array $context = array() ): array {
+			unset( $tool_definition, $context );
+			$this->executed[] = $tool_call;
+			return array(
+				'success'   => true,
+				'tool_name' => $tool_call['tool_name'],
+				'result'    => array( 'value' => 'looked-up' ),
+			);
+		}
+	};
+
+	/*
+	 * The loop calls the adapter once per turn. First turn emits a tool call, the
+	 * loop mediates it through the executor, then the second turn returns final text.
+	 */
+	$results_by_turn = array(
+		1 => $make_result( 'Need a lookup.', array( array( 'name' => 'client/lookup', 'parameters' => array( 'query' => 'beta' ), 'id' => 'call-conv-1' ) ), array( 3, 4, 7 ) ),
+		2 => $make_result( 'All done from default adapter.', array(), array( 2, 2, 4 ) ),
+	);
+
+	// Recreate the fake builder so each turn pulls its own queued result.
+	$GLOBALS['__adapter_smoke']['next_result'] = $results_by_turn[1];
+
+	// The builder reads next_result lazily at generate time, so swap it as turns advance
+	// by wrapping wp_ai_client_prompt via a turn counter on the recorder.
+	$GLOBALS['__adapter_smoke']['turn'] = 0;
+	$GLOBALS['__adapter_smoke']['results_by_turn'] = $results_by_turn;
+
+	// Override the builder's generate to advance the queued result per call.
+	// Achieved by a subclass installed through a closure-bound result selector.
+	$GLOBALS['__adapter_smoke']['select_next'] = static function () use ( $results_by_turn ) {
+		$GLOBALS['__adapter_smoke']['turn'] = ( $GLOBALS['__adapter_smoke']['turn'] ?? 0 ) + 1;
+		$index                              = $GLOBALS['__adapter_smoke']['turn'];
+		return $results_by_turn[ $index ] ?? $results_by_turn[ 2 ];
+	};
+
+	$conversation = AgentsAPI\AI\WP_Agent_Conversation_Loop::run_conversation(
+		array( array( 'role' => 'user', 'content' => 'look up beta' ) ),
+		array(
+			'client/lookup' => array(
+				'name'        => 'client/lookup',
+				'source'      => 'client',
+				'description' => 'Look up one value.',
+				'parameters'  => array( 'type' => 'object', 'properties' => array( 'query' => array( 'type' => 'string' ) ) ),
+				'executor'    => 'client',
+				'scope'       => 'run',
+			),
+		),
+		'fake-provider',
+		'fake-model',
+		array(
+			'system_prompt' => 'run-conversation-system',
+			'tool_executor' => $executor,
+			'max_turns'     => 3,
+		)
+	);
+
+	agents_api_smoke_assert_equals( 1, count( $executor->executed ), 'run_conversation mediated the adapter tool call through the executor', $failures, $passes );
+	agents_api_smoke_assert_equals( 'call-conv-1', $executor->executed[0]['id'] ?? '', 'run_conversation preserved the provider tool-call id', $failures, $passes );
+	agents_api_smoke_assert_equals( 'All done from default adapter.', $conversation['final_content'], 'run_conversation surfaces the adapter final content', $failures, $passes );
+	agents_api_smoke_assert_equals( 11, $conversation['usage']['total_tokens'], 'run_conversation accumulates adapter usage across turns', $failures, $passes );
+	agents_api_smoke_assert_equals( AgentsAPI\AI\WP_Agent_Conversation_Result::OUTCOME_STATUS_COMPLETED, $conversation['run_outcome']['status'] ?? '', 'run_conversation completes the run', $failures, $passes );
+
+	agents_api_smoke_finish( 'Agents API default provider-turn adapter', $failures, $passes );
+}


### PR DESCRIPTION
## Summary

Ships the missing reference implementation of the provider-turn adapter
contract. agents-api defined `WP_Agent_Provider_Turn_Adapter` and the whole
request/result contract around it but had **zero** concrete implementations, so
every consumer hand-built the one step the substrate didn't provide. This PR
adds that primitive plus a one-call conversation facade.

Closes Automattic/agents-api#369

## What landed

### `WP_Agent_Default_Provider_Turn_Adapter implements WP_Agent_Provider_Turn_Adapter`

The first concrete adapter. It owns only the generic turn: map → dispatch →
extract → normalize.

```php
public function __construct(
    string $provider_id,
    string $model_id,
    string $system_prompt = '',
    array  $options = array()   // temperature, max_tokens, prompt_input_provider
);
public function run_turn( WP_Agent_Provider_Turn_Request $request ): array;
public function set_prompt_input_provider( ?callable $prompt_input_provider ): self;
```

`run_turn()`:
1. Resolves provider/model (request `model` metadata → constructor default).
2. Builds the request via the **upstream wp-ai-client builder** reached through
   `wp_ai_client_prompt()` — `with_message_parts()` (latest user turn),
   `with_history()` (earlier turns, including canonical tool-call/tool-result
   envelopes → `FunctionCall`/`FunctionResponse`), `using_provider()`/
   `using_model()`/`using_system_instruction()`, and
   `using_function_declarations()` (declarations → `FunctionDeclaration`).
3. Dispatches via `generate_text_result()`; a `WP_Error` result throws a
   `RuntimeException` (the shape `resolve_turn_runner()` expects on turn failure).
4. Extracts tool calls via the **already-shipped**
   `WP_Agent_Provider_Turn_Result::extract_tool_calls()` — no re-implementation.
5. Returns `{ content, tool_calls, usage, request_metadata }` exactly as
   `WP_Agent_Provider_Turn_Result::normalize()` expects.

### Does NOT invent a new builder

Per the [#369 clarification comment](https://github.com/Automattic/agents-api/issues/369),
the adapter consumes the **upstream wp-ai-client `PromptBuilder`** directly (via
the `wp_ai_client_prompt()` entrypoint consumers already use). The only generic
work added is the mapping step *into* that existing builder — the same mapping
both consumers hand-roll today. No new builder abstraction is created.

### The pluggable prompt-input seam

Not a new prompt builder. It is a single injectable **prompt-input provider**
controlling how `(system_prompt, messages)` are produced before the wp-ai-client
builder is populated:

- **Default = identity / pass-through** — request system prompt + messages used as-is.
- **Override** — `__construct( ..., [ 'prompt_input_provider' => callable ] )` or
  `set_prompt_input_provider( callable )`. The callable receives
  `(string $system_prompt, array $messages, array $context)` and returns either
  `[ $system_prompt, $messages ]` or `[ 'system_prompt' => ..., 'messages' => ... ]`.

Only the identity default ships here. No consumer-specific prompt concepts enter
the substrate.

### `WP_Agent_Conversation_Loop::run_conversation()` facade

```php
public static function run_conversation(
    array  $messages,
    array  $tool_declarations,
    string $provider_id,
    string $model_id,
    array  $options = array()   // tool_executor, completion_policy, max_turns,
                                // context, system_prompt, temperature, max_tokens,
                                // prompt_input_provider, ...
): array;
```

Constructs the default adapter internally and runs the loop through the
**mediated path** (`provider_turn_adapter` + `tool_executor`), so the loop
executes tools and assembles envelopes — the adapter never executes tools.

## Layer purity

The new production file is grep-clean of consumer names
(`kimaki|discord|telegram|slack|whatsapp|cc-connect|datamachine|extrachill`).
Everything consumer-specific arrives via constructor args, the injectable
prompt-input strategy, or the request object. The `no-product-imports-smoke`
test (which scans production source for forbidden vocabulary/imports) passes.

The wp-ai-client builder/DTO **stubs** under `stubs/` are analysis-only;
agents-api keeps **no hard runtime dependency** on wp-ai-client — every call is
guarded by `function_exists()` / `class_exists()`.

## Tests + gates

Added `tests/default-provider-turn-adapter-smoke.php` (wired into the
`composer smoke` list) covering:
- `run_turn()` returns a normalized result from a mocked wp-ai-client dispatch
  (text, tool-call extraction via the shipped extractor, usage normalization,
  provider/model/system/history/declaration mapping).
- The prompt-input seam: default = identity, override is applied before dispatch.
- `run_turn()` converts a `WP_Error` dispatch result into a thrown `RuntimeException`.
- `run_conversation()` drives the loop end-to-end through the default adapter,
  mediating a tool call through the executor and accumulating usage across turns.

```
$ composer smoke    # smoke-exit=0, 85 suites, 0 failures
... All 21 Agents API default provider-turn adapter assertions passed.
... All 7 Agents API no-product-imports assertions passed.

$ composer phpstan  # level: max
 [OK] No errors
```

`php -l` passes on every new/edited file.

## Downstream

Once merged, the two consumer cleanups that motivated #369 can migrate onto this
primitive (delete their hand-built dispatch closures and duplicated
extract/history/schema helpers):
- Extra-Chill/extrachill-ai-adventure#9
- Extra-Chill/data-machine#2803

Those are **separate issues** and are intentionally untouched here.