### PR TITLE
Raise agentic per-request provider timeout from wp-ai-client's 30s default

### DIFF
--- a/src/Runtime/class-wp-agent-default-provider-turn-adapter.php
+++ b/src/Runtime/class-wp-agent-default-provider-turn-adapter.php
@@ -50,6 +50,30 @@ defined( 'ABSPATH' ) || exit;
 // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Turn-dispatch exceptions are caught by the conversation loop and returned as structured arrays, never rendered.
 class WP_Agent_Default_Provider_Turn_Adapter implements WP_Agent_Provider_Turn_Adapter {
 
+	/**
+	 * Default per-request HTTP timeout, in seconds, for one agentic provider turn.
+	 *
+	 * wp-ai-client defaults the request timeout to 30s (see
+	 * WP_AI_Client_Prompt_Builder), which is tuned for a single short completion.
+	 * One turn of an agentic loop is a different shape of request: a large system
+	 * prompt, many tool declarations, accumulated transcript, and — for reasoning
+	 * models — extended server-side thinking before any bytes return. A single
+	 * such turn routinely runs for several minutes, so the 30s ceiling aborts the
+	 * request mid-generation with a transport timeout (cURL error 28) and zero
+	 * completion tokens.
+	 *
+	 * This is the PER-REQUEST (per-turn) timeout only. It bounds one provider
+	 * response, not the whole agentic session — the conversation loop bounds the
+	 * session separately via its own turn count and time budget. 600s (10 minutes)
+	 * is a generous ceiling for a single long reasoning turn while still failing
+	 * fast on a genuinely hung connection; callers needing more can raise it via
+	 * the `request_timeout` option or the
+	 * `agents_api_provider_turn_request_timeout` filter.
+	 *
+	 * @var float
+	 */
+	private const DEFAULT_REQUEST_TIMEOUT = 600.0;
+
 	/** @var string Provider identifier passed to the wp-ai-client builder. */
 	private string $provider_id;
 
@@ -74,6 +98,9 @@ class WP_Agent_Default_Provider_Turn_Adapter implements WP_Agent_Provider_Turn_A
 	 * @param string                $system_prompt Default system prompt.
 	 * @param array<string, mixed>  $options       Dispatch options. Recognized keys:
 	 *                                              `temperature` (float), `max_tokens` (int),
+	 *                                              `request_timeout` (float, seconds; per-turn
+	 *                                              HTTP timeout, defaults to
+	 *                                              self::DEFAULT_REQUEST_TIMEOUT),
 	 *                                              `prompt_input_provider` (callable),
 	 *                                              `dispatch_provider` (callable). Only keys
 	 *                                              the wp-ai-client builder supports are wired.
@@ -263,7 +290,102 @@ class WP_Agent_Default_Provider_Turn_Adapter implements WP_Agent_Provider_Turn_A
 			$builder = $builder->using_function_declarations( ...$function_declarations );
 		}
 
+		$builder = $this->apply_request_timeout( $builder );
+
 		return $builder->generate_text_result();
