### PR TITLE
feat: add dispatch-provider seam to default provider-turn adapter

### DIFF
--- a/src/Runtime/class-wp-agent-default-provider-turn-adapter.php
+++ b/src/Runtime/class-wp-agent-default-provider-turn-adapter.php
@@ -33,6 +33,19 @@ defined( 'ABSPATH' ) || exit;
  * callable that transforms `(system_prompt, messages, context)` into
  * `(system_prompt, messages)` before the builder is populated, without
  * replacing the dispatch, extraction, or normalization the adapter provides.
+ *
+ * Dispatch is the second consumer-variable concern. A consumer that needs an
+ * authenticated, transport-tuned, cached, model-config-aware, or vision-capable
+ * request cannot influence the bare builder this adapter constructs by default.
+ * For that case the adapter exposes a second injectable "dispatch provider"
+ * strategy, symmetric with the prompt-input one. When a dispatcher is injected,
+ * the adapter still owns the generic mapping (provider/model/system/messages/
+ * declarations) and the generic tail (tool-call extraction, text/usage
+ * normalization, result-shape assembly); the consumer owns only request
+ * construction and dispatch, returning a wp-ai-client `GenerativeAiResult`. When
+ * no dispatcher is injected the adapter builds and dispatches the bare
+ * `wp_ai_client_prompt()` builder exactly as before — the seam is a pure
+ * addition with no behavior change on the default path.
  */
 // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Turn-dispatch exceptions are caught by the conversation loop and returned as structured arrays, never rendered.
 class WP_Agent_Default_Provider_Turn_Adapter implements WP_Agent_Provider_Turn_Adapter {
@@ -52,13 +65,17 @@ class WP_Agent_Default_Provider_Turn_Adapter implements WP_Agent_Provider_Turn_A
 	/** @var callable|null Injectable prompt-input strategy, defaulting to identity. */
 	private $prompt_input_provider;
 
+	/** @var callable|null Injectable dispatch strategy, defaulting to the bare builder. */
+	private $dispatch_provider;
+
 	/**
 	 * @param string                $provider_id   Provider identifier (for example `openai`).
 	 * @param string                $model_id      Model identifier.
 	 * @param string                $system_prompt Default system prompt.
 	 * @param array<string, mixed>  $options       Dispatch options. Recognized keys:
 	 *                                              `temperature` (float), `max_tokens` (int),
-	 *                                              `prompt_input_provider` (callable). Only keys
+	 *                                              `prompt_input_provider` (callable),
+	 *                                              `dispatch_provider` (callable). Only keys
 	 *                                              the wp-ai-client builder supports are wired.
 	 */
 	public function __construct( string $provider_id, string $model_id, string $system_prompt = '', array $options = array() ) {
@@ -67,10 +84,12 @@ class WP_Agent_Default_Provider_Turn_Adapter implements WP_Agent_Provider_Turn_A
 		$this->system_prompt = $system_prompt;
 
 		$prompt_input_provider = $options['prompt_input_provider'] ?? null;
-		unset( $options['prompt_input_provider'] );
+		$dispatch_provider     = $options['dispatch_provider'] ?? null;
+		unset( $options['prompt_input_provider'], $options['dispatch_provider'] );
 		$this->options = $options;
 
 		$this->prompt_input_provider = is_callable( $prompt_input_provider ) ? $prompt_input_provider : null;
+		$this->dispatch_provider     = is_callable( $dispatch_provider ) ? $dispatch_provider : null;
 	}
 
 	/**
@@ -90,16 +109,59 @@ class WP_Agent_Default_Provider_Turn_Adapter implements WP_Agent_Provider_Turn_A
 	}
 
 	/**
+	 * Set the pluggable dispatch provider.
+	 *
+	 * When set, the adapter delegates request construction and dispatch to the
+	 * provider instead of building and dispatching the bare `wp_ai_client_prompt()`
+	 * builder. The adapter still owns the generic mapping that precedes dispatch
+	 * (prompt-input resolution, provider/model/system resolution, the canonical
+	 * message split, and tool-declaration mapping) and the generic tail that
+	 * follows it (tool-call extraction, text/usage normalization, result-shape
+	 * assembly). The provider owns only request construction, authentication,
+	 * transport tuning, caching, model-config, multimodal parts, and the actual
+	 * dispatch call.
+	 *
+	 * Passing `null` restores the default bare-builder dispatch.
+	 *
+	 * The provider is called as `$dispatcher( array $payload )` and receives a
+	 * single associative array with these keys (the mapped builder inputs, not a
+	 * pre-built builder, so the consumer fully owns construction):
+	 *
+	 * - `provider_id`           (string)              Resolved provider identifier.
+	 * - `model_id`              (string)              Resolved model identifier.
+	 * - `system_prompt`         (string)              Resolved system prompt ('' when none).
+	 * - `messages`              (array<int,array>)    The resolved canonical messages
+	 *                                                 (post prompt-input provider), so the
+	 *                                                 consumer can map them however it needs.
+	 * - `prompt_parts`          (array<int,object>)   wp-ai-client MessagePart objects for the
+	 *                                                 latest user turn (the current prompt).
+	 * - `history`               (array<int,object>)   wp-ai-client Message DTOs for earlier turns.
+	 * - `function_declarations` (array<int,object>)   wp-ai-client FunctionDeclaration objects.
+	 * - `options`               (array<string,mixed>) Adapter options (`temperature`, `max_tokens`).
+	 * - `request`               (WP_Agent_Provider_Turn_Request) The full request, for
+	 *                                                 runtime/context/model/budget/metadata access.
+	 *
+	 * The provider MUST return a wp-ai-client `GenerativeAiResult` (any object the
+	 * shipped normalizers understand — `toText()`, `getCandidates()`,
+	 * `getTokenUsage()`). To signal failure it may return a `WP_Error` or throw;
+	 * both are handled identically to the bare-builder failure path (a thrown
+	 * `RuntimeException` the conversation loop catches).
+	 *
+	 * @param callable|null $dispatch_provider Dispatch strategy.
+	 * @return self
+	 */
+	public function set_dispatch_provider( ?callable $dispatch_provider ): self {
+		$this->dispatch_provider = $dispatch_provider;
+		return $this;
+	}
+
+	/**
 	 * Run one provider turn through the upstream wp-ai-client builder.
 	 *
 	 * @param WP_Agent_Provider_Turn_Request $request Provider-turn request.
 	 * @return array<string, mixed> Normalized provider-turn result.
 	 */
 	public function run_turn( WP_Agent_Provider_Turn_Request $request ): array {
-		if ( ! function_exists( 'wp_ai_client_prompt' ) ) {
-			throw new \RuntimeException( 'wp-ai-client is unavailable: wp_ai_client_prompt() is not defined.' );
-		}
-
 		$resolved      = $this->resolve_prompt_input( $request );
 		$system_prompt = $resolved['system_prompt'];
 		$messages      = $resolved['messages'];
@@ -107,7 +169,48 @@ class WP_Agent_Default_Provider_Turn_Adapter implements WP_Agent_Provider_Turn_A
 		$provider_id = $this->resolve_provider_id( $request );
 		$model_id    = $this->resolve_model_id( $request );
 
-		$prompt_context = self::split_prompt_context( $messages );
+		$prompt_context        = self::split_prompt_context( $messages );
+		$function_declarations = self::function_declarations( $request->toolDeclarations() );
+
+		if ( null !== $this->dispatch_provider ) {
+			$result = $this->dispatch_via_provider( $request, $provider_id, $model_id, $system_prompt, $messages, $prompt_context, $function_declarations );
+		} else {
+			$result = $this->dispatch_via_bare_builder( $provider_id, $model_id, $system_prompt, $prompt_context, $function_declarations );
+		}
+
+		if ( function_exists( 'is_wp_error' ) && is_wp_error( $result ) ) {
+			throw new \RuntimeException( 'wp-ai-client request failed: ' . $result->get_error_message() );
+		}
+
+		return array(
+			'content'          => WP_Agent_Provider_Turn_Result::result_text( $result ),
+			'tool_calls'       => WP_Agent_Provider_Turn_Result::extract_tool_calls( $result ),
+			'usage'            => WP_Agent_Provider_Turn_Result::result_usage( $result ),
+			'request_metadata' => array(
+				'provider_id' => $provider_id,
+				'model_id'    => $model_id,
+			),
+		);
+	}
+
+	/**
+	 * Build and dispatch the bare wp-ai-client builder (default dispatch path).
+	 *
+	 * This is the original, unmodified dispatch: it constructs a
+	 * `wp_ai_client_prompt()` builder from the mapped inputs and calls
+	 * `generate_text_result()`. It runs only when no dispatch provider is injected.
+	 *
+	 * @param string                                                          $provider_id           Resolved provider id.
+	 * @param string                                                          $model_id              Resolved model id.
+	 * @param string                                                          $system_prompt         Resolved system prompt.
+	 * @param array{prompt_parts:array<int,object>,history:array<int,object>} $prompt_context        Mapped prompt context.
+	 * @param array<int,object>                                               $function_declarations Mapped function declarations.
+	 * @return mixed wp-ai-client GenerativeAiResult or WP_Error.
+	 */
+	private function dispatch_via_bare_builder( string $provider_id, string $model_id, string $system_prompt, array $prompt_context, array $function_declarations ) {
+		if ( ! function_exists( 'wp_ai_client_prompt' ) ) {
+			throw new \RuntimeException( 'wp-ai-client is unavailable: wp_ai_client_prompt() is not defined.' );
+		}
 
 		$builder = wp_ai_client_prompt();
 
@@ -139,26 +242,49 @@ class WP_Agent_Default_Provider_Turn_Adapter implements WP_Agent_Provider_Turn_A
 			$builder = $builder->with_history( ...$prompt_context['history'] );
 		}
 
-		$function_declarations = self::function_declarations( $request->toolDeclarations() );
 		if ( ! empty( $function_declarations ) ) {
 			$builder = $builder->using_function_declarations( ...$function_declarations );
 		}
 
-		$result = $builder->generate_text_result();
+		return $builder->generate_text_result();
+	}
 
