### PR TITLE
Suspendable workflow run model + branch-executor seam (Phase 1)

### DIFF
--- a/agents-api.php
+++ b/agents-api.php
@@ -238,12 +238,15 @@ require_once AGENTS_API_PATH . 'src/Workflows/class-wp-agent-workflow-store.php'
 require_once AGENTS_API_PATH . 'src/Workflows/class-wp-agent-workflow-lifecycle.php';
 require_once AGENTS_API_PATH . 'src/Workflows/class-wp-agent-workflow-run-recorder.php';
 require_once AGENTS_API_PATH . 'src/Workflows/class-wp-agent-workflow-run-context.php';
+require_once AGENTS_API_PATH . 'src/Workflows/interface-wp-agent-workflow-branch-executor.php';
 require_once AGENTS_API_PATH . 'src/Workflows/class-wp-agent-workflow-step-executor.php';
 require_once AGENTS_API_PATH . 'src/Workflows/class-wp-agent-workflow-runner.php';
 require_once AGENTS_API_PATH . 'src/Workflows/class-wp-agent-workflow-registry.php';
 require_once AGENTS_API_PATH . 'src/Workflows/class-wp-agent-workflow-action-scheduler-bridge.php';
 require_once AGENTS_API_PATH . 'src/Workflows/register-workflows.php';
+require_once AGENTS_API_PATH . 'src/Workflows/register-workflow-step-executor.php';
 require_once AGENTS_API_PATH . 'src/Workflows/register-agents-workflow-abilities.php';
+require_once AGENTS_API_PATH . 'src/Workflows/register-reconcile-workflow-branch.php';
 require_once AGENTS_API_PATH . 'src/Workflows/register-workflow-bridge-sync.php';
 require_once AGENTS_API_PATH . 'src/Workflows/register-action-scheduler-listener.php';
 require_once AGENTS_API_PATH . 'src/Routines/class-wp-agent-routine.php';

--- a/composer.json
+++ b/composer.json
@@ -112,6 +112,7 @@
       "php tests/workflow-spec-validator-smoke.php",
       "php tests/workflow-runner-smoke.php",
       "php tests/workflow-parallel-smoke.php",
+      "php tests/workflow-parallel-async-smoke.php",
       "php tests/workflow-lifecycle-smoke.php",
       "php tests/agents-workflow-ability-smoke.php",
       "php tests/routine-smoke.php",

--- a/src/Workflows/class-wp-agent-workflow-run-result.php
+++ b/src/Workflows/class-wp-agent-workflow-run-result.php
@@ -14,6 +14,10 @@
  *   `failed`    — at least one step returned a WP_Error or threw.
  *   `skipped`   — the runner declined to execute (e.g. unknown step
  *                 type that no consumer registered a handler for).
