### PR TITLE
Ship a default provider-agnostic agents/chat runtime handler

### DIFF
--- a/agents-api.php
+++ b/agents-api.php
@@ -222,6 +222,7 @@ require_once AGENTS_API_PATH . 'src/Channels/class-wp-agent-option-bridge-store.
 require_once AGENTS_API_PATH . 'src/Channels/class-wp-agent-bridge.php';
 require_once AGENTS_API_PATH . 'src/Channels/class-wp-agent-channel.php';
 require_once AGENTS_API_PATH . 'src/Channels/register-agents-chat-ability.php';
+require_once AGENTS_API_PATH . 'src/Channels/register-default-agents-chat-handler.php';
 require_once AGENTS_API_PATH . 'src/Channels/register-agents-chat-run-control-abilities.php';
 require_once AGENTS_API_PATH . 'src/Runtime/register-runtime-package-run-ability.php';
 require_once AGENTS_API_PATH . 'src/Tasks/register-agents-task-abilities.php';

--- a/composer.json
+++ b/composer.json
@@ -79,6 +79,7 @@
       "php tests/conversation-loop-smoke.php",
       "php tests/provider-turn-adapter-smoke.php",
       "php tests/default-provider-turn-adapter-smoke.php",
+      "php tests/default-agents-chat-handler-smoke.php",
       "php tests/ability-tool-executor-smoke.php",
       "php tests/tool-mediation-runner-smoke.php",
       "php tests/conversation-loop-tool-execution-smoke.php",

--- a/src/Channels/register-agents-chat-ability.php
+++ b/src/Channels/register-agents-chat-ability.php
@@ -8,8 +8,10 @@
  * itself is a dispatcher: it validates the canonical input/output shape from
  * https://github.com/Automattic/agents-api/issues/100 and routes execution
  * to whichever runtime registered itself via the `wp_agent_chat_handler` filter.
- * Consumers register a runtime in their own bootstrap; agents-api itself ships
- * no chat runtime.
+ * Agents API ships a provider-agnostic default runtime as a low-priority
+ * fallback (see register-default-agents-chat-handler.php), so a vanilla install
+ * runs an agent loop natively. Consumers register their own runtime in their
+ * bootstrap at the default priority to take over.
  *
  * Consumers register a runtime by hooking the filter:
  *

