### PR TITLE
Retry transient provider failures (429 + 5xx) with bounded backoff in the default turn adapter

### DIFF
--- a/src/Runtime/class-wp-agent-default-provider-turn-adapter.php
+++ b/src/Runtime/class-wp-agent-default-provider-turn-adapter.php
@@ -74,6 +74,47 @@ class WP_Agent_Default_Provider_Turn_Adapter implements WP_Agent_Provider_Turn_A
 	 */
 	private const DEFAULT_REQUEST_TIMEOUT = 600.0;
 
+	/**
+	 * Default maximum number of dispatch attempts (initial try + retries) for one turn.
+	 *
+	 * A multi-turn agentic loop fires provider requests in rapid succession and
+	 * routinely brushes a provider's per-minute rate limit, so a single HTTP 429
+	 * (or a transient 5xx / connection-reset) must not abort the whole run. Five
+	 * attempts — the initial request plus up to four retries — rides through a
+	 * short transient spike while still failing fast on a genuine outage. The
+	 * default exponential schedule (2s, 4s, 8s, 16s, see
+	 * {@see self::DEFAULT_RETRY_BASE_DELAY}) bounds worst-case backoff for one
+	 * turn to roughly a minute even with full jitter, comfortably inside the
+	 * per-request timeout ({@see self::DEFAULT_REQUEST_TIMEOUT}).
+	 *
+	 * @var int
+	 */
+	private const DEFAULT_RETRY_MAX_ATTEMPTS = 5;
+
+	/**
+	 * Default base delay, in seconds, for the exponential-backoff schedule.
+	 *
+	 * The unjittered backoff for retry N (1-indexed) is
+	 * `base_delay * 2^(N-1)` — 2s, 4s, 8s, 16s, … — capped per wait at
+	 * {@see self::DEFAULT_RETRY_MAX_DELAY}. 2s is large enough to let a brief
+	 * per-minute rate-limit window drain yet small enough not to stall an
+	 * interactive run on the first transient blip.
+	 *
+	 * @var float
+	 */
+	private const DEFAULT_RETRY_BASE_DELAY = 2.0;
+
+	/**
+	 * Default ceiling, in seconds, for any single backoff wait.
+	 *
+	 * Caps both the exponential schedule and any provider-supplied `Retry-After`
+	 * hint so one wait can never run away. 60s spans a full per-minute
+	 * rate-limit window while keeping a single turn's total backoff bounded.
+	 *
+	 * @var float
+	 */
+	private const DEFAULT_RETRY_MAX_DELAY = 60.0;
+
 	/** @var string Provider identifier passed to the wp-ai-client builder. */
 	private string $provider_id;
 
@@ -92,6 +133,12 @@ class WP_Agent_Default_Provider_Turn_Adapter implements WP_Agent_Provider_Turn_A
 	/** @var callable|null Injectable dispatch strategy, defaulting to the bare builder. */
 	private $dispatch_provider;
 
