### PR TITLE
Fix silent hang: serialize branch reconcile so concurrent completions never lose the resume

### DIFF
--- a/agents-api.php
+++ b/agents-api.php
@@ -247,6 +247,7 @@ require_once AGENTS_API_PATH . 'src/Workflows/class-wp-agent-workflow-action-sch
 require_once AGENTS_API_PATH . 'src/Workflows/register-workflows.php';
 require_once AGENTS_API_PATH . 'src/Workflows/register-workflow-step-executor.php';
 require_once AGENTS_API_PATH . 'src/Workflows/register-agents-workflow-abilities.php';
+require_once AGENTS_API_PATH . 'src/Workflows/class-wp-agent-workflow-reconcile-lock.php';
 require_once AGENTS_API_PATH . 'src/Workflows/register-reconcile-workflow-branch.php';
 require_once AGENTS_API_PATH . 'src/Workflows/register-workflow-branch-executor.php';
 require_once AGENTS_API_PATH . 'src/Workflows/register-workflow-bridge-sync.php';

--- a/composer.json
+++ b/composer.json
@@ -114,6 +114,7 @@
       "php tests/workflow-parallel-smoke.php",
       "php tests/workflow-parallel-async-smoke.php",
       "php tests/workflow-as-branch-smoke.php",
+      "php tests/workflow-reconcile-race-smoke.php",
       "php tests/workflow-lifecycle-smoke.php",
       "php tests/agents-workflow-ability-smoke.php",
       "php tests/routine-smoke.php",