--- a/src/Channels/register-default-agents-chat-handler.php
+++ b/src/Channels/register-default-agents-chat-handler.php
@@ -1,0 +1,528 @@
+<?php
+/**
+ * Default agents/chat runtime handler.
+ *
+ * Agents API ships the canonical `agents/chat` dispatcher
+ * (see register-agents-chat-ability.php) but, historically, registered no
+ * runtime behind it: an install with no consumer plugin returned
+ * "No agents/chat handler is registered." This file makes Agents API
+ * self-sufficient by registering a default, provider-agnostic runtime that
+ * runs a real agent loop natively.
+ *
+ * The handler is the generic driver only — it owns nothing a consumer would
+ * want to override:
+ *
+ *   1. resolve the agent from Agents API's own runtime-bundle registry
+ *      ({@see WP_Agents_Registry});
+ *   2. resolve provider/model/system-prompt/tools from the chat input and the
+ *      registered agent's default config;
+ *   3. build provider-agnostic dispatch through the generic AI-client
+ *      abstraction via {@see WP_Agent_Conversation_Loop::run_conversation()},
+ *      which constructs the {@see WP_Agent_Default_Provider_Turn_Adapter} (a
+ *      wp-ai-client builder keyed purely by the requested provider + model — no
+ *      provider hardcoding);
+ *   4. mediate tool calls through Agents API's own
+ *      {@see WP_Agent_Ability_Tool_Executor} and the per-target executor
+ *      registry from #377;
+ *   5. return the canonical `agents/chat` output shape.
+ *
+ * It registers itself as a FALLBACK at a high filter priority, so any explicit
+ * consumer runtime registered at the default priority still wins. A vanilla
+ * Agents API install gets a working `agents/chat` for free; a consumer-backed
+ * install is unchanged.
+ *
+ * @package AgentsAPI
+ * @since   0.106.0
+ */
+
+namespace AgentsAPI\AI\Channels;
+
+use AgentsAPI\AI\WP_Agent_Conversation_Loop;
+use AgentsAPI\AI\WP_Agent_Message;
+use AgentsAPI\AI\Tools\WP_Agent_Ability_Tool_Executor;
+use AgentsAPI\AI\Tools\WP_Agent_Tool_Declaration;
+use AgentsAPI\Core\Database\Chat\WP_Agent_Conversation_Sessions;
+use AgentsAPI\Core\Database\Chat\WP_Agent_Conversation_Store;
+use AgentsAPI\Core\Workspace\WP_Agent_Workspace_Scope;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Provider-agnostic default runtime for the canonical `agents/chat` ability.
+ */
+class WP_Agent_Default_Chat_Handler {
+
+	/**
+	 * Fallback filter priority for the default handler.
+	 *
+	 * `wp_agent_chat_handler` resolves to the first non-null callable returned as
+	 * the filter chain runs in ascending priority order. Registering this default
+	 * at a deliberately high priority number means any consumer runtime added at
+	 * the default priority (10) returns its callable first and wins; the default
+	 * only fills the seam when nothing else has.
+	 */
+	public const FALLBACK_PRIORITY = 1000;
+
+	/**
+	 * Default maximum agent-loop turns when neither the request nor the agent
+	 * config specifies one. Bounds tool-mediated runs so the default driver
+	 * cannot spin unbounded.
+	 */
+	public const DEFAULT_MAX_TURNS = 12;
+
+	/**
+	 * Register the default handler as a fallback chat runtime.
+	 *
+	 * @return void
+	 */
+	public static function register(): void {
+		register_chat_handler( array( self::class, 'execute' ), self::FALLBACK_PRIORITY );
+	}
+
+	/**
+	 * Execute one canonical chat turn natively, without any external runtime.
+	 *
+	 * @param array<string,mixed> $input Canonical agents/chat input.
+	 * @return array<string,mixed>|\WP_Error Canonical agents/chat output, or WP_Error.
+	 */
+	public static function execute( array $input ) {
+		$message = is_string( $input['message'] ?? null ) ? trim( $input['message'] ) : '';
+		if ( '' === $message ) {
+			return new \WP_Error( 'agents_chat_empty_message', 'Message cannot be empty.', array( 'status' => 400 ) );
+		}
+
+		$agent_slug = is_string( $input['agent'] ?? null ) ? trim( $input['agent'] ) : '';
+		$agent      = self::resolve_agent( $agent_slug );
+		if ( is_wp_error( $agent ) ) {
+			return $agent;
+		}
+
+		$config = ( $agent instanceof \WP_Agent ) ? $agent->get_default_config() : array();
+
+		$provider = self::first_non_empty(
+			is_string( $input['provider'] ?? null ) ? $input['provider'] : '',
+			is_string( $config['provider'] ?? null ) ? $config['provider'] : '',
+			is_string( $config['provider_id'] ?? null ) ? $config['provider_id'] : ''
+		);
+		if ( '' === $provider ) {
+			return new \WP_Error(
+				'agents_chat_provider_required',
+				'A provider id is required. Supply input.provider or set a provider in the agent default config.',
+				array( 'status' => 400 )
+			);
+		}
+
+		$model = self::first_non_empty(
+			is_string( $input['model'] ?? null ) ? $input['model'] : '',
+			is_string( $config['model'] ?? null ) ? $config['model'] : '',
+			is_string( $config['model_id'] ?? null ) ? $config['model_id'] : ''
+		);
+		if ( '' === $model ) {
+			return new \WP_Error(
+				'agents_chat_model_required',
+				'A model id is required. Supply input.model or set a model in the agent default config.',
+				array( 'status' => 400 )
+			);
+		}
+
+		$system_prompt     = self::resolve_system_prompt( $config );
+		$tool_declarations = self::resolve_tool_declarations( $config );
+		$max_turns         = self::resolve_max_turns( $input, $config );
+
+		$store      = WP_Agent_Conversation_Sessions::get_store( $input );
+		$session_id = is_string( $input['session_id'] ?? null ) ? trim( $input['session_id'] ) : '';
+		$messages   = array();
+
+		if ( $store instanceof WP_Agent_Conversation_Store ) {
+			$loaded = ( '' !== $session_id ) ? $store->get_session( $session_id ) : null;
+			if ( is_array( $loaded ) && is_array( $loaded['messages'] ?? null ) ) {
+				$messages = $loaded['messages'];
+			} else {
+				$created = self::create_session( $store, $agent_slug, $input );
+				if ( '' !== $created ) {
+					$session_id = $created;
+				}
+			}
+		}
+
+		if ( '' === $session_id ) {
+			$session_id = self::generate_session_id();
+		}
+
+		$messages[] = WP_Agent_Message::text( 'user', $message );
+		$messages   = WP_Agent_Message::normalize_many( $messages );
+
+		$loop_options = array(
+			'system_prompt' => $system_prompt,
+			'max_turns'     => $max_turns,
+			'context'       => array(
+				'session_id' => $session_id,
+				'agent_slug' => $agent_slug,
+			),
+		);
+		if ( ! empty( $tool_declarations ) ) {
+			// Default executor: dispatch tool calls through registered abilities.
+			// The loop also consults the #377 per-target executor registry
+			// (`agents_api_tool_executors`) for declarations that select another
+			// execution environment, so consumers can override per tool target.
+			$loop_options['tool_executor'] = new WP_Agent_Ability_Tool_Executor();
+		}
+
+		$result = WP_Agent_Conversation_Loop::run_conversation(
+			$messages,
+			$tool_declarations,
+			$provider,
+			$model,
+			$loop_options
+		);
+
+		if ( $store instanceof WP_Agent_Conversation_Store ) {
+			$final_messages = is_array( $result['messages'] ?? null ) ? $result['messages'] : $messages;
+			$store->update_session(
+				$session_id,
+				$final_messages,
+				self::session_metadata( $result ),
+				$provider,
+				$model
+			);
+		}
+
+		return self::to_canonical_output( $session_id, $result );
+	}
+
+	/**
+	 * Resolve a registered agent from the Agents API runtime registry.
+	 *
+	 * An empty slug runs an agent-less turn (provider/model/system-prompt must
+	 * then come from the request). A non-empty slug that is not registered is a
+	 * hard error so callers learn the agent is missing rather than silently
+	 * falling back to bare input.
+	 *
+	 * @param string $agent_slug Requested agent slug.
+	 * @return \WP_Agent|\WP_Error|null Registered agent, null for agent-less, or error.
+	 */
+	private static function resolve_agent( string $agent_slug ) {
+		if ( '' === $agent_slug ) {
+			return null;
+		}
+
+		if ( ! class_exists( '\WP_Agents_Registry' ) ) {
+			return new \WP_Error(
+				'agents_chat_registry_unavailable',
+				'The Agents API registry is unavailable.',
+				array( 'status' => 500 )
+			);
+		}
+
+		$registry = \WP_Agents_Registry::get_instance();
+		if ( ! $registry instanceof \WP_Agents_Registry ) {
+			return new \WP_Error(
+				'agents_chat_registry_unavailable',
+				'The Agents API registry is not yet initialized.',
+				array( 'status' => 500 )
+			);
+		}
+
+		if ( ! $registry->is_registered( $agent_slug ) ) {
+			return new \WP_Error(
+				'agents_chat_agent_not_found',
+				sprintf( 'Agent "%s" is not registered.', $agent_slug ),
+				array( 'status' => 404 )
+			);
+		}
+
+		return $registry->get_registered( $agent_slug );
+	}
+
+	/**
+	 * Resolve the agent system prompt from its default config.
+	 *
+	 * @param array<string,mixed> $config Agent default config.
+	 * @return string
+	 */
+	private static function resolve_system_prompt( array $config ): string {
+		foreach ( array( 'system_prompt', 'instructions', 'system', 'prompt' ) as $key ) {
+			if ( is_string( $config[ $key ] ?? null ) && '' !== trim( $config[ $key ] ) ) {
+				return $config[ $key ];
+			}
+		}
+
+		return '';
+	}
+
+	/**
+	 * Build host-mediated tool declarations from the agent's declared abilities.
+	 *
+	 * The agent config lists the ability names the agent may call (under `tools`
+	 * or `abilities`). Each becomes a server tool declaration whose model-facing
+	 * name is the ability name; {@see WP_Agent_Ability_Tool_Executor} dispatches
+	 * it back through the Abilities API.
+	 *
+	 * @param array<string,mixed> $config Agent default config.
+	 * @return array<string,array<string,mixed>> Declarations keyed by tool name.
+	 */
+	private static function resolve_tool_declarations( array $config ): array {
+		$names = array();
+		foreach ( array( 'tools', 'abilities', 'tool_names' ) as $key ) {
+			if ( is_array( $config[ $key ] ?? null ) ) {
+				$names = array_merge( $names, $config[ $key ] );
+			}
+		}
+
+		$declarations = array();
+		foreach ( $names as $name ) {
+			if ( ! is_string( $name ) || '' === trim( $name ) ) {
+				continue;
+			}
+			$name = trim( $name );
+			if ( isset( $declarations[ $name ] ) ) {
+				continue;
+			}
+
+			$ability     = function_exists( 'wp_get_ability' ) ? wp_get_ability( $name ) : null;
+			$description = '';
+			$parameters  = array();
+			if ( $ability instanceof \WP_Ability ) {
+				$description = trim( (string) $ability->get_description() );
+				$parameters  = $ability->get_input_schema();
+			}
+
+			$source = WP_Agent_Tool_Declaration::sourceFromName( $name );
+			if ( '' === $source ) {
+				$source = 'agents';
+			}
+
+			$declarations[ $name ] = array(
+				'name'        => $name,
+				'source'      => $source,
+				'description' => '' !== $description ? $description : $name,
+				'parameters'  => $parameters,
+				'executor'    => WP_Agent_Tool_Declaration::EXECUTOR_HOST,
+				'scope'       => WP_Agent_Tool_Declaration::SCOPE_RUN,
+				'ability'     => $name,
+			);
+		}
+
+		return $declarations;
+	}
+
+	/**
+	 * Resolve the maximum number of agent-loop turns for this request.
+	 *
+	 * @param array<string,mixed> $input  Canonical chat input.
+	 * @param array<string,mixed> $config Agent default config.
+	 * @return int
+	 */
+	private static function resolve_max_turns( array $input, array $config ): int {
+		foreach ( array( $input['max_turns'] ?? null, $config['max_turns'] ?? null ) as $candidate ) {
+			if ( is_numeric( $candidate ) && (int) $candidate > 0 ) {
+				return (int) $candidate;
+			}
+		}
+
+		return self::DEFAULT_MAX_TURNS;
+	}
+
+	/**
+	 * Best-effort creation of a transcript session row for a user-owned chat.
+	 *
+	 * The default driver stays generic: it only creates a row when a store is
+	 * registered and a WordPress user owns the turn (the contracts-only default
+	 * CPT store keys sessions by user id). Anonymous or principal-owned chats run
+	 * statelessly with a synthesized session id rather than coupling this default
+	 * to a specific principal-store implementation.
+	 *
+	 * @param WP_Agent_Conversation_Store $store      Resolved conversation store.
+	 * @param string                      $agent_slug Registered agent slug.
+	 * @param array<string,mixed>         $input      Canonical chat input.
+	 * @return string Created session id, or empty string when none was created.
+	 */
+	private static function create_session( WP_Agent_Conversation_Store $store, string $agent_slug, array $input ): string {
+		$user_id = self::resolve_user_id( $input );
+		if ( $user_id <= 0 ) {
+			return '';
+		}
+
+		try {
+			$workspace = WP_Agent_Workspace_Scope::from_parts( 'site', self::default_workspace_id() );
+		} catch ( \Throwable $error ) {
+			unset( $error );
+			return '';
+		}
+
+		try {
+			$session_id = $store->create_session(
+				$workspace,
+				$user_id,
+				$agent_slug,
+				array( 'source' => 'agents-api-default-chat-handler' ),
+				'chat'
+			);
+		} catch ( \Throwable $error ) {
+			unset( $error );
+			return '';
+		}
+
+		return $session_id;
+	}
+
+	/**
+	 * Resolve the owning WordPress user id for transcript persistence.
+	 *
+	 * @param array<string,mixed> $input Canonical chat input.
+	 * @return int
+	 */
+	private static function resolve_user_id( array $input ): int {
+		$user_id = function_exists( 'get_current_user_id' ) ? (int) get_current_user_id() : 0;
+		if ( $user_id > 0 ) {
+			return $user_id;
+		}
+
+		$principal = $input['principal'] ?? null;
+		if ( is_array( $principal ) && is_numeric( $principal['acting_user_id'] ?? null ) ) {
+			return max( 0, (int) $principal['acting_user_id'] );
+		}
+
+		return 0;
+	}
+
+	/**
+	 * Resolve the default workspace id without assuming multisite.
+	 *
+	 * @return string
+	 */
+	private static function default_workspace_id(): string {
+		if ( function_exists( 'get_current_blog_id' ) ) {
+			return (string) get_current_blog_id();
+		}
+
+		return 'default';
+	}
+
+	/**
+	 * Build generic session metadata for transcript persistence.
+	 *
+	 * @param array<string,mixed> $result Conversation loop result.
+	 * @return array<string,mixed>
+	 */
+	private static function session_metadata( array $result ): array {
+		$completed = (bool) ( $result['completed'] ?? true );
+
+		return array(
+			'status'        => $completed ? 'completed' : 'processing',
+			'message_count' => is_array( $result['messages'] ?? null ) ? count( $result['messages'] ) : 0,
+			'current_turn'  => self::int_value( $result['turn_count'] ?? null ),
+		);
+	}
+
+	/**
+	 * Project the loop result to the canonical `agents/chat` output shape.
+	 *
+	 * @param string              $session_id Session id to thread further turns under.
+	 * @param array<string,mixed> $result     Conversation loop result.
+	 * @return array<string,mixed>
+	 */
+	private static function to_canonical_output( string $session_id, array $result ): array {
+		$metadata = array_filter(
+			array(
+				'status'      => is_string( $result['status'] ?? null ) ? $result['status'] : null,
+				'turn_count'  => isset( $result['turn_count'] ) ? self::int_value( $result['turn_count'] ) : null,
+				'usage'       => is_array( $result['usage'] ?? null ) ? $result['usage'] : null,
+				'run_outcome' => is_array( $result['run_outcome'] ?? null ) ? $result['run_outcome'] : null,
+			),
+			static fn( $value ): bool => null !== $value
+		);
+
+		return array(
+			'session_id' => $session_id,
+			'reply'      => is_string( $result['final_content'] ?? null ) ? $result['final_content'] : '',
+			'messages'   => self::to_canonical_messages( is_array( $result['messages'] ?? null ) ? array_values( $result['messages'] ) : array() ),
+			'completed'  => (bool) ( $result['completed'] ?? true ),
+			'metadata'   => array( 'agents_api' => $metadata ),
+		);
+	}
+
+	/**
+	 * Reduce loop transcript envelopes to the canonical `{role, content}` list.
+	 *
+	 * Tool-call and tool-result envelopes are runtime detail and are omitted; the
+	 * canonical message list carries only assistant/user text turns.
+	 *
+	 * @param array<int,mixed> $conversation Loop transcript messages.
+	 * @return array<int,array{role:string,content:string}>
+	 */
+	private static function to_canonical_messages( array $conversation ): array {
+		$messages = array();
+		foreach ( $conversation as $message ) {
+			if ( ! is_array( $message ) ) {
+				continue;
+			}
+
+			$type = is_string( $message['type'] ?? null ) ? $message['type'] : '';
+			if ( WP_Agent_Message::TYPE_TOOL_CALL === $type || WP_Agent_Message::TYPE_TOOL_RESULT === $type ) {
+				continue;
+			}
+
+			$role    = $message['role'] ?? null;
+			$content = $message['content'] ?? null;
+			if ( ! is_string( $role ) || '' === $role || ! is_string( $content ) ) {
+				continue;
+			}
+
+			$messages[] = array(
+				'role'    => $role,
+				'content' => $content,
+			);
+		}
+
+		return $messages;
+	}
+
+	/**
+	 * Coerce a mixed value to an int, defaulting non-numerics to zero.
+	 *
+	 * @param mixed $value Raw value.
+	 * @return int
+	 */
+	private static function int_value( mixed $value ): int {
+		return is_numeric( $value ) ? (int) $value : 0;
+	}
+
+	/**
+	 * Return the first non-empty trimmed string from the supplied candidates.
+	 *
+	 * @param string ...$candidates Candidate strings.
+	 * @return string
+	 */
+	private static function first_non_empty( string ...$candidates ): string {
+		foreach ( $candidates as $candidate ) {
+			if ( '' !== trim( $candidate ) ) {
+				return trim( $candidate );
+			}
+		}
+
+		return '';
+	}
+
+	/**
+	 * Generate an opaque session id for stateless (store-less) turns.
+	 *
+	 * @return string
+	 */
+	private static function generate_session_id(): string {
+		if ( function_exists( 'wp_generate_uuid4' ) ) {
+			return (string) wp_generate_uuid4();
+		}
+
+		try {
+			$bytes = random_bytes( 16 );
+		} catch ( \Throwable $error ) {
+			unset( $error );
+			return 'session-' . uniqid( '', true );
+		}
+
+		return vsprintf( '%s%s-%s-%s-%s-%s%s%s', str_split( bin2hex( $bytes ), 4 ) );
+	}
+}
+
+WP_Agent_Default_Chat_Handler::register();

