### PR TITLE
Carry the full pending-action shape in the canonical approval envelope

### DIFF
--- a/src/Abilities/class-wp-agent-ability-lifecycle-bridge.php
+++ b/src/Abilities/class-wp-agent-ability-lifecycle-bridge.php
@@ -10,7 +10,6 @@ namespace AgentsAPI\AI\Abilities;
 
 use AgentsAPI\AI\Approvals\WP_Agent_Pending_Action;
 use AgentsAPI\AI\Approvals\WP_Agent_Pending_Action_Store;
-use AgentsAPI\AI\WP_Agent_Message;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -151,27 +150,31 @@ class WP_Agent_Ability_Lifecycle_Bridge {
 			return $pre;
 		}
 
+		$decision_array = is_array( $decision ) ? self::string_keyed_array( $decision ) : array();
+
 		$pending = $decision instanceof WP_Agent_Pending_Action
 			? $decision
-			: WP_Agent_Pending_Action::from_array( self::string_keyed_array( $decision ) );
+			: WP_Agent_Pending_Action::from_array( $decision_array );
 
 		$store = apply_filters( self::FILTER_PENDING_ACTION_STORE, null );
 		if ( $store instanceof WP_Agent_Pending_Action_Store ) {
 			$store->store( $pending );
 		}
 
-		$pending_data = $pending->to_array();
-		$summary      = $pending->get_summary();
+		// A host that hands the bridge a raw decision array may attach the
+		// optional canonical orchestration slots alongside the pending-action
+		// fields. They are routed into the standardized envelope slots rather
+		// than the action value object, which only models the action itself.
+		$instruction = isset( $decision_array['instruction'] ) && is_string( $decision_array['instruction'] )
+			? $decision_array['instruction']
+			: null;
+		$grants      = isset( $decision_array['grants'] ) && is_array( $decision_array['grants'] )
+			? $decision_array['grants']
+			: array();
 