-		if ( function_exists( 'is_wp_error' ) && is_wp_error( $result ) ) {
-			throw new \RuntimeException( 'wp-ai-client request failed: ' . $result->get_error_message() );
+	/**
+	 * Delegate request construction and dispatch to the injected dispatch provider.
+	 *
+	 * The provider receives the mapped builder inputs (see {@see self::set_dispatch_provider()}
+	 * for the exact payload contract) and returns a wp-ai-client GenerativeAiResult
+	 * (or a WP_Error / throws on failure). The adapter retains ownership of the
+	 * generic tail in {@see self::run_turn()}.
+	 *
+	 * @param WP_Agent_Provider_Turn_Request                                  $request               Provider-turn request.
+	 * @param string                                                          $provider_id           Resolved provider id.
+	 * @param string                                                          $model_id              Resolved model id.
+	 * @param string                                                          $system_prompt         Resolved system prompt.
+	 * @param array<int,array<string,mixed>>                                  $messages              Resolved canonical messages.
+	 * @param array{prompt_parts:array<int,object>,history:array<int,object>} $prompt_context        Mapped prompt context.
+	 * @param array<int,object>                                               $function_declarations Mapped function declarations.
+	 * @return mixed wp-ai-client GenerativeAiResult or WP_Error.
+	 */
+	private function dispatch_via_provider( WP_Agent_Provider_Turn_Request $request, string $provider_id, string $model_id, string $system_prompt, array $messages, array $prompt_context, array $function_declarations ) {
+		$dispatcher = $this->dispatch_provider;
+		if ( ! is_callable( $dispatcher ) ) {
+			throw new \RuntimeException( 'Dispatch provider is unavailable.' );
 		}
 
-		return array(
-			'content'          => self::result_text( $result ),
-			'tool_calls'       => WP_Agent_Provider_Turn_Result::extract_tool_calls( $result ),
-			'usage'            => self::result_usage( $result ),
-			'request_metadata' => array(
-				'provider_id' => $provider_id,
-				'model_id'    => $model_id,
-			),
+		$payload = array(
+			'provider_id'           => $provider_id,
+			'model_id'              => $model_id,
+			'system_prompt'         => $system_prompt,
+			'messages'              => $messages,
+			'prompt_parts'          => $prompt_context['prompt_parts'],
+			'history'               => $prompt_context['history'],
+			'function_declarations' => $function_declarations,
+			'options'               => $this->options,
+			'request'               => $request,
 		);
+
+		return call_user_func( $dispatcher, $payload );
 	}
 
 	/**
@@ -468,70 +594,5 @@ class WP_Agent_Default_Provider_Turn_Adapter implements WP_Agent_Provider_Turn_A
 		}
 
 		return $declarations;
-	}
-
-	/**
-	 * Extract assistant text from a wp-ai-client result.
-	 *
-	 * @param mixed $result wp-ai-client GenerativeAiResult.
-	 * @return string
-	 */
-	private static function result_text( $result ): string {
-		if ( is_object( $result ) && method_exists( $result, 'toText' ) ) {
-			try {
-				$text = $result->toText();
-
-				return is_string( $text ) ? $text : '';
-			} catch ( \Throwable $error ) {
-				// Results without text content (tool-only turns) throw; treat as empty.
-				if ( false !== strpos( $error->getMessage(), 'No text content found' ) ) {
-					return '';
-				}
-
-				throw $error;
-			}
-		}
-
-		return '';
-	}
-
-	/**
-	 * Normalize token usage from a wp-ai-client result.
-	 *
-	 * @param mixed $result wp-ai-client GenerativeAiResult.
-	 * @return array{prompt_tokens:int,completion_tokens:int,total_tokens:int}
-	 */
-	private static function result_usage( $result ): array {
-		$usage = array(
-			'prompt_tokens'     => 0,
-			'completion_tokens' => 0,
-			'total_tokens'      => 0,
-		);
-
-		if ( ! is_object( $result ) || ! method_exists( $result, 'getTokenUsage' ) ) {
-			return $usage;
-		}
-
-		$token_usage = $result->getTokenUsage();
-		if ( ! is_object( $token_usage ) ) {
-			return $usage;
-		}
-
-		if ( method_exists( $token_usage, 'getPromptTokens' ) ) {
-			$prompt_tokens          = $token_usage->getPromptTokens();
-			$usage['prompt_tokens'] = is_numeric( $prompt_tokens ) ? (int) $prompt_tokens : 0;
-		}
-
-		if ( method_exists( $token_usage, 'getCompletionTokens' ) ) {
-			$completion_tokens          = $token_usage->getCompletionTokens();
-			$usage['completion_tokens'] = is_numeric( $completion_tokens ) ? (int) $completion_tokens : 0;
-		}
-
-		if ( method_exists( $token_usage, 'getTotalTokens' ) ) {
-			$total_tokens          = $token_usage->getTotalTokens();
-			$usage['total_tokens'] = is_numeric( $total_tokens ) ? (int) $total_tokens : 0;
-		}
-
-		return $usage;
 	}
 }

--- a/src/Runtime/class-wp-agent-provider-turn-result.php
+++ b/src/Runtime/class-wp-agent-provider-turn-result.php
@@ -127,6 +127,80 @@ class WP_Agent_Provider_Turn_Result {
 	}
 
 	/**
+	 * Extract assistant text from a wp-ai-client result.
+	 *
+	 * Consumers that own dispatch (via the default adapter's dispatch-provider
+	 * seam, or entirely outside the adapter) can reuse this normalization so they
+	 * do not duplicate the result-text extraction boilerplate. Results without
+	 * text content (tool-only turns) yield an empty string.
+	 *
+	 * @param mixed $result wp-ai-client GenerativeAiResult.
+	 * @return string
+	 */
+	public static function result_text( $result ): string {
+		if ( is_object( $result ) && method_exists( $result, 'toText' ) ) {
+			try {
+				$text = $result->toText();
+
+				return is_string( $text ) ? $text : '';
+			} catch ( \Throwable $error ) {
+				// Results without text content (tool-only turns) throw; treat as empty.
+				if ( false !== strpos( $error->getMessage(), 'No text content found' ) ) {
+					return '';
+				}
+
+				throw $error;
+			}
+		}
+
+		return '';
+	}
+
+	/**
+	 * Normalize token usage from a wp-ai-client result.
+	 *
+	 * Consumers that own dispatch can reuse this normalization to produce the
+	 * canonical `{prompt_tokens, completion_tokens, total_tokens}` usage shape
+	 * without duplicating the token-usage extraction boilerplate.
+	 *
+	 * @param mixed $result wp-ai-client GenerativeAiResult.
+	 * @return array{prompt_tokens:int,completion_tokens:int,total_tokens:int}
+	 */
+	public static function result_usage( $result ): array {
+		$usage = array(
+			'prompt_tokens'     => 0,
+			'completion_tokens' => 0,
+			'total_tokens'      => 0,
+		);
+
+		if ( ! is_object( $result ) || ! method_exists( $result, 'getTokenUsage' ) ) {
+			return $usage;
+		}
+
+		$token_usage = $result->getTokenUsage();
+		if ( ! is_object( $token_usage ) ) {
+			return $usage;
+		}
+
+		if ( method_exists( $token_usage, 'getPromptTokens' ) ) {
+			$prompt_tokens          = $token_usage->getPromptTokens();
+			$usage['prompt_tokens'] = is_numeric( $prompt_tokens ) ? (int) $prompt_tokens : 0;
+		}
+
+		if ( method_exists( $token_usage, 'getCompletionTokens' ) ) {
+			$completion_tokens          = $token_usage->getCompletionTokens();
+			$usage['completion_tokens'] = is_numeric( $completion_tokens ) ? (int) $completion_tokens : 0;
+		}
+
+		if ( method_exists( $token_usage, 'getTotalTokens' ) ) {
+			$total_tokens          = $token_usage->getTotalTokens();
+			$usage['total_tokens'] = is_numeric( $total_tokens ) ? (int) $total_tokens : 0;
+		}
+
+		return $usage;
+	}
+
+	/**
 	 * Normalize provider tool calls.
 	 *
 	 * @param array<mixed> $tool_calls Raw tool calls.

--- a/tests/default-provider-turn-adapter-smoke.php
+++ b/tests/default-provider-turn-adapter-smoke.php
@@ -427,5 +427,157 @@ namespace {
 	agents_api_smoke_assert_equals( 11, $conversation['usage']['total_tokens'], 'run_conversation accumulates adapter usage across turns', $failures, $passes );
 	agents_api_smoke_assert_equals( AgentsAPI\AI\WP_Agent_Conversation_Result::OUTCOME_STATUS_COMPLETED, $conversation['run_outcome']['status'] ?? '', 'run_conversation completes the run', $failures, $passes );
 
+	echo "\n[5] Dispatch seam: injected dispatcher receives the documented payload and its result drives the shared tail:\n";
+	$GLOBALS['__adapter_smoke']                = array();
+	$GLOBALS['__adapter_smoke']['next_result'] = $make_result( 'should-not-be-used', array(), array( 99, 99, 99 ) );
+
+	$dispatch_payload  = null;
+	$dispatcher_result = $make_result(
+		'Dispatched answer.',
+		array( array( 'name' => 'client/lookup', 'parameters' => array( 'query' => 'gamma' ), 'id' => 'call-dispatch-1' ) ),
+		array( 8, 9, 17 )
+	);
+
+	$dispatch_adapter = new AgentsAPI\AI\WP_Agent_Default_Provider_Turn_Adapter( 'fake-provider', 'fake-model', 'dispatch-system', array( 'temperature' => 0.5, 'max_tokens' => 256 ) );
+	$dispatch_adapter->set_dispatch_provider(
+		static function ( array $payload ) use ( &$dispatch_payload, $dispatcher_result ) {
+			$dispatch_payload = $payload;
+			return $dispatcher_result;
+		}
+	);
+
+	$dispatch_request = new AgentsAPI\AI\WP_Agent_Provider_Turn_Request(
+		array(
+			array( 'role' => 'user', 'content' => 'earlier turn' ),
+			array( 'role' => 'assistant', 'content' => 'earlier answer' ),
+			array( 'role' => 'user', 'content' => 'look up gamma' ),
+		),
+		array(
+			'client/lookup' => array(
+				'name'        => 'client/lookup',
+				'source'      => 'client',
+				'description' => 'Look up one value.',
+				'parameters'  => array(
+					'type'       => 'object',
+					'required'   => array( 'query' ),
+					'properties' => array( 'query' => array( 'type' => 'string' ) ),
+				),
+				'executor'    => 'client',
+				'scope'       => 'run',
+			),
+		),
+		array( 'provider_id' => 'fake-provider', 'model_id' => 'fake-model' )
+	);
+
+	$dispatch_raw    = $dispatch_adapter->run_turn( $dispatch_request );
+	$dispatch_result = AgentsAPI\AI\WP_Agent_Provider_Turn_Result::normalize( $dispatch_raw );
+
+	// The injected dispatcher's result must drive the shared tail, NOT the bare builder.
+	agents_api_smoke_assert_equals( 'Dispatched answer.', $dispatch_result['content'], 'dispatch seam: adapter normalizes the dispatcher result text', $failures, $passes );
+	agents_api_smoke_assert_equals( 'client/lookup', $dispatch_result['tool_calls'][0]['name'] ?? '', 'dispatch seam: adapter still extracts tool calls from the dispatcher result', $failures, $passes );
+	agents_api_smoke_assert_equals( 'gamma', $dispatch_result['tool_calls'][0]['parameters']['query'] ?? '', 'dispatch seam: adapter decodes tool-call args from the dispatcher result', $failures, $passes );
+	agents_api_smoke_assert_equals( 17, $dispatch_result['usage']['total_tokens'], 'dispatch seam: adapter normalizes usage from the dispatcher result', $failures, $passes );
+	agents_api_smoke_assert_equals( 'fake-provider', $dispatch_result['request_metadata']['provider_id'] ?? '', 'dispatch seam: adapter assembles request metadata', $failures, $passes );
+	// The bare builder must NOT have been invoked (its recorded result is unused).
+	agents_api_smoke_assert_equals( true, ! isset( $GLOBALS['__adapter_smoke']['provider'] ), 'dispatch seam: bare builder is bypassed entirely when a dispatcher is set', $failures, $passes );
+
+	// The documented payload contract.
+	agents_api_smoke_assert_equals( 'fake-provider', $dispatch_payload['provider_id'] ?? '', 'dispatch payload carries provider_id', $failures, $passes );
+	agents_api_smoke_assert_equals( 'fake-model', $dispatch_payload['model_id'] ?? '', 'dispatch payload carries model_id', $failures, $passes );
+	agents_api_smoke_assert_equals( 'dispatch-system', $dispatch_payload['system_prompt'] ?? '', 'dispatch payload carries the resolved system prompt', $failures, $passes );
+	agents_api_smoke_assert_equals( 3, count( $dispatch_payload['messages'] ?? array() ), 'dispatch payload carries the resolved canonical messages', $failures, $passes );
+	agents_api_smoke_assert_equals( 1, count( $dispatch_payload['prompt_parts'] ?? array() ), 'dispatch payload carries the current-prompt message parts', $failures, $passes );
+	agents_api_smoke_assert_equals( 2, count( $dispatch_payload['history'] ?? array() ), 'dispatch payload carries the history messages', $failures, $passes );
+	agents_api_smoke_assert_equals( 1, count( $dispatch_payload['function_declarations'] ?? array() ), 'dispatch payload carries the function declarations', $failures, $passes );
+	agents_api_smoke_assert_equals( 'client/lookup', $dispatch_payload['function_declarations'][0]->name ?? '', 'dispatch payload function declaration carries the logical tool name', $failures, $passes );
+	agents_api_smoke_assert_equals( 0.5, $dispatch_payload['options']['temperature'] ?? null, 'dispatch payload carries adapter options (temperature)', $failures, $passes );
+	agents_api_smoke_assert_equals( 256, $dispatch_payload['options']['max_tokens'] ?? null, 'dispatch payload carries adapter options (max_tokens)', $failures, $passes );
+	agents_api_smoke_assert_equals( true, ( $dispatch_payload['request'] ?? null ) instanceof AgentsAPI\AI\WP_Agent_Provider_Turn_Request, 'dispatch payload carries the WP_Agent_Provider_Turn_Request', $failures, $passes );
+
+	echo "\n[6] Dispatch seam honors the prompt-input seam (mapping runs before dispatch):\n";
+	$GLOBALS['__adapter_smoke'] = array();
+	$seam_payload              = null;
+	$composed_adapter          = new AgentsAPI\AI\WP_Agent_Default_Provider_Turn_Adapter(
+		'fake-provider',
+		'fake-model',
+		'base-system',
+		array(
+			'prompt_input_provider' => static function ( string $system_prompt, array $messages, array $context ): array {
+				unset( $messages, $context );
+				return array(
+					'system_prompt' => 'composed-before-dispatch',
+					'messages'      => array( array( 'role' => 'user', 'content' => 'composed for dispatch' ) ),
+				);
+			},
+			'dispatch_provider'     => static function ( array $payload ) use ( &$seam_payload, $make_result ) {
+				$seam_payload = $payload;
+				return $make_result( 'composed dispatched', array(), array( 1, 1, 2 ) );
+			},
+		)
+	);
+	$composed_adapter->run_turn(
+		new AgentsAPI\AI\WP_Agent_Provider_Turn_Request(
+			array( array( 'role' => 'user', 'content' => 'original' ) )
+		)
+	);
+	agents_api_smoke_assert_equals( 'composed-before-dispatch', $seam_payload['system_prompt'] ?? '', 'dispatch payload reflects the prompt-input seam transform', $failures, $passes );
+
+	echo "\n[7] Dispatch seam: dispatcher failure (WP_Error and throw) is handled like the bare path:\n";
+	$wp_error_adapter = new AgentsAPI\AI\WP_Agent_Default_Provider_Turn_Adapter( 'fake-provider', 'fake-model', 'sys' );
+	$wp_error_adapter->set_dispatch_provider(
+		static function ( array $payload ) {
+			unset( $payload );
+			return new WP_Error( 'wp_ai_client_text_exception', 'dispatcher exploded' );
+		}
+	);
+	$wp_error_threw = false;
+	try {
+		$wp_error_adapter->run_turn(
+			new AgentsAPI\AI\WP_Agent_Provider_Turn_Request( array( array( 'role' => 'user', 'content' => 'fail' ) ) )
+		);
+	} catch ( \RuntimeException $error ) {
+		$wp_error_threw = false !== strpos( $error->getMessage(), 'dispatcher exploded' );
+	}
+	agents_api_smoke_assert_equals( true, $wp_error_threw, 'dispatch seam: a WP_Error from the dispatcher throws a RuntimeException', $failures, $passes );
+
+	$throw_adapter = new AgentsAPI\AI\WP_Agent_Default_Provider_Turn_Adapter( 'fake-provider', 'fake-model', 'sys' );
+	$throw_adapter->set_dispatch_provider(
+		static function ( array $payload ) {
+			unset( $payload );
+			throw new \RuntimeException( 'dispatcher threw directly' );
+		}
+	);
+	$throw_propagated = false;
+	try {
+		$throw_adapter->run_turn(
+			new AgentsAPI\AI\WP_Agent_Provider_Turn_Request( array( array( 'role' => 'user', 'content' => 'fail' ) ) )
+		);
+	} catch ( \RuntimeException $error ) {
+		$throw_propagated = false !== strpos( $error->getMessage(), 'dispatcher threw directly' );
+	}
+	agents_api_smoke_assert_equals( true, $throw_propagated, 'dispatch seam: a thrown error from the dispatcher propagates to the caller', $failures, $passes );
+
+	echo "\n[8] set_dispatch_provider( null ) restores the default bare-builder dispatch:\n";
+	$GLOBALS['__adapter_smoke']                = array();
+	$GLOBALS['__adapter_smoke']['next_result'] = $make_result( 'bare again', array(), array( 1, 2, 3 ) );
+	$restore_adapter                           = new AgentsAPI\AI\WP_Agent_Default_Provider_Turn_Adapter( 'fake-provider', 'fake-model', 'restore-system' );
+	$restore_adapter->set_dispatch_provider( static fn ( array $payload ) => $make_result( 'via dispatcher', array(), array( 0, 0, 0 ) ) );
+	$restore_adapter->set_dispatch_provider( null );
+	$restore_raw = $restore_adapter->run_turn(
+		new AgentsAPI\AI\WP_Agent_Provider_Turn_Request( array( array( 'role' => 'user', 'content' => 'hi' ) ) )
+	);
+	agents_api_smoke_assert_equals( 'bare again', $restore_raw['content'], 'set_dispatch_provider(null) falls back to the bare builder', $failures, $passes );
+	agents_api_smoke_assert_equals( 'fake-provider', $GLOBALS['__adapter_smoke']['provider'] ?? '', 'restored bare path drives the wp_ai_client builder again', $failures, $passes );
+
+	echo "\n[9] Public result normalization helpers on WP_Agent_Provider_Turn_Result:\n";
+	$helper_result = $make_result( 'helper text', array(), array( 4, 6, 10 ) );
+	agents_api_smoke_assert_equals( 'helper text', AgentsAPI\AI\WP_Agent_Provider_Turn_Result::result_text( $helper_result ), 'public result_text() extracts assistant text', $failures, $passes );
+	$helper_usage = AgentsAPI\AI\WP_Agent_Provider_Turn_Result::result_usage( $helper_result );
+	agents_api_smoke_assert_equals( 4, $helper_usage['prompt_tokens'], 'public result_usage() extracts prompt tokens', $failures, $passes );
+	agents_api_smoke_assert_equals( 6, $helper_usage['completion_tokens'], 'public result_usage() extracts completion tokens', $failures, $passes );
+	agents_api_smoke_assert_equals( 10, $helper_usage['total_tokens'], 'public result_usage() extracts total tokens', $failures, $passes );
+	$tool_only_result = $make_result( '', array( array( 'name' => 'client/lookup', 'parameters' => array( 'q' => 'x' ), 'id' => 'tc-1' ) ), array( 1, 0, 1 ) );
+	agents_api_smoke_assert_equals( '', AgentsAPI\AI\WP_Agent_Provider_Turn_Result::result_text( $tool_only_result ), 'public result_text() returns empty for a tool-only turn', $failures, $passes );
+
 	agents_api_smoke_finish( 'Agents API default provider-turn adapter', $failures, $passes );
 }


### PR DESCRIPTION
## Summary

Adds a **dispatch-level seam** to `WP_Agent_Default_Provider_Turn_Adapter` so a consumer can own request construction/dispatch — authenticated, transport-tuned, cached, model-config-aware, vision-capable — while still reusing the adapter's generic message-mapping, tool-call extraction, and usage/result normalization. This unblocks the Data Machine provider-turn-adapter refactor.

Closes Automattic/agents-api#371

## What changed

### 1. `set_dispatch_provider( ?callable $dispatcher ): self`

A second injectable strategy, symmetric with `set_prompt_input_provider()`. Also accepted via the constructor `$options['dispatch_provider']`. Passing `null` restores the default bare-builder dispatch.

`run_turn()` now: resolve prompt input → map provider/model/system/messages/declarations → **IF** a dispatcher is set, call it for the result; **ELSE** build + dispatch the bare `wp_ai_client_prompt()` builder as today → run the **shared tail** (extract tool calls, normalize text/usage, assemble result shape) for **both** paths.

**Exact payload passed to the dispatcher** — `$dispatcher( array $payload )` where `$payload` is:

| key | type | meaning |
|-----|------|---------|
| `provider_id` | `string` | resolved provider identifier |
| `model_id` | `string` | resolved model identifier |
| `system_prompt` | `string` | resolved system prompt (`''` when none) |
| `messages` | `array<int,array>` | resolved canonical messages (post prompt-input provider), so the consumer maps them however it needs |
| `prompt_parts` | `array<int,object>` | wp-ai-client `MessagePart` objects for the latest user turn (current prompt) |
| `history` | `array<int,object>` | wp-ai-client Message DTOs for earlier turns |
| `function_declarations` | `array<int,object>` | wp-ai-client `FunctionDeclaration` objects |
| `options` | `array<string,mixed>` | adapter options (`temperature`, `max_tokens`) |
| `request` | `WP_Agent_Provider_Turn_Request` | full request, for runtime/context/model/budget/metadata access |

**Expected return:** a wp-ai-client `GenerativeAiResult` (any object the shipped normalizers understand — `toText()` / `getCandidates()` / `getTokenUsage()`). To signal failure the dispatcher may **return a `WP_Error`** or **throw** — both are handled identically to the bare-builder failure path (a thrown `RuntimeException` the conversation loop catches).

The consumer passes mapped **builder inputs**, not a pre-built bare builder, so it fully owns construction/auth/transport. The seam is generic — it knows nothing about any specific consumer's auth/cache/transport.

### 2. Default path is byte-for-byte unchanged

When no dispatcher is injected, `dispatch_via_bare_builder()` constructs and dispatches the same `wp_ai_client_prompt()` builder with the same fluent calls in the same order as before, then `generate_text_result()`. The #370 prompt-input seam is fully intact (it runs before dispatch on both paths). AI Adventure (already on the bare path) is unaffected. This is a pure addition.

### 3. Public result-normalization helpers (secondary, per #371)

Promoted `result_text()` and `result_usage()` to **public static** methods on `WP_Agent_Provider_Turn_Result` (which already owns `extract_tool_calls` / `normalize`). They were previously private statics on the default adapter; the adapter now calls the public versions. No behavior change — this lets a consumer that owns dispatch reuse the same normalization without going through `run_turn()`.

## Layer purity

The seam is generic substrate with zero consumer references. Grep of all changed code is clean:

```
$ grep -rinE 'datamachine|data_machine|extrachill|RequestBuilder|ApiKeyRequestAuthentication|WpAiClientCache' \
    src/Runtime/class-wp-agent-default-provider-turn-adapter.php \
    src/Runtime/class-wp-agent-provider-turn-result.php \
    tests/default-provider-turn-adapter-smoke.php
CLEAN: no consumer references in changed files
```

The seam only knows "a consumer may supply a dispatcher callable." All consumer-specific concerns (auth, timeouts, cache, model-config, vision) live behind the seam in the consumer, not here.

## Tests

Extended `tests/default-provider-turn-adapter-smoke.php` (already in the composer `smoke` list) with coverage for:

- **[5]** injected dispatcher receives the **documented payload** (every key asserted) and its returned `GenerativeAiResult` drives the shared tail (extract/usage/normalize), while the bare builder is **bypassed entirely**;
- **[6]** the prompt-input seam transform is reflected in the dispatch payload (mapping runs before dispatch);
- **[7]** dispatcher failure via **`WP_Error`** and via **throw** are both handled like the bare-path failure;
- **[8]** `set_dispatch_provider( null )` restores the bare-builder path;
- **[9]** direct unit assertions on the now-public `result_text()` / `result_usage()` (including the tool-only-turn empty-text case).

Existing sections [1]–[4] (default dispatch, prompt seam, failure, full `run_conversation` loop) pass unchanged.

```
All 48 Agents API default provider-turn adapter assertions passed.

$ composer smoke    # full suite, zero failures
=== ZERO FAILURES ACROSS FULL SMOKE SUITE ===

$ composer phpstan
 [OK] No errors
```

`php -l` clean on every file touched.

## Downstream

Extra-Chill/data-machine#2805 (which depends on #2803) will adopt this seam to route DM's authenticated, transport-tuned, cached, model-config-aware, vision-capable dispatch (`RequestBuilder::build`) through `run_turn()` without dropping parity — and will use the public `result_text()`/`result_usage()` helpers to shed its bespoke normalization. That adoption is a separate PR; this PR is the substrate seam only.