+ *   `suspended` — the run dispatched one or more parallel branches for
+ *                 out-of-band execution and parked mid-flight, waiting on
+ *                 a reconcile to complete + resume it. The suspension frame
+ *                 rides in `metadata._suspension` (see {@see self::get_suspension()}).
  *
  * Step records have the same statuses minus `pending` (steps either ran
  * or didn't), plus a `started_at` / `ended_at` pair for timing.
@@ -36,6 +40,7 @@ final class WP_Agent_Workflow_Run_Result {
 	public const STATUS_FAILED    = 'failed';
 	public const STATUS_SKIPPED   = 'skipped';
 	public const STATUS_CANCELLED = 'cancelled';
+	public const STATUS_SUSPENDED = 'suspended';
 
 	/**
 	 * @since 0.103.0
@@ -176,6 +181,42 @@ final class WP_Agent_Workflow_Run_Result {
 
 	public function is_failed(): bool {
 		return self::STATUS_FAILED === $this->status;
+	}
+
+	/**
+	 * Whether this run is suspended mid-flight waiting on a branch reconcile.
+	 *
+	 * @since 0.5.0
+	 */
+	public function is_suspended(): bool {
+		return self::STATUS_SUSPENDED === $this->status;
+	}
+
+	/**
+	 * Return the suspension frame carried in `metadata._suspension`, or an
+	 * empty array when the run is not suspended. No new constructor argument
+	 * is needed — the frame rides the existing `metadata` field, so it
+	 * round-trips through `to_array()`/`from_array()`/`with()` for free.
+	 *
+	 * @since 0.5.0
+	 *
+	 * @return array<string,mixed>
+	 */
+	public function get_suspension(): array {
+		$suspension = $this->metadata['_suspension'] ?? array();
+		if ( ! is_array( $suspension ) ) {
+			return array();
+		}
+
+		/** @var array<string,mixed> $result */
+		$result = array();
+		foreach ( $suspension as $key => $value ) {
+			if ( is_string( $key ) ) {
+				$result[ $key ] = $value;
+			}
+		}
+
+		return $result;
 	}
 
 	public function to_run_result_envelope(): WP_Agent_Run_Result_Envelope {

--- a/src/Workflows/class-wp-agent-workflow-runner.php
+++ b/src/Workflows/class-wp-agent-workflow-runner.php
@@ -194,14 +194,118 @@ class WP_Agent_Workflow_Runner {
 				'_workflow_store_key' => self::RUN_CONTROL_STORE,
 			)
 		);
-		$executor = new WP_Agent_Workflow_Step_Executor( $this->step_handlers );
 
-		$step_records      = array();
+		return $this->run_step_loop( $spec, $context, $result, array(), 0, ! empty( $options['continue_on_error'] ) );
+	}
+
+	/**
+	 * Resume a suspended run from its persisted suspension frame.
+	 *
+	 * Reloads the run via the recorder, rebuilds the run context from the
+	 * frame's `context_snapshot`, restores the already-executed step records,
+	 * and continues the step loop from `step_index` (the suspended step's
+	 * final output must already be spliced into its record by the caller —
+	 * see {@see agents_reconcile_workflow_branch()}). The `_suspension`
+	 * metadata is cleared so the resumed run is not treated as still parked.
+	 *
+	 * @since 0.5.0
+	 *
+	 * @param string       $run_id  The suspended run's id.
+	 * @param array<mixed> $options Runtime options. Recognized: `continue_on_error`.
+	 * @return WP_Agent_Workflow_Run_Result
+	 */
+	public function resume( string $run_id, array $options = array() ): WP_Agent_Workflow_Run_Result {
+		if ( null === $this->recorder ) {
+			return self::resume_error_result( $run_id, 'workflow_resume_no_recorder', 'A recorder is required to resume a suspended run.' );
+		}
+
+		$result = $this->recorder->find( $run_id );
+		if ( null === $result ) {
+			return self::resume_error_result( $run_id, 'workflow_resume_run_not_found', sprintf( 'No suspended run was found for run_id `%s`.', $run_id ) );
+		}
+		if ( ! $result->is_suspended() ) {
+			// Idempotency guard: an already-resumed (or never-suspended) run is
+			// returned as-is so a duplicate resume is a harmless no-op.
+			return $result;
+		}
+
+		$suspension = $result->get_suspension();
+		$spec       = self::spec_from_result( $result );
+		if ( null === $spec ) {
+			return self::resume_error_result( $run_id, 'workflow_resume_spec_unavailable', 'The suspended run has no replayable spec snapshot to resume from.' );
+		}
+
+		$snapshot = is_array( $suspension['context_snapshot'] ?? null ) ? $suspension['context_snapshot'] : array();
+		$context  = new WP_Agent_Workflow_Run_Context(
+			array(
+				'inputs'              => is_array( $snapshot['inputs'] ?? null ) ? $snapshot['inputs'] : $result->get_inputs(),
+				'steps'               => is_array( $snapshot['steps'] ?? null ) ? $snapshot['steps'] : array(),
+				'vars'                => is_array( $snapshot['vars'] ?? null ) ? $snapshot['vars'] : array(),
+				'_workflow_run_id'    => $run_id,
+				'_workflow_store_key' => self::RUN_CONTROL_STORE,
+			)
+		);
+
+		/** @var array<int,array<string,mixed>> $step_records */
+		$step_records = array();
+		foreach ( $result->get_steps() as $record ) {
+			if ( is_array( $record ) ) {
+				$step_records[] = self::string_keyed_array( $record );
+			}
+		}
+
+		$resume_index      = self::int_value( $suspension['step_index'] ?? 0 ) + 1;
 		$continue_on_error = ! empty( $options['continue_on_error'] );
-		$failed            = false;
-		$failure_error     = array();
 
-		foreach ( $spec->get_steps() as $step ) {
+		// Clear the suspension frame so the resumed run is no longer parked and
+		// the table-free per-run row (metadata._suspension) is not carried
+		// forward once the run reaches a terminal outcome.
+		$metadata = $result->get_metadata();
+		unset( $metadata['_suspension'] );
+		$result = $result->with(
+			array(
+				'status'   => WP_Agent_Workflow_Run_Result::STATUS_RUNNING,
+				'metadata' => $metadata,
+				'steps'    => $step_records,
+			)
+		);
+
+		return $this->run_step_loop( $spec, $context, $result, $step_records, $resume_index, $continue_on_error );
+	}
+
+	/**
+	 * The shared, indexed, resumable step loop. Both `run()` (start at 0) and
+	 * `resume()` (start at `step_index + 1`) drive it. Walks the spec's steps
+	 * from `$start_index`, records each outcome, gates on the `'pending'`
+	 * suspend marker BEFORE the failure gate, and finalizes the run.
+	 *
+	 * @since 0.5.0
+	 *
+	 * @param WP_Agent_Workflow_Spec        $spec              Workflow spec.
+	 * @param WP_Agent_Workflow_Run_Context $context           Run context (already rebuilt on resume).
+	 * @param WP_Agent_Workflow_Run_Result  $result            Current run result.
+	 * @param array<int,array<string,mixed>> $step_records     Step records completed so far.
+	 * @param int                           $start_index       Index in $spec->get_steps() to begin at.
+	 * @param bool                          $continue_on_error Keep running after a failed step.
+	 * @return WP_Agent_Workflow_Run_Result
+	 */
+	private function run_step_loop( WP_Agent_Workflow_Spec $spec, WP_Agent_Workflow_Run_Context $context, WP_Agent_Workflow_Run_Result $result, array $step_records, int $start_index, bool $continue_on_error ): WP_Agent_Workflow_Run_Result {
+		$executor = new WP_Agent_Workflow_Step_Executor( $this->step_handlers );
+		$steps    = array_values( $spec->get_steps() );
+
+		$failed        = false;
+		$failure_error = array();
+		foreach ( $step_records as $existing ) {
+			if ( WP_Agent_Workflow_Run_Result::STATUS_SUCCEEDED !== ( $existing['status'] ?? '' ) && 'pending' !== ( $existing['status'] ?? '' ) ) {
+				$failed        = true;
+				$failure_error = is_array( $existing['error'] ?? null ) ? $existing['error'] : array();
+			}
+		}
+
+		$step_count = count( $steps );
+		for ( $step_index = $start_index; $step_index < $step_count; $step_index++ ) {
+			$step = $steps[ $step_index ];
+
 			if ( self::is_cancel_requested( $result->get_run_id() ) ) {
 				$result = self::cancelled_result( $result, $step_records );
 				if ( $this->recorder ) {
@@ -210,11 +314,33 @@ class WP_Agent_Workflow_Runner {
 				return $result;
 			}
 
-			$record         = $executor->execute( $step, $context );
+			$record         = self::string_keyed_array( $executor->execute( $step, $context ) );
 			$step_records[] = $record;
 
 			if ( self::is_cancel_requested( $result->get_run_id() ) ) {
 				$result = self::cancelled_result( $result, $step_records );
+				if ( $this->recorder ) {
+					$this->recorder->update( $result );
+				}
+				return $result;
+			}
+
+			// Pending / suspend gate — BEFORE the failure gate. The step asked
+			// to park the run mid-flight (its handler returned a `_suspend`
+			// directive; the step executor recorded status `'pending'`). Persist
+			// a table-free suspension frame in metadata._suspension and return
+			// SUSPENDED. The addressable run stays live (RUNNING at the
+			// run-control layer) — it is finished only after resume reaches a
+			// terminal step-loop exit.
+			if ( 'pending' === ( $record['status'] ?? '' ) ) {
+				$suspension = self::build_suspension_frame( $step_index, $step, $record, $context );
+				$result     = $result->with(
+					array(
+						'status'   => WP_Agent_Workflow_Run_Result::STATUS_SUSPENDED,
+						'steps'    => $step_records,
+						'metadata' => $result->get_metadata() + array( '_suspension' => $suspension ),
+					)
+				);
 				if ( $this->recorder ) {
 					$this->recorder->update( $result );
 				}
@@ -276,6 +402,82 @@ class WP_Agent_Workflow_Runner {
 			$failed ? WP_Agent_Run_Control::STATUS_FAILED : WP_Agent_Run_Control::STATUS_SUCCEEDED
 		);
 		return $result;
+	}
+
+	/**
+	 * Build the table-free suspension frame persisted under
+	 * `metadata._suspension`. Everything a later reconcile + resume needs to
+	 * continue deterministically: the position to resume AT, the dispatched
+	 * branch handles, the aggregate plan, and a frozen context snapshot. The
+	 * already-executed step records live in the run result's `steps[]` (via
+	 * the recorder), so they are not duplicated here.
+	 *
+	 * @since 0.5.0
+	 *
+	 * @param int                           $step_index The suspended step's index.
+	 * @param array<mixed>                  $step       The suspended step (resolved).
+	 * @param array<mixed>                  $record     The `'pending'` step record (carries `suspend`).
+	 * @param WP_Agent_Workflow_Run_Context $context    The run context at suspend time.
+	 * @return array<string,mixed>
+	 */
+	private static function build_suspension_frame( int $step_index, array $step, array $record, WP_Agent_Workflow_Run_Context $context ): array {
+		$directive = is_array( $record['suspend'] ?? null ) ? $record['suspend'] : array();
+		$snapshot  = $context->to_array();
+
+		return array(
+			'step_index'       => $step_index,
+			'step_id'          => self::string_value( $record['id'] ?? ( $step['id'] ?? '' ) ),
+			'executor_id'      => self::string_value( $directive['executor'] ?? '' ),
+			'reason'           => self::string_value( $directive['reason'] ?? '' ),
+			'handles'          => is_array( $directive['handles'] ?? null ) ? array_values( $directive['handles'] ) : array(),
+			'aggregate'        => is_array( $directive['aggregate'] ?? null ) ? $directive['aggregate'] : array(),
+			'context_snapshot' => array(
+				'inputs' => is_array( $snapshot['inputs'] ?? null ) ? $snapshot['inputs'] : array(),
+				'steps'  => is_array( $snapshot['steps'] ?? null ) ? $snapshot['steps'] : array(),
+				'vars'   => is_array( $snapshot['vars'] ?? null ) ? $snapshot['vars'] : array(),
+			),
+			'completed'        => array(),
+		);
+	}
+
+	/**
+	 * Rebuild the spec from a run result's replay snapshot so a resume can
+	 * walk the exact steps the run started with.
+	 *
+	 * @since 0.5.0
+	 */
+	private static function spec_from_result( WP_Agent_Workflow_Run_Result $result ): ?WP_Agent_Workflow_Spec {
+		$replay   = $result->get_replay_metadata();
+		$snapshot = is_array( $replay['workflow_spec_snapshot'] ?? null ) ? $replay['workflow_spec_snapshot'] : array();
+		if ( empty( $snapshot ) ) {
+			return null;
+		}
+
+		$spec = WP_Agent_Workflow_Spec::from_array( $snapshot );
+		return $spec instanceof WP_Agent_Workflow_Spec ? $spec : null;
+	}
+
+	/**
+	 * Build a terminal failed result for an un-resumable run.
+	 *
+	 * @since 0.5.0
+	 */
+	private static function resume_error_result( string $run_id, string $code, string $message ): WP_Agent_Workflow_Run_Result {
+		return new WP_Agent_Workflow_Run_Result(
+			$run_id,
+			'',
+			WP_Agent_Workflow_Run_Result::STATUS_FAILED,
+			array(),
+			array(),
+			array(),
+			array(
+				'code'    => $code,
+				'message' => $message,
+			),
+			time(),
+			time(),
+			array()
+		);
 	}
 
 	/** @phpstan-impure */
@@ -637,17 +839,312 @@ class WP_Agent_Workflow_Runner {
 		$has_branches = isset( $step['branches'] ) && is_array( $step['branches'] );
 		$has_items    = array_key_exists( 'items', $step );
 
-		if ( $has_branches ) {
-			return self::run_parallel_roles( $step, $context, $handlers );
+		if ( ! $has_branches && ! $has_items ) {
+			return new \WP_Error(
+				'workflow_parallel_shape_invalid',
+				'parallel step must declare either `branches` (roles+aggregate) or `items` (map).'
+			);
 		}
 
-		if ( $has_items ) {
-			return self::run_parallel_map( $step, $context, $handlers );
+		// Resolve the branch executor (the concurrency seam). Core supplies a
+		// low-priority default that returns null unless Action Scheduler (or a
+		// caller override) is present. When no executor is selected the handler
+		// runs the in-process v0.5.0 loops — byte-for-byte today's behavior, no
+		// suspend, no reconcile.
+		$executor = apply_filters( 'wp_agent_workflow_step_executor', null, $step, $context );
+		if ( ! $executor instanceof WP_Agent_Workflow_Branch_Executor ) {
+			return $has_branches
+				? self::run_parallel_roles( $step, $context, $handlers )
+				: self::run_parallel_map( $step, $context, $handlers );
 		}
 
-		return new \WP_Error(
-			'workflow_parallel_shape_invalid',
-			'parallel step must declare either `branches` (roles+aggregate) or `items` (map).'
+		// An executor is selected: dispatch the branches for out-of-band
+		// execution and return a `_suspend` directive so the runner parks the
+		// run mid-flight and resumes it once the branches reconcile.
+		return self::dispatch_parallel_async( $executor, $step, $context, $handlers, $has_branches );
+	}
+
+	/**
+	 * Build branch descriptors for the selected executor, dispatch them, and
+	 * return the `_suspend` directive the step executor recognizes. If the
+	 * executor returns handles that are already all-complete (a synchronous
+	 * executor), the run never suspends — collect + aggregate inline and return
+	 * a terminal result, exactly like the sync loops.
+	 *
+	 * @since 0.5.0
+	 *
+	 * @param WP_Agent_Workflow_Branch_Executor $executor     Selected branch executor.
+	 * @param array<mixed>                      $step         Resolved parallel step.
+	 * @param array<mixed>                      $context      Resolution context.
+	 * @param array<string,mixed>               $handlers     Step-type handler map.
+	 * @param bool                              $has_branches Whether this is the roles shape.
+	 * @return array<mixed>|\WP_Error
+	 */
+	private static function dispatch_parallel_async( WP_Agent_Workflow_Branch_Executor $executor, array $step, array $context, array $handlers, bool $has_branches ) {
+		$plan = $has_branches
+			? self::build_roles_dispatch_plan( $step )
+			: self::build_map_dispatch_plan( $step );
+		if ( is_wp_error( $plan ) ) {
+			return $plan;
+		}
+
+		$handles = $executor->dispatch( $plan['branches'], $plan['shared_context'] );
+
+		// A synchronous executor may return already-complete handles; then the
+		// run must NOT suspend — collect + aggregate inline and return terminal.
+		if ( $executor->are_all_complete( $handles ) ) {
+			$branch_results = $executor->collect( $handles );
+			return self::aggregate_branch_results( $plan['aggregate'], $branch_results, $handlers );
+		}
+
+		return array(
+			'_suspend' => array(
+				'reason'    => 'parallel_branches_dispatched',
+				'executor'  => $executor->id(),
+				'handles'   => array_values( $handles ),
+				'aggregate' => $plan['aggregate'],
+			),
+		);
+	}
+
+	/**
+	 * Build the dispatch plan for the roles+aggregate shape: one branch
+	 * descriptor per sibling role, the deferred aggregator plan, and the shared
+	 * immutable context. Mirrors the sync `run_parallel_roles()` validation so
+	 * the async path rejects the same malformed specs.
+	 *
+	 * @since 0.5.0
+	 *
+	 * @param array<mixed> $step Resolved parallel step.
+	 * @return array{branches:array<int,array<string,mixed>>,shared_context:array<string,mixed>,aggregate:array<string,mixed>}|\WP_Error
+	 */
+	private static function build_roles_dispatch_plan( array $step ) {
+		$branch_specs = array();
+		foreach ( (array) $step['branches'] as $branch_spec ) {
+			if ( ! is_array( $branch_spec ) ) {
+				return new \WP_Error(
+					'workflow_parallel_branch_invalid',
+					'parallel branch entries must be arrays.'
+				);
+			}
+			$branch_specs[] = $branch_spec;
+		}
+
+		if ( empty( $branch_specs ) ) {
+			return new \WP_Error(
+				'workflow_parallel_branches_empty',
+				'parallel-roles step must declare a non-empty `branches` list.'
+			);
+		}
+
+		$aggregator       = null;
+		$aggregator_roles = array();
+		$sibling_branches = array();
+		foreach ( $branch_specs as $branch_spec ) {
+			if ( ! empty( $branch_spec['can_write_final_bundle'] ) ) {
+				$aggregator         = $branch_spec;
+				$aggregator_roles[] = self::string_value( $branch_spec['role'] ?? '' );
+				continue;
+			}
+			$sibling_branches[] = $branch_spec;
+		}
+		if ( 1 !== count( $aggregator_roles ) || null === $aggregator ) {
+			return new \WP_Error(
+				'workflow_parallel_aggregator_invalid',
+				sprintf(
+					'parallel-roles step must declare exactly one aggregator branch (`can_write_final_bundle` true); found %d.',
+					count( $aggregator_roles )
+				)
+			);
+		}
+
+		$shared_context = is_array( $step['context'] ?? null ) ? self::string_keyed_array( $step['context'] ) : array();
+
+		/** @var array<int,array<string,mixed>> $descriptors */
+		$descriptors = array();
+		foreach ( $sibling_branches as $branch_spec ) {
+			$role = self::string_value( $branch_spec['role'] ?? '' );
+			if ( '' === $role ) {
+				return new \WP_Error(
+					'workflow_parallel_branch_role_missing',
+					'each parallel branch must declare a non-empty `role`.'
+				);
+			}
+			$descriptors[] = self::role_branch_descriptor( self::string_keyed_array( $branch_spec ), $shared_context );
+		}
+
+		return array(
+			'branches'       => $descriptors,
+			'shared_context' => $shared_context,
+			'aggregate'      => array(
+				'mode'            => 'roles',
+				'aggregator_role' => self::string_value( $aggregator['role'] ?? '' ),
+				'aggregator_spec' => $aggregator,
+				'shared_context'  => $shared_context,
+				'shape'           => 'roles',
+			),
+		);
+	}
+
+	/**
+	 * Build the dispatch plan for the map shape: one branch descriptor per
+	 * resolved item, no aggregator (reconcile just collects).
+	 *
+	 * @since 0.5.0
+	 *
+	 * @param array<mixed> $step Resolved parallel step.
+	 * @return array{branches:array<int,array<string,mixed>>,shared_context:array<string,mixed>,aggregate:array<string,mixed>}|\WP_Error
+	 */
+	private static function build_map_dispatch_plan( array $step ) {
+		$items = $step['items'] ?? array();
+		if ( ! is_array( $items ) ) {
+			return new \WP_Error(
+				'workflow_parallel_items_invalid',
+				'parallel-map step `items` must resolve to an array.'
+			);
+		}
+
+		$steps = $step['steps'] ?? array();
+		if ( empty( $steps ) || ! is_array( $steps ) ) {
+			return new \WP_Error(
+				'workflow_parallel_steps_invalid',
+				'parallel-map step must include a non-empty nested `steps` list.'
+			);
+		}
+
+		$as_value          = self::string_value( $step['as'] ?? null );
+		$index_as_value    = self::string_value( $step['index_as'] ?? null );
+		$as                = '' !== $as_value ? $as_value : 'item';
+		$index_as          = '' !== $index_as_value ? $index_as_value : 'index';
+		$continue_on_error = ! empty( $step['continue_on_error'] );
+
+		$descriptors = array();
+		foreach ( array_values( $items ) as $index => $item ) {
+			$descriptors[] = array(
+				'key'               => (string) $index,
+				'index'            => $index,
+				'item'             => $item,
+				'steps'            => $steps,
+				'branch_vars'      => array(
+					$as       => $item,
+					$index_as => $index,
+				),
+				'continue_on_error' => $continue_on_error,
+			);
+		}
+
+		return array(
+			'branches'       => $descriptors,
+			'shared_context' => array(),
+			'aggregate'      => array(
+				'mode'  => 'map',
+				'shape' => 'map',
+			),
+		);
+	}
+
+	/**
+	 * Build a self-contained descriptor for one role-scoped branch. The
+	 * descriptor is the payload an executor runs later; it carries the branch's
+	 * nested steps, its scoped vars (shared context + role contract), and the
+	 * required / continue-on-error policy.
+	 *
+	 * @since 0.5.0
+	 *
+	 * @param array<mixed>        $branch_spec    Branch / role contract.
+	 * @param array<string,mixed> $shared_context Shared immutable context snapshot.
+	 * @return array<string,mixed>
+	 */
+	private static function role_branch_descriptor( array $branch_spec, array $shared_context ): array {
+		$role          = self::string_value( $branch_spec['role'] ?? '' );
+		$role_contract = $branch_spec;
+		unset( $role_contract['steps'] );
+
+		return array(
+			'key'               => $role,
+			'role'             => $role,
+			'required'         => ! empty( $branch_spec['required'] ),
+			'steps'            => is_array( $branch_spec['steps'] ?? null ) ? $branch_spec['steps'] : array(),
+			'branch_vars'      => array(
+				'context' => $shared_context,
+				'role'    => $role_contract,
+			),
+			'continue_on_error' => ! empty( $branch_spec['continue_on_error'] ),
+		);
+	}
+
+	/**
+	 * Run the aggregate plan once every branch has reconciled, producing the
+	 * parallel step's final output in the SAME shape the sync loops return.
+	 * Shared by the reconcile entry point ({@see agents_reconcile_workflow_branch()})
+	 * and the synchronous-executor inline path. For `roles`, the aggregator
+	 * branch runs synchronously (aggregation is cheap fusion, not N slow AI
+	 * calls) with `${vars.branch_outputs.*}` populated from the reconciled
+	 * sibling results. For `map`, there is no aggregator — collect into the
+	 * `{ shape:'map', count, branches }` envelope.
+	 *
+	 * @since 0.5.0
+	 *
+	 * @param array<string,mixed> $aggregate      Aggregate plan (§2.5).
+	 * @param array<string,mixed> $branch_results Reconciled BranchResult[] keyed by role|index.
+	 * @param array<string,mixed> $handlers       Step-type handler map.
+	 * @return array<mixed>|\WP_Error
+	 */
+	public static function aggregate_branch_results( array $aggregate, array $branch_results, array $handlers ) {
+		$mode = self::string_value( $aggregate['mode'] ?? '' );
+
+		if ( 'map' === $mode ) {
+			$branches = array();
+			foreach ( $branch_results as $key => $result ) {
+				$result     = is_array( $result ) ? $result : array();
+				$branches[] = array(
+					'index'  => is_numeric( $key ) ? (int) $key : $key,
+					'item'   => $result['item'] ?? null,
+					'steps'  => is_array( $result['steps'] ?? null ) ? $result['steps'] : array(),
+					'output' => $result['output'] ?? null,
+				);
+			}
+			return array(
+				'shape'    => 'map',
+				'count'    => count( $branches ),
+				'branches' => $branches,
+			);
+		}
+
+		// roles: fuse sibling outputs through the aggregator branch.
+		$aggregator = is_array( $aggregate['aggregator_spec'] ?? null ) ? self::string_keyed_array( $aggregate['aggregator_spec'] ) : array();
+		if ( empty( $aggregator ) ) {
+			return new \WP_Error(
+				'workflow_parallel_aggregator_missing',
+				'parallel-roles reconcile is missing its aggregator branch.'
+			);
+		}
+
+		$shared_context = is_array( $aggregate['shared_context'] ?? null ) ? self::string_keyed_array( $aggregate['shared_context'] ) : array();
+		$aggregator_key = self::string_value( $aggregate['aggregator_role'] ?? '' );
+
+		$branch_outputs = array();
+		foreach ( $branch_results as $key => $result ) {
+			if ( (string) $key === $aggregator_key ) {
+				continue;
+			}
+			$result                          = is_array( $result ) ? $result : array();
+			$branch_outputs[ (string) $key ] = $result['output'] ?? null;
+		}
+
+		$executor = new WP_Agent_Workflow_Step_Executor( $handlers );
+		$run      = self::run_role_branch( $aggregator, $shared_context, $branch_outputs, array(), $executor, $handlers );
+		if ( is_wp_error( $run ) ) {
+			return $run;
+		}
+
+		$branch_outputs[ $aggregator_key ] = $run['output'];
+
+		return array(
+			'shape'          => 'roles',
+			'aggregator'     => $aggregator_key,
+			'branch_outputs' => $branch_outputs,
+			'final'          => $run['output'],
 		);
 	}
 
@@ -924,7 +1421,7 @@ class WP_Agent_Workflow_Runner {
 	 * @param string              $branch_label      Branch identifier for error messages.
 	 * @return array{steps:array<string,mixed>,last:mixed}|WP_Error
 	 */
-	private static function run_branch_steps( array $steps, WP_Agent_Workflow_Run_Context $branch_context, WP_Agent_Workflow_Step_Executor $executor, array $handlers, bool $continue_on_error, string $branch_label ) {
+	public static function run_branch_steps( array $steps, WP_Agent_Workflow_Run_Context $branch_context, WP_Agent_Workflow_Step_Executor $executor, array $handlers, bool $continue_on_error, string $branch_label ) {
 		$step_outputs = array();
 		$last_output  = null;
 
@@ -1052,5 +1549,31 @@ class WP_Agent_Workflow_Runner {
 		}
 
 		return '';
+	}
+
+	/**
+	 * Coerce a value to an int for numeric-only frame fields.
+	 *
+	 * @param mixed $value Value to normalize.
+	 */
+	private static function int_value( $value ): int {
+		return is_numeric( $value ) ? (int) $value : 0;
+	}
+
+	/**
+	 * Keep only string keys, giving PHPStan a precise `array<string,mixed>`.
+	 *
+	 * @param array<mixed> $value Raw array.
+	 * @return array<string,mixed>
+	 */
+	private static function string_keyed_array( array $value ): array {
+		$result = array();
+		foreach ( $value as $key => $item ) {
+			if ( is_string( $key ) ) {
+				$result[ $key ] = $item;
+			}
+		}
+
+		return $result;
 	}
 }

--- a/src/Workflows/class-wp-agent-workflow-step-executor.php
+++ b/src/Workflows/class-wp-agent-workflow-step-executor.php
@@ -89,6 +89,24 @@ class WP_Agent_Workflow_Step_Executor {
 			return $record;
 		}
 
+		// Suspend directive: a successful handler MAY ask the run to park
+		// mid-flight by returning an array carrying a reserved `_suspend`
+		// envelope key (see WP_Agent_Workflow_Runner suspend/resume model).
+		// This is invisible to existing handlers (none emit it), so it is
+		// purely additive. The step is NOT ended and NOT marked succeeded;
+		// it is parked. The runner recognizes the `'pending'` step status and
+		// persists a suspension frame instead of advancing. We deliberately
+		// skip set_step_output(): the step has no output yet — its real output
+		// lands later, on resume, once the dispatched branches reconcile.
+		if ( is_array( $step_output ) && isset( $step_output['_suspend'] ) && is_array( $step_output['_suspend'] ) ) {
+			$record['status']   = 'pending';
+			$record['suspend']  = $step_output['_suspend'];
+			$record['output']   = null;
+			$record['ended_at'] = 0;
+
+			return $record;
+		}
+
 		$record['status']   = WP_Agent_Workflow_Run_Result::STATUS_SUCCEEDED;
 		$record['output']   = is_array( $step_output ) ? $step_output : array( 'value' => $step_output );
 		$record['ended_at'] = time();

--- a/src/Workflows/interface-wp-agent-workflow-branch-executor.php
+++ b/src/Workflows/interface-wp-agent-workflow-branch-executor.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * The generic concurrency seam for the workflow runner's suspend/resume model.
+ *
+ * A branch executor is the ONLY thing the runner talks to for out-of-band
+ * branch execution. It knows nothing about the underlying mechanism — Action
+ * Scheduler (the executor core ships in a later phase), a caller's own worker
+ * pool, or a deterministic test double. The runner owns the state machine
+ * (suspend → dispatch → reconcile → aggregate → resume); the executor owns
+ * only the mechanism that actually runs branches and, ultimately, drives the
+ * canonical reconcile entry point ({@see agents_reconcile_workflow_branch()})
+ * when a branch finishes.
+ *
+ * Core ships no default executor and makes no concurrency-safety promise for a
+ * caller-registered one: a caller that registers its own executor owns the
+ * durable park for the suspended run AND the cross-process atomic guard for the
+ * resume transition.
+ *
+ * @package AgentsAPI
+ * @since   0.5.0
+ */
+
+namespace AgentsAPI\AI\Workflows;
+
+defined( 'ABSPATH' ) || exit;
+
+interface WP_Agent_Workflow_Branch_Executor {
+
+	/**
+	 * Stable executor id, e.g. `action_scheduler`. Stored on each branch
+	 * handle so the runner can attribute handles to the owning executor.
+	 *
+	 * @since 0.5.0
+	 */
+	public function id(): string;
+
+	/**
+	 * Dispatch N branches for out-of-band execution.
+	 *
+	 * @since 0.5.0
+	 *
+	 * @param array<int,array<string,mixed>> $branches Branch descriptors: each is a
+	 *        self-contained payload the executor can run later — `{ key, steps,
+	 *        branch_vars, continue_on_error, run_id, step_id }`.
+	 * @param array<string,mixed>            $context  Serializable shared context snapshot.
+	 * @return array<int,array<string,mixed>> BranchHandle[] — `{ id, key, executor,
+	 *         status, ref }`. Handles MAY be returned already-complete (a
+	 *         synchronous executor), in which case the runner never suspends.
+	 */
+	public function dispatch( array $branches, array $context ): array;
+
+	/**
+	 * Whether every dispatched handle has reached a terminal state.
+	 *
+	 * @since 0.5.0
+	 *
+	 * @param array<int,array<string,mixed>> $handles BranchHandle[].
+	 * @return bool True when every handle is terminal (`succeeded` or `failed`).
+	 */
+	public function are_all_complete( array $handles ): bool;
+
+	/**
+	 * Collect terminal branch outputs keyed by the branch key (role or index).
+	 *
+	 * @since 0.5.0
+	 *
+	 * @param array<int,array<string,mixed>> $handles BranchHandle[].
+	 * @return array<string,mixed> BranchResult[] keyed by role|index.
+	 */
+	public function collect( array $handles ): array;
+}

--- a/src/Workflows/register-agents-workflow-abilities.php
+++ b/src/Workflows/register-agents-workflow-abilities.php
@@ -486,7 +486,7 @@ function agents_run_workflow_output_schema(): array {
 			'workflow_id'   => array( 'type' => 'string' ),
 			'status'        => array(
 				'type' => 'string',
-				'enum' => array( 'pending', 'running', 'succeeded', 'failed', 'skipped' ),
+				'enum' => array( 'pending', 'running', 'succeeded', 'failed', 'skipped', 'suspended' ),
 			),
 			'output'        => array( 'type' => 'object' ),
 			'steps'         => array( 'type' => 'array' ),

--- a/src/Workflows/register-reconcile-workflow-branch.php
+++ b/src/Workflows/register-reconcile-workflow-branch.php
@@ -1,0 +1,375 @@
+<?php
+/**
+ * The single reconcile entry point for the workflow suspend/resume model.
+ *
+ * Every branch executor drives ONE canonical function when a branch finishes:
+ * {@see agents_reconcile_workflow_branch()}. It merges the completed branch
+ * into the suspended run's frame and, once every branch is terminal, runs the
+ * aggregate plan and resumes the run from the suspended step. The function is
+ * also registered as the `agents/reconcile-workflow-branch` ability so it is
+ * reachable uniformly via REST / abilities, mirroring the existing
+ * `agents/*-workflow-run` control abilities.
+ *
+ * Core owns the state machine (merge → all-terminal? → aggregate → resume);
+ * the executor owns only the mechanism that runs branches and calls back here.
+ *
+ * @package AgentsAPI
+ * @since   0.5.0
+ */
+
+namespace AgentsAPI\AI\Workflows;
+
+defined( 'ABSPATH' ) || exit;
+
+const AGENTS_RECONCILE_WORKFLOW_BRANCH_ABILITY = 'agents/reconcile-workflow-branch';
+
+add_action(
+	'wp_abilities_api_init',
+	static function (): void {
+		if ( wp_has_ability( AGENTS_RECONCILE_WORKFLOW_BRANCH_ABILITY ) ) {
+			return;
+		}
+
+		wp_register_ability(
+			AGENTS_RECONCILE_WORKFLOW_BRANCH_ABILITY,
+			array(
+				'label'               => 'Reconcile Workflow Branch',
+				'description'         => 'Reconcile a single completed parallel branch into a suspended workflow run and, when it was the last outstanding branch, aggregate + resume the run.',
+				'category'            => 'agents-api',
+				'input_schema'        => array(
+					'type'       => 'object',
+					'required'   => array( 'run_id', 'handle_id', 'branch_result' ),
+					'properties' => array(
+						'run_id'        => array( 'type' => 'string' ),
+						'handle_id'     => array( 'type' => 'string' ),
+						'branch_result' => array(
+							'type'        => 'object',
+							'description' => 'BranchResult: { key, status, output, steps?, error? }.',
+						),
+					),
+				),
+				'output_schema'       => agents_run_workflow_output_schema(),
+				'execute_callback'    => __NAMESPACE__ . '\\agents_reconcile_workflow_branch_ability',
+				'permission_callback' => __NAMESPACE__ . '\\agents_workflow_run_cancel_permission',
+				'meta'                => array(
+					'show_in_rest' => true,
+					'annotations'  => array(
+						'destructive' => true,
+						'idempotent'  => true,
+					),
+				),
+			)
+		);
+	}
+);
+
+/**
+ * Ability wrapper for {@see agents_reconcile_workflow_branch()}. Returns the
+ * (possibly still-suspended) run's canonical output array, or a WP_Error.
+ *
+ * @since 0.5.0
+ *
+ * @param array<string,mixed> $input Ability input.
+ * @return array<string,mixed>|\WP_Error
+ */
+function agents_reconcile_workflow_branch_ability( array $input ) {
+	$run_id        = agents_workflow_string( $input['run_id'] ?? '' );
+	$handle_id     = agents_workflow_string( $input['handle_id'] ?? '' );
+	$branch_result = is_array( $input['branch_result'] ?? null ) ? \AgentsAPI\AI\WP_Agent_Run_Control::string_keyed_array( $input['branch_result'] ) : array();
+
+	if ( '' === $run_id || '' === $handle_id ) {
+		return new \WP_Error( 'agents_reconcile_workflow_branch_invalid_input', 'run_id and handle_id are required.' );
+	}
+
+	$result = agents_reconcile_workflow_branch( $run_id, $handle_id, $branch_result );
+	if ( is_wp_error( $result ) ) {
+		return $result;
+	}
+
+	return $result->to_array();
+}
+
+/**
+ * Reconcile a single completed branch into a suspended run and, if it was the
+ * last outstanding branch, aggregate + resume.
+ *
+ * Algorithm (design §3.4):
+ *   1. Load the suspended run via the recorder (guard: must be SUSPENDED;
+ *      idempotent — a duplicate reconcile for an already-recorded terminal
+ *      handle is a no-op that returns the current run).
+ *   2. Merge the branch result into `metadata._suspension.completed[handle_id]`
+ *      and flip that handle's status. Persist.
+ *   3. If NOT all handles terminal → return the still-suspended run.
+ *   4. If all terminal → run the aggregate plan, splice the parallel step's
+ *      final output into that step's record, then resume the step loop from
+ *      `step_index + 1`.
+ *
+ * @since 0.5.0
+ *
+ * @param string              $run_id        Suspended run id.
+ * @param string              $handle_id     The completed branch's handle id.
+ * @param array<string,mixed> $branch_result BranchResult: { key, status, output, steps?, error? }.
+ * @return WP_Agent_Workflow_Run_Result|\WP_Error The (possibly still-suspended) run.
+ */
+function agents_reconcile_workflow_branch( string $run_id, string $handle_id, array $branch_result ) {
+	$recorder = agents_workflow_resolve_recorder();
+	if ( null === $recorder ) {
+		return new \WP_Error( 'agents_reconcile_workflow_branch_no_recorder', 'A recorder is required to reconcile a suspended run. Register one via the `wp_agent_workflow_run_recorder` filter.' );
+	}
+
+	$result = $recorder->find( $run_id );
+	if ( null === $result ) {
+		return new \WP_Error( 'agents_reconcile_workflow_branch_not_found', sprintf( 'No suspended run was found for run_id `%s`.', $run_id ) );
+	}
+	if ( ! $result->is_suspended() ) {
+		// Idempotency: the run already resumed (or was never suspended). A
+		// late/duplicate reconcile is a harmless no-op.
+		return $result;
+	}
+
+	$suspension = $result->get_suspension();
+	/** @var array<int,mixed> $handles */
+	$handles = is_array( $suspension['handles'] ?? null ) ? array_values( $suspension['handles'] ) : array();
+	/** @var array<string,mixed> $completed */
+	$completed = is_array( $suspension['completed'] ?? null ) ? \AgentsAPI\AI\WP_Agent_Run_Control::string_keyed_array( $suspension['completed'] ) : array();
+
+	// Idempotency: a handle already recorded terminal does not re-merge or
+	// re-resume. Return the current run untouched.
+	if ( isset( $completed[ $handle_id ] ) ) {
+		return $result;
+	}
+
+	$status = agents_workflow_string( $branch_result['status'] ?? '' );
+	$status = ( WP_Agent_Workflow_Run_Result::STATUS_FAILED === $status ) ? WP_Agent_Workflow_Run_Result::STATUS_FAILED : WP_Agent_Workflow_Run_Result::STATUS_SUCCEEDED;
+
+	$completed[ $handle_id ] = array(
+		'key'    => agents_workflow_string( $branch_result['key'] ?? '' ),
+		'status' => $status,
+		'output' => $branch_result['output'] ?? null,
+		'steps'  => is_array( $branch_result['steps'] ?? null ) ? $branch_result['steps'] : array(),
+		'error'  => is_array( $branch_result['error'] ?? null ) ? $branch_result['error'] : null,
+		'item'   => $branch_result['item'] ?? null,
+	);
+
+	// Flip the matching handle's status.
+	foreach ( $handles as $index => $handle ) {
+		if ( is_array( $handle ) && agents_workflow_string( $handle['id'] ?? '' ) === $handle_id ) {
+			$handle['status']    = $status;
+			$handles[ $index ]   = $handle;
+		}
+	}
+
+	$suspension['handles']   = $handles;
+	$suspension['completed'] = $completed;
+
+	$metadata                 = $result->get_metadata();
+	$metadata['_suspension']  = $suspension;
+	$result                   = $result->with( array( 'metadata' => $metadata ) );
+	$recorder->update( $result );
+
+	// Not all terminal yet → wait for more reconcile calls.
+	if ( count( $completed ) < count( $handles ) ) {
+		return $result;
+	}
+
+	// All branches terminal. Was a REQUIRED branch failed? A required-branch
+	// failure fails the parallel step, which re-enters the failure path on
+	// resume (mirrors the sync `run_role_branch()` required-branch rule).
+	$branch_results  = agents_workflow_branch_results_by_key( $completed );
+	$required_failed = agents_workflow_required_branch_failed( $suspension, $completed );
+
+	$step_index = is_numeric( $suspension['step_index'] ?? null ) ? (int) $suspension['step_index'] : 0;
+	$aggregate  = is_array( $suspension['aggregate'] ?? null ) ? \AgentsAPI\AI\WP_Agent_Run_Control::string_keyed_array( $suspension['aggregate'] ) : array();
+	$handlers   = agents_workflow_resolve_step_handlers();
+
+	if ( $required_failed ) {
+		$step_output = new \WP_Error( 'workflow_parallel_required_branch_failed', 'A required parallel branch failed during out-of-band execution.' );
+	} else {
+		$step_output = WP_Agent_Workflow_Runner::aggregate_branch_results( $aggregate, $branch_results, $handlers );
+	}
+
+	// Splice the parallel step's final output (or failure) into its record so
+	// resume sees a terminal step and downstream `${steps.<id>.output}`
+	// bindings resolve against the aggregated result.
+	$result = agents_workflow_splice_step_output( $result, $step_index, $step_output );
+	$recorder->update( $result );
+
+	// Resume the step loop from step_index + 1. resume() clears the suspension
+	// frame and continues (or fails) from the aggregated output.
+	$runner = agents_workflow_resolve_runner( $recorder );
+	return $runner->resume( $run_id );
+}
+
+/**
+ * Collect reconciled BranchResult[] keyed by branch key (role or index) from
+ * the frame's `completed` map.
+ *
+ * @since 0.5.0
+ *
+ * @param array<string,mixed> $completed Frame completed map keyed by handle id.
+ * @return array<string,mixed>
+ */
+function agents_workflow_branch_results_by_key( array $completed ): array {
+	$by_key = array();
+	foreach ( $completed as $entry ) {
+		if ( ! is_array( $entry ) ) {
+			continue;
+		}
+		$key            = agents_workflow_string( $entry['key'] ?? '' );
+		$by_key[ $key ] = $entry;
+	}
+	return $by_key;
+}
+
+/**
+ * Whether any REQUIRED branch reconciled as failed. A branch is required when
+ * its handle carries `required` truthy OR the aggregator plan's branch spec
+ * marked it required; the executor stamps `required` on the handle at dispatch
+ * so reconcile can decide without re-reading the spec.
+ *
+ * @since 0.5.0
+ *
+ * @param array<string,mixed> $suspension The suspension frame.
+ * @param array<string,mixed> $completed  Frame completed map keyed by handle id.
+ * @return bool
+ */
+function agents_workflow_required_branch_failed( array $suspension, array $completed ): bool {
+	$handles         = is_array( $suspension['handles'] ?? null ) ? $suspension['handles'] : array();
+	$required_by_key = array();
+	foreach ( $handles as $handle ) {
+		if ( is_array( $handle ) ) {
+			$required_by_key[ agents_workflow_string( $handle['key'] ?? '' ) ] = ! empty( $handle['required'] );
+		}
+	}
+
+	foreach ( $completed as $entry ) {
+		if ( ! is_array( $entry ) ) {
+			continue;
+		}
+		if ( WP_Agent_Workflow_Run_Result::STATUS_FAILED !== agents_workflow_string( $entry['status'] ?? '' ) ) {
+			continue;
+		}
+		$key = agents_workflow_string( $entry['key'] ?? '' );
+		if ( ! empty( $required_by_key[ $key ] ) ) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+/**
+ * Splice a terminal output (array) or failure (WP_Error) into the suspended
+ * step's record so the resumed run sees a terminal step and the aggregated
+ * output flows to downstream bindings.
+ *
+ * @since 0.5.0
+ *
+ * @param WP_Agent_Workflow_Run_Result $result     The suspended run.
+ * @param int                          $step_index The suspended step's index.
+ * @param array<mixed>|\WP_Error       $output     Aggregated output or a failure.
+ * @return WP_Agent_Workflow_Run_Result
+ */
+function agents_workflow_splice_step_output( WP_Agent_Workflow_Run_Result $result, int $step_index, $output ): WP_Agent_Workflow_Run_Result {
+	$steps = $result->get_steps();
+	if ( ! isset( $steps[ $step_index ] ) || ! is_array( $steps[ $step_index ] ) ) {
+		return $result;
+	}
+
+	$record = $steps[ $step_index ];
+	unset( $record['suspend'] );
+
+	if ( is_wp_error( $output ) ) {
+		$record['status'] = WP_Agent_Workflow_Run_Result::STATUS_FAILED;
+		$record['output'] = null;
+		$record['error']  = array(
+			'code'    => $output->get_error_code(),
+			'message' => $output->get_error_message(),
+			'data'    => $output->get_error_data(),
+		);
+	} else {
+		$record['status'] = WP_Agent_Workflow_Run_Result::STATUS_SUCCEEDED;
+		$record['output'] = $output;
+		unset( $record['error'] );
+	}
+	$record['ended_at']    = time();
+	$steps[ $step_index ]  = $record;
+
+	// Also seed the resumed context snapshot's `steps` map so downstream
+	// `${steps.<id>.output}` bindings resolve against the aggregated output.
+	$suspension = $result->get_suspension();
+	$step_id    = agents_workflow_string( $record['id'] ?? '' );
+	if ( '' !== $step_id && is_array( $suspension['context_snapshot'] ?? null ) ) {
+		$snapshot_steps = is_array( $suspension['context_snapshot']['steps'] ?? null ) ? $suspension['context_snapshot']['steps'] : array();
+		if ( ! is_wp_error( $output ) ) {
+			$snapshot_steps[ $step_id ] = array( 'output' => $output );
+		}
+		$suspension['context_snapshot']['steps'] = $snapshot_steps;
+		$metadata                                = $result->get_metadata();
+		$metadata['_suspension']                 = $suspension;
+		$result                                  = $result->with( array( 'metadata' => $metadata ) );
+	}
+
+	return $result->with( array( 'steps' => $steps ) );
+}
+
+/**
+ * Resolve the workflow run recorder used by reconcile / resume. Consumers own
+ * persistence, so the recorder is supplied via a filter — the same seam a
+ * consumer already uses to wire a runtime.
+ *
+ * @since 0.5.0
+ */
+function agents_workflow_resolve_recorder(): ?WP_Agent_Workflow_Run_Recorder {
+	/**
+	 * Filter the workflow run recorder used to reload + resume suspended runs.
+	 *
+	 * @since 0.5.0
+	 *
+	 * @param WP_Agent_Workflow_Run_Recorder|null $recorder Currently resolved recorder.
+	 */
+	$recorder = apply_filters( 'wp_agent_workflow_run_recorder', null );
+	return $recorder instanceof WP_Agent_Workflow_Run_Recorder ? $recorder : null;
+}
+
+/**
+ * Resolve the runner used to resume a suspended run. Defaults to a fresh runner
+ * bound to the supplied recorder; a consumer may override to inject its own
+ * handler map or subclass.
+ *
+ * @since 0.5.0
+ */
+function agents_workflow_resolve_runner( WP_Agent_Workflow_Run_Recorder $recorder ): WP_Agent_Workflow_Runner {
+	/**
+	 * Filter the runner used to resume a suspended workflow run.
+	 *
+	 * @since 0.5.0
+	 *
+	 * @param WP_Agent_Workflow_Runner|null       $runner   Currently resolved runner.
+	 * @param WP_Agent_Workflow_Run_Recorder      $recorder The resolved recorder.
+	 */
+	$runner = apply_filters( 'wp_agent_workflow_resume_runner', null, $recorder );
+	return $runner instanceof WP_Agent_Workflow_Runner ? $runner : new WP_Agent_Workflow_Runner( $recorder );
+}
+
+/**
+ * Resolve the step-type handler map for aggregate execution during reconcile.
+ *
+ * @since 0.5.0
+ *
+ * @return array<string,mixed>
+ */
+function agents_workflow_resolve_step_handlers(): array {
+	/** @var array<string,mixed> $handlers */
+	$handlers = (array) apply_filters(
+		'wp_agent_workflow_step_handlers',
+		array(
+			'ability'  => array( WP_Agent_Workflow_Runner::class, 'default_ability_handler' ),
+			'agent'    => array( WP_Agent_Workflow_Runner::class, 'default_agent_handler' ),
+			'foreach'  => array( WP_Agent_Workflow_Runner::class, 'default_foreach_handler' ),
+			'parallel' => array( WP_Agent_Workflow_Runner::class, 'default_parallel_handler' ),
+		)
+	);
+
+	return $handlers;
+}

--- a/src/Workflows/register-workflow-step-executor.php
+++ b/src/Workflows/register-workflow-step-executor.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Core branch-executor selector.
+ *
+ * The parallel handler resolves whether (and how) to run branches out-of-band
+ * through the `wp_agent_workflow_step_executor` filter. Core supplies the
+ * default at LOW priority so a caller can override at normal priority (10+).
+ *
+ * Selection order:
+ *
+ *   1. A caller-forced executor wins — a consumer that has its own durable +
+ *      atomic story may return its own {@see WP_Agent_Workflow_Branch_Executor}
+ *      at priority 10+. Core makes no concurrency-safety promise for one.
+ *   2. Else Action Scheduler, when its async enqueue is present — the only
+ *      table-free durable + atomic path. (Phase 2 ships that executor; until
+ *      then no executor is returned even when AS is present.)
+ *   3. Else `null` → SYNCHRONOUS. The parallel handler, seeing no executor,
+ *      runs the in-process `run_parallel_roles()` / `run_parallel_map()` loops
+ *      exactly as v0.5.0. No suspend, no reconcile, no table.
+ *
+ * There is thus always a correct behavior with zero configuration: an install
+ * with no async executor selected is byte-for-byte v0.5.0 (serial).
+ *
+ * @package AgentsAPI
+ * @since   0.5.0
+ */
+
+namespace AgentsAPI\AI\Workflows;
+
+defined( 'ABSPATH' ) || exit;
+
+add_filter(
+	'wp_agent_workflow_step_executor',
+	/**
+	 * Core default selector for the branch executor.
+	 *
+	 * @param mixed                $executor Executor resolved so far. A caller
+	 *                                       override may already have supplied one.
+	 * @param array<string,mixed>  $step     The parallel step being dispatched.
+	 * @param array<string,mixed>  $context  Resolution context.
+	 * @return WP_Agent_Workflow_Branch_Executor|null
+	 */
+	static function ( $executor, $step, $context ) {
+		unset( $step, $context );
+
+		// A caller forced one (priority 10+ runs after this priority-5 default,
+		// so a caller override lands as $executor here on the NEXT pass — but a
+		// higher-priority caller filter would also short-circuit by returning
+		// early; either way, respect an already-resolved executor).
+		if ( $executor instanceof WP_Agent_Workflow_Branch_Executor ) {
+			return $executor;
+		}
+
+		// Phase 2 will return the Action Scheduler executor here when
+		// `function_exists( 'as_enqueue_async_action' )`. Phase 1 ships no async
+		// executor, so the selector returns null and the parallel handler runs
+		// the v0.5.0 synchronous loops. This keeps existing installs byte-for-byte
+		// unchanged while the state machine + interface land dormant.
+		return null;
+	},
+	5,
+	3
+);

--- a/tests/workflow-parallel-async-smoke.php
+++ b/tests/workflow-parallel-async-smoke.php
@@ -1,0 +1,585 @@
+<?php
+/**
+ * Pure-PHP end-to-end smoke test for the async suspend/resume workflow model
+ * (Phase 1: state machine + interface + sync default, no Action Scheduler).
+ *
+ * Run with: php tests/workflow-parallel-async-smoke.php
+ *
+ * This drives the REAL runner suspend → reconcile → resume path — NOT shape
+ * assertions. A test-only FakeExecutor is registered through the SAME real
+ * `wp_agent_workflow_step_executor` filter a caller executor uses. Its
+ * dispatch() records branch descriptors and returns `dispatched` handles
+ * WITHOUT running them; a `complete( handle_id, branch_result )` helper calls
+ * the REAL `agents_reconcile_workflow_branch()`. Every assertion executes
+ * production code: real run(), real `_suspend` handling in the step executor,
+ * the real suspend gate, the real recorder round-trip, the real reconcile,
+ * the real aggregate, and the real resume().
+ *
+ * Covered (design §9.2): suspend correctness, reconcile ordering + idempotency,
+ * resume continuation (a step AFTER the parallel step consumes the aggregate),
+ * required-branch failure, non-required-branch failure, sync-floor parity
+ * (selector returns null → v0.5.0), selection rule (override wins),
+ * crash-resume durability (discard runner, resume from find()), recorder
+ * round-trip preserves metadata._suspension, and idempotent duplicate reconcile.
+ *
+ * No WordPress required.
+ *
+ * @package AgentsAPI\Tests
+ */
+
+defined( 'ABSPATH' ) || define( 'ABSPATH', __DIR__ . '/' );
+
+$failures = array();
+$passes   = 0;
+
+echo "workflow-parallel-async-smoke\n";
+
+if ( ! class_exists( 'WP_Error' ) ) {
+	class WP_Error {
+		public function __construct( private string $code = '', private string $message = '', private $data = null ) {}
+		public function get_error_code(): string { return $this->code; }
+		public function get_error_message(): string { return $this->message; }
+		public function get_error_data() { return $this->data; }
+	}
+}
+if ( ! function_exists( 'is_wp_error' ) ) {
+	function is_wp_error( $value ): bool {
+		return $value instanceof WP_Error;
+	}
+}
+if ( ! class_exists( 'WP_Ability' ) ) {
+	class WP_Ability {
+		public function __construct( private string $name, private array $args ) {}
+		public function get_name(): string { return $this->name; }
+		public function execute( $input = null ) {
+			$callback = $this->args['execute_callback'] ?? null;
+			return is_callable( $callback ) ? call_user_func( $callback, is_array( $input ) ? $input : array() ) : null;
+		}
+	}
+}
+
+$GLOBALS['__filters']   = array();
+$GLOBALS['__abilities'] = array();
+$GLOBALS['__options']   = array();
+
+if ( ! function_exists( 'add_filter' ) ) {
+	function add_filter( string $hook, callable $cb, int $priority = 10, int $accepted_args = 1 ): void {
+		unset( $accepted_args );
+		$GLOBALS['__filters'][ $hook ][ $priority ][] = $cb;
+	}
+}
+if ( ! function_exists( 'remove_all_filters' ) ) {
+	function remove_all_filters( string $hook ): void {
+		unset( $GLOBALS['__filters'][ $hook ] );
+	}
+}
+if ( ! function_exists( 'apply_filters' ) ) {
+	function apply_filters( string $hook, $value, ...$args ) {
+		$cbs = $GLOBALS['__filters'][ $hook ] ?? array();
+		ksort( $cbs );
+		foreach ( $cbs as $bucket ) {
+			foreach ( $bucket as $cb ) {
+				$value = call_user_func_array( $cb, array_merge( array( $value ), $args ) );
+			}
+		}
+		return $value;
+	}
+}
+if ( ! function_exists( 'add_action' ) ) {
+	function add_action( string $hook, callable $cb, int $priority = 10, int $accepted_args = 1 ): void {
+		add_filter( $hook, $cb, $priority, $accepted_args );
+	}
+}
+if ( ! function_exists( 'do_action' ) ) {
+	function do_action( string $hook, ...$args ): void {
+		$cbs = $GLOBALS['__filters'][ $hook ] ?? array();
+		ksort( $cbs );
+		foreach ( $cbs as $bucket ) {
+			foreach ( $bucket as $cb ) {
+				call_user_func_array( $cb, $args );
+			}
+		}
+	}
+}
+if ( ! function_exists( 'wp_get_ability' ) ) {
+	function wp_get_ability( string $name ) { return $GLOBALS['__abilities'][ $name ] ?? null; }
+}
+if ( ! function_exists( 'wp_has_ability' ) ) {
+	function wp_has_ability( string $name ): bool { return isset( $GLOBALS['__abilities'][ $name ] ); }
+}
+if ( ! function_exists( 'wp_register_ability' ) ) {
+	function wp_register_ability( string $name, array $args ) {
+		$GLOBALS['__abilities'][ $name ] = new WP_Ability( $name, $args );
+		return $GLOBALS['__abilities'][ $name ];
+	}
+}
+if ( ! function_exists( 'current_user_can' ) ) {
+	function current_user_can( $cap ): bool { unset( $cap ); return true; }
+}
+if ( ! function_exists( 'get_option' ) ) {
+	function get_option( string $option, $default = false ) { return $GLOBALS['__options'][ $option ] ?? $default; }
+}
+if ( ! function_exists( 'update_option' ) ) {
+	function update_option( string $option, $value, $autoload = null ): bool {
+		unset( $autoload );
+		$GLOBALS['__options'][ $option ] = $value;
+		return true;
+	}
+}
+
+function async_smoke_register_ability( string $name, \Closure $handler ): void {
+	$GLOBALS['__abilities'][ $name ] = new WP_Ability(
+		$name,
+		array( 'execute_callback' => $handler )
+	);
+}
+
+function smoke_assert( $expected, $actual, string $name, array &$failures, int &$passes ): void {
+	if ( $expected === $actual ) {
+		++$passes;
+		echo "  PASS {$name}\n";
+		return;
+	}
+	$failures[] = $name;
+	echo "  FAIL {$name}\n";
+	echo '    expected: ' . var_export( $expected, true ) . "\n";
+	echo '    actual:   ' . var_export( $actual, true ) . "\n";
+}
+
+function smoke_assert_true( $actual, string $name, array &$failures, int &$passes ): void {
+	smoke_assert( true, (bool) $actual, $name, $failures, $passes );
+}
+
+require_once __DIR__ . '/../src/Workflows/class-wp-agent-workflow-bindings.php';
+require_once __DIR__ . '/../src/Workflows/class-wp-agent-workflow-spec-validator.php';
+require_once __DIR__ . '/../src/Workflows/class-wp-agent-workflow-spec.php';
+require_once __DIR__ . '/../src/Workflows/class-wp-agent-workflow-run-result.php';
+require_once __DIR__ . '/../src/Workflows/class-wp-agent-workflow-store.php';
+require_once __DIR__ . '/../src/Workflows/class-wp-agent-workflow-run-recorder.php';
+require_once __DIR__ . '/../src/Abilities/class-wp-agent-ability-dispatcher.php';
+require_once __DIR__ . '/../src/Runtime/interface-wp-agent-run-control-store.php';
+require_once __DIR__ . '/../src/Runtime/class-wp-agent-option-run-control-store.php';
+require_once __DIR__ . '/../src/Runtime/class-wp-agent-run-control.php';
+require_once __DIR__ . '/../src/Workflows/class-wp-agent-workflow-run-context.php';
+require_once __DIR__ . '/../src/Workflows/interface-wp-agent-workflow-branch-executor.php';
+require_once __DIR__ . '/../src/Workflows/class-wp-agent-workflow-step-executor.php';
+require_once __DIR__ . '/../src/Workflows/class-wp-agent-workflow-runner.php';
+// Reconcile references agents_run_workflow_output_schema / agents_workflow_string
+// / agents_workflow_run_cancel_permission from the abilities file.
+require_once __DIR__ . '/../src/Workflows/register-agents-workflow-abilities.php';
+require_once __DIR__ . '/../src/Workflows/register-reconcile-workflow-branch.php';
+
+use AgentsAPI\AI\Workflows\WP_Agent_Workflow_Run_Result;
+use AgentsAPI\AI\Workflows\WP_Agent_Workflow_Run_Recorder;
+use AgentsAPI\AI\Workflows\WP_Agent_Workflow_Branch_Executor;
+use AgentsAPI\AI\Workflows\WP_Agent_Workflow_Runner;
+use AgentsAPI\AI\Workflows\WP_Agent_Workflow_Spec;
+
+use function AgentsAPI\AI\Workflows\agents_reconcile_workflow_branch;
+
+// ── A durable, reloadable in-memory recorder ─────────────────────────────────
+// Persists the serialized run-result array (round-tripped through to_array /
+// from_array). "Durable" enough to prove crash-resume: find() rebuilds from the
+// stored array, so a fresh runner loaded from find() sees the exact frame.
+
+final class Async_Smoke_Recorder implements WP_Agent_Workflow_Run_Recorder {
+	/** @var array<string,array<string,mixed>> */
+	public array $rows = array();
+
+	public function start( WP_Agent_Workflow_Run_Result $result ) {
+		$this->rows[ $result->get_run_id() ] = $result->to_array();
+		return $result->get_run_id();
+	}
+	public function update( WP_Agent_Workflow_Run_Result $result ) {
+		$this->rows[ $result->get_run_id() ] = $result->to_array();
+		return true;
+	}
+	public function find( string $run_id ): ?WP_Agent_Workflow_Run_Result {
+		return isset( $this->rows[ $run_id ] )
+			? WP_Agent_Workflow_Run_Result::from_array( $this->rows[ $run_id ] )
+			: null;
+	}
+	public function recent( array $args = array() ): array {
+		unset( $args );
+		return array_map(
+			array( WP_Agent_Workflow_Run_Result::class, 'from_array' ),
+			array_values( $this->rows )
+		);
+	}
+}
+
+// ── The FakeExecutor — registered through the REAL filter ────────────────────
+// dispatch() records descriptors + returns 'dispatched' handles WITHOUT running
+// anything. Completion is scripted by the test via complete().
+
+final class Fake_Branch_Executor implements WP_Agent_Workflow_Branch_Executor {
+	/** @var array<string,array<string,mixed>> handle_id => handle */
+	public array $handles = array();
+	/** @var array<string,array<string,mixed>> handle_id => descriptor */
+	public array $descriptors = array();
+	private int $seq = 0;
+
+	public function id(): string { return 'fake'; }
+
+	public function dispatch( array $branches, array $context ): array {
+		unset( $context );
+		$out = array();
+		foreach ( $branches as $branch ) {
+			$key       = (string) ( $branch['key'] ?? $this->seq );
+			$handle_id = 'h_' . ( ++$this->seq ) . '_' . $key;
+			$handle    = array(
+				'id'       => $handle_id,
+				'key'      => $key,
+				'executor' => $this->id(),
+				'status'   => 'dispatched',
+				'required' => ! empty( $branch['required'] ),
+				'ref'      => null,
+			);
+			$this->handles[ $handle_id ]     = $handle;
+			$this->descriptors[ $handle_id ] = $branch;
+			$out[]                           = $handle;
+		}
+		return $out;
+	}
+
+	public function are_all_complete( array $handles ): bool {
+		foreach ( $handles as $handle ) {
+			$status = (string) ( $handle['status'] ?? '' );
+			if ( 'succeeded' !== $status && 'failed' !== $status ) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	public function collect( array $handles ): array {
+		$out = array();
+		foreach ( $handles as $handle ) {
+			$out[ (string) ( $handle['key'] ?? '' ) ] = array();
+		}
+		return $out;
+	}
+}
+
+// Register the FakeExecutor through the REAL selection filter (priority 10 wins
+// over the core priority-5 default that returns null).
+$GLOBALS['__fake_executor'] = null;
+add_filter(
+	'wp_agent_workflow_step_executor',
+	static function ( $executor, $step, $context ) {
+		unset( $step, $context );
+		if ( $executor instanceof WP_Agent_Workflow_Branch_Executor ) {
+			return $executor;
+		}
+		return $GLOBALS['__fake_executor'];
+	},
+	10,
+	3
+);
+
+/**
+ * Test helper: simulate a branch finishing by calling the REAL reconcile.
+ *
+ * @return WP_Agent_Workflow_Run_Result|WP_Error
+ */
+function async_smoke_complete( string $run_id, string $handle_id, string $key, string $status, $output, $extra = array() ) {
+	return agents_reconcile_workflow_branch(
+		$run_id,
+		$handle_id,
+		array_merge(
+			array(
+				'key'    => $key,
+				'status' => $status,
+				'output' => $output,
+			),
+			$extra
+		)
+	);
+}
+
+// ── Stub abilities (aggregator + sequential consumer) ────────────────────────
+
+async_smoke_register_ability(
+	'demo/aggregate',
+	static function ( array $input ): array {
+		return array(
+			'final_bundle' => 'FUSED[' . (string) ( $input['headline'] ?? '' ) . '|' . (string) ( $input['body'] ?? '' ) . ']',
+		);
+	}
+);
+
+async_smoke_register_ability(
+	'demo/consume',
+	static function ( array $input ): array {
+		return array( 'consumed' => 'GOT:' . (string) ( $input['bundle'] ?? '' ) );
+	}
+);
+
+// Role worker used by the sibling branches when they run SYNCHRONOUSLY (the
+// sync-floor case). In the async case the FakeExecutor never runs them; the
+// test supplies fragments directly through reconcile.
+async_smoke_register_ability(
+	'demo/role-worker',
+	static function ( array $input ): array {
+		unset( $input );
+		return array( 'fragment' => 'SYNC' );
+	}
+);
+
+// ── The spec: parallel-roles step FOLLOWED BY a sequential step that consumes
+//    the aggregated bundle. This proves resume continuation.
+
+function async_smoke_roles_spec(): WP_Agent_Workflow_Spec {
+	return WP_Agent_Workflow_Spec::from_array(
+		array(
+			'id'    => 'demo/async-roles',
+			'steps' => array(
+				array(
+					'id'       => 'scatter',
+					'type'     => 'parallel',
+					'context'  => array( 'marker' => 'M' ),
+					'branches' => array(
+						array(
+							'role'                   => 'headline',
+							'required'               => true,
+							'can_write_final_bundle' => false,
+							'steps'                  => array(
+								array( 'id' => 'h', 'type' => 'ability', 'ability' => 'demo/role-worker', 'args' => array() ),
+							),
+						),
+						array(
+							'role'                   => 'body',
+							'required'               => true,
+							'can_write_final_bundle' => false,
+							'steps'                  => array(
+								array( 'id' => 'b', 'type' => 'ability', 'ability' => 'demo/role-worker', 'args' => array() ),
+							),
+						),
+						array(
+							'role'                   => 'fuse',
+							'required'               => true,
+							'can_write_final_bundle' => true,
+							'steps'                  => array(
+								array(
+									'id'      => 'agg',
+									'type'    => 'ability',
+									'ability' => 'demo/aggregate',
+									'args'    => array(
+										'headline' => '${vars.branch_outputs.headline.fragment}',
+										'body'     => '${vars.branch_outputs.body.fragment}',
+									),
+								),
+							),
+						),
+					),
+				),
+				// Sequential step AFTER the parallel step — consumes the aggregate.
+				array(
+					'id'      => 'after',
+					'type'    => 'ability',
+					'ability' => 'demo/consume',
+					'args'    => array( 'bundle' => '${steps.scatter.output.final.final_bundle}' ),
+				),
+			),
+		)
+	);
+}
+
+// ═════════════════════════════════════════════════════════════════════════════
+// 1. Suspend correctness + 2. reconcile ordering/idempotency + 3. resume
+// ═════════════════════════════════════════════════════════════════════════════
+
+$recorder                   = new Async_Smoke_Recorder();
+$GLOBALS['__fake_executor'] = new Fake_Branch_Executor();
+$fake                       = $GLOBALS['__fake_executor'];
+
+// Wire the recorder for reconcile/resume through the real filter.
+remove_all_filters( 'wp_agent_workflow_run_recorder' );
+add_filter( 'wp_agent_workflow_run_recorder', static function () use ( $recorder ) { return $recorder; } );
+
+$spec   = async_smoke_roles_spec();
+$run    = ( new WP_Agent_Workflow_Runner( $recorder ) )->run( $spec, array(), array( 'run_id' => 'run-A' ) );
+
+// SUSPEND CORRECTNESS.
+smoke_assert( WP_Agent_Workflow_Run_Result::STATUS_SUSPENDED, $run->get_status(), 'run returns SUSPENDED when an executor is selected', $failures, $passes );
+smoke_assert_true( $run->is_suspended(), 'is_suspended() true on the suspended run', $failures, $passes );
+
+$frame = $run->get_suspension();
+smoke_assert( 0, $frame['step_index'] ?? -1, 'frame records the suspended step_index (0)', $failures, $passes );
+smoke_assert( 'scatter', $frame['step_id'] ?? '', 'frame records the suspended step_id', $failures, $passes );
+smoke_assert( 'fake', $frame['executor_id'] ?? '', 'frame records the owning executor id', $failures, $passes );
+smoke_assert( 2, count( $frame['handles'] ?? array() ), 'frame carries N sibling handles (2, aggregator deferred)', $failures, $passes );
+smoke_assert( 'roles', $frame['aggregate']['mode'] ?? '', 'frame carries the roles aggregate plan', $failures, $passes );
+
+// The addressable run must NOT be finished on suspend (stays live).
+$rc = \AgentsAPI\AI\WP_Agent_Run_Control::get_run( WP_Agent_Workflow_Runner::RUN_CONTROL_STORE, 'run-A' );
+smoke_assert( 'running', $rc['status'] ?? '', 'addressable run stays RUNNING while suspended (not finished)', $failures, $passes );
+
+// Recorder round-trip preserves metadata._suspension losslessly.
+$reloaded = $recorder->find( 'run-A' );
+smoke_assert_true( is_array( $reloaded->get_suspension()['handles'] ?? null ), 'recorder round-trip preserves metadata._suspension', $failures, $passes );
+smoke_assert( 2, count( $reloaded->get_suspension()['handles'] ), 'reloaded frame preserves handle count', $failures, $passes );
+
+// Identify handle ids for headline + body.
+$handle_by_key = array();
+foreach ( $frame['handles'] as $h ) {
+	$handle_by_key[ $h['key'] ] = $h['id'];
+}
+
+// RECONCILE ORDERING: complete body first (out of order), then headline last.
+$after_body = async_smoke_complete( 'run-A', $handle_by_key['body'], 'body', 'succeeded', array( 'fragment' => 'BODY' ) );
+smoke_assert( WP_Agent_Workflow_Run_Result::STATUS_SUSPENDED, $after_body->get_status(), 'still SUSPENDED after 1 of 2 branches reconcile', $failures, $passes );
+
+// IDEMPOTENT DUPLICATE RECONCILE: reconciling body again must not resume or double-count.
+$dup = async_smoke_complete( 'run-A', $handle_by_key['body'], 'body', 'succeeded', array( 'fragment' => 'BODY-DUP' ) );
+smoke_assert( WP_Agent_Workflow_Run_Result::STATUS_SUSPENDED, $dup->get_status(), 'duplicate reconcile is a no-op (still SUSPENDED)', $failures, $passes );
+smoke_assert( 1, count( $dup->get_suspension()['completed'] ?? array() ), 'duplicate reconcile does not double-count completed', $failures, $passes );
+
+// The LAST branch reconciles → aggregate + resume.
+$final = async_smoke_complete( 'run-A', $handle_by_key['headline'], 'headline', 'succeeded', array( 'fragment' => 'HEAD' ) );
+
+// RESUME CONTINUATION: run succeeds, the sequential `after` step ran and
+// consumed the aggregated bundle.
+smoke_assert( WP_Agent_Workflow_Run_Result::STATUS_SUCCEEDED, $final->get_status(), 'last branch resumes → run SUCCEEDED', $failures, $passes );
+$out_steps = $final->get_output()['steps'] ?? array();
+smoke_assert( 'FUSED[HEAD|BODY]', $out_steps['scatter']['final']['final_bundle'] ?? '', 'aggregate fused reconciled sibling outputs on resume', $failures, $passes );
+smoke_assert( 'GOT:FUSED[HEAD|BODY]', $out_steps['after']['consumed'] ?? '', 'step AFTER the parallel step consumed the aggregated output on resume', $failures, $passes );
+
+// The suspension frame is cleared after resume (table-free row gone).
+smoke_assert( array(), $final->get_suspension(), 'suspension frame cleared after resume', $failures, $passes );
+
+// A reconcile after the run already resumed is a harmless no-op.
+$late = async_smoke_complete( 'run-A', $handle_by_key['headline'], 'headline', 'succeeded', array( 'fragment' => 'X' ) );
+smoke_assert( WP_Agent_Workflow_Run_Result::STATUS_SUCCEEDED, $late->get_status(), 'reconcile after resume is a no-op (run stays SUCCEEDED)', $failures, $passes );
+
+// ═════════════════════════════════════════════════════════════════════════════
+// 4. Required-branch failure fails the run on resume
+// ═════════════════════════════════════════════════════════════════════════════
+
+$recorder2 = new Async_Smoke_Recorder();
+remove_all_filters( 'wp_agent_workflow_run_recorder' );
+add_filter( 'wp_agent_workflow_run_recorder', static function () use ( $recorder2 ) { return $recorder2; } );
+$GLOBALS['__fake_executor'] = new Fake_Branch_Executor();
+
+$run2   = ( new WP_Agent_Workflow_Runner( $recorder2 ) )->run( async_smoke_roles_spec(), array(), array( 'run_id' => 'run-B' ) );
+$frame2 = $run2->get_suspension();
+$hk2    = array();
+foreach ( $frame2['handles'] as $h ) {
+	$hk2[ $h['key'] ] = $h['id'];
+}
+async_smoke_complete( 'run-B', $hk2['headline'], 'headline', 'succeeded', array( 'fragment' => 'HEAD' ) );
+$res2 = async_smoke_complete( 'run-B', $hk2['body'], 'body', 'failed', null, array( 'error' => array( 'code' => 'boom', 'message' => 'body exploded' ) ) );
+
+smoke_assert( WP_Agent_Workflow_Run_Result::STATUS_FAILED, $res2->get_status(), 'required-branch failure → run FAILED on resume', $failures, $passes );
+smoke_assert( 'workflow_parallel_required_branch_failed', $res2->get_error()['code'] ?? '', 'required-branch failure surfaces the parallel failure code', $failures, $passes );
+
+// ═════════════════════════════════════════════════════════════════════════════
+// 5. Non-required-branch failure surfaces error but run still succeeds
+// ═════════════════════════════════════════════════════════════════════════════
+
+function async_smoke_optional_spec(): WP_Agent_Workflow_Spec {
+	return WP_Agent_Workflow_Spec::from_array(
+		array(
+			'id'    => 'demo/async-optional',
+			'steps' => array(
+				array(
+					'id'       => 'scatter',
+					'type'     => 'parallel',
+					'context'  => array( 'marker' => 'M' ),
+					'branches' => array(
+						array(
+							'role'                   => 'flaky',
+							'required'               => false,
+							'can_write_final_bundle' => false,
+							'steps'                  => array( array( 'id' => 'f', 'type' => 'ability', 'ability' => 'demo/aggregate', 'args' => array() ) ),
+						),
+						array(
+							'role'                   => 'fuse',
+							'required'               => true,
+							'can_write_final_bundle' => true,
+							'steps'                  => array(
+								array( 'id' => 'agg', 'type' => 'ability', 'ability' => 'demo/aggregate', 'args' => array( 'headline' => 'x', 'body' => 'y' ) ),
+							),
+						),
+					),
+				),
+			),
+		)
+	);
+}
+
+$recorder3 = new Async_Smoke_Recorder();
+remove_all_filters( 'wp_agent_workflow_run_recorder' );
+add_filter( 'wp_agent_workflow_run_recorder', static function () use ( $recorder3 ) { return $recorder3; } );
+$GLOBALS['__fake_executor'] = new Fake_Branch_Executor();
+
+$run3   = ( new WP_Agent_Workflow_Runner( $recorder3 ) )->run( async_smoke_optional_spec(), array(), array( 'run_id' => 'run-C' ) );
+$frame3 = $run3->get_suspension();
+$hk3    = array();
+foreach ( $frame3['handles'] as $h ) {
+	$hk3[ $h['key'] ] = $h['id'];
+}
+$res3 = async_smoke_complete( 'run-C', $hk3['flaky'], 'flaky', 'failed', array( 'error' => array( 'code' => 'flaky_boom', 'message' => 'flaked' ) ), array( 'error' => array( 'code' => 'flaky_boom', 'message' => 'flaked' ) ) );
+
+smoke_assert( WP_Agent_Workflow_Run_Result::STATUS_SUCCEEDED, $res3->get_status(), 'non-required branch failure → run still SUCCEEDED', $failures, $passes );
+$out3 = $res3->get_output()['steps']['scatter']['final'] ?? array();
+smoke_assert( 'FUSED[x|y]', $out3['final_bundle'] ?? '', 'aggregator still fuses despite a tolerated branch failure', $failures, $passes );
+
+// ═════════════════════════════════════════════════════════════════════════════
+// 6. Crash-resume durability: discard the runner, resume from find()
+// ═════════════════════════════════════════════════════════════════════════════
+
+$recorder4 = new Async_Smoke_Recorder();
+remove_all_filters( 'wp_agent_workflow_run_recorder' );
+add_filter( 'wp_agent_workflow_run_recorder', static function () use ( $recorder4 ) { return $recorder4; } );
+$GLOBALS['__fake_executor'] = new Fake_Branch_Executor();
+
+$run4   = ( new WP_Agent_Workflow_Runner( $recorder4 ) )->run( async_smoke_roles_spec(), array(), array( 'run_id' => 'run-D' ) );
+$frame4 = $run4->get_suspension();
+$hk4    = array();
+foreach ( $frame4['handles'] as $h ) {
+	$hk4[ $h['key'] ] = $h['id'];
+}
+smoke_assert( WP_Agent_Workflow_Run_Result::STATUS_SUSPENDED, $run4->get_status(), 'crash-resume: run suspends', $failures, $passes );
+
+// Throw away every runner instance. Reconcile resolves a FRESH runner from the
+// recorder via the resume-runner filter default — nothing from $run4 survives.
+unset( $run4 );
+
+async_smoke_complete( 'run-D', $hk4['body'], 'body', 'succeeded', array( 'fragment' => 'B2' ) );
+$res4 = async_smoke_complete( 'run-D', $hk4['headline'], 'headline', 'succeeded', array( 'fragment' => 'H2' ) );
+
+smoke_assert( WP_Agent_Workflow_Run_Result::STATUS_SUCCEEDED, $res4->get_status(), 'crash-resume: fresh runner from find() completes the run', $failures, $passes );
+smoke_assert( 'GOT:FUSED[H2|B2]', $res4->get_output()['steps']['after']['consumed'] ?? '', 'crash-resume: sequential step ran after resume through a fresh runner', $failures, $passes );
+
+// ═════════════════════════════════════════════════════════════════════════════
+// 7. Sync-floor parity: selector returns null → NO SUSPENDED, v0.5.0 output
+// ═════════════════════════════════════════════════════════════════════════════
+
+$GLOBALS['__fake_executor'] = null; // selector now resolves null → sync loops.
+$recorder5                  = new Async_Smoke_Recorder();
+
+$sync_run = ( new WP_Agent_Workflow_Runner( $recorder5 ) )->run( async_smoke_roles_spec(), array(), array( 'run_id' => 'run-E' ) );
+
+smoke_assert( WP_Agent_Workflow_Run_Result::STATUS_SUCCEEDED, $sync_run->get_status(), 'sync floor: no executor → single terminal SUCCEEDED (no SUSPENDED)', $failures, $passes );
+smoke_assert_true( ! $sync_run->is_suspended(), 'sync floor: never produces SUSPENDED', $failures, $passes );
+smoke_assert( array(), $sync_run->get_suspension(), 'sync floor: no suspension frame', $failures, $passes );
+// The aggregate ran inline in ONE request and the sequential step consumed it.
+smoke_assert( 'roles', $sync_run->get_output()['steps']['scatter']['shape'] ?? '', 'sync floor: parallel-roles shape produced inline', $failures, $passes );
+
+// ═════════════════════════════════════════════════════════════════════════════
+// 8. Selection rule: an override at priority 10 wins over the core null default
+// ═════════════════════════════════════════════════════════════════════════════
+
+// With the FakeExecutor registered (priority 10) the run suspends; with it null
+// the run is synchronous. Both cases are exercised above (run-A vs run-E),
+// proving the override wins over the core priority-5 null default.
+$GLOBALS['__fake_executor'] = new Fake_Branch_Executor();
+$selected = apply_filters( 'wp_agent_workflow_step_executor', null, array( 'id' => 'x', 'type' => 'parallel' ), array() );
+smoke_assert_true( $selected instanceof WP_Agent_Workflow_Branch_Executor, 'selection rule: priority-10 override wins over core null default', $failures, $passes );
+$GLOBALS['__fake_executor'] = null;
+$selected_null = apply_filters( 'wp_agent_workflow_step_executor', null, array( 'id' => 'x', 'type' => 'parallel' ), array() );
+smoke_assert( null, $selected_null, 'selection rule: no override + no AS → null (sync)', $failures, $passes );
+
+echo "Passed: {$passes}, Failed: " . count( $failures ) . "\n";
+exit( count( $failures ) > 0 ? 1 : 0 );


### PR DESCRIPTION
## What this is

**Phase 1** of the async/concurrent parallel-branch redesign for the agents-api workflow runner (`Refs #390`). It lands the **state machine + executor interface + reconcile entry point, with a synchronous default**. There is **no Action Scheduler code** here (that is Phase 2) and **no new database tables** — ever.

The design this implements is the approved async/parallel design doc; this PR is its §8 "Phase 1" scope.

## Backward compatibility — the #1 requirement

**On an install with no async executor selected, behavior is byte-for-byte v0.5.0.** The core selector (`register-workflow-step-executor.php`) returns `null` at low priority, so `default_parallel_handler` runs the existing in-process `run_parallel_roles()` / `run_parallel_map()` loops, returns a terminal array that satisfies the existing `:224` gate, and **never produces `SUSPENDED`**. Existing installs see zero behavior change. The existing `tests/workflow-parallel-smoke.php` passes unchanged as the sync-parity proof (30/30).

## What changed

- **`WP_Agent_Workflow_Run_Result`** — adds `STATUS_SUSPENDED`, `is_suspended()`, `get_suspension()` (reads `metadata._suspension`). **No new constructor args** — the suspension frame rides the existing `metadata` field and round-trips through `to_array()`/`from_array()`/`with()`.
- **`WP_Agent_Workflow_Step_Executor::execute()`** — recognizes a `_suspend` sentinel in a successful handler return and emits a `'pending'` step record carrying the suspend payload, without setting SUCCEEDED / step output. Invisible to existing handlers (none emit it) — purely additive.
- **`WP_Agent_Workflow_Runner`** — the step loop is now indexed/resumable; a **pending gate before the failure gate** persists a table-free suspension frame and returns `SUSPENDED`; **`resume( $run_id, $options )`** reloads via the recorder `find()`, rebuilds context from the frame's `context_snapshot`, and continues from `step_index`. `run_branch_steps()` is now a shared public static so the sync path and the (future) async branch action call **one** implementation.
- **`interface-wp-agent-workflow-branch-executor.php`** (new) — the 3-method concurrency seam `dispatch()` / `are_all_complete()` / `collect()`.
- **`agents_reconcile_workflow_branch( $run_id, $handle_id, $branch_result )`** (new) + the `agents/reconcile-workflow-branch` ability; `suspended` added to the `agents/run-workflow` output enum. Reconcile merges a completed branch into the frame; on all-terminal it runs the aggregate plan (a required-branch failure fails the run) and calls `resume()`. Idempotent and out-of-order-safe.
- **`register-workflow-step-executor.php`** (new) — the core selector: a caller-forced executor wins; else (Phase 2) Action Scheduler; else `null` → synchronous. Filter-overridable.
- **`default_parallel_handler`** consults the selected executor: `null` → the v0.5.0 sync loops unchanged; a real executor → build branch descriptors, `dispatch()`, and return the `_suspend` directive.

## Table-free storage

The suspension frame is a **single, bounded, `run_id`-keyed row** carried in the run result's `metadata._suspension`, persisted through the recorder's existing `update()`/`find()` seam and **deleted on resume**. No new table, no `dbDelta`, no activation hook (the `no-product-imports-smoke` table-free gate passes).

## Testing (drives the REAL path, not shape mocks)

`tests/workflow-parallel-async-smoke.php` (new) extends the pure-PHP harness and drives the **real** runner suspend → reconcile → resume path via a **FakeExecutor registered through the real `wp_agent_workflow_step_executor` filter** — no Action Scheduler, no AI. Its `dispatch()` records handles without running them; a `complete()` helper calls the **real** `agents_reconcile_workflow_branch()`. Every assertion executes production code (`run()`, the `_suspend` handling, the suspend gate, the recorder round-trip, the reconcile, the aggregate, `resume()`).

Covered: suspend correctness (SUSPENDED + frame with correct `step_index` + N handles), reconcile ordering + idempotency (out-of-order completes; only the last resumes; duplicate reconcile is a no-op), resume continuation (a step **after** the parallel step consumes the aggregated output), required-branch-failure fails the run on resume, non-required-branch-failure surfaces the error but the run succeeds, **sync-floor parity** (selector null → exact v0.5.0, single terminal return, no `SUSPENDED`), the selection rule (priority-10 override wins over the core null default), crash-resume durability (discard the runner, resume through a fresh runner from `find()`), and recorder round-trip preserving `metadata._suspension`.

Checks (level max / full suite): `composer phpstan` → **No errors**; `composer smoke` → **green** (async smoke 31/31, sync-parity smoke 30/30). `php -l` clean on every changed/new file.

## Follow-ups

- **Phase 2** — the Action Scheduler branch executor (descriptors ride in AS payloads; the resume is an atomically-claimed AS action). Auto-selected when `as_enqueue_async_action` exists. Required for actual concurrency; no new tables.
- **Phase 3** — consumer adoption (author `parallel` fan-out steps; concurrency comes automatically on AS-equipped hosts).

`Refs #390`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Claude Opus 4.8)
- **Used for:** Implementing the Phase 1 state machine, executor interface, reconcile entry point, sync-default selector, and the async suspend/resume smoke test.