--- a/src/Workflows/class-wp-agent-workflow-reconcile-lock.php
+++ b/src/Workflows/class-wp-agent-workflow-reconcile-lock.php
@@ -1,0 +1,222 @@
+<?php
+/**
+ * Cross-process serialization lock for the branch-reconcile critical section.
+ *
+ * WHY THIS EXISTS. {@see agents_reconcile_workflow_branch()} merges one finished
+ * branch into the suspended run's `metadata._suspension.completed[]` map, then
+ * decides whether EVERY branch is now terminal (and, if so, aggregates + resumes).
+ * That merge is a read-modify-write on shared per-run state:
+ *
+ *     $frame     = load();          // read completed[]
+ *     $completed = merge( $me );    // modify: add my handle
+ *     save( $frame );               // write completed[] back
+ *     if ( count($completed) === count($handles) ) resume();  // decide
+ *
+ * When N branches finish CONCURRENTLY in N separate processes (the async Action
+ * Scheduler path — each branch runs in its own claimed AS worker), two reconciles
+ * can both read the frame BEFORE either writes. Each merges only its OWN handle
+ * and the later write CLOBBERS the earlier one (a classic lost update). The frame
+ * then permanently shows fewer than N completed handles, the "all terminal →
+ * enqueue resume" transition NEVER fires, and the run hangs SUSPENDED forever —
+ * observed twice in a real MySQL multi-page fanout A/B.
+ *
+ * AS's atomic action-claim already de-duplicates the RESUME action, but it does
+ * NOT guard THIS write — a different write, on the frame, not the resume action.
+ * This lock closes that gap by serializing the reconcile critical section per
+ * run so each reconcile reads the frame AFTER the previous one committed.
+ *
+ * TABLE-FREE. Under the substrate's no-new-tables constraint the lock uses
+ * `add_option()` as the atomic compare-and-set — `add_option()` performs an
+ * INSERT that fails (returns false) when the option row already exists, because
+ * `option_name` is a UNIQUE key. That is exactly the primitive the CPT
+ * conversation lock uses (`add_post_meta( ..., $unique = true )`); this is its
+ * option-scoped sibling, chosen because reconcile is core and cannot assume a
+ * consumer's recorder storage. No new table, no hand-rolled file/APCu lock.
+ *
+ * PLUGGABLE. A consumer with a stronger primitive (MySQL `GET_LOCK`, Redis) can
+ * replace acquisition/release via the `wp_agent_workflow_reconcile_lock` filter.
+ * The default here is correct and dependency-free.
+ *
+ * @package AgentsAPI
+ * @since   0.5.0
+ */
+
+namespace AgentsAPI\AI\Workflows;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Default `add_option()`-CAS per-run reconcile lock.
+ *
+ * A held lock stores an expiry so a crashed holder's lock is reclaimable after
+ * its TTL (a process that dies mid-critical-section must not strand every future
+ * reconcile for the run). Acquisition blocks with bounded retries because a
+ * reconcile critical section is short (an in-memory merge + a recorder write),
+ * so a waiter reliably wins within a few spins rather than dropping the branch.
+ */
+final class WP_Agent_Workflow_Reconcile_Lock {
+
+	/**
+	 * Option-name prefix for the per-run lock row. The run id is appended so
+	 * locks never collide across runs and are trivially inspectable/cleanable.
+	 *
+	 * @since 0.5.0
+	 */
+	private const OPTION_PREFIX = 'agents_wf_reconcile_lock_';
+
+	/**
+	 * Lock time-to-live (seconds). After this a stale lock (crashed holder) is
+	 * reclaimable. Generous relative to a reconcile's real duration so a healthy
+	 * holder is never evicted mid-section, yet short enough that a crash does not
+	 * strand the run for long.
+	 *
+	 * @since 0.5.0
+	 */
+	private const TTL_SECONDS = 60;
+
+	/**
+	 * Max acquisition attempts before giving up. With the sleep below this is a
+	 * bounded wait; a reconcile section is short, so contenders win quickly.
+	 *
+	 * @since 0.5.0
+	 */
+	private const MAX_ATTEMPTS = 50;
+
+	/**
+	 * Per-attempt backoff (microseconds). 20ms × 50 attempts ≈ 1s worst-case
+	 * wait — well under the TTL, so a waiter either wins or reclaims a stale lock.
+	 *
+	 * @since 0.5.0
+	 */
+	private const RETRY_USLEEP = 20000;
+
+	/**
+	 * Run one callback under an exclusive per-run lock. The callback runs at most
+	 * once and only while the lock is held; the lock is always released, even if
+	 * the callback throws. When the lock genuinely cannot be acquired (a wedged
+	 * holder that never expires) the callback still runs — stranding the branch
+	 * would be strictly worse than a best-effort merge, and the TTL makes a real
+	 * crash reclaimable so this fallback is rare.
+	 *
+	 * @since 0.5.0
+	 *
+	 * @template T
+	 * @param string           $run_id   Run whose reconcile section is serialized.
+	 * @param callable():T     $critical The critical section (find → merge → decide).
+	 * @return T The callback's return value.
+	 */
+	public static function with_lock( string $run_id, callable $critical ) {
+		$token = self::acquire( $run_id );
+		try {
+			return $critical();
+		} finally {
+			if ( null !== $token ) {
+				self::release( $run_id, $token );
+			}
+		}
+	}
+
+	/**
+	 * Acquire the per-run lock, blocking with bounded retries. Returns the lock
+	 * token on success, or null when acquisition ultimately failed (the caller
+	 * proceeds without the lock rather than dropping the branch — see
+	 * {@see self::with_lock()}).
+	 *
+	 * @since 0.5.0
+	 *
+	 * @param string $run_id Run id.
+	 * @return string|null Lock token, or null if unacquired after MAX_ATTEMPTS.
+	 */
+	private static function acquire( string $run_id ): ?string {
+		if ( ! function_exists( 'add_option' ) || ! function_exists( 'get_option' ) ) {
+			// No option layer (e.g. a non-WordPress harness) — nothing to lock
+			// against; callers are already single-process there.
+			return null;
+		}
+
+		$option = self::OPTION_PREFIX . md5( $run_id );
+
+		for ( $attempt = 0; $attempt < self::MAX_ATTEMPTS; $attempt++ ) {
+			$token   = self::mint_token();
+			$expires = time() + self::TTL_SECONDS;
+			$payload = array(
+				'token'   => $token,
+				'expires' => $expires,
+			);
+
+			// Fast path: no lock row → atomic INSERT wins. add_option() returns
+			// false if the row already exists (the option_name unique key is the
+			// compare-and-set), so exactly one concurrent caller sees true.
+			if ( add_option( $option, $payload, '', false ) ) {
+				return $token;
+			}
+
+			// A lock row exists. Reclaim it only if it has expired (a crashed
+			// holder). update_option() is not itself a CAS, so re-read after
+			// writing and confirm OUR token won — two racers reclaiming the same
+			// stale lock both write, but only the last writer's token survives the
+			// re-read, and the loser retries.
+			$existing   = get_option( $option, false );
+			$expires_at = is_array( $existing ) && is_numeric( $existing['expires'] ?? null ) ? (int) $existing['expires'] : 0;
+			if ( $expires_at <= time() ) {
+				update_option( $option, $payload, false );
+				$confirm = get_option( $option, false );
+				if ( is_array( $confirm ) && ( $confirm['token'] ?? '' ) === $token ) {
+					return $token;
+				}
+			}
+
+			self::backoff();
+		}
+
+		return null;
+	}
+
+	/**
+	 * Release the per-run lock only if the supplied token still owns it. A token
+	 * that no longer matches (the lock expired and was reclaimed by another
+	 * process) must NOT delete the current holder's lock.
+	 *
+	 * @since 0.5.0
+	 *
+	 * @param string $run_id Run id.
+	 * @param string $token  Token returned by acquire().
+	 * @return void
+	 */
+	private static function release( string $run_id, string $token ): void {
+		if ( ! function_exists( 'get_option' ) || ! function_exists( 'delete_option' ) ) {
+			return;
+		}
+		$option   = self::OPTION_PREFIX . md5( $run_id );
+		$existing = get_option( $option, false );
+		if ( is_array( $existing ) && ( $existing['token'] ?? '' ) === $token ) {
+			delete_option( $option );
+		}
+	}
+
+	/**
+	 * Mint a unique lock token.
+	 *
+	 * @since 0.5.0
+	 */
+	private static function mint_token(): string {
+		if ( function_exists( 'wp_generate_uuid4' ) ) {
+			return wp_generate_uuid4();
+		}
+		try {
+			return bin2hex( random_bytes( 16 ) );
+		} catch ( \Throwable $error ) {
+			unset( $error );
+			return uniqid( 'lock_', true );
+		}
+	}
+
+	/**
+	 * Sleep briefly between acquisition attempts.
+	 *
+	 * @since 0.5.0
+	 */
+	private static function backoff(): void {
+		usleep( self::RETRY_USLEEP );
+	}
+}

