### PR TITLE
refactor: scrub channel vendor names from generic Channels layer

### DIFF
--- a/src/Channels/class-wp-agent-channel.php
+++ b/src/Channels/class-wp-agent-channel.php
@@ -2,9 +2,9 @@
 /**
  * Abstract base class for agent messaging channels.
  *
- * A "channel" is a transport that connects an external messaging surface
- * (Telegram, Slack, WhatsApp, Email, …) to a chat ability registered through
- * the WordPress Abilities API. The channel handles transport-specific I/O
+ * A "channel" is a transport adapter, registered by a consuming product,
+ * that connects an external messaging surface to a chat ability registered
+ * through the WordPress Abilities API. The channel handles transport-specific I/O
  * (how to extract a user message from a webhook payload, how to send a reply
  * back) while delegating the actual agent run to the configured chat ability.
  *
@@ -21,7 +21,7 @@
  * `agents/chat`); override `run_agent()` to plug in a different runtime.
  *
  * Mirrors a similar pattern used internally at WordPress.com to drive
- * Telegram, Slack, and other agent surfaces. The host-specific orchestration
+ * a range of agent surfaces. The host-specific orchestration
  * (multi-tenant user resolution, blog switching, internal agent runtime) is
  * intentionally not part of this contract — implementations that need those
  * concerns should add their own subclass layer between this base class and
@@ -86,18 +86,18 @@ abstract class WP_Agent_Channel {
 	 * Stable identifier for the channel type and instance. Used together with
 	 * the per-conversation `external_id` to scope sessions across redeploys.
 	 *
-	 * Convention: `<channel-type>` for single-instance channels (`slack`,
-	 * `whatsapp`); `<channel-type>_<bot-or-account>` when one site runs
-	 * multiple instances of the same channel (`telegram_<bot-name>`).
+	 * Convention: `<channel-type>` for single-instance channels;
+	 * `<channel-type>_<instance>` when one site runs multiple instances
+	 * of the same channel (e.g. `<channel-type>_<bot-or-account>`).
 	 *
 	 * @return string
 	 */
 	abstract public function get_external_id_provider(): string;
 
 	/**
-	 * The channel-side ID of the conversation. Telegram chat ID, Slack
-	 * channel ID, WhatsApp JID — whatever the channel uses to address a
-	 * single thread. Returning null disables per-conversation isolation.
+	 * The channel-side ID of the conversation — whatever the channel uses
+	 * to address a single thread (a conversation id, channel id, or
+	 * address). Returning null disables per-conversation isolation.
 	 *
 	 * @return string|null
 	 */
