### PR TITLE
Make the parallel-roles aggregator optional and generically named

### DIFF
--- a/src/Workflows/class-wp-agent-workflow-runner.php
+++ b/src/Workflows/class-wp-agent-workflow-runner.php
@@ -22,11 +22,12 @@
  *   - Real concurrency. The runner is synchronous and single-process; PHP
  *     ships no threads here. The `parallel` step type expresses *fanout
  *     orchestration* (declare N branches, propagate a shared immutable
- *     context to each, collect every branch output, hand them to an
- *     aggregator) — not parallel execution. Whether branches actually run on
- *     separate processes (Action Scheduler, sandboxed subprocesses, loopback)
- *     is a consumer-supplied executor concern; the substrate owns the
- *     dispatch/collect/aggregate contract, not the concurrency mechanism.
+ *     context to each, collect every branch output, and optionally run one
+ *     aggregator branch over the collected outputs) — not parallel execution.
+ *     Whether branches actually run on separate processes (Action Scheduler,
+ *     sandboxed subprocesses, loopback) is a consumer-supplied executor
+ *     concern; the substrate owns the scatter/collect/return contract (plus
+ *     the optional aggregate pass), not the concurrency mechanism.
  *   - Triggering. Triggers are wired separately
  *     ({@see WP_Agent_Workflow_Action_Scheduler_Bridge} for cron, and a
  *     consumer-registered listener for `wp_action`). The runner only