+	}
+
+	/**
+	 * Apply the agentic per-request HTTP timeout to the bare wp-ai-client builder.
+	 *
+	 * Scopes the raised timeout to this adapter's own provider turn through the
+	 * builder's per-request transport options (`using_request_options()` →
+	 * `RequestOptions::KEY_TIMEOUT`), rather than mutating the global
+	 * `wp_ai_client_default_request_timeout` filter, so every other wp-ai-client
+	 * consumer in the process keeps its own default. Replacing the builder's
+	 * RequestOptions overrides the 30s default wp-ai-client sets in its
+	 * constructor (the only field that default populates is the timeout).
+	 *
+	 * No-ops when the wp-ai-client RequestOptions DTO or the builder's
+	 * `using_request_options()` setter is unavailable, leaving the default
+	 * dispatch unchanged.
+	 *
+	 * Typed via docblock only (no PHP type hint) so the duck-typed builder the
+	 * bare path constructs is accepted exactly as the surrounding dispatch code
+	 * accepts it.
+	 *
+	 * @param \WP_AI_Client_Prompt_Builder $builder wp-ai-client prompt builder.
+	 * @return \WP_AI_Client_Prompt_Builder The builder, with the per-request timeout applied when supported.
+	 */
+	private function apply_request_timeout( $builder ) {
+		$timeout = $this->resolve_request_timeout();
+		if ( $timeout <= 0.0 ) {
+			return $builder;
+		}
+
+		/*
+		 * The RequestOptions DTO and the builder's usingRequestOptions() setter ship
+		 * together in the same wp-ai-client/php-ai-client version, so the DTO's
+		 * presence is the honest capability signal. (The builder proxies setters
+		 * through __call, which makes a method_exists/is_callable probe unreliable.)
+		 * When the DTO is absent, leave the default dispatch untouched.
+		 */
+		if ( ! class_exists( \WordPress\AiClient\Providers\Http\DTO\RequestOptions::class ) ) {
+			return $builder;
+		}
+
+		return $builder->using_request_options(
+			\WordPress\AiClient\Providers\Http\DTO\RequestOptions::fromArray(
+				array(
+					\WordPress\AiClient\Providers\Http\DTO\RequestOptions::KEY_TIMEOUT => $timeout,
+				)
+			)
+		);
+	}
+
+	/**
+	 * Resolve the per-request HTTP timeout (seconds) for one agentic provider turn.
+	 *
+	 * Resolution order, each layer overriding the previous only with a positive
+	 * numeric value:
+	 *
+	 * 1. {@see self::DEFAULT_REQUEST_TIMEOUT} — the adequate out-of-the-box default.
+	 * 2. The `request_timeout` adapter option — an explicit caller/agent-config override.
+	 * 3. The `agents_api_provider_turn_request_timeout` filter — the runtime/site lever.
+	 *
+	 * Provider-agnostic: provider and model ids are passed to the filter purely as
+	 * context for callers that want to tune by deployment, never branched on here.
+	 *
+	 * @return float Timeout in seconds.
+	 */
+	private function resolve_request_timeout(): float {
+		$timeout = self::DEFAULT_REQUEST_TIMEOUT;
+
+		if ( isset( $this->options['request_timeout'] ) && is_numeric( $this->options['request_timeout'] ) && (float) $this->options['request_timeout'] > 0.0 ) {
+			$timeout = (float) $this->options['request_timeout'];
+		}
+
+		if ( function_exists( 'apply_filters' ) ) {
+			/**
+			 * Filters the per-request HTTP timeout for one agentic provider turn.
+			 *
+			 * Scopes only to the default provider-turn adapter's own request, not
+			 * to every wp-ai-client request in the process. The value bounds a
+			 * single provider response; the conversation loop bounds the overall
+			 * session separately.
+			 *
+			 * @param float  $timeout     Timeout in seconds.
+			 * @param string $provider_id Resolved provider identifier (context only).
+			 * @param string $model_id    Resolved model identifier (context only).
+			 */
+			/** @var mixed $filtered Filters may return anything; validate before trusting it. */
+			$filtered = apply_filters( 'agents_api_provider_turn_request_timeout', $timeout, $this->provider_id, $this->model_id );
+			if ( is_numeric( $filtered ) && (float) $filtered > 0.0 ) {
+				$timeout = (float) $filtered;
+			}
+		}
+
+		return $timeout;
 	}
 
 	/**

--- a/stubs/class-wp-ai-client-prompt-builder.php
+++ b/stubs/class-wp-ai-client-prompt-builder.php
@@ -64,6 +64,11 @@ class WP_AI_Client_Prompt_Builder {
 		return $this;
 	}
 
+	public function using_request_options( \WordPress\AiClient\Providers\Http\DTO\RequestOptions $options ): self {
+		unset( $options );
+		return $this;
+	}
+
 	/**
 	 * @return object|\WP_Error wp-ai-client GenerativeAiResult or a WP_Error on failure.
 	 */

--- a/stubs/wp-ai-client-dtos.php
+++ b/stubs/wp-ai-client-dtos.php
@@ -80,3 +80,23 @@ namespace WordPress\AiClient\Tools\DTO {
 		}
 	}
 }
+
+namespace WordPress\AiClient\Providers\Http\DTO {
+
+	class RequestOptions {
+
+		public const KEY_TIMEOUT = 'timeout';
+
+		/**
+		 * @param array<string, mixed> $array Request option values keyed by RequestOptions constants.
+		 */
+		public static function fromArray( array $array ): self {
+			unset( $array );
+			return new self();
+		}
+
+		public function getTimeout(): ?float {
+			return null;
+		}
+	}
+}

