### PR TITLE
Resolve model id string to ModelInterface in the default turn adapter

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -15,3 +15,4 @@ parameters:
 		- stubs/wp-ai-client-functions.php
 		- stubs/class-wp-ai-client-prompt-builder.php
 		- stubs/wp-ai-client-dtos.php
+		- stubs/wp-ai-client-provider-registry.php

--- a/src/Runtime/class-wp-agent-default-provider-turn-adapter.php
+++ b/src/Runtime/class-wp-agent-default-provider-turn-adapter.php
@@ -218,12 +218,29 @@ class WP_Agent_Default_Provider_Turn_Adapter implements WP_Agent_Provider_Turn_A
 			$builder = $builder->with_message_parts( ...$prompt_context['prompt_parts'] );
 		}
 
-		if ( '' !== $provider_id ) {
-			$builder = $builder->using_provider( $provider_id );
-		}
-
+		/*
+		 * wp-ai-client's PromptBuilder::usingModel() requires a resolved
+		 * ModelInterface, not a model-id string. Passing the raw string raises a
+		 * TypeError before any request is dispatched, so the model id must be
+		 * resolved to the concrete model object through the provider registry
+		 * first. Resolution is provider-agnostic: any provider/model registered
+		 * in the wp-ai-client registry resolves the same way, with no
+		 * provider-specific branching.
+		 */
 		if ( '' !== $model_id ) {
-			$builder = $builder->using_model( $model_id );
+			if ( '' !== $provider_id ) {
+				$builder = $builder->using_model( $this->resolve_model_interface( $provider_id, $model_id ) );
+			} else {
+				/*
+				 * No provider context: hand the model id to the registry as a
+				 * model preference so it can discover the owning provider. This
+				 * is the string-accepting sibling of usingModel() and keeps the
+				 * path provider-agnostic.
+				 */
+				$builder = $builder->using_model_preference( $model_id );
+			}
+		} elseif ( '' !== $provider_id ) {
+			$builder = $builder->using_provider( $provider_id );
 		}
 
 		if ( '' !== $system_prompt ) {
@@ -247,6 +264,44 @@ class WP_Agent_Default_Provider_Turn_Adapter implements WP_Agent_Provider_Turn_A
 		}
 
 		return $builder->generate_text_result();
+	}
+
+	/**
+	 * Resolve a provider id + model id string pair into a concrete wp-ai-client ModelInterface.
+	 *
+	 * wp-ai-client's `PromptBuilder::usingModel()` requires a resolved
+	 * {@see \WordPress\AiClient\Providers\Models\Contracts\ModelInterface}, never
+	 * a model-id string. The provider registry (`AiClient::defaultRegistry()`,
+	 * the same registry the bare builder is constructed from) is the canonical
+	 * resolver: `getProviderModel()` maps a registered provider id + model id to
+	 * the concrete model object. This stays provider-agnostic — it never special
+	 * cases a provider or model id; any registered provider/model resolves
+	 * through the identical call.
+	 *
+	 * @param string $provider_id Provider identifier.
+	 * @param string $model_id    Model identifier.
+	 * @return \WordPress\AiClient\Providers\Models\Contracts\ModelInterface Resolved model instance.
+	 * @throws \RuntimeException When wp-ai-client is unavailable or the provider/model cannot be resolved.
+	 */
+	private function resolve_model_interface( string $provider_id, string $model_id ): \WordPress\AiClient\Providers\Models\Contracts\ModelInterface {
+		if ( ! class_exists( \WordPress\AiClient\AiClient::class ) ) {
+			throw new \RuntimeException( 'wp-ai-client is unavailable: WordPress\\AiClient\\AiClient is not loaded.' );
+		}
+
+		try {
+			$model = \WordPress\AiClient\AiClient::defaultRegistry()->getProviderModel( $provider_id, $model_id );
+		} catch ( \Throwable $error ) {
+			throw new \RuntimeException(
+				sprintf(
+					'Unable to resolve model "%s" for provider "%s" through the wp-ai-client provider registry: %s',
+					$model_id,
+					$provider_id,
+					$error->getMessage()
+				)
+			);
+		}
+
+		return $model;
 	}
 
 	/**

--- a/stubs/class-wp-ai-client-prompt-builder.php
+++ b/stubs/class-wp-ai-client-prompt-builder.php
@@ -26,8 +26,16 @@ class WP_AI_Client_Prompt_Builder {
 		return $this;
 	}
 
-	public function using_model( string $model ): self {
+	public function using_model( \WordPress\AiClient\Providers\Models\Contracts\ModelInterface $model ): self {
 		unset( $model );
+		return $this;
+	}
+
+	/**
+	 * @param string|\WordPress\AiClient\Providers\Models\Contracts\ModelInterface|array{0:string,1:string} ...$preferred_models Preferred models.
+	 */
+	public function using_model_preference( ...$preferred_models ): self {
+		unset( $preferred_models );
 		return $this;
 	}
 