--- a/src/Workflows/register-reconcile-workflow-branch.php
+++ b/src/Workflows/register-reconcile-workflow-branch.php
@@ -104,6 +104,20 @@ function agents_reconcile_workflow_branch_ability( array $input ) {
  *      final output into that step's record, then resume the step loop from
  *      `step_index + 1`.
  *
+ * CONCURRENCY. Steps 1–3 are a read-modify-write on the shared per-run frame's
+ * `completed[]` map. When N branches finish CONCURRENTLY in N separate processes
+ * (the async Action Scheduler path), two reconciles reading the frame before
+ * either writes would lose an update — the later write clobbers the earlier
+ * merge, the frame never reaches all-terminal, and the run hangs SUSPENDED
+ * forever (observed in a real MySQL fanout A/B). So the whole load → merge →
+ * all-terminal? → aggregate → resume-dispatch section runs under a per-run
+ * cross-process lock ({@see agents_workflow_reconcile_with_lock()}), serializing
+ * concurrent reconciles so each reads the frame AFTER the previous one committed.
+ * The lock is table-free (`add_option()` CAS) and pluggable via the
+ * `wp_agent_workflow_reconcile_lock` filter. AS's atomic action-claim remains the
+ * resume-DEDUP guard; the lock closes the completed[]-ACCOUNTING gap it never
+ * covered.
+ *
  * @since 0.5.0
  *
  * @param string              $run_id        Suspended run id.
@@ -117,6 +131,34 @@ function agents_reconcile_workflow_branch( string $run_id, string $handle_id, ar
 		return new \WP_Error( 'agents_reconcile_workflow_branch_no_recorder', 'A recorder is required to reconcile a suspended run. Register one via the `wp_agent_workflow_run_recorder` filter.' );
 	}
 
+	// Serialize the merge → all-terminal? → aggregate → resume-dispatch section
+	// per run so concurrent reconciles from separate processes cannot lose a
+	// completion. Every recorder read below happens INSIDE the lock, so each
+	// reconcile observes the previous one's committed frame.
+	return agents_workflow_reconcile_with_lock(
+		$run_id,
+		static function () use ( $recorder, $run_id, $handle_id, $branch_result ) {
+			return agents_reconcile_workflow_branch_locked( $recorder, $run_id, $handle_id, $branch_result );
+		}
+	);
+}
+
+/**
+ * The reconcile critical section, run under the per-run lock. Loads the run FRESH
+ * (inside the lock), merges the branch, decides all-terminal, and aggregates +
+ * dispatches resume when it was the last branch. Extracted from
+ * {@see agents_reconcile_workflow_branch()} so the lock wraps exactly the
+ * load-modify-decide window and nothing more.
+ *
+ * @since 0.5.0
+ *
+ * @param WP_Agent_Workflow_Run_Recorder $recorder      Resolved recorder.
+ * @param string                         $run_id        Suspended run id.
+ * @param string                         $handle_id     The completed branch's handle id.
+ * @param array<string,mixed>            $branch_result BranchResult.
+ * @return WP_Agent_Workflow_Run_Result|\WP_Error
+ */
+function agents_reconcile_workflow_branch_locked( WP_Agent_Workflow_Run_Recorder $recorder, string $run_id, string $handle_id, array $branch_result ) {
 	$result = $recorder->find( $run_id );
 	if ( null === $result ) {
 		return new \WP_Error( 'agents_reconcile_workflow_branch_not_found', sprintf( 'No suspended run was found for run_id `%s`.', $run_id ) );
@@ -255,6 +297,45 @@ function agents_workflow_defer_resume( string $run_id, WP_Agent_Workflow_Run_Res
 	 * @param WP_Agent_Workflow_Run_Result $result      The aggregate-spliced, still-suspended run.
 	 */
 	return (bool) apply_filters( 'wp_agent_workflow_resume_dispatch', false, $run_id, $executor_id, $result );
+}
+
+/**
+ * Run the reconcile critical section under a per-run cross-process lock so
+ * concurrent branch completions cannot lose an update on the frame's
+ * `completed[]` map (the silent-stall root cause). The lock is table-free and
+ * pluggable: a consumer may replace it via the `wp_agent_workflow_reconcile_lock`
+ * filter (e.g. a MySQL `GET_LOCK` or Redis lock); the default is an
+ * `add_option()`-backed atomic CAS lock ({@see WP_Agent_Workflow_Reconcile_Lock}).
+ *
+ * A filter override receives ( $run_id, $critical ) and MUST invoke `$critical`
+ * exactly once under mutual exclusion for `$run_id`, returning its result. A
+ * falsey filter return means "no override" and the default lock is used.
+ *
+ * @since 0.5.0
+ *
+ * @template T
+ * @param string       $run_id   Suspended run id whose reconcile is serialized.
+ * @param callable():T $critical The load → merge → decide → resume-dispatch section.
+ * @return T
+ */
+function agents_workflow_reconcile_with_lock( string $run_id, callable $critical ) {
+	/**
+	 * Filter the per-run reconcile lock. Return the critical section's result to
+	 * take over serialization with a custom primitive; return a falsey value (the
+	 * default) to use the built-in `add_option()` CAS lock.
+	 *
+	 * @since 0.5.0
+	 *
+	 * @param mixed        $override No override by default (null → built-in lock runs).
+	 * @param string       $run_id   The suspended run id.
+	 * @param callable():T $critical The critical section to run under mutual exclusion.
+	 */
+	$override = apply_filters( 'wp_agent_workflow_reconcile_lock', null, $run_id, $critical );
+	if ( null !== $override && false !== $override ) {
+		return $override;
+	}
+
+	return WP_Agent_Workflow_Reconcile_Lock::with_lock( $run_id, $critical );
 }
 
 /**

--- a/tests/workflow-as-branch-smoke.php
+++ b/tests/workflow-as-branch-smoke.php
@@ -246,6 +246,7 @@ require_once __DIR__ . '/../src/Workflows/interface-wp-agent-workflow-branch-exe
 require_once __DIR__ . '/../src/Workflows/class-wp-agent-workflow-step-executor.php';
 require_once __DIR__ . '/../src/Workflows/class-wp-agent-workflow-runner.php';
 require_once __DIR__ . '/../src/Workflows/register-agents-workflow-abilities.php';
+require_once __DIR__ . '/../src/Workflows/class-wp-agent-workflow-reconcile-lock.php';
 require_once __DIR__ . '/../src/Workflows/register-reconcile-workflow-branch.php';
 require_once __DIR__ . '/../src/Workflows/class-wp-agent-workflow-action-scheduler-bridge.php';
 require_once __DIR__ . '/../src/Workflows/class-wp-agent-workflow-action-scheduler-branch-executor.php';

--- a/tests/workflow-parallel-async-smoke.php
+++ b/tests/workflow-parallel-async-smoke.php
@@ -167,6 +167,7 @@ require_once __DIR__ . '/../src/Workflows/class-wp-agent-workflow-runner.php';
 // Reconcile references agents_run_workflow_output_schema / agents_workflow_string
 // / agents_workflow_run_cancel_permission from the abilities file.
 require_once __DIR__ . '/../src/Workflows/register-agents-workflow-abilities.php';
+require_once __DIR__ . '/../src/Workflows/class-wp-agent-workflow-reconcile-lock.php';
 require_once __DIR__ . '/../src/Workflows/register-reconcile-workflow-branch.php';
 
 use AgentsAPI\AI\Workflows\WP_Agent_Workflow_Run_Result;

--- a/tests/workflow-reconcile-race-smoke.php
+++ b/tests/workflow-reconcile-race-smoke.php
@@ -1,0 +1,456 @@
+<?php
+/**
+ * Pure-PHP regression test for the concurrent-reconcile lost-update stall.
+ *
+ * Run with: php tests/workflow-reconcile-race-smoke.php
+ *
+ * THE BUG (observed twice in a real MySQL multi-page fanout A/B): when two (or
+ * more) branches of a parallel fanout finish "at the same time" in SEPARATE
+ * processes, both processes call the REAL agents_reconcile_workflow_branch() for
+ * the SAME suspended run. The reconcile entry point does a naive
+ * read-modify-write on the suspension frame's `completed[]` map:
+ *
+ *     $result    = $recorder->find( $run_id );   // READ frame
+ *     $completed = ...;                           // MODIFY: merge my handle
+ *     $recorder->update( $result );               // WRITE whole frame back
+ *     if ( count($completed) < count($handles) ) return; // DECIDE all-terminal
+ *
+ * With no cross-process serialization, two reconciles both read the SAME
+ * pre-merge frame, each merges only ITS OWN handle, and the later write CLOBBERS
+ * the earlier one (a lost update). The frame then permanently shows fewer than N
+ * completed handles, the "all terminal → enqueue resume" transition NEVER fires,
+ * and the run stays SUSPENDED forever — the exact silent hang observed in prod.
+ *
+ * The Action Scheduler atomic action-claim guards the RESUME action (dedup), but
+ * it does NOT guard this completed[] read-modify-write — a different write. That
+ * is the gap this test pins.
+ *
+ * This test drives the REAL reconcile / aggregate / resume state machine (no
+ * shape mocks). It reproduces the race deterministically with a recorder that
+ * models two processes reading the frame before either writes, then asserts:
+ *   - the run reaches SUCCEEDED (resume fired),
+ *   - a resume was enqueued exactly once,
+ *   - the aggregate fused ALL branch outputs (no completion was lost).
+ *
+ * It FAILS before the fix (run stuck SUSPENDED, no resume) and PASSES after.
+ *
+ * @package AgentsAPI\Tests
+ */
+
+defined( 'ABSPATH' ) || define( 'ABSPATH', __DIR__ . '/' );
+
+$failures = array();
+$passes   = 0;
+
+echo "workflow-reconcile-race-smoke\n";
+
+if ( ! class_exists( 'WP_Error' ) ) {
+	class WP_Error {
+		public function __construct( private string $code = '', private string $message = '', private $data = null ) {}
+		public function get_error_code(): string { return $this->code; }
+		public function get_error_message(): string { return $this->message; }
+		public function get_error_data() { return $this->data; }
+	}
+}
+if ( ! function_exists( 'is_wp_error' ) ) {
+	function is_wp_error( $value ): bool {
+		return $value instanceof WP_Error;
+	}
+}
+if ( ! class_exists( 'WP_Ability' ) ) {
+	class WP_Ability {
+		public function __construct( private string $name, private array $args ) {}
+		public function get_name(): string { return $this->name; }
+		public function execute( $input = null ) {
+			$callback = $this->args['execute_callback'] ?? null;
+			return is_callable( $callback ) ? call_user_func( $callback, is_array( $input ) ? $input : array() ) : null;
+		}
+	}
+}
+
+$GLOBALS['__filters']   = array();
+$GLOBALS['__abilities'] = array();
+$GLOBALS['__options']   = array();
+
+if ( ! function_exists( 'add_filter' ) ) {
+	function add_filter( string $hook, callable $cb, int $priority = 10, int $accepted_args = 1 ): void {
+		unset( $accepted_args );
+		$GLOBALS['__filters'][ $hook ][ $priority ][] = $cb;
+	}
+}
+if ( ! function_exists( 'remove_all_filters' ) ) {
+	function remove_all_filters( string $hook ): void {
+		unset( $GLOBALS['__filters'][ $hook ] );
+	}
+}
+if ( ! function_exists( 'apply_filters' ) ) {
+	function apply_filters( string $hook, $value, ...$args ) {
+		$cbs = $GLOBALS['__filters'][ $hook ] ?? array();
+		ksort( $cbs );
+		foreach ( $cbs as $bucket ) {
+			foreach ( $bucket as $cb ) {
+				$value = call_user_func_array( $cb, array_merge( array( $value ), $args ) );
+			}
+		}
+		return $value;
+	}
+}
+if ( ! function_exists( 'add_action' ) ) {
+	function add_action( string $hook, callable $cb, int $priority = 10, int $accepted_args = 1 ): void {
+		add_filter( $hook, $cb, $priority, $accepted_args );
+	}
+}
+if ( ! function_exists( 'do_action' ) ) {
+	function do_action( string $hook, ...$args ): void {
+		$cbs = $GLOBALS['__filters'][ $hook ] ?? array();
+		ksort( $cbs );
+		foreach ( $cbs as $bucket ) {
+			foreach ( $bucket as $cb ) {
+				call_user_func_array( $cb, $args );
+			}
+		}
+	}
+}
+if ( ! function_exists( 'wp_get_ability' ) ) {
+	function wp_get_ability( string $name ) { return $GLOBALS['__abilities'][ $name ] ?? null; }
+}
+if ( ! function_exists( 'wp_has_ability' ) ) {
+	function wp_has_ability( string $name ): bool { return isset( $GLOBALS['__abilities'][ $name ] ); }
+}
+if ( ! function_exists( 'wp_register_ability' ) ) {
+	function wp_register_ability( string $name, array $args ) {
+		$GLOBALS['__abilities'][ $name ] = new WP_Ability( $name, $args );
+		return $GLOBALS['__abilities'][ $name ];
+	}
+}
+if ( ! function_exists( 'current_user_can' ) ) {
+	function current_user_can( $cap ): bool { unset( $cap ); return true; }
+}
+
+// ── Option-backed store shim. The default reconcile lock uses add_option() as an
+// atomic table-free CAS: add_option() INSERTs and returns false if the option
+// row already exists (the option_name unique key is the compare-and-swap). We
+// model exactly that contract here so the REAL default lock is exercised.
+if ( ! function_exists( 'get_option' ) ) {
+	function get_option( string $option, $default = false ) {
+		return array_key_exists( $option, $GLOBALS['__options'] ) ? $GLOBALS['__options'][ $option ] : $default;
+	}
+}
+if ( ! function_exists( 'update_option' ) ) {
+	function update_option( string $option, $value, $autoload = null ): bool {
+		unset( $autoload );
+		$GLOBALS['__options'][ $option ] = $value;
+		return true;
+	}
+}
+if ( ! function_exists( 'add_option' ) ) {
+	function add_option( string $option, $value = '', $deprecated = '', $autoload = null ): bool {
+		unset( $deprecated, $autoload );
+		if ( array_key_exists( $option, $GLOBALS['__options'] ) ) {
+			return false; // Atomic INSERT semantics: the row already exists.
+		}
+		$GLOBALS['__options'][ $option ] = $value;
+		return true;
+	}
+}
+if ( ! function_exists( 'delete_option' ) ) {
+	function delete_option( string $option ): bool {
+		if ( ! array_key_exists( $option, $GLOBALS['__options'] ) ) {
+			return false;
+		}
+		unset( $GLOBALS['__options'][ $option ] );
+		return true;
+	}
+}
+
+function smoke_assert( $expected, $actual, string $name, array &$failures, int &$passes ): void {
+	if ( $expected === $actual ) {
+		++$passes;
+		echo "  PASS {$name}\n";
+		return;
+	}
+	$failures[] = $name;
+	echo "  FAIL {$name}\n";
+	echo '    expected: ' . var_export( $expected, true ) . "\n";
+	echo '    actual:   ' . var_export( $actual, true ) . "\n";
+}
+
+function smoke_assert_true( $actual, string $name, array &$failures, int &$passes ): void {
+	smoke_assert( true, (bool) $actual, $name, $failures, $passes );
+}
+
+require_once __DIR__ . '/../src/Workflows/class-wp-agent-workflow-bindings.php';
+require_once __DIR__ . '/../src/Workflows/class-wp-agent-workflow-spec-validator.php';
+require_once __DIR__ . '/../src/Workflows/class-wp-agent-workflow-spec.php';
+require_once __DIR__ . '/../src/Workflows/class-wp-agent-workflow-run-result.php';
+require_once __DIR__ . '/../src/Workflows/class-wp-agent-workflow-store.php';
+require_once __DIR__ . '/../src/Workflows/class-wp-agent-workflow-run-recorder.php';
+require_once __DIR__ . '/../src/Abilities/class-wp-agent-ability-dispatcher.php';
+require_once __DIR__ . '/../src/Runtime/interface-wp-agent-run-control-store.php';
+require_once __DIR__ . '/../src/Runtime/class-wp-agent-option-run-control-store.php';
+require_once __DIR__ . '/../src/Runtime/class-wp-agent-run-control.php';
+require_once __DIR__ . '/../src/Workflows/class-wp-agent-workflow-run-context.php';
+require_once __DIR__ . '/../src/Workflows/interface-wp-agent-workflow-branch-executor.php';
+require_once __DIR__ . '/../src/Workflows/class-wp-agent-workflow-step-executor.php';
+require_once __DIR__ . '/../src/Workflows/class-wp-agent-workflow-runner.php';
+require_once __DIR__ . '/../src/Workflows/register-agents-workflow-abilities.php';
+require_once __DIR__ . '/../src/Workflows/class-wp-agent-workflow-reconcile-lock.php';
+require_once __DIR__ . '/../src/Workflows/register-reconcile-workflow-branch.php';
+
+use AgentsAPI\AI\Workflows\WP_Agent_Workflow_Run_Result;
+use AgentsAPI\AI\Workflows\WP_Agent_Workflow_Run_Recorder;
+use AgentsAPI\AI\Workflows\WP_Agent_Workflow_Runner;
+use AgentsAPI\AI\Workflows\WP_Agent_Workflow_Spec;
+
+use function AgentsAPI\AI\Workflows\agents_reconcile_workflow_branch;
+
+// ── A durable, reloadable in-memory recorder that models cross-process
+//    concurrency FAITHFULLY against the REAL lock. ───────────────────────────
+//
+// `freeze_reads()` captures the current row state as a "pre-merge snapshot" that
+// two simultaneous processes would both read. But a stale read only actually
+// happens in the UNLOCKED window: if the reconcile lock is held (the fix), a
+// second process blocks until the first releases and therefore reads the FRESH,
+// post-merge frame. So find() serves the frozen snapshot ONLY when no reconcile
+// lock is currently held for the run; once the fix takes the lock, the frozen
+// read is bypassed and the second reconcile sees the committed frame — exactly
+// the cross-process ordering a real DB lock enforces.
+//
+// This makes the test honest in BOTH directions: without the lock the frozen
+// snapshot is served to both callers (the real lost-update stall); with the lock
+// the second caller reads fresh (the real serialized behavior).
+
+final class Race_Recorder implements WP_Agent_Workflow_Run_Recorder {
+	/** @var array<string,array<string,mixed>> */
+	public array $rows = array();
+
+	/** @var array<string,array<string,mixed>>|null */
+	private ?array $frozen = null;
+
+	public function start( WP_Agent_Workflow_Run_Result $result ) {
+		$this->rows[ $result->get_run_id() ] = $result->to_array();
+		return $result->get_run_id();
+	}
+	public function update( WP_Agent_Workflow_Run_Result $result ) {
+		$this->rows[ $result->get_run_id() ] = $result->to_array();
+		return true;
+	}
+	public function find( string $run_id ): ?WP_Agent_Workflow_Run_Result {
+		// Serve the stale pre-merge snapshot only in the unlocked window; a held
+		// reconcile lock means a real second process would have blocked and read
+		// fresh, so honor that ordering here too.
+		if ( null !== $this->frozen && isset( $this->frozen[ $run_id ] ) && ! self::reconcile_lock_held( $run_id ) ) {
+			return WP_Agent_Workflow_Run_Result::from_array( $this->frozen[ $run_id ] );
+		}
+		return isset( $this->rows[ $run_id ] )
+			? WP_Agent_Workflow_Run_Result::from_array( $this->rows[ $run_id ] )
+			: null;
+	}
+	public function recent( array $args = array() ): array {
+		unset( $args );
+		return array_map( array( WP_Agent_Workflow_Run_Result::class, 'from_array' ), array_values( $this->rows ) );
+	}
+
+	/** Pin find() to the CURRENT row state — models "both processes read here". */
+	public function freeze_reads(): void {
+		$this->frozen = $this->rows;
+	}
+	/** Resume serving live rows. */
+	public function unfreeze_reads(): void {
+		$this->frozen = null;
+	}
+
+	/** Whether the built-in add_option() reconcile lock row exists for the run. */
+	private static function reconcile_lock_held( string $run_id ): bool {
+		$option = 'agents_wf_reconcile_lock_' . md5( $run_id );
+		return array_key_exists( $option, $GLOBALS['__options'] );
+	}
+}
+
+function race_register_ability( string $name, \Closure $handler ): void {
+	$GLOBALS['__abilities'][ $name ] = new WP_Ability( $name, array( 'execute_callback' => $handler ) );
+}
+
+race_register_ability(
+	'demo/role-worker',
+	static function ( array $input ): array {
+		return array( 'fragment' => strtoupper( (string) ( $input['label'] ?? 'X' ) ) );
+	}
+);
+race_register_ability(
+	'demo/aggregate',
+	static function ( array $input ): array {
+		// Fuse ALL sibling fragments; a lost completion shows up as a blank slot.
+		return array( 'final_bundle' => 'FUSED[' . (string) ( $input['a'] ?? '' ) . '|' . (string) ( $input['b'] ?? '' ) . '|' . (string) ( $input['c'] ?? '' ) . ']' );
+	}
+);
+
+// A parallel-roles spec with THREE sibling branches + an aggregator. Three
+// siblings makes the lost-update unmistakable: drop any one and the aggregate
+// bundle is missing a fragment (and, pre-fix, the run never resumes at all).
+function race_roles_spec(): WP_Agent_Workflow_Spec {
+	return WP_Agent_Workflow_Spec::from_array(
+		array(
+			'id'    => 'demo/race-roles',
+			'steps' => array(
+				array(
+					'id'       => 'scatter',
+					'type'     => 'parallel',
+					'context'  => array( 'marker' => 'M' ),
+					'branches' => array(
+						array( 'role' => 'a', 'required' => true, 'can_write_final_bundle' => false, 'steps' => array( array( 'id' => 'sa', 'type' => 'ability', 'ability' => 'demo/role-worker', 'args' => array( 'label' => 'a' ) ) ) ),
+						array( 'role' => 'b', 'required' => true, 'can_write_final_bundle' => false, 'steps' => array( array( 'id' => 'sb', 'type' => 'ability', 'ability' => 'demo/role-worker', 'args' => array( 'label' => 'b' ) ) ) ),
+						array( 'role' => 'c', 'required' => true, 'can_write_final_bundle' => false, 'steps' => array( array( 'id' => 'sc', 'type' => 'ability', 'ability' => 'demo/role-worker', 'args' => array( 'label' => 'c' ) ) ) ),
+						array(
+							'role'                   => 'fuse',
+							'required'               => true,
+							'can_write_final_bundle' => true,
+							'steps'                  => array(
+								array(
+									'id'      => 'agg',
+									'type'    => 'ability',
+									'ability' => 'demo/aggregate',
+									'args'    => array(
+										'a' => '${vars.branch_outputs.a.fragment}',
+										'b' => '${vars.branch_outputs.b.fragment}',
+										'c' => '${vars.branch_outputs.c.fragment}',
+									),
+								),
+							),
+						),
+					),
+				),
+			),
+		)
+	);
+}
+
+// ── A test executor that suspends the run and hands back the branch descriptors
+//    so the test can drive reconcile directly (like the Phase 1 FakeExecutor). ─
+
+final class Race_Executor implements \AgentsAPI\AI\Workflows\WP_Agent_Workflow_Branch_Executor {
+	/** @var array<int,array<string,mixed>> */
+	public static array $dispatched = array();
+
+	public function id(): string { return 'race_exec'; }
+
+	public function dispatch( array $branches, array $context ): array {
+		self::$dispatched = array();
+		$run_id  = (string) ( $context['_workflow_run_id'] ?? '' );
+		$step_id = (string) ( $context['_workflow_step_id'] ?? '' );
+		$handles = array();
+		foreach ( $branches as $index => $branch ) {
+			$key       = (string) ( $branch['key'] ?? (string) $index );
+			$handle_id = $run_id . ':' . $step_id . ':' . $key . ':' . $index;
+			$descriptor = array_merge( $branch, array( 'run_id' => $run_id, 'step_id' => $step_id, 'handle_id' => $handle_id, 'key' => $key ) );
+			self::$dispatched[] = $descriptor;
+			$handles[] = array(
+				'id'       => $handle_id,
+				'key'      => $key,
+				'executor' => $this->id(),
+				'status'   => 'dispatched',
+				'required' => ! empty( $branch['required'] ),
+				'ref'      => $index + 1,
+			);
+		}
+		return $handles;
+	}
+
+	public function are_all_complete( array $handles ): bool {
+		foreach ( $handles as $handle ) {
+			$status = (string) ( $handle['status'] ?? '' );
+			if ( WP_Agent_Workflow_Run_Result::STATUS_SUCCEEDED !== $status && WP_Agent_Workflow_Run_Result::STATUS_FAILED !== $status ) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	public function collect( array $handles ): array {
+		$out = array();
+		foreach ( $handles as $handle ) {
+			$key         = (string) ( $handle['key'] ?? '' );
+			$out[ $key ] = array( 'key' => $key, 'status' => (string) ( $handle['status'] ?? 'dispatched' ), 'output' => null );
+		}
+		return $out;
+	}
+}
+
+// Run one branch descriptor through the REAL shared branch runner and build the
+// REAL BranchResult, exactly as the AS executor's run_branch_action() does.
+function race_execute_branch( array $descriptor ): array {
+	$key      = (string) ( $descriptor['key'] ?? '' );
+	$steps    = is_array( $descriptor['steps'] ?? null ) ? $descriptor['steps'] : array();
+	$handlers = array(
+		'ability'  => array( WP_Agent_Workflow_Runner::class, 'default_ability_handler' ),
+		'agent'    => array( WP_Agent_Workflow_Runner::class, 'default_agent_handler' ),
+		'foreach'  => array( WP_Agent_Workflow_Runner::class, 'default_foreach_handler' ),
+		'parallel' => array( WP_Agent_Workflow_Runner::class, 'default_parallel_handler' ),
+	);
+	$executor       = new \AgentsAPI\AI\Workflows\WP_Agent_Workflow_Step_Executor( $handlers );
+	$branch_vars    = is_array( $descriptor['branch_vars'] ?? null ) ? $descriptor['branch_vars'] : array();
+	$branch_context = ( new \AgentsAPI\AI\Workflows\WP_Agent_Workflow_Run_Context(
+		array( 'inputs' => array(), 'steps' => array(), 'vars' => array() )
+	) )->with_vars( $branch_vars );
+
+	$run = WP_Agent_Workflow_Runner::run_branch_steps( $steps, $branch_context, $executor, $handlers, false, $key );
+	if ( is_wp_error( $run ) ) {
+		return array( 'key' => $key, 'status' => WP_Agent_Workflow_Run_Result::STATUS_FAILED, 'output' => null, 'steps' => array(), 'error' => array( 'code' => $run->get_error_code(), 'message' => $run->get_error_message() ) );
+	}
+	return array( 'key' => $key, 'status' => WP_Agent_Workflow_Run_Result::STATUS_SUCCEEDED, 'output' => $run['last'], 'steps' => $run['steps'], 'error' => null );
+}
+
+// ═════════════════════════════════════════════════════════════════════════════
+// THE RACE: two sibling branches reconcile CONCURRENTLY (both read the frame
+// before either writes). Under the buggy code the later write clobbers the
+// earlier merge → the frame never reaches all-terminal → NO resume → the run
+// stays SUSPENDED forever. Under the fix, the reconcile critical section is
+// serialized cross-process, both completions survive, and resume fires once.
+// ═════════════════════════════════════════════════════════════════════════════
+
+$GLOBALS['__options'] = array();
+$recorder = new Race_Recorder();
+remove_all_filters( 'wp_agent_workflow_run_recorder' );
+remove_all_filters( 'wp_agent_workflow_step_executor' );
+remove_all_filters( 'wp_agent_workflow_resume_dispatch' );
+add_filter( 'wp_agent_workflow_run_recorder', static function () use ( $recorder ) { return $recorder; } );
+add_filter( 'wp_agent_workflow_step_executor', static function () { return new Race_Executor(); } );
+
+// Count resume dispatches. We drive resume INLINE here (no AS executor) to prove
+// the bug is the completed[] accounting, not the resume-dedup guard: even with a
+// perfectly working resume path, a lost completion means resume is never reached.
+$GLOBALS['__resume_dispatch_calls'] = 0;
+
+$run = ( new WP_Agent_Workflow_Runner( $recorder ) )->run( race_roles_spec(), array(), array( 'run_id' => 'race-1' ) );
+smoke_assert( WP_Agent_Workflow_Run_Result::STATUS_SUSPENDED, $run->get_status(), 'race: run SUSPENDED after dispatch', $failures, $passes );
+
+$descriptors = Race_Executor::$dispatched; // three siblings: a, b, c
+smoke_assert( 3, count( $descriptors ), 'race: three sibling branches dispatched', $failures, $passes );
+
+// Branch A finishes first, alone — no contention. Frame now shows {a}.
+$result_a = race_execute_branch( $descriptors[0] );
+agents_reconcile_workflow_branch( 'race-1', (string) $descriptors[0]['handle_id'], $result_a );
+smoke_assert( WP_Agent_Workflow_Run_Result::STATUS_SUSPENDED, $recorder->find( 'race-1' )->get_status(), 'race: still suspended after branch a', $failures, $passes );
+
+// Now branches B and C finish "simultaneously" in two separate processes: BOTH
+// read the frame (showing {a}) before EITHER writes. freeze_reads() pins find()
+// to that shared pre-merge snapshot for the duration of both reconciles.
+$result_b = race_execute_branch( $descriptors[1] );
+$result_c = race_execute_branch( $descriptors[2] );
+
+$recorder->freeze_reads(); // both processes observe frame == {a}
+agents_reconcile_workflow_branch( 'race-1', (string) $descriptors[1]['handle_id'], $result_b );
+agents_reconcile_workflow_branch( 'race-1', (string) $descriptors[2]['handle_id'], $result_c );
+$recorder->unfreeze_reads();
+
+// A serialized reconcile guarantees the completed[] map ends with all three
+// siblings, the run resumes, and the aggregate fuses A|B|C. A lost-update leaves
+// the run SUSPENDED forever (the observed prod stall).
+$final = $recorder->find( 'race-1' );
+smoke_assert( WP_Agent_Workflow_Run_Result::STATUS_SUCCEEDED, $final->get_status(), 'race: run resumes to SUCCEEDED (NOT stuck suspended) under concurrent reconcile', $failures, $passes );
+
+$bundle = $final->get_output()['steps']['scatter']['final']['final_bundle'] ?? '';
+smoke_assert( 'FUSED[A|B|C]', $bundle, 'race: aggregate fused ALL branch outputs — no completion lost', $failures, $passes );
+
+echo "Passed: {$passes}, Failed: " . count( $failures ) . "\n";
+exit( count( $failures ) > 0 ? 1 : 0 );


### PR DESCRIPTION
## Symptom

During a real 4-branch fanout on a MySQL-backed native-PHP runtime, all branch actions completed successfully (each reconciled its result), but **no resume/aggregator action was ever enqueued** — the run stayed `suspended` forever (a finish-driver ran its full 1800s budget without a resume firing). No error, correct branch outputs, run never finishes. Observed twice, including once in the deterministic Phase-1 A/B. A silent hang.

## Root cause (with evidence)

`agents_reconcile_workflow_branch()` in `src/Workflows/register-reconcile-workflow-branch.php` merged each finished branch into the suspension frame's `metadata._suspension.completed[]` map with a naive **read-modify-write**:

```php
$result    = $recorder->find( $run_id );   // READ frame
$completed = ...merge my handle...;         // MODIFY
$recorder->update( $result );               // WRITE whole frame back
if ( count($completed) < count($handles) ) return;  // DECIDE all-terminal
```

Under the async Action Scheduler executor each branch runs in its own claimed AS worker (a separate process). When two branches finish concurrently, both reconciles `find()` the **same pre-merge frame**, each merges only **its own** handle, and the later `update()` **clobbers** the earlier merge — a classic lost update. The frame then permanently shows fewer than N completed handles, the "all terminal → enqueue resume" transition never fires, and the run hangs `suspended` forever.

Action Scheduler's atomic action-claim de-duplicates the **RESUME action**, but it never guarded this **completed[] write** — a different write, on the frame, not the resume action. That accounting gap (not the resume dedup) is the root cause.

## Fix (table-free, exactly-once)

Run the reconcile critical section (load → merge → all-terminal? → aggregate → resume-dispatch) under a **per-run cross-process lock** so each reconcile reads the frame *after* the previous one committed. Serializing the section eliminates the lost update, so the frame reliably reaches all-terminal and the resume is enqueued exactly once.

- **Table-free:** the default lock (`WP_Agent_Workflow_Reconcile_Lock`) uses `add_option()` as an atomic compare-and-set — `add_option()` INSERTs and fails (returns false) when the option row already exists, because `option_name` is a UNIQUE key. Same primitive the existing CPT conversation lock uses via `add_post_meta(..., $unique=true)`. No new table.
- **Crash-safe:** a held lock stores a TTL so a crashed holder is reclaimable; acquisition blocks with bounded retries (a reconcile section is short).
- **Pluggable:** consumers with a stronger primitive (MySQL `GET_LOCK`, Redis) override via the `wp_agent_workflow_reconcile_lock` filter.
- AS's atomic claim remains the resume-dedup guard; this lock closes the completed[]-accounting gap it never covered.

## Reproduction test (fails before, passes after)

`tests/workflow-reconcile-race-smoke.php` drives the **real** reconcile/aggregate/resume path (no shape mocks) with three sibling branches + an aggregator, where two branches complete via concurrent/interleaved reconcile (both read the frame before either writes). It asserts the run resumes to `SUCCEEDED` exactly once and the aggregate fused **all** branch outputs.

With the reconcile lock bypassed (simulating the old code):

```
  FAIL race: run resumes to SUCCEEDED (NOT stuck suspended) under concurrent reconcile
    expected: 'succeeded'
    actual:   'suspended'
  FAIL race: aggregate fused ALL branch outputs — no completion lost
    expected: 'FUSED[A|B|C]'
    actual:   ''
Passed: 3, Failed: 2
```

With the fix:

```
  PASS race: run resumes to SUCCEEDED (NOT stuck suspended) under concurrent reconcile
  PASS race: aggregate fused ALL branch outputs — no completion lost
Passed: 5, Failed: 0
```

The stuck-`suspended` / empty-aggregate failure is exactly the prod stall.

## Verification

- `composer phpstan` (level max): **No errors**
- `composer smoke`: full suite green (exit 0)
- Existing workflow tests stay green: `workflow-as-branch-smoke` (32/32), `workflow-parallel-async-smoke` (31/31), `workflow-parallel-smoke` (30/30), `workflow-runner-smoke` (59/59), `workflow-lifecycle-smoke` (16/16)
- New `workflow-reconcile-race-smoke` added to the `composer smoke` list

Refs #390

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Claude Opus 4.8)
- **Used for:** root-cause analysis, the reconcile lock + serialization fix, and the concurrent-reconcile reproduction test. Chris remains responsible for every line.