+	/** @var callable|null Injectable sleep strategy, defaulting to usleep(). Replaced in tests with a non-sleeping spy. */
+	private $sleeper;
+
+	/** @var callable|null Injectable jitter source returning a float in [0,1), defaulting to mt_rand(). */
+	private $randomizer;
+
 	/**
 	 * @param string                $provider_id   Provider identifier (for example `openai`).
 	 * @param string                $model_id      Model identifier.
@@ -101,6 +148,17 @@ class WP_Agent_Default_Provider_Turn_Adapter implements WP_Agent_Provider_Turn_A
 	 *                                              `request_timeout` (float, seconds; per-turn
 	 *                                              HTTP timeout, defaults to
 	 *                                              self::DEFAULT_REQUEST_TIMEOUT),
+	 *                                              `retry_max_attempts` (int; total dispatch
+	 *                                              attempts, defaults to
+	 *                                              self::DEFAULT_RETRY_MAX_ATTEMPTS),
+	 *                                              `retry_base_delay` (float, seconds; backoff
+	 *                                              base, defaults to self::DEFAULT_RETRY_BASE_DELAY),
+	 *                                              `retry_max_delay` (float, seconds; per-wait cap,
+	 *                                              defaults to self::DEFAULT_RETRY_MAX_DELAY),
+	 *                                              `retry_sleeper` (callable(float $seconds): void;
+	 *                                              overrides usleep, mainly for tests),
+	 *                                              `retry_randomizer` (callable(): float in [0,1);
+	 *                                              overrides the jitter source, mainly for tests),
 	 *                                              `prompt_input_provider` (callable),
 	 *                                              `dispatch_provider` (callable). Only keys
 	 *                                              the wp-ai-client builder supports are wired.
@@ -112,11 +170,15 @@ class WP_Agent_Default_Provider_Turn_Adapter implements WP_Agent_Provider_Turn_A
 
 		$prompt_input_provider = $options['prompt_input_provider'] ?? null;
 		$dispatch_provider     = $options['dispatch_provider'] ?? null;
-		unset( $options['prompt_input_provider'], $options['dispatch_provider'] );
+		$sleeper               = $options['retry_sleeper'] ?? null;
+		$randomizer            = $options['retry_randomizer'] ?? null;
+		unset( $options['prompt_input_provider'], $options['dispatch_provider'], $options['retry_sleeper'], $options['retry_randomizer'] );
 		$this->options = $options;
 
 		$this->prompt_input_provider = is_callable( $prompt_input_provider ) ? $prompt_input_provider : null;
 		$this->dispatch_provider     = is_callable( $dispatch_provider ) ? $dispatch_provider : null;
+		$this->sleeper               = is_callable( $sleeper ) ? $sleeper : null;
+		$this->randomizer            = is_callable( $randomizer ) ? $randomizer : null;
 	}
 
 	/**
@@ -200,10 +262,16 @@ class WP_Agent_Default_Provider_Turn_Adapter implements WP_Agent_Provider_Turn_A
 		$function_declarations = self::function_declarations( $request->toolDeclarations() );
 
 		if ( null !== $this->dispatch_provider ) {
-			$result = $this->dispatch_via_provider( $request, $provider_id, $model_id, $system_prompt, $messages, $prompt_context, $function_declarations );
+			$dispatch = function () use ( $request, $provider_id, $model_id, $system_prompt, $messages, $prompt_context, $function_declarations ) {
+				return $this->dispatch_via_provider( $request, $provider_id, $model_id, $system_prompt, $messages, $prompt_context, $function_declarations );
+			};
 		} else {
-			$result = $this->dispatch_via_bare_builder( $provider_id, $model_id, $system_prompt, $prompt_context, $function_declarations );
+			$dispatch = function () use ( $provider_id, $model_id, $system_prompt, $prompt_context, $function_declarations ) {
+				return $this->dispatch_via_bare_builder( $provider_id, $model_id, $system_prompt, $prompt_context, $function_declarations );
+			};
 		}
+
+		$result = $this->dispatch_with_retry( $dispatch, $provider_id, $model_id );
 
 		if ( function_exists( 'is_wp_error' ) && is_wp_error( $result ) ) {
 			throw new \RuntimeException( 'wp-ai-client request failed: ' . $result->get_error_message() );
@@ -218,6 +286,334 @@ class WP_Agent_Default_Provider_Turn_Adapter implements WP_Agent_Provider_Turn_A
 				'model_id'    => $model_id,
 			),
 		);
+	}
+
+	/**
+	 * Dispatch one provider request with deterministic retry-on-transient backoff.
+	 *
+	 * Wraps the single provider-dispatch call (bare builder or injected dispatcher)
+	 * — NOT the whole loop turn — so a retry never re-runs the loop's mediated tool
+	 * execution and never duplicates tool side effects. The adapter's own turn has
+	 * no side effects beyond the model request, so re-dispatching is safe.
+	 *
+	 * Retries only genuinely transient failures: HTTP 429 (rate limit) and any 5xx
+	 * (which also covers wp-ai-client's NetworkException, mapped to status 503, so
+	 * connection-reset / cURL-timeout transients are retried too). Deterministic 4xx
+	 * failures (400/401/403/404/422) are NOT retried — they fail fast so a real
+	 * misconfiguration surfaces immediately instead of after several pointless waits.
+	 *
+	 * In this runtime a provider HTTP error surfaces as a WP_Error from
+	 * `generate_text_result()` carrying `error_data['status']` (the HTTP status —
+	 * see {@see \WP_AI_Client_Prompt_Builder} `exception_to_wp_error()`, which maps
+	 * php-ai-client's ClientException/ServerException status code through). A thrown
+	 * exception is also handled: its `getCode()` carries the HTTP status for
+	 * php-ai-client ClientException/ServerException, while non-HTTP failures (model
+	 * resolution, etc.) carry code 0 and therefore fail fast.
+	 *
+	 * On exhausting the attempt budget the original transient failure is surfaced
+	 * unchanged (the last WP_Error is returned for the caller's `is_wp_error`
+	 * conversion, or the last exception is rethrown), so a genuine outage still
+	 * fails with a real, actionable message.
+	 *
+	 * @param callable    $dispatch    Dispatches one provider request, returning a
+	 *                                 GenerativeAiResult or WP_Error (or throwing).
+	 * @param string      $provider_id Resolved provider id (retry policy context + event).
+	 * @param string      $model_id    Resolved model id (retry policy context + event).
+	 * @return mixed The successful result, or the last non-retryable / exhausted WP_Error.
+	 */
+	private function dispatch_with_retry( callable $dispatch, string $provider_id, string $model_id ) {
+		$policy       = $this->resolve_retry_policy( $provider_id, $model_id );
+		$max_attempts = $policy['max_attempts'];
+		$attempt      = 1;
+
+		while ( true ) {
+			$caught       = null;
+			$retry_signal = null;
+			$result       = null;
+
+			try {
+				$result = call_user_func( $dispatch );
+			} catch ( \Throwable $error ) {
+				if ( ! $this->is_retryable_status( (int) $error->getCode() ) ) {
+					// Deterministic failure (e.g. model resolution, code 0; a 4xx): fail fast.
+					throw $error;
+				}
+				$caught       = $error;
+				$retry_signal = array(
+					'status'      => (int) $error->getCode(),
+					'retry_after' => null,
+					'message'     => $error->getMessage(),
+				);
+			}
+
+			if ( null === $caught ) {
+				$retry_signal = $this->retryable_failure_signal( $result );
+				if ( null === $retry_signal ) {
+					// Success, or a non-retryable WP_Error (4xx): hand back for fail-fast handling.
+					return $result;
+				}
+			}
+
+			if ( $attempt >= $max_attempts ) {
+				// Budget exhausted: surface the original transient failure unchanged.
+				if ( null !== $caught ) {
+					throw $caught;
+				}
+				return $result;
+			}
+
+			$delay = $this->compute_backoff_delay( $attempt, $policy, $retry_signal['retry_after'] );
+			$this->emit_retry_event( $provider_id, $model_id, $attempt, $max_attempts, $delay, $retry_signal );
+			$this->sleep( $delay );
+			++$attempt;
+		}
+	}
+
+	/**
+	 * Determine whether an HTTP status code denotes a retryable transient failure.
+	 *
+	 * Retryable: 429 (rate limit) and any 5xx (server error / mapped network
+	 * transient). Everything else — including the deterministic 4xx family and the
+	 * code-0 sentinel non-HTTP failures carry — is not retried.
+	 *
+	 * @param int $status HTTP status code (0 when none is available).
+	 * @return bool
+	 */
+	private function is_retryable_status( int $status ): bool {
+		return 429 === $status || ( $status >= 500 && $status < 600 );
+	}
+
+	/**
+	 * Inspect a dispatch result for a retryable transient failure.
+	 *
+	 * Returns a retry signal (`status`, optional `retry_after` seconds, `message`)
+	 * only for a WP_Error whose `error_data['status']` is retryable. A successful
+	 * result, a non-WP_Error value, or a non-retryable WP_Error all yield null.
+	 *
+	 * `retry_after` is read from the WP_Error data when present — wp-ai-client does
+	 * not currently surface a provider `Retry-After` header through this path, so
+	 * the value is honored defensively for the day it does and is otherwise absent,
+	 * leaving the exponential schedule to drive the wait.
+	 *
+	 * @param mixed $result Dispatch result.
+	 * @return array{status:int,retry_after:float|null,message:string}|null
+	 */
+	private function retryable_failure_signal( $result ): ?array {
+		if ( ! function_exists( 'is_wp_error' ) || ! is_wp_error( $result ) ) {
+			return null;
+		}
+
+		$data   = $result->get_error_data();
+		$status = ( is_array( $data ) && isset( $data['status'] ) && is_numeric( $data['status'] ) ) ? (int) $data['status'] : 0;
+		if ( ! $this->is_retryable_status( $status ) ) {
+			return null;
+		}
+
+		$retry_after = null;
+		if ( is_array( $data ) && isset( $data['retry_after'] ) && is_numeric( $data['retry_after'] ) && (float) $data['retry_after'] > 0.0 ) {
+			$retry_after = (float) $data['retry_after'];
+		}
+
+		return array(
+			'status'      => $status,
+			'retry_after' => $retry_after,
+			'message'     => $result->get_error_message(),
+		);
+	}
+
+	/**
+	 * Compute the backoff wait (seconds) before the next dispatch attempt.
+	 *
+	 * Honors a provider `Retry-After` hint when present (capped at the per-wait
+	 * ceiling). Otherwise applies exponential backoff with additive jitter: the
+	 * capped exponential floor `min(max_delay, base * 2^(attempt-1))` — 2s, 4s, 8s,
+	 * 16s, … — plus a random fraction of that floor on top, re-clamped to the
+	 * ceiling. Spreading concurrent runners across `[floor, 2*floor)` decorrelates
+	 * retries that all tripped the same rate limit (avoiding a thundering herd)
+	 * while every wait still grows with the attempt number and never drops below
+	 * the exponential floor. With an injected randomizer returning 0 the schedule
+	 * is the deterministic exponential sequence the smoke asserts on.
+	 *
+	 * @param int                                                         $attempt     1-indexed attempt that just failed.
+	 * @param array{max_attempts:int,base_delay:float,max_delay:float}    $policy      Resolved retry policy.
+	 * @param float|null                                                  $retry_after Provider-supplied hint, when available.
+	 * @return float Seconds to wait (>= 0).
+	 */
+	private function compute_backoff_delay( int $attempt, array $policy, ?float $retry_after ): float {
+		if ( null !== $retry_after && $retry_after > 0.0 ) {
+			return min( $retry_after, $policy['max_delay'] );
+		}
+
+		$exponential = $policy['base_delay'] * ( 2 ** ( $attempt - 1 ) );
+		$floor       = min( (float) $exponential, $policy['max_delay'] );
+		$jittered    = $floor + ( $this->random_unit() * $floor );
+
+		return min( $jittered, $policy['max_delay'] );
+	}
+
+	/**
+	 * Resolve the retry policy for one provider turn (option + filter layered).
+	 *
+	 * Resolution order mirrors {@see self::resolve_request_timeout()}: an adequate
+	 * built-in default, overridable by an explicit adapter option, then by a
+	 * provider-agnostic filter that receives the provider/model ids as context
+	 * only (never branched on here).
+	 *
+	 * @param string $provider_id Resolved provider id (filter context).
+	 * @param string $model_id    Resolved model id (filter context).
+	 * @return array{max_attempts:int,base_delay:float,max_delay:float}
+	 */
+	private function resolve_retry_policy( string $provider_id, string $model_id ): array {
+		$max_attempts = self::DEFAULT_RETRY_MAX_ATTEMPTS;
+		if ( isset( $this->options['retry_max_attempts'] ) && is_numeric( $this->options['retry_max_attempts'] ) && (int) $this->options['retry_max_attempts'] >= 1 ) {
+			$max_attempts = (int) $this->options['retry_max_attempts'];
+		}
+
+		$base_delay = self::DEFAULT_RETRY_BASE_DELAY;
+		if ( isset( $this->options['retry_base_delay'] ) && is_numeric( $this->options['retry_base_delay'] ) && (float) $this->options['retry_base_delay'] >= 0.0 ) {
+			$base_delay = (float) $this->options['retry_base_delay'];
+		}
+
+		$max_delay = self::DEFAULT_RETRY_MAX_DELAY;
+		if ( isset( $this->options['retry_max_delay'] ) && is_numeric( $this->options['retry_max_delay'] ) && (float) $this->options['retry_max_delay'] > 0.0 ) {
+			$max_delay = (float) $this->options['retry_max_delay'];
+		}
+
+		if ( function_exists( 'apply_filters' ) ) {
+			/**
+			 * Filters the maximum dispatch attempts (initial try + retries) for one provider turn.
+			 *
+			 * @param int    $max_attempts Total attempts (>= 1).
+			 * @param string $provider_id  Resolved provider identifier (context only).
+			 * @param string $model_id     Resolved model identifier (context only).
+			 */
+			/** @var mixed $filtered */
+			$filtered = apply_filters( 'agents_api_provider_turn_retry_max_attempts', $max_attempts, $provider_id, $model_id );
+			if ( is_numeric( $filtered ) && (int) $filtered >= 1 ) {
+				$max_attempts = (int) $filtered;
+			}
+
+			/**
+			 * Filters the exponential-backoff base delay (seconds) for one provider turn.
+			 *
+			 * @param float  $base_delay  Base delay in seconds (>= 0).
+			 * @param string $provider_id Resolved provider identifier (context only).
+			 * @param string $model_id    Resolved model identifier (context only).
+			 */
+			/** @var mixed $filtered */
+			$filtered = apply_filters( 'agents_api_provider_turn_retry_base_delay', $base_delay, $provider_id, $model_id );
+			if ( is_numeric( $filtered ) && (float) $filtered >= 0.0 ) {
+				$base_delay = (float) $filtered;
+			}
+
+			/**
+			 * Filters the per-wait backoff ceiling (seconds) for one provider turn.
+			 *
+			 * @param float  $max_delay   Per-wait cap in seconds (> 0).
+			 * @param string $provider_id Resolved provider identifier (context only).
+			 * @param string $model_id    Resolved model identifier (context only).
+			 */
+			/** @var mixed $filtered */
+			$filtered = apply_filters( 'agents_api_provider_turn_retry_max_delay', $max_delay, $provider_id, $model_id );
+			if ( is_numeric( $filtered ) && (float) $filtered > 0.0 ) {
+				$max_delay = (float) $filtered;
+			}
+		}
+
+		return array(
+			'max_attempts' => $max_attempts,
+			'base_delay'   => $base_delay,
+			'max_delay'    => $max_delay,
+		);
+	}
+
+	/**
+	 * Emit a per-retry diagnostic so stalled/retrying runs are observable.
+	 *
+	 * Fires the `agents_api_provider_turn_retry` action before each backoff wait.
+	 * Observer failures are swallowed so a broken listener can never change the
+	 * dispatch outcome.
+	 *
+	 * @param string                                                      $provider_id  Resolved provider id.
+	 * @param string                                                      $model_id     Resolved model id.
+	 * @param int                                                         $attempt      1-indexed attempt that just failed.
+	 * @param int                                                         $max_attempts Total attempt budget.
+	 * @param float                                                       $delay        Seconds to wait before the next attempt.
+	 * @param array{status:int,retry_after:float|null,message:string}     $signal       The transient-failure signal driving the retry.
+	 * @return void
+	 */
+	private function emit_retry_event( string $provider_id, string $model_id, int $attempt, int $max_attempts, float $delay, array $signal ): void {
+		if ( ! function_exists( 'do_action' ) ) {
+			return;
+		}
+
+		try {
+			/**
+			 * Fires before the default provider-turn adapter waits to retry a transient provider failure.
+			 *
+			 * @param array<string, mixed> $context Retry context: provider_id, model_id, attempt,
+			 *                                       max_attempts, delay_seconds, status, retry_after, message.
+			 */
+			do_action(
+				'agents_api_provider_turn_retry',
+				array(
+					'provider_id'   => $provider_id,
+					'model_id'      => $model_id,
+					'attempt'       => $attempt,
+					'max_attempts'  => $max_attempts,
+					'delay_seconds' => $delay,
+					'status'        => $signal['status'],
+					'retry_after'   => $signal['retry_after'],
+					'message'       => $signal['message'],
+				)
+			);
+		} catch ( \Throwable $error ) {
+			// Diagnostic observers must never change the dispatch outcome.
+			unset( $error );
+		}
+	}
+
+	/**
+	 * Sleep for the given seconds through the injectable sleeper (default usleep).
+	 *
+	 * Tests inject a non-sleeping spy so the backoff schedule can be asserted
+	 * without real waits.
+	 *
+	 * @param float $seconds Seconds to sleep (no-op when <= 0).
+	 * @return void
+	 */
+	private function sleep( float $seconds ): void {
+		if ( $seconds <= 0.0 ) {
+			return;
+		}
+
+		if ( null !== $this->sleeper ) {
+			call_user_func( $this->sleeper, $seconds );
+			return;
+		}
+
+		usleep( (int) round( $seconds * 1000000 ) );
+	}
+
+	/**
+	 * Draw a jitter value in [0,1) from the injectable randomizer (default mt_rand).
+	 *
+	 * @return float
+	 */
+	private function random_unit(): float {
+		if ( null !== $this->randomizer ) {
+			$raw   = call_user_func( $this->randomizer );
+			$value = is_numeric( $raw ) ? (float) $raw : 0.0;
+			if ( $value < 0.0 ) {
+				return 0.0;
+			}
+			if ( $value > 1.0 ) {
+				return 1.0;
+			}
+			return $value;
+		}
+
+		return mt_rand() / ( mt_getrandmax() + 1 );
 	}
 
 	/**

--- a/tests/default-provider-turn-adapter-smoke.php
+++ b/tests/default-provider-turn-adapter-smoke.php
@@ -308,12 +308,17 @@ namespace {
 
 	if ( ! class_exists( 'WP_Error' ) ) {
 		class WP_Error {
-			public function __construct( private string $code = '', private string $message = '' ) {}
+			/** @param array<string, mixed> $data */
+			public function __construct( private string $code = '', private string $message = '', private array $data = array() ) {}
 			public function get_error_code(): string {
 				return $this->code;
 			}
 			public function get_error_message(): string {
 				return $this->message;
+			}
+			/** @return array<string, mixed> */
+			public function get_error_data() {
+				return $this->data;
 			}
 		}
 	}