--- a/stubs/wp-ai-client-provider-registry.php
+++ b/stubs/wp-ai-client-provider-registry.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * PHPStan class stubs for the php-ai-client provider registry surface the
+ * default provider-turn adapter uses to resolve a model-id string into a
+ * concrete ModelInterface.
+ *
+ * agents-api has no hard dependency on wp-ai-client. These stubs exist only so
+ * the static analyzer can type the registry-based model resolution the adapter
+ * performs behind `class_exists()` guards. They mirror the real php-ai-client
+ * classes (shipped in WordPress core under wp-includes/php-ai-client) but are
+ * never loaded at runtime.
+ *
+ * @see https://github.com/WordPress/php-ai-client
+ */
+
+// phpcs:disable Generic.Files.OneObjectStructurePerFile.MultipleFound -- Grouped stub file.
+
+namespace WordPress\AiClient {
+
+	use WordPress\AiClient\Providers\ProviderRegistry;
+
+	class AiClient {
+
+		public static function defaultRegistry(): ProviderRegistry {
+			return new ProviderRegistry();
+		}
+	}
+}
+
+namespace WordPress\AiClient\Providers {
+
+	use WordPress\AiClient\Providers\Models\Contracts\ModelInterface;
+
+	class ProviderRegistry {
+
+		/**
+		 * @param string $id_or_class_name Provider id or class name.
+		 * @param string $model_id         Model identifier.
+		 * @param mixed  $model_config     Optional model configuration.
+		 */
+		public function getProviderModel( string $id_or_class_name, string $model_id, $model_config = null ): ModelInterface {
+			unset( $id_or_class_name, $model_id, $model_config );
+			throw new \RuntimeException( 'stub' );
+		}
+	}
+}
+
+namespace WordPress\AiClient\Providers\Models\Contracts {
+
+	interface ModelInterface {
+	}
+}

--- a/tests/default-agents-chat-handler-smoke.php
+++ b/tests/default-agents-chat-handler-smoke.php
@@ -80,10 +80,57 @@ namespace WordPress\AiClient\Tools\DTO {
 	}
 }
 
