### PR TITLE
Serialize empty function-declaration parameters as a JSON object, not []

### DIFF
--- a/src/Runtime/class-wp-agent-default-provider-turn-adapter.php
+++ b/src/Runtime/class-wp-agent-default-provider-turn-adapter.php
@@ -766,10 +766,46 @@ class WP_Agent_Default_Provider_Turn_Adapter implements WP_Agent_Provider_Turn_A
 			$declarations[] = new \WordPress\AiClient\Tools\DTO\FunctionDeclaration(
 				$tool_name,
 				$description,
-				$parameters
+				self::function_declaration_parameters( $parameters )
 			);
 		}
 
 		return $declarations;
+	}
+
+	/**
+	 * Guarantee a function declaration's parameter schema serializes as a JSON object.
+	 *
+	 * The tools API contract (OpenAI and other JSON-Schema providers) requires each
+	 * `tools[].parameters` to be a JSON Schema OBJECT. A tool with no parameters — or
+	 * whose registered ability schema resolves empty — yields an empty PHP `array()`,
+	 * which `json_encode`s to `[]` (an array, not an object). The provider then rejects
+	 * the whole request (`Invalid type for 'tools[0].parameters': expected an object,
+	 * but got an array instead`), so every turn fails before any tool can run.
+	 *
+	 * This normalizes the empty/missing case to the minimal valid empty-object schema
+	 * (`{"type":"object","properties":{}}`), using a `stdClass` for `properties` so the
+	 * inner collection also encodes as `{}` rather than `[]`. A declaration that already
+	 * carries a real schema is passed through unchanged; only an empty `properties`
+	 * collection inside an otherwise-real schema is cast to an object for the same
+	 * reason. The normalization is provider-agnostic and keys on schema shape, never on
+	 * specific tool names.
+	 *
+	 * @param array<mixed> $parameters Resolved tool parameter schema.
+	 * @return array<mixed> Schema guaranteed to JSON-encode as an object.
+	 */
+	private static function function_declaration_parameters( array $parameters ): array {
+		if ( array() === $parameters ) {
+			return array(
+				'type'       => 'object',
+				'properties' => new \stdClass(),
+			);
+		}
+
+		if ( array_key_exists( 'properties', $parameters ) && array() === $parameters['properties'] ) {
+			$parameters['properties'] = new \stdClass();
+		}
+
+		return $parameters;
 	}
 }

--- a/tests/default-provider-turn-adapter-smoke.php
+++ b/tests/default-provider-turn-adapter-smoke.php
@@ -740,5 +740,74 @@ namespace {
 	agents_api_smoke_assert_equals( true, false !== strpos( $bad_model_message, 'Unable to resolve model' ), 'an unresolvable model id throws an actionable RuntimeException (not a TypeError)', $failures, $passes );
 	agents_api_smoke_assert_equals( true, false !== strpos( $bad_model_message, '__unregistered__' ), 'the resolution error names the unresolvable model id', $failures, $passes );
 
+	echo "\n[12] Regression: a no-parameter tool's function declaration serializes 'parameters' as a JSON OBJECT, never an array:\n";
+	$GLOBALS['__adapter_smoke']                = array();
+	$GLOBALS['__adapter_smoke']['next_result'] = $make_result( 'ok', array(), array( 1, 1, 2 ) );
+
+	$params_adapter = new AgentsAPI\AI\WP_Agent_Default_Provider_Turn_Adapter( 'fake-provider', 'fake-model', 'sys' );
+	$params_request = new AgentsAPI\AI\WP_Agent_Provider_Turn_Request(
+		array( array( 'role' => 'user', 'content' => 'use the tools' ) ),
+		array(
+			// A no-arg tool whose registered schema resolved empty — the exact native-runtime
+			// case (workspace_*, *_github_* tools) that produced `"parameters":[]` → OpenAI 400.
+			'workspace_show' => array(
+				'name'        => 'workspace_show',
+				'source'      => 'agents',
+				'description' => 'Show a workspace.',
+				'parameters'  => array(),
+				'executor'    => 'host',
+				'scope'       => 'run',
+			),
+			// A tool that already carries a real object schema — must pass through unchanged.
+			'client/lookup'  => array(
+				'name'        => 'client/lookup',
+				'source'      => 'client',
+				'description' => 'Look up one value.',
+				'parameters'  => array(
+					'type'       => 'object',
+					'required'   => array( 'query' ),
+					'properties' => array( 'query' => array( 'type' => 'string' ) ),
+				),
+				'executor'    => 'client',
+				'scope'       => 'run',
+			),
+		),
+		array( 'provider_id' => 'fake-provider', 'model_id' => 'fake-model' )
+	);
+
+	$params_adapter->run_turn( $params_request );
+	$mapped_declarations = $GLOBALS['__adapter_smoke']['declarations'] ?? array();
+	agents_api_smoke_assert_equals( 2, count( $mapped_declarations ), 'both tool declarations are mapped to function declarations', $failures, $passes );
+
+	$decls_by_name = array();
+	foreach ( $mapped_declarations as $decl ) {
+		$decls_by_name[ $decl->name ?? '' ] = $decl;
+	}
+
+	// The no-arg tool: parameters MUST json-encode to an object, never `[]`.
+	$empty_json = json_encode( $decls_by_name['workspace_show']->parameters ?? null );
+	agents_api_smoke_assert_equals( '{"type":"object","properties":{}}', $empty_json, 'no-parameter tool emits the minimal valid empty-object schema', $failures, $passes );
+	agents_api_smoke_assert_equals( true, false !== strpos( $empty_json, '"properties":{' ), 'empty parameters serialize properties as an object ({), not an array ([)', $failures, $passes );
+	agents_api_smoke_assert_equals( false, '[]' === $empty_json, "no-parameter tool never serializes 'parameters' as []", $failures, $passes );
+	agents_api_smoke_assert_equals( true, '{' === substr( $empty_json, 0, 1 ), 'no-parameter tool parameters JSON begins with { (an object)', $failures, $passes );
+
+	// Prove the exact provider-facing payload shape: `"parameters":{` must appear and
+	// `"parameters":[` must never appear when the declaration is wrapped for the API.
+	$wrapped_empty = json_encode(
+		array(
+			'type'       => 'function',
+			'name'       => $decls_by_name['workspace_show']->name ?? '',
+			'parameters' => $decls_by_name['workspace_show']->parameters ?? null,
+		)
+	);
+	agents_api_smoke_assert_equals( true, false !== strpos( $wrapped_empty, '"parameters":{' ), 'wrapped tool payload contains "parameters":{ (an object)', $failures, $passes );
+	agents_api_smoke_assert_equals( false, false !== strpos( $wrapped_empty, '"parameters":[' ), 'wrapped tool payload never contains "parameters":[ (the OpenAI 400 shape)', $failures, $passes );
+
+	// The real-schema tool: object stays an object and the declared schema is preserved verbatim.
+	$real_json = json_encode( $decls_by_name['client/lookup']->parameters ?? null );
+	agents_api_smoke_assert_equals( true, '{' === substr( $real_json, 0, 1 ), 'real-schema tool parameters remain a JSON object', $failures, $passes );
+	agents_api_smoke_assert_equals( true, false !== strpos( $real_json, '"query"' ), 'real-schema tool preserves its declared properties unchanged', $failures, $passes );
+	agents_api_smoke_assert_equals( 'object', $decls_by_name['client/lookup']->parameters['type'] ?? '', 'real-schema tool keeps its declared type', $failures, $passes );
+
 	agents_api_smoke_finish( 'Agents API default provider-turn adapter', $failures, $passes );
 }