@@ -479,6 +484,196 @@ namespace {
 		$threw = false !== strpos( $error->getMessage(), 'provider exploded' );
 	}
 	agents_api_smoke_assert_equals( true, $threw, 'run_turn throws on a WP_Error dispatch result', $failures, $passes );
+
+	echo "\n[3b] Retry-on-transient: a 429 rate limit is retried with exponential backoff, then succeeds:\n";
+	$GLOBALS['__adapter_smoke'] = array();
+	$retry_attempts            = 0;
+	$retry_sleeps              = array();
+	// Fail the first two dispatches with HTTP 429, then succeed on the third.
+	$GLOBALS['__adapter_smoke']['select_next'] = static function () use ( &$retry_attempts, $make_result ) {
+		++$retry_attempts;
+		if ( $retry_attempts <= 2 ) {
+			return new WP_Error( 'prompt_client_error', 'Too Many Requests (429)', array( 'status' => 429 ) );
+		}
+		return $make_result( 'recovered after backoff', array(), array( 1, 1, 2 ) );
+	};
+	$retry_adapter = new AgentsAPI\AI\WP_Agent_Default_Provider_Turn_Adapter(
+		'fake-provider',
+		'fake-model',
+		'sys',
+		array(
+			'retry_base_delay'   => 2,
+			'retry_max_attempts' => 5,
+			// Non-sleeping spy: record the requested wait without ever sleeping.
+			'retry_sleeper'      => static function ( $seconds ) use ( &$retry_sleeps ) {
+				$retry_sleeps[] = $seconds;
+			},
+			// Zero jitter so the backoff schedule is the deterministic half-of-capped sequence.
+			'retry_randomizer'   => static function () {
+				return 0.0;
+			},
+		)
+	);
+	$retry_raw    = $retry_adapter->run_turn(
+		new AgentsAPI\AI\WP_Agent_Provider_Turn_Request( array( array( 'role' => 'user', 'content' => 'hi' ) ) )
+	);
+	$retry_result = AgentsAPI\AI\WP_Agent_Provider_Turn_Result::normalize( $retry_raw );
+	agents_api_smoke_assert_equals( 'recovered after backoff', $retry_result['content'], 'run_turn retries past transient 429s and returns the eventual success', $failures, $passes );
+	agents_api_smoke_assert_equals( 3, $retry_attempts, 'run_turn dispatched 3 times (2 retried 429s + 1 success)', $failures, $passes );
+	agents_api_smoke_assert_equals( 2, count( $retry_sleeps ), 'run_turn waited once before each of the 2 retries (and never after success)', $failures, $passes );
+	agents_api_smoke_assert_equals( 2.0, $retry_sleeps[0] ?? null, 'first backoff wait is the 2s exponential floor (zero jitter)', $failures, $passes );
+	agents_api_smoke_assert_equals( 4.0, $retry_sleeps[1] ?? null, 'second backoff wait doubles to the 4s exponential floor', $failures, $passes );
+	agents_api_smoke_assert_equals( true, ( $retry_sleeps[1] ?? 0 ) > ( $retry_sleeps[0] ?? 0 ), 'backoff waits strictly increase across retries', $failures, $passes );
+
+	echo "\n[3c] Fail-fast: a deterministic 400 is NOT retried:\n";
+	$GLOBALS['__adapter_smoke'] = array();
+	$ff_attempts               = 0;
+	$ff_sleeps                 = array();
+	$GLOBALS['__adapter_smoke']['select_next'] = static function () use ( &$ff_attempts ) {
+		++$ff_attempts;
+		return new WP_Error( 'prompt_client_error', 'Bad Request (400)', array( 'status' => 400 ) );
+	};
+	$ff_adapter = new AgentsAPI\AI\WP_Agent_Default_Provider_Turn_Adapter(
+		'fake-provider',
+		'fake-model',
+		'sys',
+		array(
+			'retry_sleeper'    => static function ( $seconds ) use ( &$ff_sleeps ) {
+				$ff_sleeps[] = $seconds;
+			},
+			'retry_randomizer' => static function () {
+				return 0.0;
+			},
+		)
+	);
+	$ff_threw = false;
+	try {
+		$ff_adapter->run_turn(
+			new AgentsAPI\AI\WP_Agent_Provider_Turn_Request( array( array( 'role' => 'user', 'content' => 'hi' ) ) )
+		);
+	} catch ( \RuntimeException $error ) {
+		$ff_threw = false !== strpos( $error->getMessage(), '400' );
+	}
+	agents_api_smoke_assert_equals( true, $ff_threw, 'a 400 fails fast as a RuntimeException carrying the real message', $failures, $passes );
+	agents_api_smoke_assert_equals( 1, $ff_attempts, 'a 400 is dispatched exactly once (never retried)', $failures, $passes );
+	agents_api_smoke_assert_equals( 0, count( $ff_sleeps ), 'a 400 never triggers a backoff wait', $failures, $passes );
+
+	echo "\n[3d] Transient 5xx is retried; exhausting the attempt budget surfaces the original error:\n";
+	$GLOBALS['__adapter_smoke'] = array();
+	$exhaust_attempts          = 0;
+	$exhaust_sleeps            = array();
+	$GLOBALS['__adapter_smoke']['select_next'] = static function () use ( &$exhaust_attempts ) {
+		++$exhaust_attempts;
+		return new WP_Error( 'prompt_upstream_server_error', 'Service Unavailable (503)', array( 'status' => 503 ) );
+	};
+	$exhaust_adapter = new AgentsAPI\AI\WP_Agent_Default_Provider_Turn_Adapter(
+		'fake-provider',
+		'fake-model',
+		'sys',
+		array(
+			'retry_max_attempts' => 3,
+			'retry_base_delay'   => 2,
+			'retry_sleeper'      => static function ( $seconds ) use ( &$exhaust_sleeps ) {
+				$exhaust_sleeps[] = $seconds;
+			},
+			'retry_randomizer'   => static function () {
+				return 0.0;
+			},
+		)
+	);
+	$exhaust_threw = false;
+	try {
+		$exhaust_adapter->run_turn(
+			new AgentsAPI\AI\WP_Agent_Provider_Turn_Request( array( array( 'role' => 'user', 'content' => 'hi' ) ) )
+		);
+	} catch ( \RuntimeException $error ) {
+		$exhaust_threw = false !== strpos( $error->getMessage(), '503' );
+	}
+	agents_api_smoke_assert_equals( true, $exhaust_threw, 'an unrecovered 5xx surfaces the original error after the budget is exhausted', $failures, $passes );
+	agents_api_smoke_assert_equals( 3, $exhaust_attempts, 'a persistent 5xx is dispatched exactly retry_max_attempts (3) times', $failures, $passes );
+	agents_api_smoke_assert_equals( 2, count( $exhaust_sleeps ), 'a persistent 5xx waits between attempts but not after the final one', $failures, $passes );
+
+	echo "\n[3e] A provider Retry-After hint is honored as the wait when present:\n";
+	$GLOBALS['__adapter_smoke'] = array();
+	$ra_attempts               = 0;
+	$ra_sleeps                 = array();
+	$GLOBALS['__adapter_smoke']['select_next'] = static function () use ( &$ra_attempts, $make_result ) {
+		++$ra_attempts;
+		if ( 1 === $ra_attempts ) {
+			return new WP_Error( 'prompt_client_error', 'Too Many Requests (429)', array( 'status' => 429, 'retry_after' => 5 ) );
+		}
+		return $make_result( 'recovered after retry-after', array(), array( 1, 1, 2 ) );
+	};
+	$ra_adapter = new AgentsAPI\AI\WP_Agent_Default_Provider_Turn_Adapter(
+		'fake-provider',
+		'fake-model',
+		'sys',
+		array(
+			'retry_base_delay' => 2,
+			'retry_sleeper'    => static function ( $seconds ) use ( &$ra_sleeps ) {
+				$ra_sleeps[] = $seconds;
+			},
+			'retry_randomizer' => static function () {
+				return 0.0;
+			},
+		)
+	);
+	$ra_adapter->run_turn(
+		new AgentsAPI\AI\WP_Agent_Provider_Turn_Request( array( array( 'role' => 'user', 'content' => 'hi' ) ) )
+	);
+	agents_api_smoke_assert_equals( 5.0, $ra_sleeps[0] ?? null, 'a Retry-After hint (5s) is used as the wait instead of the exponential step', $failures, $passes );
+
+	echo "\n[3f] Retry policy is configurable via filters, and each retry emits a diagnostic event:\n";
+	$GLOBALS['__adapter_smoke'] = array();
+	$filter_attempts           = 0;
+	$filter_sleeps             = array();
+	$retry_events              = array();
+	add_action(
+		'agents_api_provider_turn_retry',
+		static function ( $context ) use ( &$retry_events ) {
+			$retry_events[] = $context;
+		}
+	);
+	add_filter(
+		'agents_api_provider_turn_retry_max_attempts',
+		static function ( $attempts, $provider_id, $model_id ) {
+			unset( $provider_id, $model_id );
+			return 2;
+		},
+		10,
+		3
+	);
+	$GLOBALS['__adapter_smoke']['select_next'] = static function () use ( &$filter_attempts ) {
+		++$filter_attempts;
+		return new WP_Error( 'prompt_client_error', 'Too Many Requests (429)', array( 'status' => 429 ) );
+	};
+	$filter_retry_adapter = new AgentsAPI\AI\WP_Agent_Default_Provider_Turn_Adapter(
+		'fake-provider',
+		'fake-model',
+		'sys',
+		array(
+			'retry_sleeper'    => static function ( $seconds ) use ( &$filter_sleeps ) {
+				$filter_sleeps[] = $seconds;
+			},
+			'retry_randomizer' => static function () {
+				return 0.0;
+			},
+		)
+	);
+	try {
+		$filter_retry_adapter->run_turn(
+			new AgentsAPI\AI\WP_Agent_Provider_Turn_Request( array( array( 'role' => 'user', 'content' => 'hi' ) ) )
+		);
+	} catch ( \RuntimeException $error ) {
+		unset( $error );
+	}
+	agents_api_smoke_assert_equals( 2, $filter_attempts, 'the retry_max_attempts filter caps the dispatch count (2)', $failures, $passes );
+	agents_api_smoke_assert_equals( 1, count( $retry_events ), 'one retry diagnostic event fires before the single retry wait', $failures, $passes );
+	agents_api_smoke_assert_equals( 429, $retry_events[0]['status'] ?? null, 'the retry event reports the transient HTTP status', $failures, $passes );
+	agents_api_smoke_assert_equals( 1, $retry_events[0]['attempt'] ?? null, 'the retry event reports the failed attempt number', $failures, $passes );
+	agents_api_smoke_assert_equals( 'fake-provider', $retry_events[0]['provider_id'] ?? '', 'the retry event carries the provider id', $failures, $passes );
+	$GLOBALS['__agents_api_smoke_actions']['agents_api_provider_turn_retry']             = array();
+	$GLOBALS['__agents_api_smoke_actions']['agents_api_provider_turn_retry_max_attempts'] = array();
 
 	echo "\n[4] run_conversation() drives the loop end-to-end through the default adapter:\n";
 	$turn = 0;