@@ -764,30 +765,35 @@ class WP_Agent_Workflow_Runner {
 	/**
 	 * Default `parallel` step handler — generic agent fanout.
 	 *
-	 * This is the substrate's fanout-orchestration primitive. It is NOT real
-	 * concurrency: PHP ships no threads here and this runner is synchronous.
-	 * What the handler owns is the reusable contract that two product plugins
-	 * independently reinvented — declare a set of branches, give every branch
-	 * the SAME shared immutable context, run them through the same step-handler
-	 * dispatch the runner already uses, collect each branch output keyed by its
-	 * role, then hand all sibling outputs to a designated aggregator branch that
-	 * fuses them into the final result. Whether branches *physically* run in
-	 * parallel (Action Scheduler, sandboxed subprocesses, loopback requests) is a
-	 * consumer-provided executor concern layered on top of this contract; the
-	 * substrate declares the dispatch/collect/aggregate flow, not the
-	 * concurrency mechanism. The reusable, real part is the fanout
-	 * orchestration, and that is all this claims.
+	 * This is the substrate's fanout-orchestration primitive: a scatter, collect,
+	 * and return over role-scoped branches, with an OPTIONAL in-run aggregator
+	 * branch. It is NOT real concurrency: PHP ships no threads here and this
+	 * runner is synchronous. What the handler owns is the reusable contract —
+	 * declare a set of branches, give every branch the SAME shared immutable
+	 * context, run them through the same step-handler dispatch the runner already
+	 * uses, and collect each branch output keyed by its role. A branch MAY be
+	 * flagged `is_aggregator`, in which case it runs AFTER its siblings and
+	 * receives their collected outputs, and its output becomes the step's final
+	 * output; when no branch is an aggregator the step simply returns the
+	 * collected branch outputs and any composition is the consumer's concern.
+	 * Whether branches *physically* run in parallel (Action Scheduler, sandboxed
+	 * subprocesses, loopback requests) is a consumer-provided executor concern
+	 * layered on top of this contract; the substrate declares the
+	 * scatter/collect/return flow (plus the optional aggregate pass), not the
+	 * concurrency mechanism.
 	 *
-	 * One declarative step expresses BOTH proven fanout shapes:
+	 * One declarative step expresses BOTH fanout shapes:
 	 *
 	 *   1. parallel-map — run the same nested `steps` across N resolved `items`
 	 *      (the non-sequential sibling of `foreach`); collect each branch result.
 	 *      Shape: { type:'parallel', items, steps, as?, index_as? }.
 	 *
-	 *   2. parallel-roles + aggregate — run a set of role-scoped `branches` in
-	 *      parallel, each receiving a shared immutable `context`, then hand all
-	 *      branch outputs to the branch flagged `can_write_final_bundle` (the
-	 *      aggregator), which emits the fused final output.
+	 *   2. parallel-roles — run a set of role-scoped `branches` in parallel, each
+	 *      receiving a shared immutable `context`, and collect their outputs keyed
+	 *      by role. If AT MOST ONE branch is flagged `is_aggregator`, that branch
+	 *      runs after the siblings, receives `${vars.branch_outputs.*}`, and its
+	 *      output becomes the step's final output. With zero aggregators the step
+	 *      returns the collected branch outputs for the consumer to compose.
 	 *      Shape: { type:'parallel', context, branches:[ <branch contract> ] }.
 	 *
 	 * Branch / role contract (parallel-roles shape):
@@ -798,13 +804,13 @@ class WP_Agent_Workflow_Runner {
 	 *     shared_context_contract: string,            // how the branch must consume the shared context
 	 *     expected_output:         { ref, shape },    // declared output ref + shape
 	 *     required:                bool,              // a failing required branch fails the step
-	 *     can_write_final_bundle:  bool,              // exactly one branch is the aggregator
+	 *     is_aggregator:           bool,              // OPTIONAL: at most one branch is the aggregator
 	 *     steps:                   array              // nested steps the branch runs
 	 *   }
 	 *
 	 * Every branch reads the shared context under `${vars.context.*}`; a
 	 * branch CANNOT mutate it for siblings — each branch gets its own
-	 * deep-copied snapshot. The aggregator additionally receives every
+	 * deep-copied snapshot. An aggregator branch additionally receives every
 	 * sibling's collected output under `${vars.branch_outputs.*}` (keyed by
 	 * role) and its own role focus under `${vars.role.*}`.
 	 *
@@ -812,7 +818,7 @@ class WP_Agent_Workflow_Runner {
 	 * filter is consulted ( default true ) so a consumer can decide WHETHER to
 	 * fan out for a given step + context (e.g. a complexity score). The
 	 * substrate embeds no heuristic of its own; when the gate returns false the
-	 * step short-circuits to a skipped, non-fused result.
+	 * step short-circuits to a skipped result.
 	 *
 	 * @since 0.4.0
 	 *
@@ -842,7 +848,7 @@ class WP_Agent_Workflow_Runner {
 		if ( ! $has_branches && ! $has_items ) {
 			return new \WP_Error(
 				'workflow_parallel_shape_invalid',
-				'parallel step must declare either `branches` (roles+aggregate) or `items` (map).'
+				'parallel step must declare either `branches` (roles) or `items` (map).'
 			);
 		}
 
@@ -930,10 +936,10 @@ class WP_Agent_Workflow_Runner {
 	}
 
 	/**
-	 * Build the dispatch plan for the roles+aggregate shape: one branch
-	 * descriptor per sibling role, the deferred aggregator plan, and the shared
-	 * immutable context. Mirrors the sync `run_parallel_roles()` validation so
-	 * the async path rejects the same malformed specs.
+	 * Build the dispatch plan for the roles shape: one branch descriptor per
+	 * sibling role, the collect plan (with its OPTIONAL aggregator branch), and
+	 * the shared immutable context. Mirrors the sync `run_parallel_roles()`
+	 * validation so the async path rejects the same malformed specs.
 	 *
 	 * @since 0.5.0
 	 *
@@ -959,22 +965,25 @@ class WP_Agent_Workflow_Runner {
 			);
 		}
 
+		// At most one branch may be the aggregator. Zero aggregators is valid
+		// (scatter-collect-return); one aggregator runs after the siblings over
+		// their collected outputs.
 		$aggregator       = null;
 		$aggregator_roles = array();
 		$sibling_branches = array();
 		foreach ( $branch_specs as $branch_spec ) {
-			if ( ! empty( $branch_spec['can_write_final_bundle'] ) ) {
+			if ( ! empty( $branch_spec['is_aggregator'] ) ) {
 				$aggregator         = $branch_spec;
 				$aggregator_roles[] = self::string_value( $branch_spec['role'] ?? '' );
 				continue;
 			}
 			$sibling_branches[] = $branch_spec;
 		}
-		if ( 1 !== count( $aggregator_roles ) || null === $aggregator ) {
+		if ( count( $aggregator_roles ) > 1 ) {
 			return new \WP_Error(
 				'workflow_parallel_aggregator_invalid',
 				sprintf(
-					'parallel-roles step must declare exactly one aggregator branch (`can_write_final_bundle` true); found %d.',
+					'parallel-roles step may declare at most one aggregator branch (`is_aggregator` true); found %d.',
 					count( $aggregator_roles )
 				)
 			);
@@ -1000,8 +1009,8 @@ class WP_Agent_Workflow_Runner {
 			'shared_context' => $shared_context,
 			'aggregate'      => array(
 				'mode'            => 'roles',
-				'aggregator_role' => self::string_value( $aggregator['role'] ?? '' ),
-				'aggregator_spec' => $aggregator,
+				'aggregator_role' => null !== $aggregator ? self::string_value( $aggregator['role'] ?? '' ) : '',
+				'aggregator_spec' => null !== $aggregator ? $aggregator : array(),
 				'shared_context'  => $shared_context,
 				'shape'           => 'roles',
 			),
@@ -1096,14 +1105,19 @@ class WP_Agent_Workflow_Runner {
 	}
 
 	/**
-	 * Run the aggregate plan once every branch has reconciled, producing the
-	 * parallel step's final output in the SAME shape the sync loops return.
-	 * Shared by the reconcile entry point ({@see agents_reconcile_workflow_branch()})
-	 * and the synchronous-executor inline path. For `roles`, the aggregator
-	 * branch runs synchronously (aggregation is cheap fusion, not N slow AI
-	 * calls) with `${vars.branch_outputs.*}` populated from the reconciled
-	 * sibling results. For `map`, there is no aggregator — collect into the
-	 * `{ shape:'map', count, branches }` envelope.
+	 * Collect the reconciled branch outputs once every branch is terminal,
+	 * producing the parallel step's output in the SAME shape the sync loops
+	 * return. Shared by the reconcile entry point
+	 * ({@see agents_reconcile_workflow_branch()}) and the synchronous-executor
+	 * inline path.
+	 *
+	 * For `roles`: collect each branch output keyed by role. When the plan names
+	 * an OPTIONAL aggregator branch, that branch runs after the siblings (cheap
+	 * synthesis, not N slow AI calls) with `${vars.branch_outputs.*}` populated
+	 * from the reconciled sibling results, and its output becomes the step's
+	 * `final`. With no aggregator the step just returns the collected
+	 * `branch_outputs` for the consumer to compose. For `map`: collect into the
+	 * `{ shape:'map', count, branches }` envelope (never an aggregator).
 	 *
 	 * @since 0.5.0
 	 *
@@ -1133,29 +1147,33 @@ class WP_Agent_Workflow_Runner {
 			);
 		}
 
-		// roles: fuse sibling outputs through the aggregator branch.
-		$aggregator = is_array( $aggregate['aggregator_spec'] ?? null ) ? self::string_keyed_array( $aggregate['aggregator_spec'] ) : array();
-		if ( empty( $aggregator ) ) {
-			return new \WP_Error(
-				'workflow_parallel_aggregator_missing',
-				'parallel-roles reconcile is missing its aggregator branch.'
-			);
-		}
-
-		$shared_context = is_array( $aggregate['shared_context'] ?? null ) ? self::string_keyed_array( $aggregate['shared_context'] ) : array();
+		// roles: collect sibling outputs keyed by role.
+		$aggregator     = is_array( $aggregate['aggregator_spec'] ?? null ) ? self::string_keyed_array( $aggregate['aggregator_spec'] ) : array();
 		$aggregator_key = self::string_value( $aggregate['aggregator_role'] ?? '' );
 
 		$branch_outputs = array();
 		foreach ( $branch_results as $key => $result ) {
-			if ( (string) $key === $aggregator_key ) {
+			if ( '' !== $aggregator_key && (string) $key === $aggregator_key ) {
 				continue;
 			}
 			$result                          = is_array( $result ) ? $result : array();
 			$branch_outputs[ (string) $key ] = $result['output'] ?? null;
 		}
 
-		$executor = new WP_Agent_Workflow_Step_Executor( $handlers );
-		$run      = self::run_role_branch( $aggregator, $shared_context, $branch_outputs, array(), $executor, $handlers );
+		// No aggregator branch: scatter-collect-return. The consumer composes the
+		// collected branch outputs downstream.
+		if ( empty( $aggregator ) ) {
+			return array(
+				'shape'          => 'roles',
+				'branch_outputs' => $branch_outputs,
+			);
+		}
+
+		// Optional aggregator branch: run it over the collected sibling outputs;
+		// its output becomes the step's final output.
+		$shared_context = is_array( $aggregate['shared_context'] ?? null ) ? self::string_keyed_array( $aggregate['shared_context'] ) : array();
+		$executor       = new WP_Agent_Workflow_Step_Executor( $handlers );
+		$run            = self::run_role_branch( $aggregator, $shared_context, $branch_outputs, array(), $executor, $handlers );
 		if ( is_wp_error( $run ) ) {
 			return $run;
 		}
@@ -1241,10 +1259,12 @@ class WP_Agent_Workflow_Runner {
 	}
 
 	/**
-	 * parallel-roles + aggregate shape: run each role-scoped branch against a
-	 * shared immutable context, collect outputs keyed by role, then run the
-	 * aggregator branch (`can_write_final_bundle` true) with sibling outputs
-	 * available so it can fuse the final result.
+	 * parallel-roles shape: run each role-scoped branch against a shared
+	 * immutable context and collect outputs keyed by role. If at most one branch
+	 * is flagged `is_aggregator`, run that branch AFTER the siblings with their
+	 * collected outputs under `${vars.branch_outputs.*}` so it can synthesize the
+	 * final result; with no aggregator, return the collected branch outputs for
+	 * the consumer to compose.
 	 *
 	 * @since 0.4.0
 	 *
@@ -1272,25 +1292,25 @@ class WP_Agent_Workflow_Runner {
 			);
 		}
 
-		// Exactly one branch must be the aggregator.
+		// At most one branch may be the aggregator (optional).
 		$aggregator_roles = array();
 		foreach ( $branch_specs as $branch_spec ) {
-			if ( ! empty( $branch_spec['can_write_final_bundle'] ) ) {
+			if ( ! empty( $branch_spec['is_aggregator'] ) ) {
 				$aggregator_roles[] = self::string_value( $branch_spec['role'] ?? '' );
 			}
 		}
-		if ( 1 !== count( $aggregator_roles ) ) {
+		if ( count( $aggregator_roles ) > 1 ) {
 			return new \WP_Error(
 				'workflow_parallel_aggregator_invalid',
 				sprintf(
-					'parallel-roles step must declare exactly one aggregator branch (`can_write_final_bundle` true); found %d.',
+					'parallel-roles step may declare at most one aggregator branch (`is_aggregator` true); found %d.',
 					count( $aggregator_roles )
 				)
 			);
 		}
 
 		// Shared immutable context: deep-copied per branch so a branch cannot
-		// mutate it for its siblings or the aggregator. Arrays are copied by
+		// mutate it for its siblings or an aggregator. Arrays are copied by
 		// value in PHP, so a fresh array per branch is a genuine snapshot.
 		$shared_context = is_array( $step['context'] ?? null ) ? $step['context'] : array();
 		$executor       = new WP_Agent_Workflow_Step_Executor( $handlers );
@@ -1299,10 +1319,10 @@ class WP_Agent_Workflow_Runner {
 		$branch_records = array();
 		$aggregator     = null;
 
-		// First pass: every non-aggregator branch, each against its own
-		// snapshot of the shared context.
+		// Scatter: every non-aggregator branch, each against its own snapshot of
+		// the shared context.
 		foreach ( $branch_specs as $branch_spec ) {
-			if ( ! empty( $branch_spec['can_write_final_bundle'] ) ) {
+			if ( ! empty( $branch_spec['is_aggregator'] ) ) {
 				$aggregator = $branch_spec;
 				continue;
 			}
@@ -1317,15 +1337,18 @@ class WP_Agent_Workflow_Runner {
 			$branch_records[ $role ] = $run['record'];
 		}
 
-		// Aggregator pass: same shared context snapshot plus every sibling's
-		// collected output under `${vars.branch_outputs.*}`.
+		// No aggregator branch: return the collected outputs for the consumer to
+		// compose downstream.
 		if ( null === $aggregator ) {
-			return new \WP_Error(
-				'workflow_parallel_aggregator_missing',
-				'parallel-roles step is missing its aggregator branch.'
+			return array(
+				'shape'          => 'roles',
+				'branch_outputs' => $branch_outputs,
+				'branch_records' => $branch_records,
 			);
 		}
 
+		// Optional aggregator pass: same shared context snapshot plus every
+		// sibling's collected output under `${vars.branch_outputs.*}`.
 		$aggregator_run = self::run_role_branch( $aggregator, $shared_context, $branch_outputs, $context, $executor, $handlers );
 		if ( is_wp_error( $aggregator_run ) ) {
 			return $aggregator_run;
@@ -1336,11 +1359,11 @@ class WP_Agent_Workflow_Runner {
 		$branch_records[ $aggregator_role ] = $aggregator_run['record'];
 
 		return array(
-			'shape'           => 'roles',
-			'aggregator'      => $aggregator_role,
-			'branch_outputs'  => $branch_outputs,
-			'branch_records'  => $branch_records,
-			'final'           => $aggregator_run['output'],
+			'shape'          => 'roles',
+			'aggregator'     => $aggregator_role,
+			'branch_outputs' => $branch_outputs,
+			'branch_records' => $branch_records,
+			'final'          => $aggregator_run['output'],
 		);
 	}
 

--- a/src/Workflows/class-wp-agent-workflow-spec-validator.php
+++ b/src/Workflows/class-wp-agent-workflow-spec-validator.php
@@ -242,8 +242,8 @@ final class WP_Agent_Workflow_Spec_Validator {
 	 *
 	 *   - parallel-map: `items` + a non-empty nested `steps` list.
 	 *   - parallel-roles: a non-empty `branches` list, each branch a role
-	 *     contract with a `role` + nested `steps`, and exactly one branch
-	 *     flagged `can_write_final_bundle` (the aggregator).
+	 *     contract with a `role` + nested `steps`. At most one branch may be
+	 *     flagged `is_aggregator` (the optional aggregator); zero is valid.
 	 *
 	 * @since 0.4.0
 	 *
@@ -260,7 +260,7 @@ final class WP_Agent_Workflow_Spec_Validator {
 			$errors[] = array(
 				'path'    => $path,
 				'code'    => 'invalid_parallel_shape',
-				'message' => 'parallel step must declare exactly one of `branches` (roles+aggregate) or `items` (map)',
+				'message' => 'parallel step must declare exactly one of `branches` (roles) or `items` (map)',
 			);
 			// Without a clear shape there's nothing further to validate.
 			if ( ! $has_branches && ! $has_items ) {
@@ -330,17 +330,19 @@ final class WP_Agent_Workflow_Spec_Validator {
 					}
 				}
 
-				if ( ! empty( $branch['can_write_final_bundle'] ) ) {
+				if ( ! empty( $branch['is_aggregator'] ) ) {
 					++$aggregator_count;
 				}
 			}
 
-			if ( 1 !== $aggregator_count ) {
+			// The aggregator branch is OPTIONAL: zero or one is valid, more than
+			// one is ambiguous (which output is the step's final?).
+			if ( $aggregator_count > 1 ) {
 				$errors[] = array(
 					'path'    => "{$path}.branches",
 					'code'    => 'invalid_parallel_aggregator',
 					'message' => sprintf(
-						'parallel-roles step must flag exactly one branch with `can_write_final_bundle` (the aggregator); found %d',
+						'parallel-roles step may flag at most one branch with `is_aggregator` (the aggregator); found %d',
 						$aggregator_count
 					),
 				);

--- a/tests/workflow-as-branch-smoke.php
+++ b/tests/workflow-as-branch-smoke.php
@@ -343,7 +343,7 @@ function as_smoke_roles_spec(): WP_Agent_Workflow_Spec {
 						array(
 							'role'                   => 'headline',
 							'required'               => true,
-							'can_write_final_bundle' => false,
+							'is_aggregator' => false,
 							'steps'                  => array(
 								array( 'id' => 'h', 'type' => 'ability', 'ability' => 'demo/role-worker', 'args' => array( 'label' => 'head' ) ),
 							),
@@ -351,7 +351,7 @@ function as_smoke_roles_spec(): WP_Agent_Workflow_Spec {
 						array(
 							'role'                   => 'body',
 							'required'               => true,
-							'can_write_final_bundle' => false,
+							'is_aggregator' => false,
 							'steps'                  => array(
 								array( 'id' => 'b', 'type' => 'ability', 'ability' => 'demo/role-worker', 'args' => array( 'label' => 'body' ) ),
 							),
@@ -359,7 +359,7 @@ function as_smoke_roles_spec(): WP_Agent_Workflow_Spec {
 						array(
 							'role'                   => 'fuse',
 							'required'               => true,
-							'can_write_final_bundle' => true,
+							'is_aggregator' => true,
 							'steps'                  => array(
 								array(
 									'id'      => 'agg',
@@ -577,7 +577,7 @@ function as_smoke_failing_spec(): WP_Agent_Workflow_Spec {
 						array(
 							'role'                   => 'headline',
 							'required'               => true,
-							'can_write_final_bundle' => false,
+							'is_aggregator' => false,
 							// An ability that isn't registered → run_branch_steps fails at
 							// runtime → required-branch failure (passes spec validation).
 							'steps'                  => array( array( 'id' => 'x', 'type' => 'ability', 'ability' => 'demo/does-not-exist', 'args' => array() ) ),
@@ -585,7 +585,7 @@ function as_smoke_failing_spec(): WP_Agent_Workflow_Spec {
 						array(
 							'role'                   => 'fuse',
 							'required'               => true,
-							'can_write_final_bundle' => true,
+							'is_aggregator' => true,
 							'steps'                  => array(
 								array( 'id' => 'agg', 'type' => 'ability', 'ability' => 'demo/aggregate', 'args' => array( 'headline' => 'x', 'body' => 'y' ) ),
 							),

--- a/tests/workflow-parallel-async-smoke.php
+++ b/tests/workflow-parallel-async-smoke.php
@@ -343,7 +343,7 @@ function async_smoke_roles_spec(): WP_Agent_Workflow_Spec {
 						array(
 							'role'                   => 'headline',
 							'required'               => true,
-							'can_write_final_bundle' => false,
+							'is_aggregator' => false,
 							'steps'                  => array(
 								array( 'id' => 'h', 'type' => 'ability', 'ability' => 'demo/role-worker', 'args' => array() ),
 							),
@@ -351,7 +351,7 @@ function async_smoke_roles_spec(): WP_Agent_Workflow_Spec {
 						array(
 							'role'                   => 'body',
 							'required'               => true,
-							'can_write_final_bundle' => false,
+							'is_aggregator' => false,
 							'steps'                  => array(
 								array( 'id' => 'b', 'type' => 'ability', 'ability' => 'demo/role-worker', 'args' => array() ),
 							),
@@ -359,7 +359,7 @@ function async_smoke_roles_spec(): WP_Agent_Workflow_Spec {
 						array(
 							'role'                   => 'fuse',
 							'required'               => true,
-							'can_write_final_bundle' => true,
+							'is_aggregator' => true,
 							'steps'                  => array(
 								array(
 									'id'      => 'agg',
@@ -491,13 +491,13 @@ function async_smoke_optional_spec(): WP_Agent_Workflow_Spec {
 						array(
 							'role'                   => 'flaky',
 							'required'               => false,
-							'can_write_final_bundle' => false,
+							'is_aggregator' => false,
 							'steps'                  => array( array( 'id' => 'f', 'type' => 'ability', 'ability' => 'demo/aggregate', 'args' => array() ) ),
 						),
 						array(
 							'role'                   => 'fuse',
 							'required'               => true,
-							'can_write_final_bundle' => true,
+							'is_aggregator' => true,
 							'steps'                  => array(
 								array( 'id' => 'agg', 'type' => 'ability', 'ability' => 'demo/aggregate', 'args' => array( 'headline' => 'x', 'body' => 'y' ) ),
 							),
@@ -581,6 +581,63 @@ smoke_assert_true( $selected instanceof WP_Agent_Workflow_Branch_Executor, 'sele
 $GLOBALS['__fake_executor'] = null;
 $selected_null = apply_filters( 'wp_agent_workflow_step_executor', null, array( 'id' => 'x', 'type' => 'parallel' ), array() );
 smoke_assert( null, $selected_null, 'selection rule: no override + no AS → null (sync)', $failures, $passes );
+
+// ═════════════════════════════════════════════════════════════════════════════
+// 9. ZERO-aggregator roles on the ASYNC suspend/resume path: fan out, suspend,
+//    reconcile every branch, resume → the step returns the collected
+//    branch_outputs with NO aggregator invoked (scatter-collect-return).
+// ═════════════════════════════════════════════════════════════════════════════
+
+function async_smoke_no_aggregator_spec(): WP_Agent_Workflow_Spec {
+	return WP_Agent_Workflow_Spec::from_array(
+		array(
+			'id'    => 'demo/async-no-aggregator',
+			'steps' => array(
+				array(
+					'id'       => 'scatter',
+					'type'     => 'parallel',
+					'context'  => array( 'marker' => 'M' ),
+					'branches' => array(
+						array(
+							'role'     => 'headline',
+							'required' => true,
+							'steps'    => array( array( 'id' => 'h', 'type' => 'ability', 'ability' => 'demo/role-worker', 'args' => array() ) ),
+						),
+						array(
+							'role'     => 'body',
+							'required' => true,
+							'steps'    => array( array( 'id' => 'b', 'type' => 'ability', 'ability' => 'demo/role-worker', 'args' => array() ) ),
+						),
+					),
+				),
+			),
+		)
+	);
+}
+
+$recorder6 = new Async_Smoke_Recorder();
+remove_all_filters( 'wp_agent_workflow_run_recorder' );
+add_filter( 'wp_agent_workflow_run_recorder', static function () use ( $recorder6 ) { return $recorder6; } );
+$GLOBALS['__fake_executor'] = new Fake_Branch_Executor();
+
+$run6   = ( new WP_Agent_Workflow_Runner( $recorder6 ) )->run( async_smoke_no_aggregator_spec(), array(), array( 'run_id' => 'run-F' ) );
+smoke_assert( WP_Agent_Workflow_Run_Result::STATUS_SUSPENDED, $run6->get_status(), 'zero-aggregator async: run suspends after dispatch', $failures, $passes );
+$frame6 = $run6->get_suspension();
+smoke_assert( 'roles', $frame6['aggregate']['mode'] ?? '', 'zero-aggregator async: frame carries the roles collect plan', $failures, $passes );
+smoke_assert( '', $frame6['aggregate']['aggregator_role'] ?? 'x', 'zero-aggregator async: collect plan names no aggregator role', $failures, $passes );
+
+$hk6 = array();
+foreach ( $frame6['handles'] as $h ) {
+	$hk6[ $h['key'] ] = $h['id'];
+}
+async_smoke_complete( 'run-F', $hk6['headline'], 'headline', 'succeeded', array( 'fragment' => 'HEAD' ) );
+$res6 = async_smoke_complete( 'run-F', $hk6['body'], 'body', 'succeeded', array( 'fragment' => 'BODY' ) );
+
+smoke_assert( WP_Agent_Workflow_Run_Result::STATUS_SUCCEEDED, $res6->get_status(), 'zero-aggregator async: last branch resumes → run SUCCEEDED', $failures, $passes );
+$scatter6 = $res6->get_output()['steps']['scatter'] ?? array();
+smoke_assert( false, array_key_exists( 'final', $scatter6 ), 'zero-aggregator async: no final key (no aggregator invoked)', $failures, $passes );
+smoke_assert( 'HEAD', $scatter6['branch_outputs']['headline']['fragment'] ?? '', 'zero-aggregator async: collected headline branch output on resume', $failures, $passes );
+smoke_assert( 'BODY', $scatter6['branch_outputs']['body']['fragment'] ?? '', 'zero-aggregator async: collected body branch output on resume', $failures, $passes );
 
 echo "Passed: {$passes}, Failed: " . count( $failures ) . "\n";
 exit( count( $failures ) > 0 ? 1 : 0 );

--- a/tests/workflow-parallel-smoke.php
+++ b/tests/workflow-parallel-smoke.php
@@ -261,7 +261,7 @@ $roles_spec = WP_Agent_Workflow_Spec::from_array(
 						'shared_context_contract' => 'read context.marker only',
 						'expected_output'         => array( 'ref' => 'headline.fragment', 'shape' => 'string' ),
 						'required'                => true,
-						'can_write_final_bundle'  => false,
+						'is_aggregator'  => false,
 						'steps'                   => array(
 							array(
 								'id'      => 'h',
@@ -281,7 +281,7 @@ $roles_spec = WP_Agent_Workflow_Spec::from_array(
 						'shared_context_contract' => 'read context.marker only',
 						'expected_output'         => array( 'ref' => 'body.fragment', 'shape' => 'string' ),
 						'required'                => true,
-						'can_write_final_bundle'  => false,
+						'is_aggregator'  => false,
 						'steps'                   => array(
 							array(
 								'id'      => 'b',
@@ -301,7 +301,7 @@ $roles_spec = WP_Agent_Workflow_Spec::from_array(
 						'shared_context_contract' => 'consume branch_outputs + context.marker',
 						'expected_output'         => array( 'ref' => 'final_bundle', 'shape' => 'string' ),
 						'required'                => true,
-						'can_write_final_bundle'  => true,
+						'is_aggregator'  => true,
 						'steps'                   => array(
 							array(
 								'id'      => 'agg',
@@ -381,7 +381,7 @@ $immut_spec = WP_Agent_Workflow_Spec::from_array(
 					array(
 						'role'                   => 'first',
 						'required'               => true,
-						'can_write_final_bundle' => false,
+						'is_aggregator' => false,
 						'steps'                  => array(
 							array(
 								'id'      => 'm1',
@@ -394,7 +394,7 @@ $immut_spec = WP_Agent_Workflow_Spec::from_array(
 					array(
 						'role'                   => 'second',
 						'required'               => true,
-						'can_write_final_bundle' => false,
+						'is_aggregator' => false,
 						'steps'                  => array(
 							array(
 								'id'      => 'm2',
@@ -407,7 +407,7 @@ $immut_spec = WP_Agent_Workflow_Spec::from_array(
 					array(
 						'role'                   => 'agg',
 						'required'               => true,
-						'can_write_final_bundle' => true,
+						'is_aggregator' => true,
 						'steps'                  => array(
 							array(
 								'id'      => 'm3',
@@ -485,7 +485,7 @@ $optional_fail_spec = WP_Agent_Workflow_Spec::from_array(
 					array(
 						'role'                   => 'flaky',
 						'required'               => false,
-						'can_write_final_bundle' => false,
+						'is_aggregator' => false,
 						'steps'                  => array(
 							array( 'id' => 'f', 'type' => 'ability', 'ability' => 'demo/fail' ),
 						),
@@ -493,7 +493,7 @@ $optional_fail_spec = WP_Agent_Workflow_Spec::from_array(
 					array(
 						'role'                   => 'agg',
 						'required'               => true,
-						'can_write_final_bundle' => true,
+						'is_aggregator' => true,
 						'steps'                  => array(
 							array(
 								'id'      => 'a',
@@ -520,6 +520,77 @@ smoke_assert( WP_Agent_Workflow_Run_Result::STATUS_SUCCEEDED, $optional_result->
 smoke_assert( 'demo_branch_boom', $optional_out['branch_outputs']['flaky']['error']['code'] ?? '', 'non-required branch surfaces its error in collected output', $failures, $passes );
 smoke_assert( 'FUSED[x|y]', $optional_out['final']['final_bundle'] ?? '', 'aggregator still fuses despite a tolerated branch failure', $failures, $passes );
 
+// ── 5b. ZERO aggregators: roles fans out, collects, and RETURNS the branch
+//        outputs (scatter-collect-return). The aggregator is OPTIONAL; with
+//        none declared the step returns collected outputs with no `final` /
+//        `aggregator` key, and the consumer composes them downstream. ────────
+
+$no_agg_spec = WP_Agent_Workflow_Spec::from_array(
+	array(
+		'id'    => 'demo/parallel-no-aggregator',
+		'steps' => array(
+			array(
+				'id'       => 'scatter',
+				'type'     => 'parallel',
+				'context'  => array( 'marker' => $shared_marker ),
+				'branches' => array(
+					array(
+						'role'     => 'headline',
+						'required' => true,
+						'steps'    => array(
+							array( 'id' => 'h', 'type' => 'ability', 'ability' => 'demo/role-worker', 'args' => array( 'role' => '${vars.role.role}', 'shared' => '${vars.context.marker}' ) ),
+						),
+					),
+					array(
+						'role'     => 'body',
+						'required' => true,
+						'steps'    => array(
+							array( 'id' => 'b', 'type' => 'ability', 'ability' => 'demo/role-worker', 'args' => array( 'role' => '${vars.role.role}', 'shared' => '${vars.context.marker}' ) ),
+						),
+					),
+				),
+			),
+			// Consumer-side composition over the RETURNED branch_outputs — this is
+			// what a consumer does when it does NOT use the optional aggregator.
+			array(
+				'id'      => 'compose',
+				'type'    => 'ability',
+				'ability' => 'demo/aggregate',
+				'args'    => array(
+					'headline' => '${steps.scatter.output.branch_outputs.headline.fragment}',
+					'body'     => '${steps.scatter.output.branch_outputs.body.fragment}',
+					'shared'   => '${inputs.marker}',
+				),
+			),
+		),
+		'inputs' => array( 'marker' => array( 'type' => 'string' ) ),
+	)
+);
+
+$no_agg_validation = WP_Agent_Workflow_Spec_Validator::validate( $no_agg_spec->to_array() );
+smoke_assert( array(), $no_agg_validation, 'validator accepts a roles step with ZERO aggregators', $failures, $passes );
+
+$no_agg_result = ( new WP_Agent_Workflow_Runner( null ) )->run( $no_agg_spec, array( 'marker' => $shared_marker ) );
+$no_agg_out    = $no_agg_result->get_output()['steps']['scatter'] ?? array();
+
+smoke_assert( WP_Agent_Workflow_Run_Result::STATUS_SUCCEEDED, $no_agg_result->get_status(), 'zero-aggregator roles run succeeds', $failures, $passes );
+smoke_assert( 'roles', $no_agg_out['shape'] ?? '', 'zero-aggregator roles reports roles shape', $failures, $passes );
+smoke_assert( false, array_key_exists( 'aggregator', $no_agg_out ), 'zero-aggregator roles output has no aggregator key', $failures, $passes );
+smoke_assert( false, array_key_exists( 'final', $no_agg_out ), 'zero-aggregator roles output has no final key', $failures, $passes );
+smoke_assert(
+	array( 'headline', 'body' ),
+	array_keys( $no_agg_out['branch_outputs'] ?? array() ),
+	'zero-aggregator roles fans out + returns collected branch outputs keyed by role',
+	$failures,
+	$passes
+);
+smoke_assert( $shared_marker, $no_agg_out['branch_outputs']['headline']['saw_context'] ?? '', 'zero-aggregator branch saw shared context', $failures, $passes );
+
+// Consumer-side composition ran downstream over the RETURNED branch_outputs.
+$no_agg_compose = $no_agg_result->get_output()['steps']['compose'] ?? array();
+$expected_no_agg = 'FUSED[headline:' . $shared_marker . '|body:' . $shared_marker . ']';
+smoke_assert( $expected_no_agg, $no_agg_compose['final_bundle'] ?? '', 'consumer-side step composed the returned branch outputs (no in-run aggregator)', $failures, $passes );
+
 // ── 6. Validator rejects malformed parallel specs ────────────────────────
 
 $no_shape  = WP_Agent_Workflow_Spec_Validator::validate(
@@ -544,8 +615,8 @@ $two_aggregators = WP_Agent_Workflow_Spec_Validator::validate(
 				'id'       => 'p',
 				'type'     => 'parallel',
 				'branches' => array(
-					array( 'role' => 'a', 'can_write_final_bundle' => true, 'steps' => array( array( 'id' => 's1', 'type' => 'ability', 'ability' => 'demo/double' ) ) ),
-					array( 'role' => 'b', 'can_write_final_bundle' => true, 'steps' => array( array( 'id' => 's2', 'type' => 'ability', 'ability' => 'demo/double' ) ) ),
+					array( 'role' => 'a', 'is_aggregator' => true, 'steps' => array( array( 'id' => 's1', 'type' => 'ability', 'ability' => 'demo/double' ) ) ),
+					array( 'role' => 'b', 'is_aggregator' => true, 'steps' => array( array( 'id' => 's2', 'type' => 'ability', 'ability' => 'demo/double' ) ) ),
 				),
 			),
 		),

--- a/tests/workflow-reconcile-race-smoke.php
+++ b/tests/workflow-reconcile-race-smoke.php
@@ -298,13 +298,13 @@ function race_roles_spec(): WP_Agent_Workflow_Spec {
 					'type'     => 'parallel',
 					'context'  => array( 'marker' => 'M' ),
 					'branches' => array(
-						array( 'role' => 'a', 'required' => true, 'can_write_final_bundle' => false, 'steps' => array( array( 'id' => 'sa', 'type' => 'ability', 'ability' => 'demo/role-worker', 'args' => array( 'label' => 'a' ) ) ) ),
-						array( 'role' => 'b', 'required' => true, 'can_write_final_bundle' => false, 'steps' => array( array( 'id' => 'sb', 'type' => 'ability', 'ability' => 'demo/role-worker', 'args' => array( 'label' => 'b' ) ) ) ),
-						array( 'role' => 'c', 'required' => true, 'can_write_final_bundle' => false, 'steps' => array( array( 'id' => 'sc', 'type' => 'ability', 'ability' => 'demo/role-worker', 'args' => array( 'label' => 'c' ) ) ) ),
+						array( 'role' => 'a', 'required' => true, 'is_aggregator' => false, 'steps' => array( array( 'id' => 'sa', 'type' => 'ability', 'ability' => 'demo/role-worker', 'args' => array( 'label' => 'a' ) ) ) ),
+						array( 'role' => 'b', 'required' => true, 'is_aggregator' => false, 'steps' => array( array( 'id' => 'sb', 'type' => 'ability', 'ability' => 'demo/role-worker', 'args' => array( 'label' => 'b' ) ) ) ),
+						array( 'role' => 'c', 'required' => true, 'is_aggregator' => false, 'steps' => array( array( 'id' => 'sc', 'type' => 'ability', 'ability' => 'demo/role-worker', 'args' => array( 'label' => 'c' ) ) ) ),
 						array(
 							'role'                   => 'fuse',
 							'required'               => true,
-							'can_write_final_bundle' => true,
+							'is_aggregator' => true,
 							'steps'                  => array(
 								array(
 									'id'      => 'agg',


### PR DESCRIPTION
## What

The `parallel`-roles shape required exactly one branch flagged
`can_write_final_bundle` (the "aggregator"), which the runner ran after the
sibling branches to emit the "fused final output." That baked one consumer's
composition pattern and website-artifact vocabulary into a generic fanout
substrate headed for wpcom / WordPress core. This makes the aggregator an
**optional, generically-named** capability — keeping the real "synthesize
within the async suspend/resume run boundary" ability while removing the
product-shaped mandate and vocabulary.

## Why the aggregator was product-shaped (two ways)

1. **Named** in website-artifact terms: `can_write_final_bundle` — "bundle" /
   "final" / "write" are consumer domain vocabulary, not generic dataflow.
2. **Mandated**: the validator errored (`invalid_parallel_aggregator`) unless
   **exactly one** aggregator existed, imposing one consumer's composition
   pattern on all consumers.

(A third product aspect — that the capability itself was lifted from a website
generator's role contracts — is fine to keep now that the capability is
optional and generic; that's a legitimate reusable primitive.)

## Changes

- **Rename** `can_write_final_bundle` → `is_aggregator` (describes the dataflow
  role: this branch receives sibling outputs and its result becomes the step's
  final output).
- **Relax the mandate**: a roles step is valid with **zero or one** aggregator.
  - Zero → scatter-collect-return: returns `{ shape:'roles', branch_outputs:{
    <role>:... }, branch_records }` for the consumer to compose downstream
    (consistent with the `map` shape).
  - One → the aggregator runs after the siblings over their collected outputs
    (`${vars.branch_outputs.*}`) and its output becomes the step's `final`.
  - More than one is still rejected (ambiguous — which output is final?).
  - Both the sync path and the async suspend/resume/reconcile path handle zero
    and one.
- **Purge domain vocabulary** ("final bundle", "fused final output") from
  generic docblocks in favor of neutral terms (aggregator branch, receives
  sibling outputs, scatter/collect/return, step output).

The `map` shape is untouched (already generic).

## Tests

- Renamed `can_write_final_bundle` → `is_aggregator` across the workflow smoke
  tests; the existing aggregator cases now exercise the **optional** path
  through the real runner (sync inline + async on resume).
- Added a **sync** and an **async** test proving a roles step with **zero**
  aggregators fans out, collects, and returns `branch_outputs` (no aggregator
  invoked, no `final` key), with a consumer-side step composing the returned
  outputs.
- The two-aggregator rejection test stays valid under the new at-most-one rule.

## Verification

- `composer phpstan` (level max) — no errors.
- `composer smoke` — all green, including `agents-api-no-product-imports-smoke`.
- Zero `can_write_final_bundle` remaining anywhere in the repo.

## Downstream

Two studio-native consumers use the aggregator (codebox generation and Site
Forge). They migrate to `is_aggregator` in a follow-up studio-native PR
(https://github.a8c.com) — no behavior change, just the renamed optional flag.

`Refs #390`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Opus 4.8 (Claude Code)
- **Used for:** Renaming the aggregator flag to a generic name, relaxing the validator mandate to at-most-one, teaching the sync/async runner paths to handle zero aggregators, purging product vocabulary from generic docblocks, and adding zero-aggregator scatter-collect-return tests.