+namespace WordPress\AiClient\Providers\Models\Contracts {
+	if ( ! interface_exists( __NAMESPACE__ . '\\ModelInterface' ) ) {
+		interface ModelInterface {}
+	}
+}
+
+namespace WordPress\AiClient\Providers {
+	if ( ! class_exists( __NAMESPACE__ . '\\ProviderRegistry' ) ) {
+		/**
+		 * Fake provider registry mirroring the resolver surface the adapter calls.
+		 *
+		 * Resolves any provider id + model id string pair into a concrete
+		 * ModelInterface, exactly like the real registry, so provider-agnostic
+		 * dispatch can be exercised without the php-ai-client SDK.
+		 */
+		class ProviderRegistry {
+			/**
+			 * @param mixed $model_config Optional model config.
+			 */
+			public function getProviderModel( string $provider_id, string $model_id, $model_config = null ): Models\Contracts\ModelInterface {
+				unset( $model_config );
+				return new \Agents_Chat_Fake_Model( $provider_id, $model_id );
+			}
+		}
+	}
+}
+
+namespace WordPress\AiClient {
+	if ( ! class_exists( __NAMESPACE__ . '\\AiClient' ) ) {
+		class AiClient {
+			public static function defaultRegistry(): Providers\ProviderRegistry {
+				return new Providers\ProviderRegistry();
+			}
+		}
+	}
+}
+
 namespace {
 
 	if ( ! defined( 'ABSPATH' ) ) {
 		define( 'ABSPATH', __DIR__ . '/' );
+	}
+
+	/**
+	 * Fake resolved model: a real ModelInterface instance (never a string),
+	 * carrying the provider/model ids it was resolved from.
+	 */
+	if ( ! class_exists( 'Agents_Chat_Fake_Model' ) ) {
+		class Agents_Chat_Fake_Model implements \WordPress\AiClient\Providers\Models\Contracts\ModelInterface {
+			public function __construct( public string $provider_id, public string $model_id ) {}
+		}
 	}
 
 	$failures = array();
@@ -254,8 +301,12 @@ namespace {
 			$GLOBALS['__adapter_smoke']['provider'] = $provider;
 			return $this;
 		}
-		public function using_model( string $model ): self {
+		public function using_model( $model ): self {
 			$GLOBALS['__adapter_smoke']['model'] = $model;
+			return $this;
+		}
+		public function using_model_preference( ...$preferred_models ): self {
+			$GLOBALS['__adapter_smoke']['model_preference'] = $preferred_models;
 			return $this;
 		}
 		public function using_system_instruction( string $system ): self {
@@ -363,8 +414,10 @@ namespace {
 	agents_api_smoke_assert_equals( true, $output['completed'] ?? false, 'output marks the turn completed', $failures, $passes );
 	agents_api_smoke_assert_equals( 1, count( $GLOBALS['__chat_handler_ability_calls'] ), 'the loop mediated exactly one tool call through the ability executor', $failures, $passes );
 	agents_api_smoke_assert_equals( 'risotto', $GLOBALS['__chat_handler_ability_calls'][0]['query'] ?? '', 'the mediated tool received the model-supplied parameters', $failures, $passes );
-	agents_api_smoke_assert_equals( 'fake-provider', $GLOBALS['__adapter_smoke']['provider'] ?? '', 'dispatch is provider-agnostic: the builder was keyed by the requested provider id', $failures, $passes );
-	agents_api_smoke_assert_equals( 'fake-model', $GLOBALS['__adapter_smoke']['model'] ?? '', 'dispatch is provider-agnostic: the builder was keyed by the requested model id', $failures, $passes );
+	$kitchen_model = $GLOBALS['__adapter_smoke']['model'] ?? null;
+	agents_api_smoke_assert_equals( true, $kitchen_model instanceof \WordPress\AiClient\Providers\Models\Contracts\ModelInterface, 'dispatch resolved the model id to a ModelInterface before using_model() (not a string)', $failures, $passes );
+	agents_api_smoke_assert_equals( 'fake-provider', $kitchen_model->provider_id ?? '', 'dispatch is provider-agnostic: the resolved model carries the requested provider id', $failures, $passes );
+	agents_api_smoke_assert_equals( 'fake-model', $kitchen_model->model_id ?? '', 'dispatch is provider-agnostic: the resolved model carries the requested model id', $failures, $passes );
 	agents_api_smoke_assert_equals( 'You are the kitchen brain.', $GLOBALS['__adapter_smoke']['system'] ?? '', 'the agent default-config system prompt drove the turn', $failures, $passes );
 	agents_api_smoke_assert_equals( 2, (int) ( $output['metadata']['agents_api']['turn_count'] ?? 0 ), 'metadata records the two-turn native loop', $failures, $passes );
 	$canonical_roles = array_map( static fn( array $m ): string => $m['role'], $output['messages'] ?? array() );
@@ -390,7 +443,10 @@ namespace {
 		)
 	);
 	agents_api_smoke_assert_equals( false, $request_provider_output instanceof WP_Error, 'request-supplied provider/model drive an agent without configured defaults', $failures, $passes );
-	agents_api_smoke_assert_equals( 'request-provider', $GLOBALS['__adapter_smoke']['provider'] ?? '', 'request provider overrides/supplies the dispatch provider', $failures, $passes );
+	$request_model = $GLOBALS['__adapter_smoke']['model'] ?? null;
+	agents_api_smoke_assert_equals( true, $request_model instanceof \WordPress\AiClient\Providers\Models\Contracts\ModelInterface, 'request-supplied provider/model resolve to a ModelInterface for dispatch', $failures, $passes );
+	agents_api_smoke_assert_equals( 'request-provider', $request_model->provider_id ?? '', 'request provider overrides/supplies the dispatch provider', $failures, $passes );
+	agents_api_smoke_assert_equals( 'request-model', $request_model->model_id ?? '', 'request model overrides/supplies the dispatch model', $failures, $passes );
 
 	echo "\n[3] Error contracts: empty message, unknown agent, missing provider:\n";
 	$empty = AgentsAPI\AI\Channels\WP_Agent_Default_Chat_Handler::execute( array( 'agent' => 'kitchen-brain', 'message' => '   ' ) );

--- a/tests/default-provider-turn-adapter-smoke.php
+++ b/tests/default-provider-turn-adapter-smoke.php
@@ -84,10 +84,61 @@ namespace WordPress\AiClient\Tools\DTO {
 	}
 }
 
+namespace WordPress\AiClient\Providers\Models\Contracts {
+	if ( ! interface_exists( __NAMESPACE__ . '\\ModelInterface' ) ) {
+		interface ModelInterface {}
+	}
+}
+
+namespace WordPress\AiClient\Providers {
+	if ( ! class_exists( __NAMESPACE__ . '\\ProviderRegistry' ) ) {
+		/**
+		 * Fake provider registry mirroring the resolver surface the adapter calls.
+		 *
+		 * The real registry resolves a provider id + model id string into a
+		 * concrete ModelInterface. This double does the same for any pair and
+		 * throws InvalidArgumentException for the sentinel unregistered model id,
+		 * so the adapter's resolution + failure paths can be driven without the
+		 * real php-ai-client SDK.
+		 */
+		class ProviderRegistry {
+			/**
+			 * @param mixed $model_config Optional model config.
+			 */
+			public function getProviderModel( string $provider_id, string $model_id, $model_config = null ): Models\Contracts\ModelInterface {
+				unset( $model_config );
+				if ( '__unregistered__' === $model_id ) {
+					throw new \InvalidArgumentException( sprintf( 'Provider model not registered: %s/%s', $provider_id, $model_id ) );
+				}
+				return new \Agents_API_Fake_Model( $provider_id, $model_id );
+			}
+		}
+	}
+}
+
+namespace WordPress\AiClient {
+	if ( ! class_exists( __NAMESPACE__ . '\\AiClient' ) ) {
+		class AiClient {
+			public static function defaultRegistry(): Providers\ProviderRegistry {
+				return new Providers\ProviderRegistry();
+			}
+		}
+	}
+}
+
 namespace {
 
 	if ( ! defined( 'ABSPATH' ) ) {
 		define( 'ABSPATH', __DIR__ . '/' );
+	}
+
+	/**
+	 * Fake resolved model: a real ModelInterface instance (never a string) that
+	 * carries the provider/model ids it was resolved from, so assertions can
+	 * prove using_model() received an object with the requested identity.
+	 */
+	class Agents_API_Fake_Model implements \WordPress\AiClient\Providers\Models\Contracts\ModelInterface {
+		public function __construct( public string $provider_id, public string $model_id ) {}
 	}
 
 	$failures = array();
@@ -184,8 +235,12 @@ namespace {
 			$GLOBALS['__adapter_smoke']['provider'] = $provider;
 			return $this;
 		}
-		public function using_model( string $model ): self {
+		public function using_model( $model ): self {
 			$GLOBALS['__adapter_smoke']['model'] = $model;
+			return $this;
+		}
+		public function using_model_preference( ...$preferred_models ): self {
+			$GLOBALS['__adapter_smoke']['model_preference'] = $preferred_models;
 			return $this;
 		}
 		public function using_system_instruction( string $system ): self {
@@ -292,8 +347,11 @@ namespace {
 	agents_api_smoke_assert_equals( 'client/lookup', $result['tool_calls'][0]['name'] ?? '', 'run_turn extracts tool calls via shipped extractor', $failures, $passes );
 	agents_api_smoke_assert_equals( 'alpha', $result['tool_calls'][0]['parameters']['query'] ?? '', 'run_turn decodes tool-call arguments', $failures, $passes );
 	agents_api_smoke_assert_equals( 12, $result['usage']['total_tokens'], 'run_turn normalizes token usage', $failures, $passes );
-	agents_api_smoke_assert_equals( 'fake-provider', $GLOBALS['__adapter_smoke']['provider'] ?? '', 'run_turn passes provider id to the builder', $failures, $passes );
-	agents_api_smoke_assert_equals( 'fake-model', $GLOBALS['__adapter_smoke']['model'] ?? '', 'run_turn passes model id to the builder', $failures, $passes );
+	$recorded_model = $GLOBALS['__adapter_smoke']['model'] ?? null;
+	agents_api_smoke_assert_equals( true, $recorded_model instanceof \WordPress\AiClient\Providers\Models\Contracts\ModelInterface, 'run_turn resolves the model id to a ModelInterface before calling using_model() (not a string)', $failures, $passes );
+	agents_api_smoke_assert_equals( false, is_string( $recorded_model ), 'run_turn never hands using_model() a raw model-id string', $failures, $passes );
+	agents_api_smoke_assert_equals( 'fake-provider', $recorded_model->provider_id ?? '', 'the resolved model carries the requested provider id', $failures, $passes );
+	agents_api_smoke_assert_equals( 'fake-model', $recorded_model->model_id ?? '', 'the resolved model carries the requested model id', $failures, $passes );
 	agents_api_smoke_assert_equals( 'You are a test agent.', $GLOBALS['__adapter_smoke']['system'] ?? '', 'run_turn passes default system prompt to the builder', $failures, $passes );
 	agents_api_smoke_assert_equals( 1, count( $GLOBALS['__adapter_smoke']['prompt_parts'] ?? array() ), 'run_turn sends the latest user turn as the current prompt', $failures, $passes );
 	agents_api_smoke_assert_equals( 2, count( $GLOBALS['__adapter_smoke']['history'] ?? array() ), 'run_turn sends earlier turns as history', $failures, $passes );
@@ -567,7 +625,7 @@ namespace {
 		new AgentsAPI\AI\WP_Agent_Provider_Turn_Request( array( array( 'role' => 'user', 'content' => 'hi' ) ) )
 	);
 	agents_api_smoke_assert_equals( 'bare again', $restore_raw['content'], 'set_dispatch_provider(null) falls back to the bare builder', $failures, $passes );
-	agents_api_smoke_assert_equals( 'fake-provider', $GLOBALS['__adapter_smoke']['provider'] ?? '', 'restored bare path drives the wp_ai_client builder again', $failures, $passes );
+	agents_api_smoke_assert_equals( true, ( $GLOBALS['__adapter_smoke']['model'] ?? null ) instanceof \WordPress\AiClient\Providers\Models\Contracts\ModelInterface, 'restored bare path drives the wp_ai_client builder again with a resolved ModelInterface', $failures, $passes );
 
 	echo "\n[9] Public result normalization helpers on WP_Agent_Provider_Turn_Result:\n";
 	$helper_result = $make_result( 'helper text', array(), array( 4, 6, 10 ) );
@@ -578,6 +636,44 @@ namespace {
 	agents_api_smoke_assert_equals( 10, $helper_usage['total_tokens'], 'public result_usage() extracts total tokens', $failures, $passes );
 	$tool_only_result = $make_result( '', array( array( 'name' => 'client/lookup', 'parameters' => array( 'q' => 'x' ), 'id' => 'tc-1' ) ), array( 1, 0, 1 ) );
 	agents_api_smoke_assert_equals( '', AgentsAPI\AI\WP_Agent_Provider_Turn_Result::result_text( $tool_only_result ), 'public result_text() returns empty for a tool-only turn', $failures, $passes );
+
+	echo "\n[10] Regression: a STRING model id is resolved to a ModelInterface and the turn dispatches (no TypeError):\n";
+	$GLOBALS['__adapter_smoke']                = array();
+	$GLOBALS['__adapter_smoke']['next_result'] = $make_result( 'resolved-and-dispatched', array(), array( 1, 2, 3 ) );
+
+	$regression_adapter = new AgentsAPI\AI\WP_Agent_Default_Provider_Turn_Adapter( 'fake-provider', 'fake-model', 'regression-system' );
+	$regression_request = new AgentsAPI\AI\WP_Agent_Provider_Turn_Request(
+		array( array( 'role' => 'user', 'content' => 'resolve my model' ) ),
+		array(),
+		// Model metadata supplied as plain STRINGS, exactly like the native runtime.
+		array( 'provider_id' => 'gpt-provider', 'model_id' => 'gpt-5.5' )
+	);
+	$regression_raw   = $regression_adapter->run_turn( $regression_request );
+	$regression_model = $GLOBALS['__adapter_smoke']['model'] ?? null;
+
+	agents_api_smoke_assert_equals( true, $regression_model instanceof \WordPress\AiClient\Providers\Models\Contracts\ModelInterface, 'string model id "gpt-5.5" is resolved to a ModelInterface (the exact TypeError regression)', $failures, $passes );
+	agents_api_smoke_assert_equals( 'gpt-provider', $regression_model->provider_id ?? '', 'resolution is provider-agnostic: an arbitrary provider id resolves the same way', $failures, $passes );
+	agents_api_smoke_assert_equals( 'gpt-5.5', $regression_model->model_id ?? '', 'the resolved ModelInterface carries the requested string model id', $failures, $passes );
+	agents_api_smoke_assert_equals( 'resolved-and-dispatched', $regression_raw['content'], 'the turn dispatches and produces content (no TypeError, no empty completion)', $failures, $passes );
+
+	echo "\n[11] Regression: an unresolvable model id surfaces a clear RuntimeException, not a TypeError:\n";
+	$GLOBALS['__adapter_smoke']                = array();
+	$GLOBALS['__adapter_smoke']['next_result'] = $make_result( 'unused', array(), array( 0, 0, 0 ) );
+	$bad_model_adapter                         = new AgentsAPI\AI\WP_Agent_Default_Provider_Turn_Adapter( 'fake-provider', 'fake-model', 'sys' );
+	$bad_model_message                         = '';
+	try {
+		$bad_model_adapter->run_turn(
+			new AgentsAPI\AI\WP_Agent_Provider_Turn_Request(
+				array( array( 'role' => 'user', 'content' => 'bad model' ) ),
+				array(),
+				array( 'provider_id' => 'fake-provider', 'model_id' => '__unregistered__' )
+			)
+		);
+	} catch ( \RuntimeException $error ) {
+		$bad_model_message = $error->getMessage();
+	}
+	agents_api_smoke_assert_equals( true, false !== strpos( $bad_model_message, 'Unable to resolve model' ), 'an unresolvable model id throws an actionable RuntimeException (not a TypeError)', $failures, $passes );
+	agents_api_smoke_assert_equals( true, false !== strpos( $bad_model_message, '__unregistered__' ), 'the resolution error names the unresolvable model id', $failures, $passes );
 
 	agents_api_smoke_finish( 'Agents API default provider-turn adapter', $failures, $passes );
 }


### PR DESCRIPTION
## Problem

The default provider-turn adapter (`WP_Agent_Default_Provider_Turn_Adapter`) passed the model id as a raw **string** to wp-ai-client's `PromptBuilder::usingModel()`, which requires a resolved `WordPress\AiClient\Providers\Models\Contracts\ModelInterface`. On the first provider turn the native `agents/chat` runtime (#380 default handler -> `WP_Agent_Conversation_Loop` -> this adapter) threw:

```
PromptBuilder::usingModel(): Argument #1 ($model) must be of type
WordPress\AiClient\Providers\Models\Contracts\ModelInterface, string given,
called in /wordpress/wp-includes/ai-client/class-wp-ai-client-prompt-builder.php
```

This was the primary blocker stopping the native runtime from making any LLM call (`completion_tokens: 0`, no output). Observed in a live native run in a wp-codebox sandbox with no Data Machine, model supplied as the string `"gpt-5.5"` (provider `openai`).

## Fix

`src/Runtime/class-wp-agent-default-provider-turn-adapter.php`:

- In the bare-builder dispatch path, resolve the requested provider id + model id into the concrete `ModelInterface` via the wp-ai-client provider registry (`AiClient::defaultRegistry()->getProviderModel( $provider_id, $model_id )` — the same registry the bare builder is constructed from) **before** calling `using_model()`.
- Resolution is **provider-agnostic**: any provider/model registered in the registry resolves through the identical call, with no special-casing of openai or any model id.
- When a model id is supplied without a provider, the string-accepting sibling `using_model_preference()` is used so the registry can discover the owning provider.
- An unresolvable provider/model now surfaces a clear, actionable `RuntimeException` (naming the provider/model) instead of a raw `TypeError`.

The injected dispatch-provider seam is unchanged — it already hands provider/model strings to the consumer, which owns request construction.

Supporting changes:
- Updated the wp-ai-client prompt-builder phpstan stub to the real `usingModel(ModelInterface)` signature and added `using_model_preference()`.
- Added a provider-registry phpstan stub (`AiClient`, `ProviderRegistry`, `ModelInterface`) for the resolver surface.
- Extended the adapter and chat-handler smoke tests: a fake provider exposes a model object resolvable by id, a turn is driven with a **string** model id, and the tests assert `using_model()` receives a `ModelInterface` (never a string), the resolved model carries the requested ids, the turn dispatches without a TypeError, and an unregistered model id raises the actionable error.

## Tests

- `composer phpstan` (level max): **OK, no errors**.
- `composer smoke` (full suite): **exit 0**, all assertions pass.
  - `default-provider-turn-adapter-smoke.php`: 56 assertions pass (incl. regression sections [10]/[11] proving string `"gpt-5.5"` resolves to a `ModelInterface`, the turn dispatches, and a bad model id throws an actionable error).
  - `default-agents-chat-handler-smoke.php`: 26 assertions pass.

The end-to-end docs run is intentionally out of scope here and should be re-run after merge.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Claude Opus 4.8)
- **Used for:** Diagnosing the TypeError, identifying the correct `ProviderRegistry::getProviderModel()` resolver in the in-core php-ai-client, implementing the provider-agnostic string-to-ModelInterface resolution in the default turn adapter, and extending the phpstan stubs and smoke coverage.