### PR DESCRIPTION
## What

A multi-turn agentic loop fires provider requests in rapid succession and routinely brushes a provider's per-minute rate limit. Before this change the default provider-turn adapter dispatched each turn through the bare wp-ai-client builder exactly **once**, so a single HTTP **429** (or a transient **5xx** / connection reset) aborted the whole run with `stop_reason: provider_error`. A verified native-runtime run hit OpenAI 429 mid-task **after** a real 6-turn agentic loop (model resolved, tools accepted, 879 completion tokens) and died with no retry. This was the last robustness gap before the native runtime produces real output.

This wraps the **single provider-dispatch call** in `WP_Agent_Default_Provider_Turn_Adapter` — the bare-builder path and the injected dispatch-provider path, **not** the whole loop turn — with deterministic retry-on-transient backoff.

## Why the retry is at the dispatch call, not the loop turn

Retrying only re-dispatches the model request. The adapter's own turn has no side effects, so the loop's mediated tool execution never re-runs and no tool side effect is duplicated. The mapping work (prompt split, function declarations) is done once outside the retried closure.

## Transient detection (the structured signal)

A provider HTTP error surfaces from `generate_text_result()` as a **`WP_Error`** whose `error_data['status']` is the HTTP status:
- `wp-includes/php-ai-client/src/Providers/Http/Util/ResponseUtil.php` throws `ClientException` for 4xx and `ServerException` for 5xx, each carrying the status as the **exception code**.
- `wp-includes/ai-client/class-wp-ai-client-prompt-builder.php` `exception_to_wp_error()` maps that status code into `error_data['status']` (ClientException/ServerException → `$e->getCode()`; NetworkException → 503).

