### PR TITLE
Add deterministic tool-call gating to the conversation loop

### DIFF
--- a/agents-api.php
+++ b/agents-api.php
@@ -149,6 +149,7 @@ require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-transcript-persister.
 require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-null-transcript-persister.php';
 require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-conversation-compaction.php';
 require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-tool-pair-validator.php';
+require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-tool-call-gate.php';
 require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-markdown-section-compaction-adapter.php';
 require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-iteration-budget.php';
 require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-spin-signature.php';

--- a/composer.json
+++ b/composer.json
@@ -83,6 +83,7 @@
       "php tests/ability-tool-executor-smoke.php",
       "php tests/tool-mediation-runner-smoke.php",
       "php tests/conversation-loop-tool-execution-smoke.php",
+      "php tests/tool-call-gate-smoke.php",
       "php tests/conversation-loop-completion-policy-smoke.php",
       "php tests/conversation-loop-transcript-persister-smoke.php",
       "php tests/conversation-loop-events-smoke.php",

--- a/src/Channels/register-default-agents-chat-handler.php
+++ b/src/Channels/register-default-agents-chat-handler.php
@@ -128,6 +128,7 @@ class WP_Agent_Default_Chat_Handler {
 		$system_prompt     = self::resolve_system_prompt( $config );
 		$tool_declarations = self::resolve_tool_declarations( $config );
 		$max_turns         = self::resolve_max_turns( $input, $config );
+		$tool_call_rules   = self::resolve_tool_call_rules( $config );
 
 		$store      = WP_Agent_Conversation_Sessions::get_store( $input );
 		$session_id = is_string( $input['session_id'] ?? null ) ? trim( $input['session_id'] ) : '';
@@ -166,6 +167,13 @@ class WP_Agent_Default_Chat_Handler {
 			// (`agents_api_tool_executors`) for declarations that select another
 			// execution environment, so consumers can override per tool target.
 			$loop_options['tool_executor'] = new WP_Agent_Ability_Tool_Executor();
+		}
+		if ( ! empty( $tool_call_rules ) ) {
+			// Declarative deterministic tool-call gating. The loop enforces these
+			// rules natively ({@see WP_Agent_Tool_Call_Gate}) — bounded discovery
+			// before a required commit, and a completion block until the commit
+			// tool runs — so the guarantee is the runtime's, not a prompt's.
+			$loop_options['tool_call_rules'] = $tool_call_rules;
 		}
 
 		$result = WP_Agent_Conversation_Loop::run_conversation(
@@ -304,6 +312,33 @@ class WP_Agent_Default_Chat_Handler {
 		}
 
 		return $declarations;
+	}
+
+	/**
+	 * Resolve declarative deterministic tool-call rules from the agent config.
+	 *
+	 * The agent's bundle declares `tool_call_rules` (bounded discovery + required
+	 * commit) and the loop enforces them natively. The handler only forwards the
+	 * declared list of rule arrays; {@see WP_Agent_Tool_Call_Gate} normalizes and
+	 * enforces them deterministically.
+	 *
+	 * @param array<string,mixed> $config Agent default config.
+	 * @return list<array<mixed>> Declared rule arrays.
+	 */
+	private static function resolve_tool_call_rules( array $config ): array {
+		$raw = $config['tool_call_rules'] ?? null;
+		if ( ! is_array( $raw ) ) {
+			return array();
+		}
+
+		$rules = array();
+		foreach ( $raw as $rule ) {
+			if ( is_array( $rule ) ) {
+				$rules[] = $rule;
+			}
+		}
+
+		return $rules;
 	}
 
 	/**

--- a/src/Runtime/class-wp-agent-conversation-loop.php
+++ b/src/Runtime/class-wp-agent-conversation-loop.php
@@ -107,7 +107,8 @@ class WP_Agent_Conversation_Loop {
 		$spin_detector         = self::resolve_spin_detector( $options );
 		$failure_tracker       = self::resolve_identical_failure_tracker( $options );
 		$result_truncator      = self::resolve_tool_result_truncator( $options );
-		$pre_tool_mediator     = self::resolve_pre_tool_mediator( $options );
+		$tool_call_gate        = self::resolve_tool_call_gate( $options );
+		$pre_tool_mediator     = self::compose_tool_call_gate_mediator( $tool_call_gate, self::resolve_pre_tool_mediator( $options ) );
 		$post_tool_diagnostics = self::resolve_post_tool_result_diagnostics( $options );
 		$interrupt_source      = self::resolve_interrupt_source( $options );
 		$request               = self::resolve_request( $messages, $options );
@@ -178,6 +179,7 @@ class WP_Agent_Conversation_Loop {
 				}
 
 				$turns_run            = $turn;
+				$force_continue       = false;
 				$turn_context         = $context;
 				$turn_context['turn'] = $turn;
 				$interrupt            = self::check_runtime_cancellation( $run_id, $lock_session_id, $turn_context, $on_event );
@@ -351,6 +353,40 @@ class WP_Agent_Conversation_Loop {
 						$interrupted = $interrupt['metadata'];
 						break;
 					}
+
+					// Deterministic completion gate. When the model stops calling
+					// tools (natural completion) but a configured tool-call rule
+					// still requires a commit tool, the loop refuses to finish and
+					// re-prompts with a runtime-owned, model-visible reason. The
+					// enforcement is the loop's -- the model cannot opt out of it.
+					if (
+						null !== $tool_call_gate
+						&& $conversation_complete
+						&& empty( $result['tool_calls'] )
+						&& null === $exceeded_budget
+						&& null === $stalled
+						&& null === $approval_required
+						&& null === $runtime_tool_pending
+					) {
+						$completion_gate = $tool_call_gate->evaluate_completion( $messages );
+						if ( ! $completion_gate['allowed'] ) {
+							$conversation_complete = false;
+							$force_continue        = true;
+							$messages[]            = WP_Agent_Message::text(
+								'user',
+								$completion_gate['reason'],
+								array(
+									'type'           => WP_Agent_Tool_Call_Gate::EVENT_COMPLETION_BLOCKED,
+									'tool_call_gate' => $completion_gate['context'],
+								)
+							);
+							$events[] = array(
+								'type'     => WP_Agent_Tool_Call_Gate::EVENT_COMPLETION_BLOCKED,
+								'metadata' => $completion_gate['context'],
+							);
+							self::emit_event( $on_event, WP_Agent_Tool_Call_Gate::EVENT_COMPLETION_BLOCKED, $completion_gate['context'] );
+						}
+					}
 				} else {
 					// Caller-managed path: turn runner handles everything internally.
 					$result       = self::normalize_conversation_result( $result );
@@ -434,7 +470,10 @@ class WP_Agent_Conversation_Loop {
 					break;
 				}
 
-				if ( ! is_callable( $should_continue ) || ! call_user_func( $should_continue, $result, $turn_context ) ) {
+				// A blocked completion gate forces another turn so the model can
+				// satisfy the required commit tool, overriding the natural-completion
+				// stop signal the turn runner would otherwise trigger.
+				if ( ! $force_continue && ( ! is_callable( $should_continue ) || ! call_user_func( $should_continue, $result, $turn_context ) ) ) {
 					break;
 				}
 			}
@@ -2260,6 +2299,61 @@ class WP_Agent_Conversation_Loop {
 	private static function resolve_pre_tool_mediator( array $options ): ?callable {
 		$mediator = $options['pre_tool_mediator'] ?? null;
 		return is_callable( $mediator ) ? $mediator : null;
+	}
+
+	/**
+	 * Resolve the deterministic tool-call gate from declarative loop options.
+	 *
+	 * @param array<string, mixed> $options Loop options.
+	 * @return WP_Agent_Tool_Call_Gate|null
+	 */
+	private static function resolve_tool_call_gate( array $options ): ?WP_Agent_Tool_Call_Gate {
+		return WP_Agent_Tool_Call_Gate::from_config( $options['tool_call_rules'] ?? null );
+	}
+
+	/**
+	 * Compose a pre-tool mediator that enforces the tool-call gate before any
+	 * caller-supplied mediator runs.
+	 *
+	 * The gate runs first so a configured rule deterministically rejects a
+	 * disallowed call regardless of what a downstream mediator would decide. When
+	 * the gate allows the call, control passes to the inner mediator (or the
+	 * default proceed) so existing mediation behavior is preserved untouched.
+	 *
+	 * @param WP_Agent_Tool_Call_Gate|null $gate  Resolved gate, or null when none configured.
+	 * @param callable|null                $inner Caller-supplied pre-tool mediator.
+	 * @return callable|null
+	 */
+	private static function compose_tool_call_gate_mediator( ?WP_Agent_Tool_Call_Gate $gate, ?callable $inner ): ?callable {
+		if ( null === $gate ) {
+			return $inner;
+		}
+
+		return static function ( array $context ) use ( $gate, $inner ) {
+			$tool_name = is_string( $context['tool_name'] ?? null ) ? $context['tool_name'] : '';
+			if ( '' !== $tool_name ) {
+				$messages     = is_array( $context['messages'] ?? null ) ? $context['messages'] : array();
+				$tool_call_id = is_string( $context['tool_call_id'] ?? null ) ? $context['tool_call_id'] : '';
+				$prior        = WP_Agent_Tool_Call_Gate::messages_before_tool_call( $messages, $tool_call_id );
+				$evaluation   = $gate->evaluate_call( $tool_name, $prior );
+				if ( ! $evaluation['allowed'] ) {
+					return array(
+						'action'   => 'reject',
+						'error'    => $evaluation['reason'],
+						'metadata' => array(
+							'error_type'     => WP_Agent_Tool_Call_Gate::ERROR_TYPE_CALL_REJECTED,
+							'tool_call_gate' => $evaluation['context'],
+						),
+					);
+				}
+			}
+
+			if ( null !== $inner ) {
+				return call_user_func( $inner, $context );
+			}
+
+			return array( 'action' => 'proceed' );
+		};
 	}
 
 	/**

--- a/src/Runtime/class-wp-agent-tool-call-gate.php
+++ b/src/Runtime/class-wp-agent-tool-call-gate.php
@@ -1,0 +1,451 @@
+<?php
+/**
+ * Deterministic declarative tool-call gate.
+ *
+ * @package AgentsAPI
+ */
+
+namespace AgentsAPI\AI;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Enforces bounded tool-sequencing rules during an agent conversation run.
+ *
+ * The gate is a pure, deterministic primitive: given a proposed tool call (or a
+ * pending completion) and the current transcript, it decides whether the loop
+ * may proceed. Enforcement lives in the runtime ({@see WP_Agent_Conversation_Loop}),
+ * not in a system prompt — a model cannot opt out of a configured rule.
+ *
+ * Each rule expresses one bounded-discovery contract:
+ *
+ *   "After `after_tool` is called, at most `max_calls` of `limited_tools` may run
+ *    before the agent must call one of `require_one_of`; and the run may not
+ *    finish until one of `require_one_of` has been called."
+ *
+ * Rule shape (declarative, provider-agnostic):
+ *
+ *   array(
+ *     'id'              => 'bounded-discovery',         // optional, sanitized
+ *     'after_tool'      => 'workspace_show',            // anchor that activates the rule
+ *     'limited_tools'   => array( 'workspace_read', … ), // rate-limited after the anchor
+ *     'max_calls'       => 12,                          // budget for limited_tools
+ *     'require_one_of'  => array( 'workspace_write', … ), // tools that satisfy/reset the rule
+ *     'gate_calls'      => true,                        // enforce per-call limit (default true)
+ *     'gate_completion' => true,                        // block completion until satisfied (default true)
+ *   )
+ *
+ * Field aliases accepted for portability with prior bundle shapes:
+ *   `then_require_one_of` => `require_one_of`, `limited_tool_names` => `limited_tools`.
+ */
+class WP_Agent_Tool_Call_Gate {
+
+	public const EVENT_CALL_REJECTED      = 'tool_call_gate_rejected';
+	public const EVENT_COMPLETION_BLOCKED = 'tool_call_gate_completion_blocked';
+
+	public const ERROR_TYPE_CALL_REJECTED      = 'tool_call_gate_rejected';
+	public const ERROR_TYPE_COMPLETION_BLOCKED = 'tool_call_gate_completion_blocked';
+
+	/** @var array<int,array{id:string,after_tool:string,limited_tools:list<string>,max_calls:int,require_one_of:list<string>,gate_calls:bool,gate_completion:bool}> Normalized rules. */
+	private array $rules;
+
+	/**
+	 * @param array<mixed> $rules Raw rule configuration.
+	 */
+	public function __construct( array $rules = array() ) {
+		$this->rules = self::normalize_rules( $rules );
+	}
+
+	/**
+	 * Build a gate from a loop options/config array, or null when no rules apply.
+	 *
+	 * @param mixed $rules Raw `tool_call_rules` value.
+	 * @return self|null
+	 */
+	public static function from_config( $rules ): ?self {
+		if ( ! is_array( $rules ) ) {
+			return null;
+		}
+
+		$gate = new self( $rules );
+
+		return $gate->has_rules() ? $gate : null;
+	}
+
+	/**
+	 * Whether any active rules are configured.
+	 *
+	 * @return bool
+	 */
+	public function has_rules(): bool {
+		return ! empty( $this->rules );
+	}
+
+	/**
+	 * Decide whether a proposed tool call may proceed against per-call rules.
+	 *
+	 * `$prior_messages` must contain the transcript BEFORE the proposed call (the
+	 * current tool-call message excluded) so the proposed tool is not counted
+	 * against its own limit.
+	 *
+	 * @param string            $tool_name      Proposed tool name.
+	 * @param array<int,mixed>  $prior_messages Transcript before the proposed call.
+	 * @return array{allowed:bool,reason:string,context:array<string,mixed>}
+	 */
+	public function evaluate_call( string $tool_name, array $prior_messages ): array {
+		foreach ( $this->rules as $rule ) {
+			if ( empty( $rule['gate_calls'] ) ) {
+				continue;
+			}
+
+			$after_index = self::last_tool_call_index( $prior_messages, $rule['after_tool'] );
+			if ( $after_index < 0 ) {
+				continue;
+			}
+
+			if ( in_array( $tool_name, $rule['require_one_of'], true ) ) {
+				continue;
+			}
+
+			if ( self::has_tool_call_after( $prior_messages, $after_index, $rule['require_one_of'] ) ) {
+				continue;
+			}
+
+			$limited_count = self::count_tool_calls_after( $prior_messages, $after_index, $rule['limited_tools'] );
+			if ( $limited_count < $rule['max_calls'] ) {
+				continue;
+			}
+
+			$required = implode( ', ', $rule['require_one_of'] );
+			$reason   = sprintf(
+				'TOOL CALL BLOCKED: after %1$s you have already used %2$d of %3$d permitted discovery tools. Do not inspect further. Your next tool call must be one of: %4$s.',
+				$rule['after_tool'],
+				$limited_count,
+				$rule['max_calls'],
+				$required
+			);
+
+			return array(
+				'allowed' => false,
+				'reason'  => $reason,
+				'context' => array(
+					'rule_id'        => $rule['id'],
+					'after_tool'     => $rule['after_tool'],
+					'limited_tools'  => $rule['limited_tools'],
+					'limited_count'  => $limited_count,
+					'max_calls'      => $rule['max_calls'],
+					'require_one_of' => $rule['require_one_of'],
+					'rejected_tool'  => $tool_name,
+				),
+			);
+		}
+
+		return array(
+			'allowed' => true,
+			'reason'  => '',
+			'context' => array(),
+		);
+	}
+
+	/**
+	 * Decide whether the run may complete against completion rules.
+	 *
+	 * A completion rule blocks the run from finishing once its `after_tool` anchor
+	 * has been reached but none of its `require_one_of` tools has been called — the
+	 * restored "bounded discovery, then commit" guarantee.
+	 *
+	 * @param array<int,mixed> $messages Current transcript.
+	 * @return array{allowed:bool,reason:string,context:array<string,mixed>}
+	 */
+	public function evaluate_completion( array $messages ): array {
+		foreach ( $this->rules as $rule ) {
+			if ( empty( $rule['gate_completion'] ) ) {
+				continue;
+			}
+
+			$anchor_index = self::first_tool_call_index( $messages, $rule['after_tool'] );
+			if ( $anchor_index < 0 ) {
+				continue;
+			}
+
+			if ( self::has_tool_call_after( $messages, $anchor_index - 1, $rule['require_one_of'] ) ) {
+				continue;
+			}
+
+			$required = implode( ', ', $rule['require_one_of'] );
+			$reason   = sprintf(
+				'COMPLETION BLOCKED: you began discovery with %1$s but have not yet committed your work. Call one of these tools before finishing: %2$s.',
+				$rule['after_tool'],
+				$required
+			);
+
+			return array(
+				'allowed' => false,
+				'reason'  => $reason,
+				'context' => array(
+					'rule_id'        => $rule['id'],
+					'after_tool'     => $rule['after_tool'],
+					'require_one_of' => $rule['require_one_of'],
+				),
+			);
+		}
+
+		return array(
+			'allowed' => true,
+			'reason'  => '',
+			'context' => array(),
+		);
+	}
+
+	/**
+	 * Return the subset of messages that precede the given tool-call id.
+	 *
+	 * Used to exclude the in-flight proposed tool-call message from per-call
+	 * counts so a tool is never gated against itself.
+	 *
+	 * @param array<mixed> $messages     Transcript messages.
+	 * @param string       $tool_call_id Current tool-call id.
+	 * @return array<int,mixed>
+	 */
+	public static function messages_before_tool_call( array $messages, string $tool_call_id ): array {
+		if ( '' === $tool_call_id ) {
+			return array_values( $messages );
+		}
+
+		$prior = array();
+		foreach ( array_values( $messages ) as $message ) {
+			if ( ! is_array( $message ) ) {
+				$prior[] = $message;
+				continue;
+			}
+			$envelope = WP_Agent_Message::normalize( $message );
+			if ( WP_Agent_Message::TYPE_TOOL_CALL === $envelope['type'] ) {
+				$metadata     = $envelope['metadata'];
+				$message_call = is_array( $metadata ) ? ( $metadata['tool_call_id'] ?? '' ) : '';
+				if ( $message_call === $tool_call_id ) {
+					break;
+				}
+			}
+			$prior[] = $message;
+		}
+
+		return $prior;
+	}
+
+	/**
+	 * Normalize raw rules to a deterministic internal shape.
+	 *
+	 * @param array<mixed> $rules Raw rules.
+	 * @return array<int,array{id:string,after_tool:string,limited_tools:list<string>,max_calls:int,require_one_of:list<string>,gate_calls:bool,gate_completion:bool}>
+	 */
+	private static function normalize_rules( array $rules ): array {
+		$normalized = array();
+		foreach ( $rules as $index => $rule ) {
+			if ( ! is_array( $rule ) ) {
+				continue;
+			}
+
+			$max_raw        = $rule['max_calls'] ?? 0;
+			$after_tool     = self::sanitize_tool_name( $rule['after_tool'] ?? '' );
+			$limited_tools  = self::sanitize_tool_list( $rule['limited_tools'] ?? ( $rule['limited_tool_names'] ?? array() ) );
+			$require_one_of = self::sanitize_tool_list( $rule['require_one_of'] ?? ( $rule['then_require_one_of'] ?? array() ) );
+			$max_calls      = max( 0, is_numeric( $max_raw ) ? (int) $max_raw : 0 );
+			$gate_calls     = self::bool_flag( $rule['gate_calls'] ?? true );
+			$gate_complete  = self::bool_flag( $rule['gate_completion'] ?? true );
+
+			// A rule must declare an anchor and at least one required commit tool.
+			if ( '' === $after_tool || empty( $require_one_of ) ) {
+				continue;
+			}
+
+			// Per-call gating needs a bounded limited-tool budget; without one,
+			// only completion gating remains meaningful.
+			$can_gate_calls = $gate_calls && ! empty( $limited_tools ) && $max_calls > 0;
+			if ( ! $can_gate_calls && ! $gate_complete ) {
+				continue;
+			}
+
+			$normalized[] = array(
+				'id'              => self::sanitize_rule_id( $rule['id'] ?? ( 'tool-call-rule-' . $index ) ),
+				'after_tool'      => $after_tool,
+				'limited_tools'   => $limited_tools,
+				'max_calls'       => $max_calls,
+				'require_one_of'  => $require_one_of,
+				'gate_calls'      => $can_gate_calls,
+				'gate_completion' => $gate_complete,
+			);
+		}
+
+		return $normalized;
+	}
+
+	/**
+	 * Index of the last tool-call message for a given tool name.
+	 *
+	 * @param array<int,mixed> $messages  Transcript messages.
+	 * @param string           $tool_name Tool name.
+	 * @return int -1 when not found.
+	 */
+	private static function last_tool_call_index( array $messages, string $tool_name ): int {
+		$messages = array_values( $messages );
+		for ( $i = count( $messages ) - 1; $i >= 0; $i-- ) {
+			if ( self::tool_call_name( $messages[ $i ] ) === $tool_name ) {
+				return $i;
+			}
+		}
+
+		return -1;
+	}
+
+	/**
+	 * Index of the first tool-call message for a given tool name.
+	 *
+	 * @param array<int,mixed> $messages  Transcript messages.
+	 * @param string           $tool_name Tool name.
+	 * @return int -1 when not found.
+	 */
+	private static function first_tool_call_index( array $messages, string $tool_name ): int {
+		$messages = array_values( $messages );
+		$count    = count( $messages );
+		for ( $i = 0; $i < $count; $i++ ) {
+			if ( self::tool_call_name( $messages[ $i ] ) === $tool_name ) {
+				return $i;
+			}
+		}
+
+		return -1;
+	}
+
+	/**
+	 * Count tool-call messages for any of the given names after an index.
+	 *
+	 * @param array<int,mixed>  $messages    Transcript messages.
+	 * @param int               $after_index Exclusive lower bound.
+	 * @param array<int,string> $tool_names  Tool names to count.
+	 * @return int
+	 */
+	private static function count_tool_calls_after( array $messages, int $after_index, array $tool_names ): int {
+		$messages = array_values( $messages );
+		$count    = 0;
+		$total    = count( $messages );
+		for ( $i = $after_index + 1; $i < $total; $i++ ) {
+			$name = self::tool_call_name( $messages[ $i ] );
+			if ( '' !== $name && in_array( $name, $tool_names, true ) ) {
+				++$count;
+			}
+		}
+
+		return $count;
+	}
+
+	/**
+	 * Whether any of the given tool names was called after an index.
+	 *
+	 * @param array<int,mixed>  $messages    Transcript messages.
+	 * @param int               $after_index Exclusive lower bound.
+	 * @param array<int,string> $tool_names  Tool names to look for.
+	 * @return bool
+	 */
+	private static function has_tool_call_after( array $messages, int $after_index, array $tool_names ): bool {
+		$messages = array_values( $messages );
+		$total    = count( $messages );
+		for ( $i = $after_index + 1; $i < $total; $i++ ) {
+			$name = self::tool_call_name( $messages[ $i ] );
+			if ( '' !== $name && in_array( $name, $tool_names, true ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Read the tool name from a tool-call message, or '' when it is not one.
+	 *
+	 * @param mixed $message Transcript message.
+	 * @return string
+	 */
+	private static function tool_call_name( $message ): string {
+		if ( ! is_array( $message ) ) {
+			return '';
+		}
+
+		$envelope = WP_Agent_Message::normalize( $message );
+		if ( WP_Agent_Message::TYPE_TOOL_CALL !== $envelope['type'] ) {
+			return '';
+		}
+
+		$payload = is_array( $envelope['payload'] ?? null ) ? $envelope['payload'] : array();
+		$name    = $payload['tool_name'] ?? '';
+
+		return is_string( $name ) ? $name : '';
+	}
+
+	/**
+	 * Coerce a flag value to bool, treating absence as the provided default.
+	 *
+	 * @param mixed $value Raw flag value.
+	 * @return bool
+	 */
+	private static function bool_flag( $value ): bool {
+		if ( is_bool( $value ) ) {
+			return $value;
+		}
+		if ( is_string( $value ) ) {
+			return ! in_array( strtolower( trim( $value ) ), array( '', '0', 'false', 'no', 'off' ), true );
+		}
+
+		return (bool) $value;
+	}
+
+	/**
+	 * Sanitize a rule id to a stable slug.
+	 *
+	 * @param mixed $value Raw id.
+	 * @return string
+	 */
+	private static function sanitize_rule_id( $value ): string {
+		$raw = is_scalar( $value ) ? (string) $value : '';
+		$id  = preg_replace( '/[^a-zA-Z0-9_\-]/', '-', $raw );
+		$id = is_string( $id ) ? trim( $id, '-' ) : '';
+
+		return '' !== $id ? $id : 'tool-call-rule';
+	}
+
+	/**
+	 * Sanitize a single tool name.
+	 *
+	 * @param mixed $value Raw tool name.
+	 * @return string
+	 */
+	private static function sanitize_tool_name( $value ): string {
+		return is_string( $value ) ? trim( $value ) : '';
+	}
+
+	/**
+	 * Sanitize a list of tool names, dropping blanks and duplicates.
+	 *
+	 * @param mixed $value Raw list (string or array).
+	 * @return list<string>
+	 */
+	private static function sanitize_tool_list( $value ): array {
+		if ( is_string( $value ) && '' !== $value ) {
+			$value = array( $value );
+		}
+		if ( ! is_array( $value ) ) {
+			return array();
+		}
+
+		$tools = array();
+		foreach ( $value as $tool ) {
+			$tool = self::sanitize_tool_name( $tool );
+			if ( '' !== $tool ) {
+				$tools[] = $tool;
+			}
+		}
+
+		return array_values( array_unique( $tools ) );
+	}
+}

--- a/tests/tool-call-gate-smoke.php
+++ b/tests/tool-call-gate-smoke.php
@@ -1,0 +1,238 @@
+<?php
+/**
+ * Pure-PHP smoke test for the deterministic tool-call gate.
+ *
+ * Proves the gate primitive ({@see WP_Agent_Tool_Call_Gate}) and that the
+ * conversation loop ENFORCES it from the runtime: a turn runner that deliberately
+ * violates a rule (inspect past the budget, or try to finish without committing)
+ * is blocked by the loop regardless of what the model "wants".
+ *
+ * Run with: php tests/tool-call-gate-smoke.php
+ *
+ * @package AgentsAPI\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+$failures = array();
+$passes   = 0;
+
+echo "agents-api-tool-call-gate-smoke\n";
+
+require_once __DIR__ . '/agents-api-smoke-helpers.php';
+agents_api_smoke_require_module();
+
+use AgentsAPI\AI\WP_Agent_Conversation_Loop;
+use AgentsAPI\AI\WP_Agent_Message;
+use AgentsAPI\AI\WP_Agent_Tool_Call_Gate;
+
+/**
+ * Build a tool-call message for a hand-assembled transcript.
+ *
+ * @param string $tool_name Tool name.
+ * @param int    $turn      Turn number.
+ * @return array<string,mixed>
+ */
+function tool_call_gate_smoke_call( string $tool_name, int $turn = 1 ): array {
+	static $sequence = 0;
+	++$sequence;
+
+	return WP_Agent_Message::toolCall( '', $tool_name, array(), $turn, array( 'tool_call_id' => $tool_name . '-' . $sequence ) );
+}
+
+// The faithful docs-agent bootstrap rule, restored as a native primitive:
+// after `anchor`, at most 2 of the `read` discovery tools, then a `write`
+// commit is required — both per-call and for completion.
+$rules = array(
+	array(
+		'id'             => 'bounded-discovery',
+		'after_tool'     => 'anchor',
+		'limited_tools'  => array( 'read', 'grep' ),
+		'max_calls'      => 2,
+		'require_one_of' => array( 'write' ),
+	),
+);
+
+echo "\n[1] Gate primitive decides per-call deterministically:\n";
+$gate = WP_Agent_Tool_Call_Gate::from_config( $rules );
+agents_api_smoke_assert_equals( true, $gate instanceof WP_Agent_Tool_Call_Gate, 'gate builds from declarative rules', $failures, $passes );
+
+// Before the anchor is called, nothing is limited.
+$pre_anchor = array( WP_Agent_Message::text( 'user', 'go' ) );
+agents_api_smoke_assert_equals( true, $gate->evaluate_call( 'read', $pre_anchor )['allowed'], 'reads are unrestricted before the anchor fires', $failures, $passes );
+
+// After the anchor + 2 reads, a 3rd read is blocked but a write is allowed.
+$after_two_reads = array(
+	WP_Agent_Message::text( 'user', 'go' ),
+	tool_call_gate_smoke_call( 'anchor' ),
+	tool_call_gate_smoke_call( 'read' ),
+	tool_call_gate_smoke_call( 'read' ),
+);
+$third_read = $gate->evaluate_call( 'read', $after_two_reads );
+agents_api_smoke_assert_equals( false, $third_read['allowed'], 'third discovery call past the budget is rejected', $failures, $passes );
+agents_api_smoke_assert_equals( 'bounded-discovery', $third_read['context']['rule_id'] ?? '', 'rejection names the violated rule', $failures, $passes );
+agents_api_smoke_assert_equals( 2, $third_read['context']['limited_count'] ?? 0, 'rejection reports the discovery count at the limit', $failures, $passes );
+agents_api_smoke_assert_equals( true, $gate->evaluate_call( 'write', $after_two_reads )['allowed'], 'the required commit tool is always allowed', $failures, $passes );
+
+// Once a write has happened after the anchor, the limit resets.
+$after_write = array_merge( $after_two_reads, array( tool_call_gate_smoke_call( 'write' ) ) );
+agents_api_smoke_assert_equals( true, $gate->evaluate_call( 'read', $after_write )['allowed'], 'discovery is permitted again after a commit', $failures, $passes );
+
+echo "\n[2] Gate primitive blocks completion until a commit happens:\n";
+agents_api_smoke_assert_equals( true, $gate->evaluate_completion( $pre_anchor )['allowed'], 'completion is allowed when discovery never began', $failures, $passes );
+$completion_blocked = $gate->evaluate_completion( $after_two_reads );
+agents_api_smoke_assert_equals( false, $completion_blocked['allowed'], 'completion is blocked after discovery with no commit', $failures, $passes );
+agents_api_smoke_assert_equals( 'bounded-discovery', $completion_blocked['context']['rule_id'] ?? '', 'completion block names the violated rule', $failures, $passes );
+agents_api_smoke_assert_equals( true, $gate->evaluate_completion( $after_write )['allowed'], 'completion is allowed once the commit tool ran', $failures, $passes );
+
+// ---------------------------------------------------------------------------
+// Loop enforcement: a tool executor that records every call it is asked to run.
+// ---------------------------------------------------------------------------
+$executor = new class() implements AgentsAPI\AI\Tools\WP_Agent_Tool_Executor {
+	/** @var array<int,string> Names of tools the loop actually executed. */
+	public array $executed = array();
+
+	public function executeWP_Agent_Tool_Call( array $tool_call, array $tool_definition, array $context = array() ): array {
+		$this->executed[] = (string) ( $tool_call['tool_name'] ?? '' );
+
+		return array(
+			'success'   => true,
+			'tool_name' => $tool_call['tool_name'],
+			'result'    => array( 'ok' => true ),
+		);
+	}
+};
+
+$tools = array();
+foreach ( array( 'anchor', 'read', 'grep', 'write' ) as $tool ) {
+	$tools[ $tool ] = array(
+		'name'        => $tool,
+		'source'      => 'client',
+		'description' => ucfirst( $tool ),
+		'parameters'  => array( 'type' => 'object', 'properties' => array() ),
+		'executor'    => 'client',
+		'scope'       => 'run',
+	);
+}
+
+echo "\n[3] Loop rejects an over-budget tool call the model insists on (within one turn):\n";
+$executor->executed = array();
+$over_budget_result = WP_Agent_Conversation_Loop::run(
+	array( array( 'role' => 'user', 'content' => 'bootstrap' ) ),
+	static function ( array $messages ): array {
+		// One turn that deliberately violates the rule: anchor, three reads
+		// (the third is over the budget of two), then a commit. The runtime —
+		// not the model — must refuse the third read.
+		return array(
+			'messages'   => $messages,
+			'tool_calls' => array(
+				array( 'id' => 'c-anchor', 'name' => 'anchor', 'parameters' => array() ),
+				array( 'id' => 'c-read-1', 'name' => 'read', 'parameters' => array() ),
+				array( 'id' => 'c-read-2', 'name' => 'read', 'parameters' => array() ),
+				array( 'id' => 'c-read-3', 'name' => 'read', 'parameters' => array() ),
+				array( 'id' => 'c-write-1', 'name' => 'write', 'parameters' => array() ),
+			),
+		);
+	},
+	array(
+		'max_turns'         => 1,
+		'tool_executor'     => $executor,
+		'tool_declarations' => $tools,
+		'tool_call_rules'   => $rules,
+	)
+);
+
+agents_api_smoke_assert_equals( array( 'anchor', 'read', 'read', 'write' ), $executor->executed, 'runtime executed anchor + 2 reads + commit, but never the over-budget read', $failures, $passes );
+
+// Locate the rejected read in the recorded results and prove the gate rejected it.
+$rejected = array();
+foreach ( $over_budget_result['tool_execution_results'] as $entry ) {
+	if ( 'read' === ( $entry['tool_name'] ?? '' ) && false === ( $entry['result']['success'] ?? true ) ) {
+		$rejected[] = $entry;
+	}
+}
+agents_api_smoke_assert_equals( 1, count( $rejected ), 'exactly one read was rejected by the runtime', $failures, $passes );
+agents_api_smoke_assert_equals( WP_Agent_Tool_Call_Gate::ERROR_TYPE_CALL_REJECTED, $rejected[0]['result']['metadata']['error_type'] ?? '', 'rejected read carries the gate error type', $failures, $passes );
+$rejected_audit = array_values( array_filter(
+	$over_budget_result['tool_audit_events'],
+	static fn( array $event ): bool => 'read' === ( $event['tool_name'] ?? '' ) && false === ( $event['success'] ?? true )
+) );
+agents_api_smoke_assert_equals( WP_Agent_Tool_Call_Gate::ERROR_TYPE_CALL_REJECTED, $rejected_audit[0]['error_type'] ?? '', 'audit trail records the deterministic gate rejection', $failures, $passes );
+
+echo "\n[4] Loop refuses to complete until the commit tool runs, no matter how often the model tries to finish:\n";
+$executor->executed   = array();
+$turns_seen           = array();
+$gate_events          = array();
+$completion_result = WP_Agent_Conversation_Loop::run(
+	array( array( 'role' => 'user', 'content' => 'bootstrap' ) ),
+	static function ( array $messages, array $context ) use ( &$turns_seen ): array {
+		$turn         = (int) ( $context['turn'] ?? 0 );
+		$turns_seen[] = $turn;
+
+		if ( 1 === $turn ) {
+			// Begin discovery, no commit yet.
+			return array(
+				'messages'   => $messages,
+				'tool_calls' => array(
+					array( 'id' => 't1-anchor', 'name' => 'anchor', 'parameters' => array() ),
+				),
+			);
+		}
+
+		if ( 2 === $turn || 3 === $turn ) {
+			// The model tries to finish (no tool calls) WITHOUT committing.
+			// The runtime must block this on every attempt.
+			return array(
+				'messages'   => $messages,
+				'content'    => 'All done.',
+				'tool_calls' => array(),
+			);
+		}
+
+		if ( 4 === $turn ) {
+			// Finally commit.
+			return array(
+				'messages'   => $messages,
+				'tool_calls' => array(
+					array( 'id' => 't4-write', 'name' => 'write', 'parameters' => array() ),
+				),
+			);
+		}
+
+		// Turn 5: now finishing is allowed.
+		return array(
+			'messages'   => $messages,
+			'content'    => 'Committed and done.',
+			'tool_calls' => array(),
+		);
+	},
+	array(
+		'max_turns'         => 8,
+		'tool_executor'     => $executor,
+		'tool_declarations' => $tools,
+		'tool_call_rules'   => $rules,
+		'on_event'          => static function ( string $event, array $payload ) use ( &$gate_events ): void {
+			if ( WP_Agent_Tool_Call_Gate::EVENT_COMPLETION_BLOCKED === $event ) {
+				$gate_events[] = $payload;
+			}
+		},
+	)
+);
+
+agents_api_smoke_assert_equals( array( 1, 2, 3, 4, 5 ), $turns_seen, 'loop kept re-prompting through the blocked finish attempts until the commit and one clean finish', $failures, $passes );
+agents_api_smoke_assert_equals( 2, count( $gate_events ), 'completion was deterministically blocked on both premature finish attempts', $failures, $passes );
+agents_api_smoke_assert_equals( true, in_array( 'write', $executor->executed, true ), 'the required commit tool ran before the loop was allowed to finish', $failures, $passes );
+agents_api_smoke_assert_equals( true, (bool) ( $completion_result['completed'] ?? false ), 'loop completes once the commit requirement is satisfied', $failures, $passes );
+agents_api_smoke_assert_equals( 'Committed and done.', $completion_result['final_content'] ?? '', 'final content is the post-commit answer, not the blocked one', $failures, $passes );
+
+// A model-visible reason was injected so the agent can self-correct.
+$injected = array_values( array_filter(
+	$completion_result['messages'],
+	static fn( array $m ): bool => WP_Agent_Tool_Call_Gate::EVENT_COMPLETION_BLOCKED === ( $m['metadata']['type'] ?? '' )
+) );
+agents_api_smoke_assert_equals( 2, count( $injected ), 'each block injects a model-visible correction message', $failures, $passes );
+agents_api_smoke_assert_equals( true, str_contains( (string) ( $injected[0]['content'] ?? '' ), 'COMPLETION BLOCKED' ), 'injected correction states the completion is blocked', $failures, $passes );
+
+agents_api_smoke_finish( 'Agents API tool-call gate', $failures, $passes );


### PR DESCRIPTION
## What

Adds `WP_Agent_Tool_Call_Gate`, a declarative, provider-agnostic run-control primitive that the conversation loop **enforces** — bounded discovery, then a required commit — so the guarantee lives in the runtime, not in a system prompt.

## Why

agents-api gained a native `agents/chat` runtime in #380. When docs-agent's bundle was converted from Data Machine format to agents-api-native (docs-agent #115, merged), its DM `tool_runtime_rules` had no native equivalent, so its intent was moved into the prompt. That demoted a deterministic loop guarantee to a suggestion the model can ignore. This restores the guarantee upstream as a generic primitive.

## DM → native semantics mapping

docs-agent's original DM rule (`bundles/technical-docs-agent/flows/technical-docs-bootstrap-flow.json`, enforced by `DataMachine\Engine\AI\DataMachineToolRuntimeRules` in the DM pre-tool mediator):

```json
{ "id": "bootstrap-write-after-discovery", "after_tool": "workspace_show",
  "limited_tools": ["workspace_ls","workspace_read","workspace_grep", ...],
  "max_calls": 12, "then_require_one_of": ["workspace_write","workspace_edit","workspace_apply_patch"] }
```

- **What DM enforced (per-call only):** once `after_tool` was seen, count `limited_tools` calls after it; at `max_calls`, reject any tool that is not in `then_require_one_of` until one of them runs (which resets the limit). `then_require_one_of` tools are always allowed. DM never gated completion — the model could discover 12 times then simply stop without writing.
- **What this primitive enforces:** the same per-call gate (faithful) **plus** a completion gate — once the anchor has fired and no commit tool has run, the loop refuses to finish, injects a model-visible correction, and forces another turn (bounded by `max_turns`/budgets). This is the intentional addition that makes "bounded discovery, then commit" an actual guarantee rather than a per-call nicety. Field rename `then_require_one_of` → `require_one_of` with the DM name accepted as an alias; `gate_calls` / `gate_completion` flags (both default true) select which hooks apply.

## Config shape + where the loop enforces it (deterministic)

Declarative rule on agent/runtime config (`tool_call_rules`):

```
array( 'id' => string, 'after_tool' => string, 'limited_tools' => string[],
       'max_calls' => int, 'require_one_of' => string[],
       'gate_calls' => bool, 'gate_completion' => bool )
```

- Primitive: `src/Runtime/class-wp-agent-tool-call-gate.php` (`evaluate_call()`, `evaluate_completion()`).
- Per-call hook: `src/Runtime/class-wp-agent-conversation-loop.php` — `compose_tool_call_gate_mediator()` wraps the existing pre-tool mediator seam; a blocked call returns a `reject` decision with `error_type=tool_call_gate_rejected`.
- Completion hook: `src/Runtime/class-wp-agent-conversation-loop.php` `run()` — after the mediated turn, on natural completion (`empty( $result['tool_calls'] )`) the gate can flip `conversation_complete` back to false, inject a model-visible reason, and set `$force_continue` so the natural-completion `should_continue` stop is overridden.
- Wiring: `src/Channels/register-default-agents-chat-handler.php` forwards a bundle's `tool_call_rules` into loop options.

## Proof (deterministic, not theater)

`tests/tool-call-gate-smoke.php` drives a fake provider turn that deliberately violates the rule:
- emits `anchor, read, read, read, write` in one turn → the runtime executes anchor + 2 reads + the commit but **never the over-budget 3rd read** (rejected with the gate error type in results and audit trail);
- across turns, tries to finish twice without committing → the loop **blocks completion both times**, keeps re-prompting, and only finishes after a `write` runs.

```
$ php tests/tool-call-gate-smoke.php
...
All 22 Agents API tool-call gate assertions passed.
```

Full suite + static analysis:
- `composer smoke` → exit 0 (all suites pass, including the new test wired into the suite)
- `composer phpstan` → `[OK] No errors`

## Scope / follow-up

Runtime + test only. docs-agent's bundle declares the field in a separate follow-up; the exact snippet its native bootstrap step should add under the AI step config:

```json
"tool_call_rules": [
  {
    "id": "bootstrap-write-after-discovery",
    "after_tool": "workspace_show",
    "limited_tools": [
      "workspace_ls", "workspace_read", "workspace_grep",
      "list_github_issues", "get_github_issue", "list_github_pulls",
      "get_github_pull", "get_github_pull_files",
      "get_github_pull_review_context", "github_pr_documentation_impact",
      "list_github_tree", "get_github_file"
    ],
    "max_calls": 12,
    "require_one_of": ["workspace_write", "workspace_edit", "workspace_apply_patch"],
    "gate_calls": true,
    "gate_completion": true
  }
]
```

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Claude Opus 4.8)
- **Used for:** Designing and implementing the deterministic tool-call-gating primitive for the conversation loop, the smoke test, and this description. Chris reviewed every line.