### PR TITLE
Dispatch tool calls to a registered executor by target_id

### DIFF
--- a/agents-api.php
+++ b/agents-api.php
@@ -183,6 +183,7 @@ require_once AGENTS_API_PATH . 'src/Tools/class-wp-agent-tool-call.php';
 require_once AGENTS_API_PATH . 'src/Tools/class-wp-agent-tool-result.php';
 require_once AGENTS_API_PATH . 'src/Tools/class-wp-agent-tool-executor.php';
 require_once AGENTS_API_PATH . 'src/Tools/class-wp-agent-ability-tool-executor.php';
+require_once AGENTS_API_PATH . 'src/Tools/class-wp-agent-tool-executor-registry.php';
 require_once AGENTS_API_PATH . 'src/Tools/class-wp-agent-tool-execution-core.php';
 require_once AGENTS_API_PATH . 'src/Tools/class-wp-agent-tool-source-registry.php';
 require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-tool-mediation-runner.php';

--- a/composer.json
+++ b/composer.json
@@ -43,6 +43,7 @@
       "php tests/consent-policy-smoke.php",
       "php tests/tool-policy-contracts-smoke.php",
       "php tests/tool-source-registry-smoke.php",
+      "php tests/tool-executor-registry-smoke.php",
       "php tests/runtime-tool-policy-smoke.php",
       "php tests/runtime-tool-lifecycle-abilities-smoke.php",
       "php tests/tool-tier-resolver-smoke.php",