### PR DESCRIPTION
## Problem

Every native-runtime agent turn now has tools (wired in #384) and builds a real OpenAI request with function declarations, but OpenAI rejects the whole request with a 400:

```
wp-ai-client request failed: Bad Request (400) - Invalid type for 'tools[0].parameters': expected an object, but got an array instead.
```

Result: `stop_reason` `provider_error`, `completion_tokens` 0, `turn_count` 1, no work done. (Verified: build-with-wordpress run 28386299613, native path, no Data Machine.)

## Root cause

The native bundle's `enabled_tools` are bare tool names. `resolve_tool_declarations()` builds each declaration's `parameters` from `WP_Ability::get_input_schema()` (`src/Channels/register-default-agents-chat-handler.php:297`). No-arg tools (the `workspace_*` and `*_github_*` tools) have **no input schema**, so `get_input_schema()` returns an empty `array()`.

That empty array flows unchanged into the function-declaration builder `WP_Agent_Default_Provider_Turn_Adapter::function_declarations()` (`src/Runtime/class-wp-agent-default-provider-turn-adapter.php:764`), which constructs a wp-ai-client `FunctionDeclaration` with `parameters = array()`. `FunctionDeclaration::toArray()` emits that array, and an empty PHP `array()` **`json_encode`s to `[]`** — a JSON array. OpenAI's tools API requires `tools[].parameters` to be a JSON Schema **object**, so the request 400s.

This affects **only the no-arg / no-schema tools**; tools that carry a real object schema already serialized correctly. It is not provider-specific to a tool name — any tool whose schema resolves empty hits it.

## Fix

Normalize the parameter schema at the single provider-agnostic chokepoint where the OpenAI-facing `FunctionDeclaration` objects are built (`function_declarations()`, used by both the bare-builder and injected-dispatch paths). An empty/missing schema becomes the minimal valid empty-object schema `{"type":"object","properties":{}}` — using a `stdClass` for `properties` so the inner collection encodes as `{}` rather than `[]`. A declaration that already carries a real schema is passed through unchanged. The normalization keys on schema **shape**, never on specific tool names, and stays generic (no DM coupling, no `dm_`-style naming).

The real per-tool schemas are surfaced when the registered ability provides one (passed through verbatim). The no-arg tools genuinely lack an input schema upstream, so this defaults them to the valid empty-object schema. Surfacing richer per-tool schemas from executors where they exist is a separate follow-up; this change makes the request valid regardless.

## Tests

Extended `tests/default-provider-turn-adapter-smoke.php` (section [12]): drives `run_turn()` with a no-parameter tool and a real-schema tool, then asserts the mapped function declaration's `parameters` json-encodes to the exact `{"type":"object","properties":{}}` shape, that `"parameters":[` never appears in the wrapped payload while `"parameters":{` does, and that the real-schema tool stays an object with its declared properties preserved.

```
composer phpstan   # [OK] No errors
composer smoke     # exit 0; All 72 default provider-turn adapter assertions passed; 0 failures across the full suite
```

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Claude Opus 4.8)
- **Used for:** Root-cause investigation, the parameter-schema normalization fix, and the smoke test coverage.