So retry keys off `WP_Error::get_error_data()['status']`. A thrown exception is also handled — its `getCode()` carries the status for ClientException/ServerException, while non-HTTP failures (model resolution, etc.) carry code 0 and **fail fast**.

- **Retried:** 429 and any 5xx (covers wp-ai-client's NetworkException → 503, so connection-reset / cURL-timeout transients retry too).
- **Not retried:** the deterministic 4xx family (400/401/403/404/422) — fails fast with the real message.

## Backoff policy

Exponential with additive jitter: `min(max_delay, base * 2^(n-1))` floor — **2s, 4s, 8s, 16s** — plus a random fraction of that floor on top, re-clamped to the per-wait ceiling (decorrelates concurrent runners that tripped the same limit). A provider `Retry-After` hint is honored as the wait when present (read defensively from the WP_Error data; wp-ai-client does not surface it through this path today, so backoff is the effective mechanism).

Defaults need no config — **5 attempts, 2s base, 60s cap** → worst-case ~1 minute of backoff per turn, well inside the 600s per-request timeout (#383). Configurable via the same option + filter pattern as the timeout:
- Options: `retry_max_attempts`, `retry_base_delay`, `retry_max_delay`, plus injectable `retry_sleeper` / `retry_randomizer` (for tests).
- Filters: `agents_api_provider_turn_retry_max_attempts` / `_base_delay` / `_max_delay` — provider-agnostic, provider/model ids passed as context only.

On exhausting the budget the **original** transient failure is surfaced unchanged so a genuine outage fails with a real message. Each retry fires an `agents_api_provider_turn_retry` diagnostic action so retrying runs are observable.

Generic and provider-agnostic — no Data Machine coupling, no `dm_` shorthand, every native-runtime consumer of the default adapter inherits this with no per-consumer patch.

## Tests (real, not theater)

Extends `tests/default-provider-turn-adapter-smoke.php` with assertions on attempt count + exact backoff schedule + final result, using the existing fake-provider/fake-builder harness and an **injected non-sleeping sleeper** (no real waits):
- 429 for first 2 attempts then success → retried, waited on the increasing 2s/4s schedule, returned the success.
- 400 → **fails fast** (one dispatch, zero waits).
- Persistent 5xx → budget exhaustion surfaces the original 503 error.
- `Retry-After: 5` → drives the wait (5s).
- Filter + event case → policy is configurable and each retry emits a diagnostic.

### Test commands + results
- `composer phpstan` → **OK, no errors** (level max)
- `composer smoke` → **exit 0, zero failures** across the full suite; the adapter smoke reports **All 90 ... assertions passed** (18 new retry assertions).

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Opus 4.8)
- **Used for:** Implementing deterministic retry/backoff for 429 + transient provider errors in the default provider-turn adapter, and the accompanying smoke tests.