--- a/tests/default-provider-turn-adapter-smoke.php
+++ b/tests/default-provider-turn-adapter-smoke.php
@@ -90,6 +90,30 @@ namespace WordPress\AiClient\Providers\Models\Contracts {
 	}
 }
 
+namespace WordPress\AiClient\Providers\Http\DTO {
+	if ( ! class_exists( __NAMESPACE__ . '\\RequestOptions' ) ) {
+		/**
+		 * Minimal stand-in for the wp-ai-client RequestOptions DTO so the adapter's
+		 * per-request timeout path (using_request_options + RequestOptions::fromArray
+		 * keyed on KEY_TIMEOUT) is exercised exactly as it is against the shipped DTO.
+		 */
+		class RequestOptions {
+			public const KEY_TIMEOUT = 'timeout';
+			private ?float $timeout = null;
+			public static function fromArray( array $array ): self {
+				$instance = new self();
+				if ( isset( $array[ self::KEY_TIMEOUT ] ) ) {
+					$instance->timeout = (float) $array[ self::KEY_TIMEOUT ];
+				}
+				return $instance;
+			}
+			public function getTimeout(): ?float {
+				return $this->timeout;
+			}
+		}
+	}
+}
+
 namespace WordPress\AiClient\Providers {
 	if ( ! class_exists( __NAMESPACE__ . '\\ProviderRegistry' ) ) {
 		/**
@@ -263,6 +287,10 @@ namespace {
 			$GLOBALS['__adapter_smoke']['declarations'] = $declarations;
 			return $this;
 		}
+		public function using_request_options( \WordPress\AiClient\Providers\Http\DTO\RequestOptions $options ): self {
+			$GLOBALS['__adapter_smoke']['request_timeout'] = $options->getTimeout();
+			return $this;
+		}
 		public function generate_text_result() {
 			if ( isset( $GLOBALS['__adapter_smoke']['select_next'] ) && is_callable( $GLOBALS['__adapter_smoke']['select_next'] ) ) {
 				return call_user_func( $GLOBALS['__adapter_smoke']['select_next'] );
@@ -357,6 +385,43 @@ namespace {
 	agents_api_smoke_assert_equals( 2, count( $GLOBALS['__adapter_smoke']['history'] ?? array() ), 'run_turn sends earlier turns as history', $failures, $passes );
 	agents_api_smoke_assert_equals( 1, count( $GLOBALS['__adapter_smoke']['declarations'] ?? array() ), 'run_turn maps tool declarations to function declarations', $failures, $passes );
 	agents_api_smoke_assert_equals( 'client/lookup', $GLOBALS['__adapter_smoke']['declarations'][0]->name ?? '', 'function declaration carries the logical tool name', $failures, $passes );
+	agents_api_smoke_assert_equals( 600.0, $GLOBALS['__adapter_smoke']['request_timeout'] ?? null, 'run_turn applies the raised 600s agentic per-request timeout to the builder by default', $failures, $passes );
+
+	echo "\n[1b] request timeout is configurable and honors a caller-supplied override + filter:\n";
+	$GLOBALS['__adapter_smoke']                = array();
+	$GLOBALS['__adapter_smoke']['next_result'] = $make_result( 'ok', array(), array( 1, 1, 2 ) );
+	$override_timeout_adapter                  = new AgentsAPI\AI\WP_Agent_Default_Provider_Turn_Adapter(
+		'fake-provider',
+		'fake-model',
+		'sys',
+		array( 'request_timeout' => 900 )
+	);
+	$override_timeout_adapter->run_turn(
+		new AgentsAPI\AI\WP_Agent_Provider_Turn_Request( array( array( 'role' => 'user', 'content' => 'hi' ) ) )
+	);
+	agents_api_smoke_assert_equals( 900.0, $GLOBALS['__adapter_smoke']['request_timeout'] ?? null, 'request_timeout option overrides the default and reaches the request', $failures, $passes );
+
+	$GLOBALS['__adapter_smoke']                = array();
+	$GLOBALS['__adapter_smoke']['next_result'] = $make_result( 'ok', array(), array( 1, 1, 2 ) );
+	$filter_seen                               = array();
+	add_filter(
+		'agents_api_provider_turn_request_timeout',
+		static function ( $timeout, $provider_id, $model_id ) use ( &$filter_seen ) {
+			$filter_seen[] = array( $timeout, $provider_id, $model_id );
+			return 1200;
+		},
+		10,
+		3
+	);
+	$filter_timeout_adapter = new AgentsAPI\AI\WP_Agent_Default_Provider_Turn_Adapter( 'fake-provider', 'fake-model', 'sys' );
+	$filter_timeout_adapter->run_turn(
+		new AgentsAPI\AI\WP_Agent_Provider_Turn_Request( array( array( 'role' => 'user', 'content' => 'hi' ) ) )
+	);
+	agents_api_smoke_assert_equals( 1200.0, $GLOBALS['__adapter_smoke']['request_timeout'] ?? null, 'agents_api_provider_turn_request_timeout filter overrides the timeout reaching the request', $failures, $passes );
+	agents_api_smoke_assert_equals( 600.0, $filter_seen[0][0] ?? null, 'timeout filter receives the resolved default as the incoming value', $failures, $passes );
+	agents_api_smoke_assert_equals( 'fake-provider', $filter_seen[0][1] ?? '', 'timeout filter receives the provider id as context', $failures, $passes );
+	agents_api_smoke_assert_equals( 'fake-model', $filter_seen[0][2] ?? '', 'timeout filter receives the model id as context', $failures, $passes );
+	$GLOBALS['__agents_api_smoke_actions']['agents_api_provider_turn_request_timeout'] = array();
 
 	echo "\n[2] Prompt-input seam defaults to identity and applies an override:\n";
 	$GLOBALS['__adapter_smoke']                = array();


### PR DESCRIPTION
## Problem

The default provider-turn adapter (`WP_Agent_Default_Provider_Turn_Adapter`) dispatches each agentic turn through the bare wp-ai-client prompt builder, which defaults its HTTP request timeout to **30 seconds** (`WP_AI_Client_Prompt_Builder::__construct()` → `RequestOptions::KEY_TIMEOUT = 30.0`).

30s is tuned for a single short completion, not one turn of an agentic loop. A real first turn — large system prompt, many tool declarations, accumulated transcript, and (for reasoning models) extended server-side thinking before any bytes return — routinely runs for minutes. The 30s ceiling aborts the request mid-generation with a transport timeout (`cURL error 28: Operation timed out`), producing `completion_tokens: 0` and no agent output.

Reproduced on the build-with-wordpress developer-docs run (native path, no Data Machine): model resolves, request is sent to the provider, then cURL 28. Egress is fine; the timeout is simply too short.

## Fix

Set an agentic-appropriate **per-request** timeout on the adapter's own provider turn, applied through the builder's per-request transport options (`using_request_options()` → `RequestOptions::KEY_TIMEOUT`) so it scopes to this adapter's agentic calls rather than globally mutating every wp-ai-client request via the `wp_ai_client_default_request_timeout` filter. Replacing the builder's `RequestOptions` overrides the 30s default wp-ai-client sets in its constructor (timeout is the only field that default populates).

- **Default: 600s (10 minutes)** — a generous ceiling for one long reasoning turn that still fails fast on a genuinely hung connection.
- **Per-request, not per-session.** This bounds a single provider response. The conversation loop bounds the overall agentic session separately (turn count + time budget), so the two are not conflated.
- **Configurable, adequate default out of the box.** Callers can set the `request_timeout` adapter option (agent-config/runtime) or filter `agents_api_provider_turn_request_timeout`; neither is required.
- **Provider-agnostic, DM-free.** No openai/gpt special-casing. Provider/model ids are passed to the filter as context only, never branched on.
- No-ops cleanly when the wp-ai-client `RequestOptions` DTO is absent, leaving the default dispatch unchanged.

Every native-runtime consumer of the default turn adapter (wp-codebox, studio-native, etc.) inherits the agentic-appropriate timeout with no per-consumer patch.

## Tests

Extends `tests/default-provider-turn-adapter-smoke.php` (the existing fake-builder harness records what the builder receives):
- asserts the raised **600s** timeout reaches the builder by default;
- asserts the `request_timeout` option override (900s) reaches the request;
- asserts the `agents_api_provider_turn_request_timeout` filter override (1200s) reaches the request and receives the resolved default + provider/model context.

Adds PHPStan stubs for the `RequestOptions` DTO and the builder's `using_request_options()` setter.

`composer phpstan` → no errors. `composer smoke` → all suites pass (62 assertions in the adapter suite, including the new timeout assertions).

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Opus 4.8)
- **Used for:** Raising the agentic provider-request timeout from the 30s default in the default turn adapter (implementation, smoke test, PHPStan stubs).