--- a/src/Tools/class-wp-agent-tool-execution-core.php
+++ b/src/Tools/class-wp-agent-tool-execution-core.php
@@ -17,6 +17,23 @@ class WP_Agent_Tool_Execution_Core {
 	public const EXECUTOR_CLIENT   = WP_Agent_Tool_Declaration::EXECUTOR_CLIENT;
 
 	/**
+	 * Per-target executor registry, or null until first resolved.
+	 *
+	 * @var WP_Agent_Tool_Executor_Registry|null
+	 */
+	private ?WP_Agent_Tool_Executor_Registry $executor_registry;
+
+	/**
+	 * @param WP_Agent_Tool_Executor_Registry|null $executor_registry Optional registry of
+	 *        target-keyed executors. When omitted, it is resolved lazily from the
+	 *        `agents_api_tool_executors` filter on first use so callers that never
+	 *        register a target keep the single-executor path unchanged.
+	 */
+	public function __construct( ?WP_Agent_Tool_Executor_Registry $executor_registry = null ) {
+		$this->executor_registry = $executor_registry;
+	}
+
+	/**
 	 * Prepare a tool call for a caller-supplied execution adapter.
 	 *
 	 * @param string $tool_name       Tool identifier.
@@ -87,6 +104,7 @@ class WP_Agent_Tool_Execution_Core {
 	 */
 	public function executePreparedTool( array $tool_call, array $tool_definition, WP_Agent_Tool_Executor $executor, array $context = array() ): array {
 		$tool_call = WP_Agent_Tool_Call::normalize( $tool_call );
+		$executor  = $this->resolveExecutorForTool( $tool_definition, $executor, $context );
 		try {
 			$result = $executor->executeWP_Agent_Tool_Call( $tool_call, $tool_definition, $context );
 		} catch ( \Throwable $throwable ) {
@@ -144,5 +162,34 @@ class WP_Agent_Tool_Execution_Core {
 		}
 
 		return $this->executePreparedTool( $tool_call, $tool_def, $executor, $context );
+	}
+
+	/**
+	 * Resolve the executor for a single tool call.
+	 *
+	 * When the tool declaration names an execution target (`runtime.executor_target`)
+	 * that a consumer registered through the `agents_api_tool_executors` filter, the
+	 * registered executor handles the call. Any tool with no target, or a target with
+	 * no registered executor, dispatches through the caller-provided default executor
+	 * exactly as before — the single-executor path and existing ability-backed tools
+	 * are unchanged.
+	 *
+	 * @param array<mixed>           $tool_definition  Tool declaration selected for the call.
+	 * @param WP_Agent_Tool_Executor $default_executor Caller-provided default executor.
+	 * @param array<mixed>           $context          Host runtime context for this invocation.
+	 * @return WP_Agent_Tool_Executor Executor to dispatch the tool call to.
+	 */
+	private function resolveExecutorForTool( array $tool_definition, WP_Agent_Tool_Executor $default_executor, array $context ): WP_Agent_Tool_Executor {
+		// Skip registry resolution entirely when the tool names no target, so the
+		// common ability-backed path never builds or consults a registry.
+		if ( '' === WP_Agent_Tool_Executor_Registry::targetIdFromDeclaration( $tool_definition ) ) {
+			return $default_executor;
+		}
+
+		if ( null === $this->executor_registry ) {
+			$this->executor_registry = WP_Agent_Tool_Executor_Registry::fromFilters( $context );
+		}
+
+		return $this->executor_registry->resolveForTool( $tool_definition, $default_executor );
 	}
 }

--- a/src/Tools/class-wp-agent-tool-executor-registry.php
+++ b/src/Tools/class-wp-agent-tool-executor-registry.php
@@ -1,0 +1,137 @@
+<?php
+/**
+ * Per-target tool executor registry.
+ *
+ * @package AgentsAPI
+ */
+
+namespace AgentsAPI\AI\Tools;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Resolves tool-call executors by `target_id`.
+ *
+ * Consumers register an executor for an execution environment (an ability-backed
+ * executor, a sandboxed-filesystem executor, a remote-runner executor, etc.) by
+ * keying a {@see WP_Agent_Tool_Executor} under a `target_id` through the
+ * `agents_api_tool_executors` filter. A tool declaration selects its environment
+ * with the `runtime.executor_target` key. The registry stays product-neutral: it
+ * only maps target ids to the executor instances consumers register and never
+ * knows which consumer registered which target.
+ */
+class WP_Agent_Tool_Executor_Registry {
+
+	/**
+	 * Canonical filter that maps `target_id` to a {@see WP_Agent_Tool_Executor}.
+	 */
+	public const EXECUTORS_FILTER = 'agents_api_tool_executors';
+
+	/**
+	 * Runtime metadata key on a tool declaration naming its execution target.
+	 */
+	public const RUNTIME_EXECUTOR_TARGET = 'executor_target';
+
+	/**
+	 * Executors keyed by target id.
+	 *
+	 * @var array<string, WP_Agent_Tool_Executor>
+	 */
+	private array $executors;
+
+	/**
+	 * @param array<mixed> $executors Raw executor map keyed by target id. Non-string keys
+	 *        and non-executor values are dropped so a malformed registration cannot break
+	 *        the default execution path.
+	 */
+	public function __construct( array $executors = array() ) {
+		$this->executors = array();
+		foreach ( $executors as $target_id => $executor ) {
+			if ( is_string( $target_id ) && '' !== $target_id && $executor instanceof WP_Agent_Tool_Executor ) {
+				$this->executors[ $target_id ] = $executor;
+			}
+		}
+	}
+
+	/**
+	 * Build a registry from the `agents_api_tool_executors` filter.
+	 *
+	 * Consumers register `target_id => WP_Agent_Tool_Executor` entries through the
+	 * filter. Non-string keys and non-executor values are ignored so a malformed
+	 * registration cannot break the default execution path.
+	 *
+	 * @param array<mixed> $context Host runtime context for this invocation.
+	 * @return self
+	 */
+	public static function fromFilters( array $context = array() ): self {
+		$executors = array();
+		if ( function_exists( 'apply_filters' ) ) {
+			$filtered = apply_filters( self::EXECUTORS_FILTER, $executors, $context );
+			if ( is_array( $filtered ) ) {
+				$executors = $filtered;
+			}
+		}
+
+		return new self( $executors );
+	}
+
+	/**
+	 * Whether any target-keyed executor is registered.
+	 *
+	 * @return bool
+	 */
+	public function hasExecutors(): bool {
+		return array() !== $this->executors;
+	}
+
+	/**
+	 * Resolve the registered executor for a target id.
+	 *
+	 * @param string $target_id Execution target id.
+	 * @return WP_Agent_Tool_Executor|null Registered executor, or null when none is registered.
+	 */
+	public function executorForTarget( string $target_id ): ?WP_Agent_Tool_Executor {
+		if ( '' === $target_id ) {
+			return null;
+		}
+
+		return $this->executors[ $target_id ] ?? null;
+	}
+
+	/**
+	 * Resolve the executor for a tool declaration, falling back to the default.
+	 *
+	 * The declaration's `runtime.executor_target` selects an execution environment.
+	 * When that target has a registered executor, it is returned; otherwise the
+	 * caller-provided default executor is returned unchanged so existing
+	 * ability-backed tools and single-executor callers behave identically.
+	 *
+	 * @param array<mixed>           $tool_definition  Tool declaration selected for the call.
+	 * @param WP_Agent_Tool_Executor $default_executor Caller-provided default executor.
+	 * @return WP_Agent_Tool_Executor Executor to dispatch the tool call to.
+	 */
+	public function resolveForTool( array $tool_definition, WP_Agent_Tool_Executor $default_executor ): WP_Agent_Tool_Executor {
+		$target_id = self::targetIdFromDeclaration( $tool_definition );
+		if ( '' === $target_id ) {
+			return $default_executor;
+		}
+
+		return $this->executorForTarget( $target_id ) ?? $default_executor;
+	}
+
+	/**
+	 * Extract the execution target id from a tool declaration's runtime metadata.
+	 *
+	 * @param array<mixed> $tool_definition Tool declaration.
+	 * @return string Target id, or empty string when unset.
+	 */
+	public static function targetIdFromDeclaration( array $tool_definition ): string {
+		$runtime = isset( $tool_definition['runtime'] ) && is_array( $tool_definition['runtime'] )
+			? $tool_definition['runtime']
+			: array();
+
+		$target_id = $runtime[ self::RUNTIME_EXECUTOR_TARGET ] ?? null;
+
+		return is_string( $target_id ) ? trim( $target_id ) : '';
+	}
+}

--- a/tests/tool-executor-registry-smoke.php
+++ b/tests/tool-executor-registry-smoke.php
@@ -1,0 +1,187 @@
+<?php
+/**
+ * Pure-PHP smoke test for per-target tool-executor dispatch.
+ *
+ * Proves that a tool declaration naming a registered executor target dispatches
+ * to that executor, while any tool without a registered target falls back to the
+ * caller-provided default executor exactly as before (backward compatibility).
+ *
+ * Run with: php tests/tool-executor-registry-smoke.php
+ *
+ * @package AgentsAPI\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+require_once __DIR__ . '/agents-api-smoke-helpers.php';
+agents_api_smoke_require_module();
+
+use AgentsAPI\AI\Tools\WP_Agent_Tool_Execution_Core;
+use AgentsAPI\AI\Tools\WP_Agent_Tool_Executor;
+use AgentsAPI\AI\Tools\WP_Agent_Tool_Executor_Registry;
+use AgentsAPI\AI\Tools\WP_Agent_Tool_Result;
+
+/**
+ * Recording executor that captures the calls it receives.
+ */
+class Agents_Api_Recording_Executor implements WP_Agent_Tool_Executor {
+
+	/** @var array<int, array<string, mixed>> */
+	public array $calls = array();
+
+	public function __construct( private string $label ) {}
+
+	/**
+	 * @param array<mixed> $tool_call       Normalized prepared tool call.
+	 * @param array<mixed> $tool_definition Tool declaration selected for the call.
+	 * @param array<mixed> $context         Host runtime context.
+	 * @return array<mixed> Tool execution result.
+	 */
+	public function executeWP_Agent_Tool_Call( array $tool_call, array $tool_definition, array $context = array() ): array {
+		$this->calls[] = array(
+			'tool_name'  => $tool_call['tool_name'] ?? '',
+			'parameters' => $tool_call['parameters'] ?? array(),
+		);
+
+		return WP_Agent_Tool_Result::success(
+			is_string( $tool_call['tool_name'] ?? null ) ? $tool_call['tool_name'] : '',
+			array( 'handled_by' => $this->label ),
+			array( 'executor_label' => $this->label )
+		);
+	}
+}
+
+$failures = array();
+$passes   = 0;
+
+echo "agents-api-tool-executor-registry-smoke\n";
+
+$default_executor = new Agents_Api_Recording_Executor( 'default' );
+$target_executor  = new Agents_Api_Recording_Executor( 'sandbox-target' );
+
+// Generic, consumer-neutral target id and tool source. Core never knows what a
+// consumer registers behind this target.
+$target_id = 'example/sandbox-runner';
+
+add_filter(
+	WP_Agent_Tool_Executor_Registry::EXECUTORS_FILTER,
+	static function ( array $executors ) use ( $target_id, $target_executor ): array {
+		$executors[ $target_id ] = $target_executor;
+		return $executors;
+	},
+	10,
+	2
+);
+
+$core = new WP_Agent_Tool_Execution_Core();
+
+$tools = array(
+	'sandbox/write_file' => array(
+		'name'        => 'sandbox/write_file',
+		'source'      => 'sandbox',
+		'description' => 'Write a file through a registered execution target.',
+		'executor'    => 'host',
+		'parameters'  => array(
+			'type'       => 'object',
+			'required'   => array( 'path' ),
+			'properties' => array(
+				'path'    => array( 'type' => 'string' ),
+				'content' => array( 'type' => 'string' ),
+			),
+		),
+		'runtime'     => array(
+			WP_Agent_Tool_Executor_Registry::RUNTIME_EXECUTOR_TARGET => $target_id,
+		),
+	),
+	'host/search'        => array(
+		'name'        => 'host/search',
+		'source'      => 'host',
+		'description' => 'A tool with no registered executor target.',
+		'executor'    => 'host',
+		'parameters'  => array(
+			'type'       => 'object',
+			'required'   => array( 'query' ),
+			'properties' => array(
+				'query' => array( 'type' => 'string' ),
+			),
+		),
+	),
+);
+
+echo "\n[1] Tool with a registered target dispatches to that executor (not the default):\n";
+$target_result = $core->executeTool(
+	'sandbox/write_file',
+	array(
+		'path'    => 'README.md',
+		'content' => 'hello',
+	),
+	$tools,
+	$default_executor,
+	array( 'tool_call_id' => 'call-target-1' )
+);
+
+agents_api_smoke_assert_equals( true, $target_result['success'] ?? false, 'targeted tool execution succeeds', $failures, $passes );
+agents_api_smoke_assert_equals( 'sandbox-target', $target_result['result']['handled_by'] ?? '', 'registered target executor handled the call', $failures, $passes );
+agents_api_smoke_assert_equals( 1, count( $target_executor->calls ), 'target executor received exactly one call', $failures, $passes );
+agents_api_smoke_assert_equals( 'sandbox/write_file', $target_executor->calls[0]['tool_name'] ?? '', 'target executor received the targeted tool', $failures, $passes );
+agents_api_smoke_assert_equals( 'README.md', $target_executor->calls[0]['parameters']['path'] ?? '', 'target executor received prepared parameters', $failures, $passes );
+agents_api_smoke_assert_equals( 0, count( $default_executor->calls ), 'default executor was not invoked for the targeted tool', $failures, $passes );
+
+echo "\n[2] Backward compatibility: a tool with no registered target uses the default executor:\n";
+$default_result = $core->executeTool(
+	'host/search',
+	array( 'query' => 'agents api' ),
+	$tools,
+	$default_executor,
+	array( 'tool_call_id' => 'call-default-1' )
+);
+
+agents_api_smoke_assert_equals( true, $default_result['success'] ?? false, 'untargeted tool execution succeeds', $failures, $passes );
+agents_api_smoke_assert_equals( 'default', $default_result['result']['handled_by'] ?? '', 'default executor handled the untargeted call', $failures, $passes );
+agents_api_smoke_assert_equals( 1, count( $default_executor->calls ), 'default executor received the untargeted call', $failures, $passes );
+agents_api_smoke_assert_equals( 'host/search', $default_executor->calls[0]['tool_name'] ?? '', 'default executor received the untargeted tool', $failures, $passes );
+agents_api_smoke_assert_equals( 1, count( $target_executor->calls ), 'target executor was not invoked for the untargeted tool', $failures, $passes );
+
+echo "\n[3] Unregistered target id falls back to the default executor:\n";
+$unmatched_tools = array(
+	'sandbox/orphan' => array(
+		'name'        => 'sandbox/orphan',
+		'source'      => 'sandbox',
+		'description' => 'Names a target id that no consumer registered.',
+		'executor'    => 'host',
+		'parameters'  => array(
+			'type'       => 'object',
+			'properties' => array(),
+		),
+		'runtime'     => array(
+			WP_Agent_Tool_Executor_Registry::RUNTIME_EXECUTOR_TARGET => 'example/never-registered',
+		),
+	),
+);
+
+$orphan_result = $core->executeTool(
+	'sandbox/orphan',
+	array(),
+	$unmatched_tools,
+	$default_executor,
+	array( 'tool_call_id' => 'call-orphan-1' )
+);
+
+agents_api_smoke_assert_equals( true, $orphan_result['success'] ?? false, 'unregistered-target tool execution succeeds', $failures, $passes );
+agents_api_smoke_assert_equals( 'default', $orphan_result['result']['handled_by'] ?? '', 'unregistered target falls back to default executor', $failures, $passes );
+agents_api_smoke_assert_equals( 2, count( $default_executor->calls ), 'default executor handled the orphan-target tool', $failures, $passes );
+agents_api_smoke_assert_equals( 1, count( $target_executor->calls ), 'target executor untouched by the orphan-target tool', $failures, $passes );
+
+echo "\n[4] Registry helpers resolve targets generically:\n";
+$registry = WP_Agent_Tool_Executor_Registry::fromFilters();
+agents_api_smoke_assert_equals( true, $registry->hasExecutors(), 'registry built from filter exposes registered executors', $failures, $passes );
+agents_api_smoke_assert_equals( $target_executor, $registry->executorForTarget( $target_id ), 'registry resolves the registered target executor', $failures, $passes );
+agents_api_smoke_assert_equals( null, $registry->executorForTarget( 'example/never-registered' ), 'registry returns null for an unregistered target', $failures, $passes );
+agents_api_smoke_assert_equals( $default_executor, $registry->resolveForTool( $tools['host/search'], $default_executor ), 'resolveForTool falls back to default when no target is declared', $failures, $passes );
+agents_api_smoke_assert_equals( $target_executor, $registry->resolveForTool( $tools['sandbox/write_file'], $default_executor ), 'resolveForTool routes a declared target to its executor', $failures, $passes );
+agents_api_smoke_assert_equals( $target_id, WP_Agent_Tool_Executor_Registry::targetIdFromDeclaration( $tools['sandbox/write_file'] ), 'targetIdFromDeclaration reads runtime.executor_target', $failures, $passes );
+agents_api_smoke_assert_equals( '', WP_Agent_Tool_Executor_Registry::targetIdFromDeclaration( $tools['host/search'] ), 'targetIdFromDeclaration is empty without a target', $failures, $passes );
+
+agents_api_smoke_finish( 'tool executor registry smoke', $failures, $passes );


### PR DESCRIPTION
## Summary

Make the dormant `agents_api_tool_executors` filter live so the conversation loop can route each tool call to a **different execution environment**, instead of only the single caller-provided executor. Generic, core-friendly, fully backward-compatible.

Closes #376.

## The mechanism

- **Canonical filter:** `agents_api_tool_executors` — maps `target_id => WP_Agent_Tool_Executor` instance. (`agents_api_executor_targets` remains descriptive target *metadata*; the executor instances live behind `agents_api_tool_executors`, matching how existing adapters already register.) The public filter contract is unchanged, so adapters that already register to it become live with no code change.
- **New `WP_Agent_Tool_Executor_Registry`** (`src/Tools/`): a product-neutral map of `target_id` to executor, built from that filter via `fromFilters()`. It validates entries (string key + `WP_Agent_Tool_Executor` value) so a malformed registration can never break the default path.
- **Per-tool resolution:** a tool declaration names its environment with the generic `runtime.executor_target` key. `WP_Agent_Tool_Execution_Core::executePreparedTool()` — the single dispatch point used by both `executeTool()` and the loop's mediation path — resolves the executor for each call: a declared target with a registered executor dispatches there; otherwise the caller-provided default executor handles it.

## Backward compatibility (non-negotiable, and how it's guaranteed)

- When a tool names **no** `runtime.executor_target`, registry resolution is skipped entirely — the registry is never even built or consulted. Existing ability-backed tools and single-executor callers take the exact same path as before.
- When a tool names a target that **nobody registered**, it also falls back to the default executor.
- The change is additive: a new optional constructor argument on the execution core (defaulting to lazy filter resolution) and one resolution call inside `executePreparedTool`. No existing call site or signature changed.

## Before / after

- **Before:** the loop used one `$options['tool_executor']` for every tool call; `agents_api_tool_executors` was registered to by adapters but consumed nowhere (a dead seam).
- **After:** core routes each tool call to the executor registered for its declared `target_id`, with the single-executor behavior preserved as the fallback.

## Generic / core-friendly

No consumer or product names or assumptions anywhere in production source. Core only maps target ids to the executor instances consumers register and knows nothing about who registered them. Confirmed by the existing `no-product-imports-smoke` (passes).

## Tests

New `tests/tool-executor-registry-smoke.php` (22 assertions, wired into `composer test`) proves both paths deterministically:

- A tool declared with a registered `target_id` dispatches to that test-registered executor — asserting the custom executor received the call **and the default executor did not**.
- A tool with **no** registered target dispatches via the default executor (backward-compat regression test).
- A tool naming an **unregistered** target id also falls back to the default executor.
- Registry helper coverage (`fromFilters`, `executorForTarget`, `resolveForTool`, `targetIdFromDeclaration`).

Full suite green and PHPStan clean:
- `composer test` — all smoke suites pass (exit 0), including `no-product-imports-smoke`.
- `composer phpstan` — `[OK] No errors`.

Baseline `origin/main` PHPStan was verified clean before the change; no pre-existing failures.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Opus 4.8 via Claude Code
- **Used for:** Design and implementation of generic per-target tool-executor dispatch.