### PR TITLE
Wire enabled_tools so native bundle agents actually invoke tools (+ require_tool_use completion gate)

### DIFF
--- a/src/Channels/register-default-agents-chat-handler.php
+++ b/src/Channels/register-default-agents-chat-handler.php
@@ -261,17 +261,19 @@ class WP_Agent_Default_Chat_Handler {
 	/**
 	 * Build host-mediated tool declarations from the agent's declared abilities.
 	 *
-	 * The agent config lists the ability names the agent may call (under `tools`
-	 * or `abilities`). Each becomes a server tool declaration whose model-facing
-	 * name is the ability name; {@see WP_Agent_Ability_Tool_Executor} dispatches
-	 * it back through the Abilities API.
+	 * The agent config lists the ability names the agent may call. Runtime agent
+	 * bundles declare this set as `enabled_tools` (the field the bundle schema and
+	 * validators standardize on); `tools`, `abilities`, and `tool_names` are also
+	 * accepted as aliases. Each name becomes a server tool declaration whose
+	 * model-facing name is the ability name; {@see WP_Agent_Ability_Tool_Executor}
+	 * dispatches it back through the Abilities API.
 	 *
 	 * @param array<string,mixed> $config Agent default config.
 	 * @return array<string,array<string,mixed>> Declarations keyed by tool name.
 	 */
 	private static function resolve_tool_declarations( array $config ): array {
 		$names = array();
-		foreach ( array( 'tools', 'abilities', 'tool_names' ) as $key ) {
+		foreach ( array( 'enabled_tools', 'tools', 'abilities', 'tool_names' ) as $key ) {
 			if ( is_array( $config[ $key ] ?? null ) ) {
 				$names = array_merge( $names, $config[ $key ] );
 			}

--- a/src/Runtime/class-wp-agent-tool-call-gate.php
+++ b/src/Runtime/class-wp-agent-tool-call-gate.php
@@ -37,6 +37,21 @@ if ( ! defined( 'ABSPATH' ) ) {
  *     'gate_completion' => true,                        // block completion until satisfied (default true)
  *   )
  *
+ * A second, anchor-independent rule shape enforces "do not finish without doing
+ * real work". It blocks completion whenever the run is about to end with fewer
+ * than `min_tool_calls` qualifying tool calls in the whole transcript — even on
+ * turn one, with no anchor required. This catches the failure mode where a model
+ * narrates its intended action as prose ("List root.") instead of emitting a
+ * tool call, which the loop would otherwise treat as natural completion:
+ *
+ *   array(
+ *     'id'               => 'require-tool-use',
+ *     'require_tool_use' => true,                       // unconditional commit guarantee
+ *     'min_tool_calls'   => 1,                          // minimum qualifying calls (default 1)
+ *     'require_one_of'   => array( 'workspace_write' ), // optional: only these calls qualify;
+ *                                                       // omit to count ANY tool call
+ *   )
+ *
  * Field aliases accepted for portability with prior bundle shapes:
  *   `then_require_one_of` => `require_one_of`, `limited_tool_names` => `limited_tools`.
  */
@@ -48,7 +63,7 @@ class WP_Agent_Tool_Call_Gate {
 	public const ERROR_TYPE_CALL_REJECTED      = 'tool_call_gate_rejected';
 	public const ERROR_TYPE_COMPLETION_BLOCKED = 'tool_call_gate_completion_blocked';
 
-	/** @var array<int,array{id:string,after_tool:string,limited_tools:list<string>,max_calls:int,require_one_of:list<string>,gate_calls:bool,gate_completion:bool}> Normalized rules. */
+	/** @var array<int,array{id:string,after_tool:string,limited_tools:list<string>,max_calls:int,require_one_of:list<string>,require_tool_use:bool,min_tool_calls:int,gate_calls:bool,gate_completion:bool}> Normalized rules. */
 	private array $rules;
 
 	/**
@@ -165,6 +180,39 @@ class WP_Agent_Tool_Call_Gate {
 				continue;
 			}
 
+			// Anchor-independent "do real work before finishing" rule. Blocks
+			// completion until at least `min_tool_calls` qualifying tool calls
+			// have run, with no anchor required — so a turn-one stop with zero
+			// tool calls (the model narrated instead of acting) is refused.
+			if ( ! empty( $rule['require_tool_use'] ) ) {
+				$qualifying = empty( $rule['require_one_of'] ) ? null : $rule['require_one_of'];
+				$seen       = self::count_any_tool_calls( $messages, $qualifying );
+				if ( $seen >= $rule['min_tool_calls'] ) {
+					continue;
+				}
+
+				if ( null !== $qualifying ) {
+					$reason = sprintf(
+						'COMPLETION BLOCKED: the task is not finished and you have not used the required tools yet. Make concrete progress now by calling one of these tools: %s. Perform actions as tool calls rather than describing them in text.',
+						implode( ', ', $rule['require_one_of'] )
+					);
+				} else {
+					$reason = 'COMPLETION BLOCKED: the task is not finished and you have not used any tools yet. Make concrete progress now by calling one of your available tools. Perform actions as tool calls rather than describing them in text.';
+				}
+
+				return array(
+					'allowed' => false,
+					'reason'  => $reason,
+					'context' => array(
+						'rule_id'          => $rule['id'],
+						'require_tool_use' => true,
+						'min_tool_calls'   => $rule['min_tool_calls'],
+						'tool_calls_seen'  => $seen,
+						'require_one_of'   => $rule['require_one_of'],
+					),
+				);
+			}
+
 			$anchor_index = self::first_tool_call_index( $messages, $rule['after_tool'] );
 			if ( $anchor_index < 0 ) {
 				continue;
@@ -238,7 +286,7 @@ class WP_Agent_Tool_Call_Gate {
 	 * Normalize raw rules to a deterministic internal shape.
 	 *
 	 * @param array<mixed> $rules Raw rules.
-	 * @return array<int,array{id:string,after_tool:string,limited_tools:list<string>,max_calls:int,require_one_of:list<string>,gate_calls:bool,gate_completion:bool}>
+	 * @return array<int,array{id:string,after_tool:string,limited_tools:list<string>,max_calls:int,require_one_of:list<string>,require_tool_use:bool,min_tool_calls:int,gate_calls:bool,gate_completion:bool}>
 	 */
 	private static function normalize_rules( array $rules ): array {
 		$normalized = array();
@@ -247,38 +295,71 @@ class WP_Agent_Tool_Call_Gate {
 				continue;
 			}
 
-			$max_raw        = $rule['max_calls'] ?? 0;
-			$after_tool     = self::sanitize_tool_name( $rule['after_tool'] ?? '' );
-			$limited_tools  = self::sanitize_tool_list( $rule['limited_tools'] ?? ( $rule['limited_tool_names'] ?? array() ) );
-			$require_one_of = self::sanitize_tool_list( $rule['require_one_of'] ?? ( $rule['then_require_one_of'] ?? array() ) );
-			$max_calls      = max( 0, is_numeric( $max_raw ) ? (int) $max_raw : 0 );
-			$gate_calls     = self::bool_flag( $rule['gate_calls'] ?? true );
-			$gate_complete  = self::bool_flag( $rule['gate_completion'] ?? true );
+			$max_raw          = $rule['max_calls'] ?? 0;
+			$min_raw          = $rule['min_tool_calls'] ?? 1;
+			$after_tool       = self::sanitize_tool_name( $rule['after_tool'] ?? '' );
+			$limited_tools    = self::sanitize_tool_list( $rule['limited_tools'] ?? ( $rule['limited_tool_names'] ?? array() ) );
+			$require_one_of   = self::sanitize_tool_list( $rule['require_one_of'] ?? ( $rule['then_require_one_of'] ?? array() ) );
+			$max_calls        = max( 0, is_numeric( $max_raw ) ? (int) $max_raw : 0 );
+			$min_tool_calls   = max( 1, is_numeric( $min_raw ) ? (int) $min_raw : 1 );
+			$require_tool_use = self::bool_flag( $rule['require_tool_use'] ?? false );
+			$gate_calls       = self::bool_flag( $rule['gate_calls'] ?? true );
+			$gate_complete    = self::bool_flag( $rule['gate_completion'] ?? true );
 
-			// A rule must declare an anchor and at least one required commit tool.
-			if ( '' === $after_tool || empty( $require_one_of ) ) {
+			// A `require_tool_use` rule is anchor-independent: it needs no anchor
+			// or commit set and enforces only completion. Every other rule must
+			// declare an anchor and at least one required commit tool.
+			if ( $require_tool_use ) {
+				if ( ! $gate_complete ) {
+					continue;
+				}
+			} elseif ( '' === $after_tool || empty( $require_one_of ) ) {
 				continue;
 			}
 
-			// Per-call gating needs a bounded limited-tool budget; without one,
-			// only completion gating remains meaningful.
-			$can_gate_calls = $gate_calls && ! empty( $limited_tools ) && $max_calls > 0;
-			if ( ! $can_gate_calls && ! $gate_complete ) {
+			// Per-call gating needs an anchor and a bounded limited-tool budget;
+			// without one, only completion gating remains meaningful.
+			$can_gate_calls = $gate_calls && '' !== $after_tool && ! empty( $limited_tools ) && $max_calls > 0;
+			if ( ! $require_tool_use && ! $can_gate_calls && ! $gate_complete ) {
 				continue;
 			}
 
 			$normalized[] = array(
-				'id'              => self::sanitize_rule_id( $rule['id'] ?? ( 'tool-call-rule-' . $index ) ),
-				'after_tool'      => $after_tool,
-				'limited_tools'   => $limited_tools,
-				'max_calls'       => $max_calls,
-				'require_one_of'  => $require_one_of,
-				'gate_calls'      => $can_gate_calls,
-				'gate_completion' => $gate_complete,
+				'id'               => self::sanitize_rule_id( $rule['id'] ?? ( 'tool-call-rule-' . $index ) ),
+				'after_tool'       => $after_tool,
+				'limited_tools'    => $limited_tools,
+				'max_calls'        => $max_calls,
+				'require_one_of'   => $require_one_of,
+				'require_tool_use' => $require_tool_use,
+				'min_tool_calls'   => $min_tool_calls,
+				'gate_calls'       => $can_gate_calls,
+				'gate_completion'  => $gate_complete,
 			);
 		}
 
 		return $normalized;
+	}
+
+	/**
+	 * Count tool-call messages across the whole transcript.
+	 *
+	 * @param array<int,mixed>       $messages   Transcript messages.
+	 * @param array<int,string>|null $tool_names Tool names to count, or null to count any tool call.
+	 * @return int
+	 */
+	private static function count_any_tool_calls( array $messages, ?array $tool_names ): int {
+		$count = 0;
+		foreach ( array_values( $messages ) as $message ) {
+			$name = self::tool_call_name( $message );
+			if ( '' === $name ) {
+				continue;
+			}
+			if ( null === $tool_names || in_array( $name, $tool_names, true ) ) {
+				++$count;
+			}
+		}
+
+		return $count;
 	}
 
 	/**

--- a/tests/default-agents-chat-handler-smoke.php
+++ b/tests/default-agents-chat-handler-smoke.php
@@ -425,6 +425,40 @@ namespace {
 	agents_api_smoke_assert_equals( true, in_array( 'assistant', $canonical_roles, true ), 'canonical messages include the assistant reply', $failures, $passes );
 	agents_api_smoke_assert_equals( true, ! in_array( 'tool', $canonical_roles, true ), 'canonical messages omit raw tool envelopes', $failures, $passes );
 
+	echo "\n[1b] Runtime-bundle agents declare their toolset as `enabled_tools` and the loop wires it:\n";
+	// Native runtime agent bundles place their toolset under
+	// `agent_config.enabled_tools` (the field the bundle schema/validators use),
+	// which the importer forwards verbatim as the agent default config. The
+	// default handler must recognize it, or the agent runs with zero tools, the
+	// model narrates instead of acting, and the loop stops after one tool-less turn.
+	$registry->register(
+		'bundle-brain',
+		array(
+			'label'          => 'Bundle Brain',
+			'default_config' => array(
+				'provider'      => 'fake-provider',
+				'model'         => 'fake-model',
+				'system_prompt' => 'You are the bundle brain.',
+				'enabled_tools' => array( 'kitchen/lookup' ),
+			),
+		)
+	);
+
+	$GLOBALS['__chat_handler_ability_calls'] = array();
+	$reset_provider();
+
+	$bundle_output = AgentsAPI\AI\Channels\WP_Agent_Default_Chat_Handler::execute(
+		array(
+			'agent'   => 'bundle-brain',
+			'message' => 'How do I prep risotto?',
+		)
+	);
+
+	agents_api_smoke_assert_equals( false, $bundle_output instanceof WP_Error, 'enabled_tools agent returns canonical output, not WP_Error', $failures, $passes );
+	agents_api_smoke_assert_equals( 1, count( $GLOBALS['__chat_handler_ability_calls'] ), 'enabled_tools wired the toolset so the loop mediated the tool call', $failures, $passes );
+	agents_api_smoke_assert_equals( 'risotto', $GLOBALS['__chat_handler_ability_calls'][0]['query'] ?? '', 'the enabled_tools-declared tool received the model-supplied parameters', $failures, $passes );
+	agents_api_smoke_assert_equals( 2, (int) ( $bundle_output['metadata']['agents_api']['turn_count'] ?? 0 ), 'enabled_tools agent ran the full tool-mediated loop, not a single tool-less turn', $failures, $passes );
+
 	echo "\n[2] Provider/model fall back to the request when the agent config omits them:\n";
 	$registry->register(
 		'bare-brain',

--- a/tests/tool-call-gate-smoke.php
+++ b/tests/tool-call-gate-smoke.php
@@ -235,4 +235,97 @@ $injected = array_values( array_filter(
 agents_api_smoke_assert_equals( 2, count( $injected ), 'each block injects a model-visible correction message', $failures, $passes );
 agents_api_smoke_assert_equals( true, str_contains( (string) ( $injected[0]['content'] ?? '' ), 'COMPLETION BLOCKED' ), 'injected correction states the completion is blocked', $failures, $passes );
 
+// ---------------------------------------------------------------------------
+// Anchor-independent require_tool_use rule: do not finish without doing real
+// work. Reproduces the native failure mode where a model narrates its intent
+// ("List root.") as text on turn one instead of emitting a tool call, which the
+// loop would otherwise treat as natural completion and stop with zero work.
+// ---------------------------------------------------------------------------
+$require_tool_use_rules = array(
+	array(
+		'id'               => 'require-tool-use',
+		'require_tool_use' => true,
+	),
+);
+
+echo "\n[5] require_tool_use rule blocks completion until at least one tool runs:\n";
+$rtu_gate = WP_Agent_Tool_Call_Gate::from_config( $require_tool_use_rules );
+agents_api_smoke_assert_equals( true, $rtu_gate instanceof WP_Agent_Tool_Call_Gate, 'gate builds from an anchor-less require_tool_use rule', $failures, $passes );
+
+$no_tools_yet = array(
+	WP_Agent_Message::text( 'user', 'List the workspace root then document it.' ),
+	WP_Agent_Message::text( 'assistant', '_List root._' ),
+);
+$rtu_blocked = $rtu_gate->evaluate_completion( $no_tools_yet );
+agents_api_smoke_assert_equals( false, $rtu_blocked['allowed'], 'completion is blocked when the transcript has zero tool calls', $failures, $passes );
+agents_api_smoke_assert_equals( 'require-tool-use', $rtu_blocked['context']['rule_id'] ?? '', 'block names the require_tool_use rule', $failures, $passes );
+agents_api_smoke_assert_equals( 0, $rtu_blocked['context']['tool_calls_seen'] ?? -1, 'block reports zero tool calls seen', $failures, $passes );
+
+$one_tool = array_merge( $no_tools_yet, array( tool_call_gate_smoke_call( 'read' ) ) );
+agents_api_smoke_assert_equals( true, $rtu_gate->evaluate_completion( $one_tool )['allowed'], 'completion is allowed once any tool call has run', $failures, $passes );
+
+echo "\n[6] Loop does not prematurely complete a turn-one narration with zero tool calls:\n";
+$executor->executed = array();
+$rtu_turns_seen     = array();
+$rtu_gate_events    = array();
+$rtu_result = WP_Agent_Conversation_Loop::run(
+	array( array( 'role' => 'user', 'content' => 'List the workspace root then document it.' ) ),
+	static function ( array $messages, array $context ) use ( &$rtu_turns_seen ): array {
+		$turn               = (int) ( $context['turn'] ?? 0 );
+		$rtu_turns_seen[]   = $turn;
+
+		if ( 1 === $turn ) {
+			// The exact native repro: the model narrates its intended action as
+			// prose instead of emitting a tool call. The runtime must refuse to
+			// treat this as a finished run.
+			return array(
+				'messages'   => $messages,
+				'content'    => '_List root._',
+				'tool_calls' => array(),
+			);
+		}
+
+		if ( 2 === $turn ) {
+			// After the nudge, the model finally acts.
+			return array(
+				'messages'   => $messages,
+				'tool_calls' => array(
+					array( 'id' => 't2-read', 'name' => 'read', 'parameters' => array() ),
+				),
+			);
+		}
+
+		// Turn 3: a tool has run, so finishing is now allowed.
+		return array(
+			'messages'   => $messages,
+			'content'    => 'Documented the workspace root.',
+			'tool_calls' => array(),
+		);
+	},
+	array(
+		'max_turns'         => 8,
+		'tool_executor'     => $executor,
+		'tool_declarations' => $tools,
+		'tool_call_rules'   => $require_tool_use_rules,
+		'on_event'          => static function ( string $event, array $payload ) use ( &$rtu_gate_events ): void {
+			if ( WP_Agent_Tool_Call_Gate::EVENT_COMPLETION_BLOCKED === $event ) {
+				$rtu_gate_events[] = $payload;
+			}
+		},
+	)
+);
+
+agents_api_smoke_assert_equals( array( 1, 2, 3 ), $rtu_turns_seen, 'loop forced another turn instead of stopping after the turn-one narration', $failures, $passes );
+agents_api_smoke_assert_equals( 1, count( $rtu_gate_events ), 'completion was blocked exactly once, on the zero-tool turn', $failures, $passes );
+agents_api_smoke_assert_equals( true, in_array( 'read', $executor->executed, true ), 'the model executed a real tool after the nudge', $failures, $passes );
+agents_api_smoke_assert_equals( true, (bool) ( $rtu_result['completed'] ?? false ), 'loop completes once a tool has actually run', $failures, $passes );
+agents_api_smoke_assert_equals( 'Documented the workspace root.', $rtu_result['final_content'] ?? '', 'final content is the post-work answer, not the narration', $failures, $passes );
+
+$rtu_injected = array_values( array_filter(
+	$rtu_result['messages'],
+	static fn( array $m ): bool => WP_Agent_Tool_Call_Gate::EVENT_COMPLETION_BLOCKED === ( $m['metadata']['type'] ?? '' )
+) );
+agents_api_smoke_assert_equals( 1, count( $rtu_injected ), 'a single model-visible nudge was injected', $failures, $passes );
+agents_api_smoke_assert_equals( true, str_contains( (string) ( $rtu_injected[0]['content'] ?? '' ), 'COMPLETION BLOCKED' ), 'the nudge tells the model its completion was blocked', $failures, $passes );
+
 agents_api_smoke_finish( 'Agents API tool-call gate', $failures, $passes );


### PR DESCRIPTION
## Symptom

A native agents-api run (WP Codebox, no Data Machine) stopped after turn 1 with **zero work done**: the provider request succeeded (`completion_tokens: 58`, no timeout), but the assistant produced a terse text turn (`_List root._`) with **no tool call**. The loop saw empty `tool_calls`, treated it as natural completion, and finished — no docs written, no PR.

## Root cause (neither H1 nor H2 — a tool-wiring key mismatch), proven by code path

**It is NOT a dropped Responses-API tool call (H1).** Disproven accessor-by-accessor: `ai-provider-for-openai` `OpenAiTextGenerationModel::parseFunctionCallOutputToCandidate()` converts a top-level `function_call` output item into a `Candidate` with a `FunctionCall` part; php-ai-client `PromptBuilder::generateTextResult()` returns the **full** `GenerativeAiResult` with all candidates (it does not strip non-text parts); agents-api `WP_Agent_Provider_Turn_Result::extract_structured_tool_calls()` walks every candidate via `getCandidates()→getMessage()→getParts()→getFunctionCall()` (every accessor name matches the DTOs). A function call, if emitted, would surface as a `tool_call`.

**The model narrated because it had no tools to call.** The native bundle declares its toolset under `agent_config.enabled_tools` — the field the bundle schema, the homeboy-extensions bundle validator, and the Data Machine flow steps all standardize on. The runtime-bundle importer forwards `agent_config` **verbatim** as the agent default config (`default_config => agent_config`). But the default agents/chat handler's `resolve_tool_declarations()` only recognized `tools | abilities | tool_names` — never `enabled_tools`, and tools are never read from the request input. So:

- `resolve_tool_declarations($config)` → **empty**
- `mediation_enabled` (`tool_executor` + non-empty `tool_declarations`) → **false**
- the provider request carried **no function declarations**
- the model narrated its intended first action (`_List root._`) as prose
- with mediation off, `should_continue` defaulted to break-after-one-turn → run ended after a single tool-less turn

`src/Channels/register-default-agents-chat-handler.php:resolve_tool_declarations()` (key allowlist) is the root-cause line.

## Fixes

**1. Root cause — wire `enabled_tools` (owning layer: agents-api default chat handler).** Add `enabled_tools` as the primary recognized tool-name key (`tools`/`abilities`/`tool_names` retained as aliases). Now a native bundle's declared toolset reaches the loop, mediation turns on, and the model is sent its tools. Provider-agnostic; no Data Machine; no `dm_` identifiers.

**2. Defense-in-depth — anchor-independent `require_tool_use` completion gate (owning layer: agents-api runtime).** Even with tools wired, a model can still narrate on turn 1 without calling a tool. `WP_Agent_Tool_Call_Gate` gains a second, anchor-independent rule shape — `array( 'require_tool_use' => true, 'min_tool_calls' => 1 )` — that blocks completion whenever a run is about to end with fewer than `min_tool_calls` qualifying tool calls in the whole transcript (even turn 1, no anchor required; `require_one_of` optionally restricts which calls qualify). The loop's existing completion-gate hook injects a model-visible nudge and forces another turn (bounded by `max_turns`/budgets). The #381 gate could not catch this because its completion check is anchored on an `after_tool` that never fired. An agent opts in by declaring the rule under `tool_call_rules` (already forwarded by the handler).

## Tests (real assertions, real PASS output)

- `tests/default-agents-chat-handler-smoke.php` [1b]: registers an agent declaring its toolset as `enabled_tools` and asserts the loop wires it, mediates the tool call with model-supplied parameters, and runs the full multi-turn loop (not one tool-less turn). → `All 30 ... assertions passed.`
- `tests/tool-call-gate-smoke.php` [5]/[6]: the exact native repro — a turn-1 zero-tool narration is refused, the loop forces another turn, the model then calls a tool, the run finishes; asserts no premature completion + single model-visible nudge. → `All 34 ... assertions passed.`
- `composer phpstan` → `[OK] No errors`
- `composer smoke` → EXIT 0, full suite green (no regressions)

## Follow-up to activate for docs-agent (separate, not in this PR)

To benefit, the docs-agent native bundle should additionally declare the `require_tool_use` rule under `agent_config.tool_call_rules` (the handler already forwards `tool_call_rules` into loop options per #380/#381). The `enabled_tools` fix here is what unblocks the run. Post-merge validation: re-run `Build With WordPress Developer Docs Agent` (`--ref fix/developer-docs-execute-via-full-run`) and expect `turn_count > 1`, tools executed, docs written, a docs PR on `docs-agent/build-with-wordpress-developer-docs`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Claude Opus 4.8)
- **Used for:** H1/H2 code-path diagnosis, locating the `enabled_tools` wiring gap, implementing both fixes, and writing the smoke coverage. Chris reviewed every line.