--- a/tests/agents-chat-ability-smoke.php
+++ b/tests/agents-chat-ability-smoke.php
@@ -85,6 +85,9 @@ use const AgentsAPI\AI\Channels\AGENTS_CHAT_ABILITY;
 smoke_assert( 'agents/chat', AGENTS_CHAT_ABILITY, 'slug_is_agents_chat', $failures, $passes );
 
 // 2. No handler registered → WP_Error agents_chat_no_handler + observability fires.
+// Agents API now ships a default fallback runtime on this filter, so clear it
+// first to exercise the dispatcher's genuine no-handler branch in isolation.
+smoke_reset_chat_filters();
 $dispatch_failures = array();
 add_filter( 'agents_chat_dispatch_failed', static function ( $reason, $input ) use ( &$dispatch_failures ) {
 	$dispatch_failures[] = array( 'reason' => $reason, 'agent' => $input['agent'] ?? null );

--- a/tests/default-agents-chat-handler-smoke.php
+++ b/tests/default-agents-chat-handler-smoke.php
@@ -1,0 +1,437 @@
+<?php
+/**
+ * Pure-PHP smoke test for the default agents/chat runtime handler.
+ *
+ * Proves that Agents API runs a real agent loop turn natively behind the
+ * canonical `agents/chat` ability — no Data Machine, no external runtime — and
+ * that dispatch is provider-agnostic (driven only by the requested provider +
+ * model through the wp-ai-client builder, here stubbed with a deterministic
+ * fake provider that emits a tool call then a final assistant message).
+ *
+ * Run with: php tests/default-agents-chat-handler-smoke.php
+ *
+ * @package AgentsAPI\Tests
+ */
+// phpcs:disable Generic.Files.OneObjectStructurePerFile.MultipleFound, Squiz.Commenting, Generic.Commenting
+
+namespace WordPress\AiClient\Messages\DTO {
+	if ( ! class_exists( __NAMESPACE__ . '\\MessagePart' ) ) {
+		class MessagePart {
+			public $value;
+			public function __construct( $value ) {
+				$this->value = $value;
+			}
+		}
+	}
+	if ( ! class_exists( __NAMESPACE__ . '\\UserMessage' ) ) {
+		class UserMessage {
+			public array $parts;
+			public function __construct( array $parts ) {
+				$this->parts = $parts;
+			}
+		}
+	}
+	if ( ! class_exists( __NAMESPACE__ . '\\ModelMessage' ) ) {
+		class ModelMessage {
+			public array $parts;
+			public function __construct( array $parts ) {
+				$this->parts = $parts;
+			}
+		}
+	}
+}
+
+namespace WordPress\AiClient\Tools\DTO {
+	if ( ! class_exists( __NAMESPACE__ . '\\FunctionCall' ) ) {
+		class FunctionCall {
+			public $id;
+			public $name;
+			public $args;
+			public function __construct( $id, $name, $args ) {
+				$this->id   = $id;
+				$this->name = $name;
+				$this->args = $args;
+			}
+		}
+	}
+	if ( ! class_exists( __NAMESPACE__ . '\\FunctionResponse' ) ) {
+		class FunctionResponse {
+			public $id;
+			public $name;
+			public $payload;
+			public function __construct( $id, $name, $payload ) {
+				$this->id      = $id;
+				$this->name    = $name;
+				$this->payload = $payload;
+			}
+		}
+	}
+	if ( ! class_exists( __NAMESPACE__ . '\\FunctionDeclaration' ) ) {
+		class FunctionDeclaration {
+			public string $name;
+			public string $description;
+			public array $parameters;
+			public function __construct( string $name, string $description, array $parameters ) {
+				$this->name        = $name;
+				$this->description = $description;
+				$this->parameters  = $parameters;
+			}
+		}
+	}
+}
+
+namespace {
+
+	if ( ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', __DIR__ . '/' );
+	}
+
+	$failures = array();
+	$passes   = 0;
+
+	echo "agents-api-default-agents-chat-handler-smoke\n";
+
+	require_once __DIR__ . '/agents-api-smoke-helpers.php';
+
+	if ( ! class_exists( 'WP_Error' ) ) {
+		class WP_Error {
+			public function __construct( private string $code = '', private string $message = '', private mixed $data = null ) {}
+			public function get_error_code(): string {
+				return $this->code;
+			}
+			public function get_error_message(): string {
+				return $this->message;
+			}
+			public function get_error_data(): mixed {
+				return $this->data;
+			}
+		}
+	}
+
+	if ( ! function_exists( 'current_user_can' ) ) {
+		function current_user_can( string $cap ): bool {
+			unset( $cap );
+			return false;
+		}
+	}
+
+	if ( ! function_exists( 'get_current_user_id' ) ) {
+		function get_current_user_id(): int {
+			return 0;
+		}
+	}
+
+	// --- Minimal Abilities API doubles so the ability tool executor can dispatch. ---
+	if ( ! class_exists( 'WP_Ability' ) ) {
+		class WP_Ability {
+			/** @var callable */
+			public $runner;
+			public function __construct(
+				private string $name,
+				private string $description,
+				private array $input_schema,
+				callable $runner
+			) {
+				$this->runner = $runner;
+			}
+			public function get_name(): string {
+				return $this->name;
+			}
+			public function get_label(): string {
+				return $this->name;
+			}
+			public function get_category(): string {
+				return 'test';
+			}
+			public function get_description(): string {
+				return $this->description;
+			}
+			public function get_input_schema(): array {
+				return $this->input_schema;
+			}
+			public function execute( array $parameters ) {
+				return call_user_func( $this->runner, $parameters );
+			}
+		}
+	}
+
+	$GLOBALS['__chat_handler_abilities'] = array();
+	$GLOBALS['__chat_handler_ability_calls'] = array();
+
+	if ( ! function_exists( 'wp_get_ability' ) ) {
+		function wp_get_ability( string $name ) {
+			return $GLOBALS['__chat_handler_abilities'][ $name ] ?? null;
+		}
+	}
+	if ( ! function_exists( 'wp_has_ability' ) ) {
+		function wp_has_ability( string $name ): bool {
+			return isset( $GLOBALS['__chat_handler_abilities'][ $name ] );
+		}
+	}
+
+	$GLOBALS['__chat_handler_abilities']['kitchen/lookup'] = new WP_Ability(
+		'kitchen/lookup',
+		'Look up a kitchen fact.',
+		array(
+			'type'       => 'object',
+			'required'   => array( 'query' ),
+			'properties' => array( 'query' => array( 'type' => 'string' ) ),
+		),
+		static function ( array $parameters ): array {
+			$GLOBALS['__chat_handler_ability_calls'][] = $parameters;
+			return array( 'answer' => 'mise en place for ' . ( $parameters['query'] ?? '' ) );
+		}
+	);
+
+	// --- Deterministic fake wp-ai-client provider (provider-agnostic dispatch). ---
+	$GLOBALS['__adapter_smoke'] = array();
+
+	class Agents_Chat_Fake_Token_Usage {
+		public function __construct( private int $prompt, private int $completion, private int $total ) {}
+		public function getPromptTokens(): int {
+			return $this->prompt;
+		}
+		public function getCompletionTokens(): int {
+			return $this->completion;
+		}
+		public function getTotalTokens(): int {
+			return $this->total;
+		}
+	}
+	class Agents_Chat_Fake_Function_Call {
+		public function __construct( private string $name, private string $args, private string $id ) {}
+		public function getName(): string {
+			return $this->name;
+		}
+		public function getArgs(): string {
+			return $this->args;
+		}
+		public function getId(): string {
+			return $this->id;
+		}
+	}
+	class Agents_Chat_Fake_Part {
+		public function __construct( private ?Agents_Chat_Fake_Function_Call $call, private string $text ) {}
+		public function getFunctionCall(): ?Agents_Chat_Fake_Function_Call {
+			return $this->call;
+		}
+		public function getText(): string {
+			return $this->text;
+		}
+	}
+	class Agents_Chat_Fake_Message {
+		public function __construct( private array $parts ) {}
+		public function getParts(): array {
+			return $this->parts;
+		}
+	}
+	class Agents_Chat_Fake_Candidate {
+		public function __construct( private Agents_Chat_Fake_Message $message ) {}
+		public function getMessage(): Agents_Chat_Fake_Message {
+			return $this->message;
+		}
+	}
+	class Agents_Chat_Fake_Generative_Result {
+		public function __construct( private string $text, private array $candidates, private Agents_Chat_Fake_Token_Usage $usage ) {}
+		public function toText(): string {
+			if ( '' === $this->text ) {
+				throw new \RuntimeException( 'No text content found in result.' );
+			}
+			return $this->text;
+		}
+		public function getCandidates(): array {
+			return $this->candidates;
+		}
+		public function getTokenUsage(): Agents_Chat_Fake_Token_Usage {
+			return $this->usage;
+		}
+	}
+	class Agents_Chat_Fake_Prompt_Builder {
+		public function with_message_parts( ...$parts ): self {
+			return $this;
+		}
+		public function using_provider( string $provider ): self {
+			$GLOBALS['__adapter_smoke']['provider'] = $provider;
+			return $this;
+		}
+		public function using_model( string $model ): self {
+			$GLOBALS['__adapter_smoke']['model'] = $model;
+			return $this;
+		}
+		public function using_system_instruction( string $system ): self {
+			$GLOBALS['__adapter_smoke']['system'] = $system;
+			return $this;
+		}
+		public function using_temperature( float $temperature ): self {
+			return $this;
+		}
+		public function using_max_tokens( int $max_tokens ): self {
+			return $this;
+		}
+		public function with_history( ...$history ): self {
+			return $this;
+		}
+		public function using_function_declarations( ...$declarations ): self {
+			$GLOBALS['__adapter_smoke']['declarations'] = $declarations;
+			return $this;
+		}
+		public function generate_text_result() {
+			$turn = ( $GLOBALS['__adapter_smoke']['turn'] ?? 0 ) + 1;
+			$GLOBALS['__adapter_smoke']['turn'] = $turn;
+			$results = $GLOBALS['__adapter_smoke']['results_by_turn'] ?? array();
+			return $results[ $turn ] ?? end( $results );
+		}
+	}
+
+	if ( ! function_exists( 'wp_ai_client_prompt' ) ) {
+		function wp_ai_client_prompt( $prompt = null ): Agents_Chat_Fake_Prompt_Builder {
+			unset( $prompt );
+			return new Agents_Chat_Fake_Prompt_Builder();
+		}
+	}
+
+	$make_result = static function ( string $text, array $tool_calls, array $usage ): Agents_Chat_Fake_Generative_Result {
+		$parts = array();
+		foreach ( $tool_calls as $call ) {
+			$parts[] = new Agents_Chat_Fake_Part(
+				new Agents_Chat_Fake_Function_Call( $call['name'], json_encode( $call['parameters'] ), $call['id'] ),
+				''
+			);
+		}
+		if ( '' !== $text ) {
+			$parts[] = new Agents_Chat_Fake_Part( null, $text );
+		}
+		return new Agents_Chat_Fake_Generative_Result(
+			$text,
+			array( new Agents_Chat_Fake_Candidate( new Agents_Chat_Fake_Message( $parts ) ) ),
+			new Agents_Chat_Fake_Token_Usage( $usage[0], $usage[1], $usage[2] )
+		);
+	};
+
+	require_once __DIR__ . '/../agents-api.php';
+
+	use function AgentsAPI\AI\Channels\agents_chat_dispatch;
+	use function AgentsAPI\AI\Channels\register_chat_handler;
+
+	// Mark `init` as fired so the registry can be read, then register an agent
+	// directly. This mirrors a runtime-bundle import that registered an agent
+	// with provider/model/system-prompt/tools in its default config.
+	$GLOBALS['__agents_api_smoke_done']['init'] = 1;
+	$registry = WP_Agents_Registry::get_instance();
+	$registry->register(
+		'kitchen-brain',
+		array(
+			'label'          => 'Kitchen Brain',
+			'default_config' => array(
+				'provider'      => 'fake-provider',
+				'model'         => 'fake-model',
+				'system_prompt' => 'You are the kitchen brain.',
+				'tools'         => array( 'kitchen/lookup' ),
+			),
+		)
+	);
+
+	// Queue the two provider turns: turn 1 calls the tool, turn 2 answers.
+	$reset_provider = static function () use ( $make_result ): void {
+		$GLOBALS['__adapter_smoke'] = array(
+			'turn'            => 0,
+			'results_by_turn' => array(
+				1 => $make_result(
+					'',
+					array( array( 'name' => 'kitchen/lookup', 'parameters' => array( 'query' => 'risotto' ), 'id' => 'call-1' ) ),
+					array( 5, 3, 8 )
+				),
+				2 => $make_result( 'All set, chef.', array(), array( 4, 6, 10 ) ),
+			),
+		);
+	};
+
+	echo "\n[1] Default handler runs a native agent loop turn through the registered agent:\n";
+	$GLOBALS['__chat_handler_ability_calls'] = array();
+	$reset_provider();
+
+	$output = AgentsAPI\AI\Channels\WP_Agent_Default_Chat_Handler::execute(
+		array(
+			'agent'   => 'kitchen-brain',
+			'message' => 'How do I prep risotto?',
+		)
+	);
+
+	agents_api_smoke_assert_equals( false, $output instanceof WP_Error, 'handler returns canonical output, not WP_Error', $failures, $passes );
+	agents_api_smoke_assert_equals( true, is_string( $output['session_id'] ?? null ) && '' !== $output['session_id'], 'output carries a non-empty session_id', $failures, $passes );
+	agents_api_smoke_assert_equals( 'All set, chef.', $output['reply'] ?? null, 'output reply is the final assistant message from the loop', $failures, $passes );
+	agents_api_smoke_assert_equals( true, $output['completed'] ?? false, 'output marks the turn completed', $failures, $passes );
+	agents_api_smoke_assert_equals( 1, count( $GLOBALS['__chat_handler_ability_calls'] ), 'the loop mediated exactly one tool call through the ability executor', $failures, $passes );
+	agents_api_smoke_assert_equals( 'risotto', $GLOBALS['__chat_handler_ability_calls'][0]['query'] ?? '', 'the mediated tool received the model-supplied parameters', $failures, $passes );
+	agents_api_smoke_assert_equals( 'fake-provider', $GLOBALS['__adapter_smoke']['provider'] ?? '', 'dispatch is provider-agnostic: the builder was keyed by the requested provider id', $failures, $passes );
+	agents_api_smoke_assert_equals( 'fake-model', $GLOBALS['__adapter_smoke']['model'] ?? '', 'dispatch is provider-agnostic: the builder was keyed by the requested model id', $failures, $passes );
+	agents_api_smoke_assert_equals( 'You are the kitchen brain.', $GLOBALS['__adapter_smoke']['system'] ?? '', 'the agent default-config system prompt drove the turn', $failures, $passes );
+	agents_api_smoke_assert_equals( 2, (int) ( $output['metadata']['agents_api']['turn_count'] ?? 0 ), 'metadata records the two-turn native loop', $failures, $passes );
+	$canonical_roles = array_map( static fn( array $m ): string => $m['role'], $output['messages'] ?? array() );
+	agents_api_smoke_assert_equals( true, in_array( 'user', $canonical_roles, true ), 'canonical messages include the user turn', $failures, $passes );
+	agents_api_smoke_assert_equals( true, in_array( 'assistant', $canonical_roles, true ), 'canonical messages include the assistant reply', $failures, $passes );
+	agents_api_smoke_assert_equals( true, ! in_array( 'tool', $canonical_roles, true ), 'canonical messages omit raw tool envelopes', $failures, $passes );
+
+	echo "\n[2] Provider/model fall back to the request when the agent config omits them:\n";
+	$registry->register(
+		'bare-brain',
+		array(
+			'label'          => 'Bare Brain',
+			'default_config' => array( 'system_prompt' => 'You are bare.' ),
+		)
+	);
+	$reset_provider();
+	$request_provider_output = AgentsAPI\AI\Channels\WP_Agent_Default_Chat_Handler::execute(
+		array(
+			'agent'    => 'bare-brain',
+			'message'  => 'hi',
+			'provider' => 'request-provider',
+			'model'    => 'request-model',
+		)
+	);
+	agents_api_smoke_assert_equals( false, $request_provider_output instanceof WP_Error, 'request-supplied provider/model drive an agent without configured defaults', $failures, $passes );
+	agents_api_smoke_assert_equals( 'request-provider', $GLOBALS['__adapter_smoke']['provider'] ?? '', 'request provider overrides/supplies the dispatch provider', $failures, $passes );
+
+	echo "\n[3] Error contracts: empty message, unknown agent, missing provider:\n";
+	$empty = AgentsAPI\AI\Channels\WP_Agent_Default_Chat_Handler::execute( array( 'agent' => 'kitchen-brain', 'message' => '   ' ) );
+	agents_api_smoke_assert_equals( 'agents_chat_empty_message', $empty instanceof WP_Error ? $empty->get_error_code() : '', 'empty message is rejected', $failures, $passes );
+
+	$missing_agent = AgentsAPI\AI\Channels\WP_Agent_Default_Chat_Handler::execute( array( 'agent' => 'ghost-brain', 'message' => 'hi' ) );
+	agents_api_smoke_assert_equals( 'agents_chat_agent_not_found', $missing_agent instanceof WP_Error ? $missing_agent->get_error_code() : '', 'unknown agent is rejected', $failures, $passes );
+
+	$registry->register( 'no-model-brain', array( 'label' => 'No Model', 'default_config' => array( 'provider' => 'fake-provider' ) ) );
+	$no_model = AgentsAPI\AI\Channels\WP_Agent_Default_Chat_Handler::execute( array( 'agent' => 'no-model-brain', 'message' => 'hi' ) );
+	agents_api_smoke_assert_equals( 'agents_chat_model_required', $no_model instanceof WP_Error ? $no_model->get_error_code() : '', 'missing model is rejected', $failures, $passes );
+
+	echo "\n[4] The default handler is a fallback: an explicit consumer runtime wins:\n";
+	// A consumer registers at the default priority (10); the default sits at 1000.
+	register_chat_handler(
+		static function ( array $input ): array {
+			unset( $input );
+			return array( 'session_id' => 'consumer-session', 'reply' => 'consumer reply', 'completed' => true );
+		},
+		10
+	);
+	$reset_provider();
+	$GLOBALS['__chat_handler_ability_calls'] = array();
+	$dispatched = agents_chat_dispatch( array( 'agent' => 'kitchen-brain', 'message' => 'who answers?' ) );
+	agents_api_smoke_assert_equals( 'consumer reply', $dispatched['reply'] ?? null, 'an explicit consumer handler overrides the default fallback', $failures, $passes );
+	agents_api_smoke_assert_equals( 0, count( $GLOBALS['__chat_handler_ability_calls'] ), 'the default loop did not run when a consumer handler is present', $failures, $passes );
+
+	echo "\n[5] With no consumer registered, dispatch resolves to the default native handler:\n";
+	if ( function_exists( 'remove_all_filters' ) ) {
+		remove_all_filters( 'wp_agent_chat_handler' );
+	} else {
+		unset( $GLOBALS['__agents_api_smoke_actions']['wp_agent_chat_handler'] );
+	}
+	// Re-register only the default (module load already did, but filters were just cleared).
+	AgentsAPI\AI\Channels\WP_Agent_Default_Chat_Handler::register();
+	$reset_provider();
+	$GLOBALS['__chat_handler_ability_calls'] = array();
+	$dispatched_default = agents_chat_dispatch( array( 'agent' => 'kitchen-brain', 'message' => 'native please' ) );
+	agents_api_smoke_assert_equals( false, $dispatched_default instanceof WP_Error, 'dispatch resolves to the default native handler with no consumer present', $failures, $passes );
+	agents_api_smoke_assert_equals( 'All set, chef.', $dispatched_default['reply'] ?? null, 'the default native handler answers through agents/chat dispatch', $failures, $passes );
+	agents_api_smoke_assert_equals( 1, count( $GLOBALS['__chat_handler_ability_calls'] ), 'the default native loop mediated the tool call via dispatch', $failures, $passes );
+
+	agents_api_smoke_finish( 'Agents API default agents/chat handler', $failures, $passes );
+}


### PR DESCRIPTION
## Summary

Agents API registered the canonical `agents/chat` dispatcher (`src/Channels/register-agents-chat-ability.php`) but shipped **no runtime behind it** — `agents_chat_dispatch` only delegates to the `wp_agent_chat_handler` filter, so a vanilla install returned *"No agents/chat handler is registered."* unless a downstream consumer filled the seam.

This PR makes Agents API self-sufficient by registering a **default, provider-agnostic chat runtime** that runs a real agent loop natively. Every consumer (wp-codebox, studio-native, etc.) now gets a working `agents/chat` for free. No consumers are migrated here — that is a separate later step.

## What it does

New default driver `WP_Agent_Default_Chat_Handler` (`src/Channels/register-default-agents-chat-handler.php`):

1. Resolves the agent from Agents API's own runtime-bundle registry (`WP_Agents_Registry`).
2. Resolves provider / model / system-prompt / tools from the chat input and the registered agent's `default_config`.
3. Dispatches provider-agnostically through `WP_Agent_Conversation_Loop::run_conversation()`, which builds the existing `WP_Agent_Default_Provider_Turn_Adapter` (the wp-ai-client builder keyed **only** by the requested provider + model — no provider hardcoding).
4. Mediates tool calls through Agents API's own `WP_Agent_Ability_Tool_Executor` and the per-target executor registry from #377.
5. Returns the canonical `agents/chat` output shape (`session_id`, `reply`, `messages`, `completed`, `metadata`).

It registers as a **fallback** (filter priority 1000), so any explicit consumer runtime registered at the default priority (10) still wins — a consumer-backed install is unchanged.

### Provider-agnostic
Dispatch flows entirely through the generic wp-ai-client builder via `run_conversation()`; the only provider/model inputs come from the request/agent config. There is no OpenAI-specific path, no `connectors_ai_*`, no hardcoded provider id (grep-clean).

### Agents-API-native (zero DM coupling)
No `DataMachine\*`, `datamachine_*`, or `dm_*`. The agent is resolved from `WP_Agents_Registry`, tools run through `WP_Agent_Ability_Tool_Executor`. The generic kernel of DM's `ChatOrchestrator` (resolve agent → build turn adapter → run loop → canonical output) was ported; DM-only machinery (session-DB transcript persistence, `AgentIdentityResolver`, `ToolPolicyResolver`, `PluginSettings`) was dropped. Transcript continuity uses Agents API's own opt-in conversation store (`WP_Agent_Conversation_Sessions`) when present, and degrades to a stateless turn with a synthesized `session_id` otherwise.

## Tests

New real smoke `tests/default-agents-chat-handler-smoke.php` drives a **two-turn native loop** (turn 1 emits a tool call, the loop mediates it through a stubbed ability, turn 2 returns the final assistant message) through the handler with a deterministic fake wp-ai-client provider. It asserts the loop executes, the tool mediates, the canonical output returns, dispatch is keyed by the requested provider/model, and that an explicit consumer handler overrides the default while the default answers when alone (via `agents_chat_dispatch`).

`tests/agents-chat-ability-smoke.php` is updated so its dispatcher "no handler" branch first clears the filter — that branch is now only reachable when the new default fallback is explicitly removed.

```
$ php tests/default-agents-chat-handler-smoke.php
...
All 23 Agents API default agents/chat handler assertions passed.
```

Full suite: all 94 smoke scripts pass; `composer phpstan` reports no errors.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code with Opus 4.8
- **Used for:** Drafting the default chat handler + provider-agnostic turn adapter wiring and the smoke test.