@@ -457,8 +457,9 @@ abstract class WP_Agent_Channel {
 
 	/**
 	 * Conversation kind: `dm`, `group`, `channel`, or null when unknown.
-	 * Override per transport — WhatsApp can derive from the JID suffix,
-	 * Slack from the channel type, Telegram from the chat type.
+	 * Override per transport — derive it from whatever metadata the
+	 * channel exposes about the conversation (e.g. an address suffix or a
+	 * channel/chat type field).
 	 *
 	 * @param array<mixed> $data
 	 * @return string|null

--- a/src/Channels/register-agents-chat-ability.php
+++ b/src/Channels/register-agents-chat-ability.php
@@ -402,11 +402,11 @@ function agents_chat_input_schema(): array {
 					),
 					'external_provider'         => array(
 						'type'        => array( 'string', 'null' ),
-						'description' => 'External network identifier (e.g. "whatsapp", "slack", "email"). Null if not applicable.',
+						'description' => 'External network identifier defined by the consuming product; null if not applicable.',
 					),
 					'external_conversation_id'  => array(
 						'type'        => array( 'string', 'null' ),
-						'description' => 'Opaque external conversation id (chat JID, channel id, thread root). Null if the source has no per-conversation isolation.',
+						'description' => 'Opaque external conversation id (e.g. a conversation id, channel id, or thread root). Null if the source has no per-conversation isolation.',
 					),
 					'external_message_id'       => array(
 						'type'        => array( 'string', 'null' ),

--- a/src/Channels/register-agents-dispatch-message-ability.php
+++ b/src/Channels/register-agents-dispatch-message-ability.php
@@ -140,11 +140,11 @@ function agents_dispatch_message_input_schema(): array {
 		'properties' => array(
 			'channel'         => array(
 				'type'        => 'string',
-				'description' => 'Outbound channel identifier, e.g. whatsapp, wacli, slack, sms, or a product-defined channel id.',
+				'description' => 'Outbound channel/transport identifier — an opaque, product-defined id.',
 			),
 			'recipient'       => array(
 				'type'        => 'string',
-				'description' => 'Transport-specific destination id, e.g. phone number, WhatsApp JID, channel id, or email address.',
+				'description' => 'Transport-specific destination id, as defined by the channel implementation (e.g. an account id, address, or handle).',
 			),
 			'message'         => array(
 				'type'        => 'string',


### PR DESCRIPTION
## Summary

Layer-purity fix. `agents-api` is generic substrate headed for WordPress Core and must remain agnostic to specific transports/channels/consumers. The `src/Channels/` layer had a hardcoded roster of product names (Telegram/Slack/WhatsApp/SMS/wacli) leaking into docblocks **and** ability field descriptions — and the field descriptions ship into the MCP/REST tool schema, so the substrate's *public API surface* was enumerating specific vendor channels.

This rewrites the affected docblocks and field descriptions to describe the **shape** of a channel/transport identifier without ever naming a product. **Description/docblock-only — zero behavior change.**

Closes Automattic/agents-api#372

## Before / After

**`src/Channels/class-wp-agent-channel.php`** (docblocks)

- L5-6: `A "channel" is a transport that connects an external messaging surface (Telegram, Slack, WhatsApp, Email, …) to a chat ability…`
  → `A "channel" is a transport adapter, registered by a consuming product, that connects an external messaging surface to a chat ability…`
- L24: `…to drive Telegram, Slack, and other agent surfaces.`
  → `…to drive a range of agent surfaces.`
- L89-91: ``Convention: `<channel-type>` for single-instance channels (`slack`, `whatsapp`); `<channel-type>_<bot-or-account>` … (`telegram_<bot-name>`).``
  → ``Convention: `<channel-type>` for single-instance channels; `<channel-type>_<instance>` when one site runs multiple instances of the same channel (e.g. `<channel-type>_<bot-or-account>`).``
- L98-99: `The channel-side ID of the conversation. Telegram chat ID, Slack channel ID, WhatsApp JID — whatever the channel uses…`
  → `The channel-side ID of the conversation — whatever the channel uses to address a single thread (a conversation id, channel id, or address).`
- L460-461: `Override per transport — WhatsApp can derive from the JID suffix, Slack from the channel type, Telegram from the chat type.`
  → `Override per transport — derive it from whatever metadata the channel exposes about the conversation (e.g. an address suffix or a channel/chat type field).`

**`src/Channels/register-agents-dispatch-message-ability.php`** (ability field descriptions → MCP/REST schema)

- `channel`: `Outbound channel identifier, e.g. whatsapp, wacli, slack, sms, or a product-defined channel id.`
  → `Outbound channel/transport identifier — an opaque, product-defined id.`
- `recipient`: `Transport-specific destination id, e.g. phone number, WhatsApp JID, channel id, or email address.`
  → `Transport-specific destination id, as defined by the channel implementation (e.g. an account id, address, or handle).`

**`src/Channels/register-agents-chat-ability.php`** (ability field descriptions)

- `external_provider`: `External network identifier (e.g. "whatsapp", "slack", "email"). Null if not applicable.`
  → `External network identifier defined by the consuming product; null if not applicable.`
- `external_conversation_id`: `Opaque external conversation id (chat JID, channel id, thread root). …`
  → `Opaque external conversation id (e.g. a conversation id, channel id, or thread root). …`
  (also scrubbed the WhatsApp-specific "JID" while in this same description, to avoid moving the problem.)

## Description-only confirmation

`git diff` touches only comment text and `'description' => …` strings. No executable code, array keys, ability names, schema types, signatures, return values, or channel mechanism changed.

## Acceptance grep proof (zero matches)

```
$ grep -rinE "telegram|slack|whatsapp|\bsms\b|wacli|discord|kimaki" src/ | grep -v vendor
$ echo $?
1   # no matches
```

Also verified no stray "JID" or other product names were introduced.

## Verification

`php -l` on all three touched files: no syntax errors.

```
$ composer smoke
... OK 6 passed (subagents-smoke)
agents-api-no-product-imports-smoke
  PASS agents-api production source has no product imports, product vocabulary, ...
All 7 Agents API no-product-imports assertions passed.

$ composer phpstan
 [OK] No errors
```

Both pass — as expected for a description-only change. Notably the existing `no-product-imports-smoke` suite (which guards against product vocabulary in the source) is green.