-		return WP_Agent_Message::approvalRequired(
-			$summary,
-			array(
-				'action_id'  => $pending_data['action_id'],
-				'kind'       => $pending_data['kind'],
-				'summary'    => $pending_data['summary'],
-				'preview'    => $pending_data['preview'],
-				'expires_at' => $pending_data['expires_at'],
-			),
+		return $pending->to_approval_envelope(
+			$instruction,
+			$grants,
 			array(
 				'ability_name' => $ability_name,
 			)

--- a/src/Abilities/class-wp-agent-ability-lifecycle-bridge.php
+++ b/src/Abilities/class-wp-agent-ability-lifecycle-bridge.php
@@ -169,7 +169,7 @@ class WP_Agent_Ability_Lifecycle_Bridge {
 			? $decision_array['instruction']
 			: null;
 		$grants      = isset( $decision_array['grants'] ) && is_array( $decision_array['grants'] )
-			? $decision_array['grants']
+			? array_values( $decision_array['grants'] )
 			: array();
 
 		return $pending->to_approval_envelope(

--- a/src/Approvals/class-wp-agent-pending-action.php
+++ b/src/Approvals/class-wp-agent-pending-action.php
@@ -7,6 +7,7 @@
 
 namespace AgentsAPI\AI\Approvals;
 
+use AgentsAPI\AI\WP_Agent_Message;
 use AgentsAPI\Core\Workspace\WP_Agent_Workspace_Scope;
 
 defined( 'ABSPATH' ) || exit;
@@ -68,6 +69,44 @@ class WP_Agent_Pending_Action {
 	 */
 	public function to_array(): array {
 		return $this->data;
+	}
+
+	/**
+	 * Build the canonical `approval_required` message envelope for this action.
+	 *
+	 * The envelope payload carries the full canonical pending-action shape — the
+	 * same fields {@see self::to_array()} returns (action_id, kind, summary,
+	 * preview, status, expires_at, …) — so every producer emits and every
+	 * consumer reads one shape. Two optional standardized slots give a product's
+	 * orchestration a canonical home without forking the envelope contract:
+	 *
+	 * - `instruction`: a natural-language directive describing how the host
+	 *   wants the agent to handle the pending approval (for example, preview the
+	 *   change and wait for explicit confirmation before resolving).
+	 * - `grants`: structured non-human resolver grants the host attaches so a
+	 *   downstream resolver can authorize the decision.
+	 *
+	 * Both slots are omitted when empty so the canonical shape stays minimal for
+	 * hosts that do not use them.
+	 *
+	 * @param string|null         $instruction Optional operator instruction.
+	 * @param array<int,mixed>    $grants      Optional resolver grants; non-array entries are dropped.
+	 * @param array<string,mixed> $metadata    Optional envelope metadata.
+	 * @return array<string,mixed> Canonical approval_required envelope.
+	 */
+	public function to_approval_envelope( ?string $instruction = null, array $grants = array(), array $metadata = array() ): array {
+		$payload = $this->data;
+
+		if ( null !== $instruction && '' !== trim( $instruction ) ) {
+			$payload['instruction'] = trim( $instruction );
+		}
+
+		$grants = array_values( array_filter( $grants, 'is_array' ) );
+		if ( array() !== $grants ) {
+			$payload['grants'] = $grants;
+		}
+
+		return WP_Agent_Message::approvalRequired( $this->get_summary(), $payload, $metadata );
 	}
 
 	public function get_action_id(): string {

--- a/tests/approval-action-value-shape-smoke.php
+++ b/tests/approval-action-value-shape-smoke.php
@@ -139,4 +139,44 @@ foreach ( $invalid_cases as $name => $invalid_action ) {
 	agents_api_smoke_assert_equals( true, $thrown, $name . ' throws contract exception', $failures, $passes );
 }
 
+echo "\n[5] to_approval_envelope() emits the canonical flat envelope with optional slots:\n";
+$envelope_action = AgentsAPI\AI\Approvals\WP_Agent_Pending_Action::from_array(
+	array(
+		'action_id'   => 'approve-200',
+		'kind'        => 'content_update',
+		'summary'     => 'Publish the revised landing copy.',
+		'preview'     => array( 'after' => 'Revised copy' ),
+		'apply_input' => array( 'post_id' => 99 ),
+		'status'      => AgentsAPI\AI\Approvals\WP_Agent_Pending_Action_Status::PENDING,
+		'created_at'  => '2026-05-03T15:00:00Z',
+		'expires_at'  => '2026-05-04T15:00:00Z',
+	)
+);
+
+$bare_envelope = $envelope_action->to_approval_envelope();
+agents_api_smoke_assert_equals( AgentsAPI\AI\WP_Agent_Message::TYPE_APPROVAL_REQUIRED, $bare_envelope['type'] ?? '', 'envelope is approval_required', $failures, $passes );
+agents_api_smoke_assert_equals( 'tool', $bare_envelope['role'] ?? '', 'envelope uses the tool role', $failures, $passes );
+agents_api_smoke_assert_equals( 'Publish the revised landing copy.', $bare_envelope['content'] ?? '', 'envelope content carries the summary', $failures, $passes );
+agents_api_smoke_assert_equals( $envelope_action->to_array(), $bare_envelope['payload'] ?? array(), 'payload carries the full canonical pending-action shape', $failures, $passes );
+agents_api_smoke_assert_equals( 'approve-200', $bare_envelope['payload']['action_id'] ?? '', 'payload carries action_id at the top level', $failures, $passes );
+agents_api_smoke_assert_equals( '2026-05-04T15:00:00Z', $bare_envelope['payload']['expires_at'] ?? '', 'payload carries expires_at', $failures, $passes );
+agents_api_smoke_assert_equals( AgentsAPI\AI\Approvals\WP_Agent_Pending_Action_Status::PENDING, $bare_envelope['payload']['status'] ?? '', 'payload carries status', $failures, $passes );
+agents_api_smoke_assert_equals( false, array_key_exists( 'instruction', $bare_envelope['payload'] ), 'instruction slot is omitted when not supplied', $failures, $passes );
+agents_api_smoke_assert_equals( false, array_key_exists( 'grants', $bare_envelope['payload'] ), 'grants slot is omitted when not supplied', $failures, $passes );
+agents_api_smoke_assert_equals( array(), $bare_envelope['metadata'] ?? null, 'metadata defaults to empty when not supplied', $failures, $passes );
+
+$grant         = array( 'resolver' => 'service:publisher', 'scope' => 'publish' );
+$rich_envelope = $envelope_action->to_approval_envelope(
+	'  Preview the change and wait for explicit approval.  ',
+	array( $grant, 'drop-non-array' ),
+	array( 'ability_name' => 'content/publish' )
+);
+agents_api_smoke_assert_equals( 'Preview the change and wait for explicit approval.', $rich_envelope['payload']['instruction'] ?? '', 'instruction slot is trimmed and carried in payload', $failures, $passes );
+agents_api_smoke_assert_equals( array( $grant ), $rich_envelope['payload']['grants'] ?? null, 'grants slot keeps array grants and drops non-array entries', $failures, $passes );
+agents_api_smoke_assert_equals( 'content/publish', $rich_envelope['metadata']['ability_name'] ?? '', 'metadata is forwarded onto the envelope', $failures, $passes );
+agents_api_smoke_assert_equals( false, array_key_exists( 'instruction', $envelope_action->to_array() ), 'instruction slot does not leak back into the action value object', $failures, $passes );
+
+$blank_instruction = $envelope_action->to_approval_envelope( '   ' );
+agents_api_smoke_assert_equals( false, array_key_exists( 'instruction', $blank_instruction['payload'] ), 'whitespace-only instruction is omitted', $failures, $passes );
+
 agents_api_smoke_finish( 'Agents API approval action value shape', $failures, $passes );

--- a/tests/pre-execute-approval-smoke.php
+++ b/tests/pre-execute-approval-smoke.php
@@ -136,6 +136,41 @@ agents_api_smoke_assert_equals( 'Delete post #42.', $envelope['payload']['summar
 agents_api_smoke_assert_equals( 'core/delete-post', $envelope['metadata']['ability_name'] ?? '', 'envelope metadata carries ability_name', $failures, $passes );
 agents_api_smoke_assert_equals( 1, count( $stored ), 'pending action staged via host store', $failures, $passes );
 agents_api_smoke_assert_equals( 'pa-smoke-001', $stored[0]->to_array()['action_id'], 'staged pending action matches the minted shape', $failures, $passes );
+// The envelope payload now carries the full canonical pending-action shape, not
+// a hand-picked subset, so consumers read one shape regardless of producer.
+agents_api_smoke_assert_equals( $stored[0]->to_array(), $envelope['payload'], 'envelope payload carries the full canonical pending-action shape', $failures, $passes );
+agents_api_smoke_assert_equals( array( 'post_id' => 42 ), $envelope['payload']['apply_input'] ?? null, 'envelope payload carries apply_input', $failures, $passes );
+agents_api_smoke_assert_equals( WP_Agent_Pending_Action::from_array( $pending_input )->get_status(), $envelope['payload']['status'] ?? null, 'envelope payload carries status', $failures, $passes );
+agents_api_smoke_assert_equals( false, array_key_exists( 'instruction', $envelope['payload'] ), 'instruction slot is omitted when the decision did not supply one', $failures, $passes );
+agents_api_smoke_assert_equals( false, array_key_exists( 'grants', $envelope['payload'] ), 'grants slot is omitted when the decision did not supply one', $failures, $passes );
+
+// Reset for the optional-slots case.
+$GLOBALS['__agents_api_smoke_actions'] = array();
+WP_Agent_Ability_Lifecycle_Bridge::register();
+
+echo "\n[3b] A decision array can attach the canonical instruction and grants slots:\n";
+$grant = array( 'resolver' => 'service:publisher', 'scope' => 'publish' );
+add_filter(
+	WP_Agent_Ability_Lifecycle_Bridge::FILTER_PRE_EXECUTE_DECISION,
+	static function ( $decision, string $ability_name ) use ( $pending_input, $grant ) {
+		if ( 'core/delete-post' !== $ability_name ) {
+			return $decision;
+		}
+		return array_merge(
+			$pending_input,
+			array(
+				'instruction' => 'Preview the deletion and wait for explicit approval.',
+				'grants'      => array( $grant ),
+			)
+		);
+	},
+	10,
+	2
+);
+$slots_envelope = apply_filters( 'wp_pre_execute_ability', new WP_Filter_Sentinel(), 'core/delete-post', array( 'post_id' => 42 ), null );
+agents_api_smoke_assert_equals( 'Preview the deletion and wait for explicit approval.', $slots_envelope['payload']['instruction'] ?? '', 'decision instruction flows into the canonical instruction slot', $failures, $passes );
+agents_api_smoke_assert_equals( array( $grant ), $slots_envelope['payload']['grants'] ?? null, 'decision grants flow into the canonical grants slot', $failures, $passes );
+agents_api_smoke_assert_equals( 'pa-smoke-001', $slots_envelope['payload']['action_id'] ?? '', 'slot-carrying envelope still carries the canonical action_id', $failures, $passes );
 
 // Reset for the coexistence case.
 $GLOBALS['__agents_api_smoke_actions'] = array();


### PR DESCRIPTION
## What

Converge every producer of an `approval_required` envelope onto **one** canonical payload shape, so producers emit consistently and consumers read one shape.

- `WP_Agent_Pending_Action::to_approval_envelope( ?string $instruction, array $grants, array $metadata )` builds the canonical `approval_required` message whose `payload` is the **full** canonical pending-action shape (`action_id`, `kind`, `summary`, `preview`, `status`, `expires_at`, `apply_input`, audit fields, …).
- Two optional standardized slots — **`instruction`** and **`grants`** — give a product's orchestration a canonical home without forking the envelope contract. Both are omitted when empty.
- `WP_Agent_Ability_Lifecycle_Bridge::gate_pre_execute()` now builds the pre-execute approval envelope through this method instead of hand-picking five fields, and routes any `instruction`/`grants` supplied on a raw decision array into the new slots.

## Why

Today there are two divergent approval-envelope shapes across the ecosystem: this bridge's flat `approval_required` (a 5-field subset) and Data Machine's nested `{ pending_action, resolve_with, instruction, … }`. This PR makes the canonical flat shape carry everything, so Data Machine (and any other producer) can conform to one shape. The conversation loop already reads `payload.action_id` from the flat shape, so this also closes a latent gap where nested producers surfaced a null `action_id` in the `approval_required` event.

## Safety

**Strictly additive.** Existing consumers (Big Sky, Odie, and any reader of `payload.action_id` / `kind` / `summary` / `preview` / `expires_at`) keep reading the same keys unchanged — the payload simply carries more fields plus the two optional slots. `metadata.ability_name` is preserved.

## Tests

Extends `approval-action-value-shape-smoke` (direct `to_approval_envelope()` coverage: full-shape payload, slot trimming/omission, non-array grant filtering, no leak into the value object) and `pre-execute-approval-smoke` (bridge emits the full canonical payload; decision-array `instruction`/`grants` flow into the slots). Full `composer smoke` suite passes (including `no-product-imports`).

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Opus 4.8 (1M context) via Claude Code
- **Used for:** Blast-radius analysis across the ecosystem, implementing the canonical builder + bridge change, and writing the test coverage. Chris reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)