### PR TITLE
Fix async branch fanout: offload payload out of AS args + fail loud on enqueue failure

### DIFF
--- a/agents-api.php
+++ b/agents-api.php
@@ -243,6 +243,7 @@ require_once AGENTS_API_PATH . 'src/Workflows/class-wp-agent-workflow-step-execu
 require_once AGENTS_API_PATH . 'src/Workflows/class-wp-agent-workflow-runner.php';
 require_once AGENTS_API_PATH . 'src/Workflows/class-wp-agent-workflow-registry.php';
 require_once AGENTS_API_PATH . 'src/Workflows/class-wp-agent-workflow-action-scheduler-bridge.php';
+require_once AGENTS_API_PATH . 'src/Workflows/class-wp-agent-workflow-branch-store.php';
 require_once AGENTS_API_PATH . 'src/Workflows/class-wp-agent-workflow-action-scheduler-branch-executor.php';
 require_once AGENTS_API_PATH . 'src/Workflows/register-workflows.php';
 require_once AGENTS_API_PATH . 'src/Workflows/register-workflow-step-executor.php';

--- a/composer.json
+++ b/composer.json
@@ -114,6 +114,7 @@
       "php tests/workflow-parallel-smoke.php",
       "php tests/workflow-parallel-async-smoke.php",
       "php tests/workflow-as-branch-smoke.php",
+      "php tests/workflow-async-branch-payload-smoke.php",
       "php tests/workflow-reconcile-race-smoke.php",
       "php tests/workflow-lifecycle-smoke.php",
       "php tests/agents-workflow-ability-smoke.php",

--- a/src/Workflows/class-wp-agent-workflow-action-scheduler-branch-executor.php
+++ b/src/Workflows/class-wp-agent-workflow-action-scheduler-branch-executor.php
@@ -95,11 +95,25 @@ final class WP_Agent_Workflow_Action_Scheduler_Branch_Executor implements WP_Age
 	}
 
 	/**
-	 * Dispatch one Action Scheduler async action per branch. The branch's
-	 * self-contained descriptor rides in the action payload — that payload,
-	 * stored in AS's own tables, IS the durable branch store (no agents-api
-	 * table). Returns a BranchHandle per branch carrying the AS action id as its
-	 * opaque `ref`.
+	 * Dispatch one Action Scheduler async action per branch.
+	 *
+	 * PAYLOAD OFFLOAD (§Bug 1). The branch's self-contained descriptor —
+	 * including the shared immutable `context` snapshot — is NOT packed inline
+	 * into the AS action `args`. Action Scheduler enforces a hard 8,000-character
+	 * limit on its `args` column, and a rich context (a multi-page brief) blows
+	 * past it. Instead the descriptor is persisted to the table-free branch store
+	 * ({@see WP_Agent_Workflow_Branch_Store}) and the AS args carry only a small,
+	 * stable reference — `{ run_id, handle_id, store_ref, context_ref }` — whose
+	 * size does not scale with context richness. The shared context is stored
+	 * ONCE per run (run-scoped) rather than duplicated into every branch payload.
+	 *
+	 * FAIL-LOUD (§Bug 2). Every `as_enqueue_async_action()` call is checked: an
+	 * enqueue that returns a non-positive id (or throws) is a hard failure, not a
+	 * phantom `ref => 0` handle. On ANY branch's enqueue failure this returns a
+	 * WP_Error and the run fails fast with a descriptive message rather than
+	 * suspending against a branch that was never enqueued and hanging until its
+	 * budget expires. A partial dispatch (some branches enqueued, one failed) is
+	 * also a hard failure — the run must not suspend against a partial branch set.
 	 *
 	 * The `run_id` / `step_id` a branch reconciles against come from the
 	 * descriptor. The runner stamps them onto each descriptor before dispatch
@@ -107,12 +121,25 @@ final class WP_Agent_Workflow_Action_Scheduler_Branch_Executor implements WP_Age
 	 * {@see WP_Agent_Workflow_Runner::build_map_dispatch_plan()}), but as a
 	 * belt-and-suspenders we also read them from the shared context.
 	 *
-	 * @inheritDoc
+	 * @param array<int,array<string,mixed>> $branches Branch descriptors.
+	 * @param array<string,mixed>            $context  Shared context snapshot.
+	 * @return array<int,array<string,mixed>>|\WP_Error BranchHandle[] or a hard failure.
 	 * @since 0.5.0
 	 */
-	public function dispatch( array $branches, array $context ): array {
+	public function dispatch( array $branches, array $context ) {
 		$context_run_id  = self::string_value( $context['_workflow_run_id'] ?? '' );
 		$context_step_id = self::string_value( $context['_workflow_step_id'] ?? '' );
+
+		// The shared immutable context is identical for every branch, so store it
+		// ONCE per run and reference it from each branch — never duplicate a
+		// multi-KB context into N branch payloads. Its ref rides in every branch's
+		// AS args (a short option name), and the branch action re-seats it into the
+		// descriptor's branch_vars.context on rehydrate.
+		$run_id_for_ctx = '' !== $context_run_id ? $context_run_id : self::first_branch_run_id( $branches );
+		$shared_context = is_array( $context['shared_context'] ?? null ) ? self::string_keyed_array( $context['shared_context'] ) : array();
+		$context_ref    = '' !== $run_id_for_ctx
+			? WP_Agent_Workflow_Branch_Store::put_shared_context( $run_id_for_ctx, $shared_context )
+			: '';
 
 		$handles = array();
 		foreach ( $branches as $index => $branch ) {
@@ -120,7 +147,7 @@ final class WP_Agent_Workflow_Action_Scheduler_Branch_Executor implements WP_Age
 
 			// Prefer the self-contained descriptor's identity; fall back to the
 			// dispatch context. The descriptor IS the durable payload, so its
-			// run_id / step_id must be authoritative once it rides in AS.
+			// run_id / step_id must be authoritative once it rides in the store.
 			$run_id  = self::string_value( $branch['run_id'] ?? '' );
 			$step_id = self::string_value( $branch['step_id'] ?? '' );
 			$run_id  = '' !== $run_id ? $run_id : $context_run_id;
@@ -131,7 +158,9 @@ final class WP_Agent_Workflow_Action_Scheduler_Branch_Executor implements WP_Age
 			$handle_id = self::build_handle_id( $run_id, $step_id, $key, $index );
 
 			// The descriptor is self-contained: it carries everything the branch
-			// action needs to run and reconcile without re-reading the spec.
+			// action needs to run and reconcile without re-reading the spec. Strip
+			// the shared context out of the stored descriptor — it lives ONCE in
+			// the run-scoped context row and is re-seated on rehydrate.
 			$descriptor = array_merge(
 				$branch,
 				array(
@@ -141,14 +170,39 @@ final class WP_Agent_Workflow_Action_Scheduler_Branch_Executor implements WP_Age
 					'key'       => $key,
 				)
 			);
+			$descriptor = self::strip_shared_context( $descriptor );
+
+			// Offload the descriptor to the store; the AS args carry only the ref.
+			$store_ref = WP_Agent_Workflow_Branch_Store::put_branch( $run_id, $handle_id, $descriptor );
 
 			$payload = array(
-				'run_id'    => $run_id,
-				'handle_id' => $handle_id,
-				'branch'    => $descriptor,
+				'run_id'      => $run_id,
+				'handle_id'   => $handle_id,
+				'store_ref'   => $store_ref,
+				'context_ref' => $context_ref,
 			);
 
 			$action_id = self::enqueue_async_action( self::BRANCH_HOOK, array( $payload ), self::GROUP );
+
+			// FAIL LOUD: a non-positive action id means the enqueue did not durably
+			// persist the branch (AS's args-size guard threw, AS is down, etc.).
+			// Returning a phantom ref=0 handle here is what previously made the run
+			// suspend against a branch that never existed and hang. Fail the whole
+			// dispatch instead — clean up what we already stored so no orphan rows
+			// linger, and surface a descriptive WP_Error.
+			if ( $action_id <= 0 ) {
+				if ( '' !== $run_id ) {
+					WP_Agent_Workflow_Branch_Store::forget_run( $run_id );
+				}
+				return new \WP_Error(
+					'workflow_branch_dispatch_enqueue_failed',
+					sprintf(
+						'Failed to enqueue async branch action for branch `%s` (run `%s`): Action Scheduler returned no action id. The run is failing fast rather than suspending against a branch that was never enqueued.',
+						$key,
+						$run_id
+					)
+				);
+			}
 
 			$handles[] = array(
 				'id'       => $handle_id,
@@ -223,15 +277,47 @@ final class WP_Agent_Workflow_Action_Scheduler_Branch_Executor implements WP_Age
 	 *
 	 * @since 0.5.0
 	 *
-	 * @param array<mixed> $payload Action payload: { run_id, handle_id, branch }.
+	 * @param array<mixed> $payload Action payload: { run_id, handle_id, store_ref, context_ref }.
 	 * @return void
 	 */
 	public static function run_branch_action( array $payload ): void {
-		$run_id     = self::string_value( $payload['run_id'] ?? '' );
-		$handle_id  = self::string_value( $payload['handle_id'] ?? '' );
-		$descriptor = is_array( $payload['branch'] ?? null ) ? self::string_keyed_array( $payload['branch'] ) : array();
+		$run_id      = self::string_value( $payload['run_id'] ?? '' );
+		$handle_id   = self::string_value( $payload['handle_id'] ?? '' );
+		$store_ref   = self::string_value( $payload['store_ref'] ?? '' );
+		$context_ref = self::string_value( $payload['context_ref'] ?? '' );
 
 		if ( '' === $run_id || '' === $handle_id ) {
+			return;
+		}
+
+		// Rehydrate the full self-contained descriptor from the branch store using
+		// the lightweight ref the AS args carried. The store re-seats the run-scoped
+		// shared context into branch_vars.context, so the branch runs against the
+		// same descriptor shape the runner built at dispatch. A backward-compatible
+		// inline descriptor (a payload enqueued before the offload) is still honored.
+		$descriptor = '' !== $store_ref
+			? WP_Agent_Workflow_Branch_Store::get_branch( $store_ref, $context_ref )
+			: null;
+		if ( null === $descriptor && is_array( $payload['branch'] ?? null ) ) {
+			$descriptor = self::string_keyed_array( $payload['branch'] );
+		}
+
+		if ( ! is_array( $descriptor ) ) {
+			// The stored descriptor is gone (expired / evicted) and no inline
+			// fallback exists. Reconcile a clean failure so the run does not hang
+			// SUSPENDED against a branch that can no longer run.
+			$branch_result = array(
+				'key'    => '',
+				'status' => WP_Agent_Workflow_Run_Result::STATUS_FAILED,
+				'output' => null,
+				'steps'  => array(),
+				'error'  => array(
+					'code'    => 'workflow_branch_descriptor_missing',
+					'message' => sprintf( 'Branch descriptor for handle `%s` (run `%s`) could not be rehydrated from the branch store.', $handle_id, $run_id ),
+				),
+				'item'   => null,
+			);
+			agents_reconcile_workflow_branch( $run_id, $handle_id, $branch_result );
 			return;
 		}
 
@@ -411,26 +497,51 @@ final class WP_Agent_Workflow_Action_Scheduler_Branch_Executor implements WP_Age
 
 		$runner = agents_workflow_resolve_runner( $recorder );
 		$runner->resume( $run_id );
+
+		// The run has resolved (the suspension frame was cleared by resume). Release
+		// this run's stored branch payloads so no orphan option rows linger — same
+		// cleanup discipline the suspension frame follows.
+		WP_Agent_Workflow_Branch_Store::forget_run( $run_id );
 	}
 
 	// ── Internals ────────────────────────────────────────────────────────────
 
 	/**
 	 * Enqueue an async action, tolerating environments where the AS shim only
-	 * defines the bare function. Returns the action id (int) or 0.
+	 * defines the bare function. Returns the action id (int), or 0 on failure.
+	 *
+	 * FAIL-LOUD SEAM. Action Scheduler THROWS from `as_enqueue_async_action()`
+	 * when the enqueue is rejected (most relevantly its 8,000-char args-size
+	 * guard: `ActionScheduler_Action::$args too long`). When AS's queue runner
+	 * calls this it catches+logs+swallows that throw, so the throw never reaches
+	 * the caller — the enqueue silently returns nothing and the branch is never
+	 * durably scheduled. We normalize BOTH failure modes to a `0` return so the
+	 * caller ({@see self::dispatch()}) can detect the failure and fail the run
+	 * loudly instead of returning a phantom `ref=0` handle that suspends against
+	 * a branch that does not exist.
 	 *
 	 * @since 0.5.0
 	 *
 	 * @param string       $hook  Action hook.
 	 * @param array<mixed> $args  Action args (a single-element list holding the payload array).
 	 * @param string       $group Action group.
-	 * @return int
+	 * @return int Action id, or 0 when the enqueue failed (threw or returned no id).
 	 */
 	private static function enqueue_async_action( string $hook, array $args, string $group ): int {
 		if ( ! function_exists( 'as_enqueue_async_action' ) ) {
 			return 0;
 		}
-		return as_enqueue_async_action( $hook, $args, $group );
+		try {
+			// AS returns the new action id (a positive int) on success. dispatch()
+			// treats a non-positive return as a hard failure.
+			return (int) as_enqueue_async_action( $hook, $args, $group );
+		} catch ( \Throwable $error ) {
+			// AS rejected the enqueue (e.g. args too long / queue unavailable).
+			// Normalize to 0 so dispatch() surfaces a clean WP_Error rather than
+			// letting the throw be swallowed by AS's queue runner into a hang.
+			unset( $error );
+			return 0;
+		}
 	}
 
 	/**
@@ -444,6 +555,45 @@ final class WP_Agent_Workflow_Action_Scheduler_Branch_Executor implements WP_Age
 	 */
 	private static function resolve_handlers(): array {
 		return agents_workflow_resolve_step_handlers();
+	}
+
+	/**
+	 * Strip the shared immutable context out of a branch descriptor before it is
+	 * stored. The shared context lives ONCE in the run-scoped context row; keeping
+	 * a copy inside every branch descriptor would re-introduce the N-copies
+	 * duplication the store exists to remove. The per-branch role/item scoping in
+	 * `branch_vars` is left intact.
+	 *
+	 * @since 0.5.0
+	 *
+	 * @param array<string,mixed> $descriptor Branch descriptor.
+	 * @return array<string,mixed>
+	 */
+	private static function strip_shared_context( array $descriptor ): array {
+		if ( is_array( $descriptor['branch_vars'] ?? null ) && array_key_exists( 'context', $descriptor['branch_vars'] ) ) {
+			unset( $descriptor['branch_vars']['context'] );
+		}
+		return $descriptor;
+	}
+
+	/**
+	 * Recover a run id from the first branch descriptor as a belt-and-suspenders
+	 * source for the run-scoped shared-context key when the dispatch context did
+	 * not carry `_workflow_run_id`.
+	 *
+	 * @since 0.5.0
+	 *
+	 * @param array<int,array<string,mixed>> $branches Branch descriptors.
+	 * @return string
+	 */
+	private static function first_branch_run_id( array $branches ): string {
+		foreach ( $branches as $branch ) {
+			$run_id = self::string_value( $branch['run_id'] ?? '' );
+			if ( '' !== $run_id ) {
+				return $run_id;
+			}
+		}
+		return '';
 	}
 
 	/**

--- a/src/Workflows/class-wp-agent-workflow-branch-store.php
+++ b/src/Workflows/class-wp-agent-workflow-branch-store.php
@@ -1,0 +1,376 @@
+<?php
+/**
+ * Table-free, option-backed store for out-of-band branch payloads.
+ *
+ * WHY THIS EXISTS. The Action Scheduler branch executor enqueues one async
+ * action per parallel branch. Before this store, the branch's ENTIRE
+ * self-contained descriptor — nested steps, per-branch vars, AND the shared
+ * immutable `context` snapshot (design intent, spec, brief) — rode INLINE in
+ * the AS action `args`. Two things made that unsafe on any realistically-sized
+ * workflow:
+ *
+ *   1. PAYLOAD SCALING. Action Scheduler enforces a hard 8,000-character limit
+ *      on its `args` column (`ActionScheduler_Action::$args too long ... should
+ *      not be more than 8000 characters when encoded as JSON`). A descriptor
+ *      whose shared context is a few KB (a multi-page brief) blows past that
+ *      limit and every enqueue throws. The payload scaled with context richness
+ *      — precisely the workflows the async fanout exists to serve.
+ *   2. DUPLICATION. The shared `context` is identical for every sibling branch,
+ *      yet it was copied into each branch descriptor — N copies of the same
+ *      multi-KB blob, compounding (1).
+ *
+ * This store moves the heavy payload OUT of the AS args and into option rows,
+ * leaving only a small, stable reference in the args (`{ run_id, handle_id,
+ * store_ref, context_ref }`) regardless of how rich the context is. The shared
+ * context is stored ONCE per run (a run-scoped row) rather than duplicated into
+ * every branch, so even the stored descriptors stay lean.
+ *
+ * TABLE-FREE. Under the substrate's no-new-tables constraint (agents-api is
+ * headed for wpcom / WordPress core) this uses the WordPress options table —
+ * the same table-free discipline as {@see WP_Agent_Workflow_Reconcile_Lock}
+ * (which uses `add_option()` as a CAS) and the suspension frame (which lives in
+ * `metadata._suspension`). No new DB table, no external service.
+ *
+ * LIFECYCLE. Rows carry an expiry so a run that dies before it resolves does
+ * not strand orphaned option rows forever; a healthy run deletes its own rows
+ * on resume via {@see self::forget_run()}. The TTL is generous relative to a
+ * real fanout so a slow-but-live run is never evicted mid-flight, yet bounded
+ * so a crashed run's rows are reclaimable.
+ *
+ * PLUGGABLE. A consumer with a stronger payload store (a custom table, an
+ * object cache, an external blob store) can replace persistence via the
+ * `wp_agent_workflow_branch_store` filter. The default here is correct and
+ * dependency-free.
+ *
+ * @package AgentsAPI
+ * @since   0.5.0
+ */
+
+namespace AgentsAPI\AI\Workflows;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Default option-backed branch payload store.
+ */
+final class WP_Agent_Workflow_Branch_Store {
+
+	/**
+	 * Option-name prefix for a per-branch descriptor row. The run id and handle
+	 * id are folded into the key so rows never collide across runs/branches and
+	 * are trivially inspectable / cleanable.
+	 *
+	 * @since 0.5.0
+	 */
+	private const BRANCH_PREFIX = 'agents_wf_branch_';
+
+	/**
+	 * Option-name prefix for the run-scoped shared-context row. Stored ONCE per
+	 * run so a shared context (identical for every branch) is not duplicated N
+	 * times across branch rows.
+	 *
+	 * @since 0.5.0
+	 */
+	private const CONTEXT_PREFIX = 'agents_wf_branch_ctx_';
+
+	/**
+	 * Option-name prefix for the per-run index of branch ref keys, so
+	 * {@see self::forget_run()} can delete every branch row a run wrote without
+	 * scanning the options table.
+	 *
+	 * @since 0.5.0
+	 */
+	private const INDEX_PREFIX = 'agents_wf_branch_index_';
+
+	/**
+	 * Payload time-to-live (seconds). After this a row belonging to a run that
+	 * never resolved is treated as expired and returns nothing on read. Generous
+	 * (2 hours) so a slow-but-live fanout is never evicted mid-flight, yet
+	 * bounded so a crashed run's rows do not linger indefinitely.
+	 *
+	 * @since 0.5.0
+	 */
+	private const TTL_SECONDS = 7200;
+
+	/**
+	 * Persist one branch descriptor under a per-(run_id, handle_id) key and
+	 * return the opaque store ref the AS args carry. The descriptor stored here
+	 * has its shared `context` STRIPPED — the branch action rehydrates that from
+	 * the run-scoped context row instead (see {@see self::put_shared_context()}),
+	 * so the shared context is not duplicated into every branch row.
+	 *
+	 * @since 0.5.0
+	 *
+	 * @param string              $run_id     Run the branch reconciles against.
+	 * @param string              $handle_id  Unique branch handle id within the run.
+	 * @param array<string,mixed> $descriptor Self-contained branch descriptor (context stripped).
+	 * @return string The store ref (the option name) placed in the AS args.
+	 */
+	public static function put_branch( string $run_id, string $handle_id, array $descriptor ): string {
+		$override = self::filtered_put_branch( $run_id, $handle_id, $descriptor );
+		if ( is_string( $override ) ) {
+			return $override;
+		}
+
+		$ref = self::BRANCH_PREFIX . md5( $run_id . ':' . $handle_id );
+		self::write_row(
+			$ref,
+			array(
+				'run_id'     => $run_id,
+				'handle_id'  => $handle_id,
+				'descriptor' => $descriptor,
+				'expires'    => time() + self::TTL_SECONDS,
+			)
+		);
+		self::index_ref( $run_id, $ref );
+		return $ref;
+	}
+
+	/**
+	 * Persist the run-scoped shared context ONCE and return its ref. Every branch
+	 * ref points at this single row rather than carrying its own copy of a
+	 * multi-KB context.
+	 *
+	 * @since 0.5.0
+	 *
+	 * @param string              $run_id  Run the context belongs to.
+	 * @param array<string,mixed> $context Shared immutable context snapshot.
+	 * @return string The context ref (the option name) placed in the AS args.
+	 */
+	public static function put_shared_context( string $run_id, array $context ): string {
+		$ref = self::CONTEXT_PREFIX . md5( $run_id );
+		self::write_row(
+			$ref,
+			array(
+				'run_id'  => $run_id,
+				'context' => $context,
+				'expires' => time() + self::TTL_SECONDS,
+			)
+		);
+		return $ref;
+	}
+
+	/**
+	 * Rehydrate a stored branch descriptor from its ref, re-merging the
+	 * run-scoped shared context (from `$context_ref`) back into the descriptor's
+	 * `branch_vars.context`. Returns null when the row is missing or expired (a
+	 * caller must treat that as a branch that can no longer run).
+	 *
+	 * @since 0.5.0
+	 *
+	 * @param string $store_ref   The branch descriptor ref.
+	 * @param string $context_ref The run-scoped shared-context ref ('' when none).
+	 * @return array<string,mixed>|null The reassembled descriptor, or null.
+	 */
+	public static function get_branch( string $store_ref, string $context_ref ): ?array {
+		$override = self::filtered_get_branch( $store_ref, $context_ref );
+		if ( is_array( $override ) ) {
+			return $override;
+		}
+
+		$row = self::read_row( $store_ref );
+		if ( null === $row || ! is_array( $row['descriptor'] ?? null ) ) {
+			return null;
+		}
+
+		/** @var array<string,mixed> $descriptor */
+		$descriptor = $row['descriptor'];
+
+		if ( '' !== $context_ref ) {
+			$context_row = self::read_row( $context_ref );
+			$context     = is_array( $context_row['context'] ?? null ) ? $context_row['context'] : array();
+			$branch_vars = is_array( $descriptor['branch_vars'] ?? null ) ? $descriptor['branch_vars'] : array();
+			// Re-seat the shared context the run-scoped row owns; branch_vars kept
+			// its per-branch role/item scoping, which never left the branch row.
+			$branch_vars['context']     = $context;
+			$descriptor['branch_vars']  = $branch_vars;
+		}
+
+		return $descriptor;
+	}
+
+	/**
+	 * Delete every row a run wrote (its branch descriptors, its shared-context
+	 * row, and its index) once the run resolves. Same cleanup discipline the
+	 * suspension frame follows — no orphaned store rows.
+	 *
+	 * @since 0.5.0
+	 *
+	 * @param string $run_id Run whose payload rows are released.
+	 * @return void
+	 */
+	public static function forget_run( string $run_id ): void {
+		if ( self::filtered_forget_run( $run_id ) ) {
+			return;
+		}
+		if ( ! function_exists( 'delete_option' ) || ! function_exists( 'get_option' ) ) {
+			return;
+		}
+
+		$index = get_option( self::INDEX_PREFIX . md5( $run_id ), array() );
+		if ( is_array( $index ) ) {
+			foreach ( $index as $ref ) {
+				if ( is_string( $ref ) ) {
+					delete_option( $ref );
+				}
+			}
+		}
+		delete_option( self::INDEX_PREFIX . md5( $run_id ) );
+		delete_option( self::CONTEXT_PREFIX . md5( $run_id ) );
+	}
+
+	/**
+	 * Write one option row (no autoload — these are transient runtime payloads).
+	 *
+	 * @since 0.5.0
+	 *
+	 * @param string              $option Option name.
+	 * @param array<string,mixed> $value  Row value.
+	 * @return void
+	 */
+	private static function write_row( string $option, array $value ): void {
+		if ( function_exists( 'update_option' ) ) {
+			update_option( $option, $value, false );
+		}
+	}
+
+	/**
+	 * Read one option row, returning null when missing or past its expiry.
+	 *
+	 * @since 0.5.0
+	 *
+	 * @param string $option Option name.
+	 * @return array<string,mixed>|null
+	 */
+	private static function read_row( string $option ): ?array {
+		if ( ! function_exists( 'get_option' ) ) {
+			return null;
+		}
+		$row = get_option( $option, null );
+		if ( ! is_array( $row ) ) {
+			return null;
+		}
+		$expires = is_numeric( $row['expires'] ?? null ) ? (int) $row['expires'] : 0;
+		if ( $expires > 0 && $expires <= time() ) {
+			return null;
+		}
+
+		$normalized = array();
+		foreach ( $row as $key => $value ) {
+			if ( is_string( $key ) ) {
+				$normalized[ $key ] = $value;
+			}
+		}
+		return $normalized;
+	}
+
+	/**
+	 * Record a branch ref in the per-run index so {@see self::forget_run()} can
+	 * delete every branch row without scanning the options table.
+	 *
+	 * @since 0.5.0
+	 *
+	 * @param string $run_id Run id.
+	 * @param string $ref    Branch ref (option name) to index.
+	 * @return void
+	 */
+	private static function index_ref( string $run_id, string $ref ): void {
+		if ( ! function_exists( 'get_option' ) || ! function_exists( 'update_option' ) ) {
+			return;
+		}
+		$option = self::INDEX_PREFIX . md5( $run_id );
+		$index  = get_option( $option, array() );
+		if ( ! is_array( $index ) ) {
+			$index = array();
+		}
+		if ( ! in_array( $ref, $index, true ) ) {
+			$index[] = $ref;
+			update_option( $option, $index, false );
+		}
+	}
+
+	/**
+	 * Offer a consumer's store the chance to persist a branch descriptor. A
+	 * filter that returns a non-empty string ref owns persistence for this
+	 * (run, handle); a falsey return falls through to the built-in option store.
+	 *
+	 * @since 0.5.0
+	 *
+	 * @param string              $run_id     Run id.
+	 * @param string              $handle_id  Handle id.
+	 * @param array<string,mixed> $descriptor Branch descriptor.
+	 * @return string|null A ref when a consumer store handled it, else null.
+	 */
+	private static function filtered_put_branch( string $run_id, string $handle_id, array $descriptor ): ?string {
+		if ( ! function_exists( 'apply_filters' ) ) {
+			return null;
+		}
+		/**
+		 * Filter branch-descriptor persistence. Return a non-empty string ref to
+		 * take over storage with a custom backend; return null (the default) to
+		 * use the built-in option store.
+		 *
+		 * @since 0.5.0
+		 *
+		 * @param string|null         $ref        No override by default.
+		 * @param string              $run_id     Run id.
+		 * @param string              $handle_id  Handle id.
+		 * @param array<string,mixed> $descriptor Branch descriptor.
+		 */
+		$ref = apply_filters( 'wp_agent_workflow_branch_store_put', null, $run_id, $handle_id, $descriptor );
+		return is_string( $ref ) && '' !== $ref ? $ref : null;
+	}
+
+	/**
+	 * Offer a consumer's store the chance to rehydrate a branch descriptor.
+	 *
+	 * @since 0.5.0
+	 *
+	 * @param string $store_ref   Branch ref.
+	 * @param string $context_ref Shared-context ref.
+	 * @return array<string,mixed>|null A descriptor when a consumer store handled it, else null.
+	 */
+	private static function filtered_get_branch( string $store_ref, string $context_ref ): ?array {
+		if ( ! function_exists( 'apply_filters' ) ) {
+			return null;
+		}
+		/**
+		 * Filter branch-descriptor rehydration. Return an array descriptor to take
+		 * over retrieval with a custom backend; return null (the default) to use
+		 * the built-in option store.
+		 *
+		 * @since 0.5.0
+		 *
+		 * @param array<string,mixed>|null $descriptor No override by default.
+		 * @param string                   $store_ref   Branch ref.
+		 * @param string                   $context_ref Shared-context ref.
+		 */
+		$descriptor = apply_filters( 'wp_agent_workflow_branch_store_get', null, $store_ref, $context_ref );
+		return is_array( $descriptor ) ? $descriptor : null;
+	}
+
+	/**
+	 * Offer a consumer's store the chance to release a run's payload rows.
+	 *
+	 * @since 0.5.0
+	 *
+	 * @param string $run_id Run id.
+	 * @return bool True when a consumer store handled cleanup (skip the built-in).
+	 */
+	private static function filtered_forget_run( string $run_id ): bool {
+		if ( ! function_exists( 'apply_filters' ) ) {
+			return false;
+		}
+		/**
+		 * Filter branch-payload cleanup. Return true to take over cleanup with a
+		 * custom backend; return false (the default) to use the built-in option
+		 * store.
+		 *
+		 * @since 0.5.0
+		 *
+		 * @param bool   $handled Whether a consumer store handled cleanup.
+		 * @param string $run_id  Run id.
+		 */
+		return (bool) apply_filters( 'wp_agent_workflow_branch_store_forget', false, $run_id );
+	}
+}

--- a/src/Workflows/class-wp-agent-workflow-runner.php
+++ b/src/Workflows/class-wp-agent-workflow-runner.php
@@ -918,6 +918,15 @@ class WP_Agent_Workflow_Runner {
 
 		$handles = $executor->dispatch( $plan['branches'], $dispatch_context );
 
+		// An executor may FAIL the dispatch (e.g. the AS executor when an async
+		// enqueue is rejected). A failed dispatch is a HARD step failure — the run
+		// must NOT suspend against a branch set that was never fully enqueued, or it
+		// would hang draining an empty queue. Surface the error so the step fails
+		// fast with a descriptive message.
+		if ( is_wp_error( $handles ) ) {
+			return $handles;
+		}
+
 		// A synchronous executor may return already-complete handles; then the
 		// run must NOT suspend — collect + aggregate inline and return terminal.
 		if ( $executor->are_all_complete( $handles ) ) {

--- a/src/Workflows/interface-wp-agent-workflow-branch-executor.php
+++ b/src/Workflows/interface-wp-agent-workflow-branch-executor.php
@@ -43,11 +43,15 @@ interface WP_Agent_Workflow_Branch_Executor {
 	 *        self-contained payload the executor can run later — `{ key, steps,
 	 *        branch_vars, continue_on_error, run_id, step_id }`.
 	 * @param array<string,mixed>            $context  Serializable shared context snapshot.
-	 * @return array<int,array<string,mixed>> BranchHandle[] — `{ id, key, executor,
-	 *         status, ref }`. Handles MAY be returned already-complete (a
-	 *         synchronous executor), in which case the runner never suspends.
+	 * @return array<int,array<string,mixed>>|\WP_Error BranchHandle[] — `{ id, key,
+	 *         executor, status, ref }`. Handles MAY be returned already-complete (a
+	 *         synchronous executor), in which case the runner never suspends. An
+	 *         executor that cannot durably schedule a branch MUST return a WP_Error
+	 *         so the run fails fast rather than suspending against a branch that was
+	 *         never dispatched — the runner treats a WP_Error dispatch as a hard
+	 *         step failure.
 	 */
-	public function dispatch( array $branches, array $context ): array;
+	public function dispatch( array $branches, array $context );
 
 	/**
 	 * Whether every dispatched handle has reached a terminal state.

--- a/tests/workflow-as-branch-smoke.php
+++ b/tests/workflow-as-branch-smoke.php
@@ -249,6 +249,7 @@ require_once __DIR__ . '/../src/Workflows/register-agents-workflow-abilities.php
 require_once __DIR__ . '/../src/Workflows/class-wp-agent-workflow-reconcile-lock.php';
 require_once __DIR__ . '/../src/Workflows/register-reconcile-workflow-branch.php';
 require_once __DIR__ . '/../src/Workflows/class-wp-agent-workflow-action-scheduler-bridge.php';
+require_once __DIR__ . '/../src/Workflows/class-wp-agent-workflow-branch-store.php';
 require_once __DIR__ . '/../src/Workflows/class-wp-agent-workflow-action-scheduler-branch-executor.php';
 require_once __DIR__ . '/../src/Workflows/register-workflow-branch-executor.php';
 
@@ -414,9 +415,23 @@ smoke_assert( 2, count( $branch_actions ), 'dispatch: one AS action enqueued per
 $first_payload = $branch_actions[0]['args'][0] ?? array();
 smoke_assert( 'agents-api', $branch_actions[0]['group'] ?? '', 'dispatch: branch action uses the agents-api group', $failures, $passes );
 smoke_assert( 'as-A', $first_payload['run_id'] ?? '', 'dispatch: payload carries run_id', $failures, $passes );
-smoke_assert_true( is_array( $first_payload['branch']['steps'] ?? null ), 'dispatch: payload carries the branch descriptor steps', $failures, $passes );
-smoke_assert( 'scatter', $first_payload['branch']['step_id'] ?? '', 'dispatch: descriptor is self-contained (step_id)', $failures, $passes );
-smoke_assert_true( is_array( $first_payload['branch']['branch_vars']['context'] ?? null ), 'dispatch: descriptor carries the shared context in branch_vars', $failures, $passes );
+
+// PAYLOAD OFFLOAD (Bug 1): the AS args are now a SMALL reference — no inline
+// branch descriptor, no inline shared context. The heavy descriptor lives in the
+// branch store, rehydrated by the branch action from the ref.
+smoke_assert_true( '' === (string) ( $first_payload['branch'] ?? '' ), 'dispatch: NO inline branch descriptor in AS args (offloaded to store)', $failures, $passes );
+smoke_assert_true( '' !== (string) ( $first_payload['store_ref'] ?? '' ), 'dispatch: AS args carry a small store_ref', $failures, $passes );
+smoke_assert_true( '' !== (string) ( $first_payload['context_ref'] ?? '' ), 'dispatch: AS args carry a run-scoped context_ref', $failures, $passes );
+
+// The rehydrated descriptor from the store IS self-contained: steps + step_id +
+// re-seated shared context — everything the branch action needs.
+$rehydrated = \AgentsAPI\AI\Workflows\WP_Agent_Workflow_Branch_Store::get_branch(
+	(string) ( $first_payload['store_ref'] ?? '' ),
+	(string) ( $first_payload['context_ref'] ?? '' )
+);
+smoke_assert_true( is_array( $rehydrated['steps'] ?? null ), 'store: rehydrated descriptor carries the branch steps', $failures, $passes );
+smoke_assert( 'scatter', $rehydrated['step_id'] ?? '', 'store: rehydrated descriptor is self-contained (step_id)', $failures, $passes );
+smoke_assert_true( is_array( $rehydrated['branch_vars']['context'] ?? null ), 'store: rehydrated descriptor re-seats the run-scoped shared context', $failures, $passes );
 
 // The handle's ref is the AS action id.
 $frame   = $run->get_suspension();

--- a/tests/workflow-async-branch-payload-smoke.php
+++ b/tests/workflow-async-branch-payload-smoke.php
@@ -1,0 +1,506 @@
+<?php
+/**
+ * Regression smoke for the TWO real correctness bugs in the Action Scheduler
+ * branch executor, found by a real 6-page Site Forge fanout:
+ *
+ *   BUG 1 (payload scaling). The branch descriptor — including the full shared
+ *   `context` — rode INLINE in the AS action `args`. Action Scheduler enforces a
+ *   hard 8,000-char limit on `args`; a realistic multi-KB context blew past it and
+ *   every enqueue threw. This test uses a >8KB shared context and an AS shim that
+ *   ENFORCES the 8,000-char args limit (throwing exactly as AS does). Before the
+ *   fix, dispatch's inline payload exceeds the limit → the enqueue throws → FAIL.
+ *   After the fix, the AS args are a small ref (well under 8,000 chars), the full
+ *   descriptor is retrievable from the branch store, and the branch action
+ *   rehydrates + runs it → PASS.
+ *
+ *   BUG 2 (silent failure). dispatch() enqueued with NO size guard and NO error
+ *   handling. When the enqueue threw, AS's queue runner caught+logged+swallowed
+ *   it, so dispatch() returned a phantom `ref => 0` handle for a branch that was
+ *   never enqueued; the run then SUSPENDED against a branch that does not exist
+ *   and hung. This test shims `as_enqueue_async_action` to fail (return 0), then
+ *   asserts dispatch() surfaces a WP_Error and the run FAILS fast — never a
+ *   phantom ref=0 handle, never a suspend. Before the fix: phantom handle + no
+ *   error (silent). After: clean WP_Error / failed run (loud).
+ *
+ * Run with: php tests/workflow-async-branch-payload-smoke.php
+ *
+ * No WordPress required. Drives the REAL AS executor + REAL runner + REAL
+ * reconcile/resume + REAL branch store — only Action Scheduler itself is shimmed.
+ *
+ * @package AgentsAPI\Tests
+ */
+
+defined( 'ABSPATH' ) || define( 'ABSPATH', __DIR__ . '/' );
+
+$failures = array();
+$passes   = 0;
+
+echo "workflow-async-branch-payload-smoke\n";
+
+if ( ! class_exists( 'WP_Error' ) ) {
+	class WP_Error {
+		public function __construct( private string $code = '', private string $message = '', private $data = null ) {}
+		public function get_error_code(): string { return $this->code; }
+		public function get_error_message(): string { return $this->message; }
+		public function get_error_data() { return $this->data; }
+	}
+}
+if ( ! function_exists( 'is_wp_error' ) ) {
+	function is_wp_error( $value ): bool {
+		return $value instanceof WP_Error;
+	}
+}
+if ( ! class_exists( 'WP_Ability' ) ) {
+	class WP_Ability {
+		public function __construct( private string $name, private array $args ) {}
+		public function get_name(): string { return $this->name; }
+		public function execute( $input = null ) {
+			$callback = $this->args['execute_callback'] ?? null;
+			return is_callable( $callback ) ? call_user_func( $callback, is_array( $input ) ? $input : array() ) : null;
+		}
+	}
+}
+
+$GLOBALS['__filters']   = array();
+$GLOBALS['__abilities'] = array();
+$GLOBALS['__options']   = array();
+
+if ( ! function_exists( 'add_filter' ) ) {
+	function add_filter( string $hook, callable $cb, int $priority = 10, int $accepted_args = 1 ): void {
+		unset( $accepted_args );
+		$GLOBALS['__filters'][ $hook ][ $priority ][] = $cb;
+	}
+}
+if ( ! function_exists( 'remove_all_filters' ) ) {
+	function remove_all_filters( string $hook ): void {
+		unset( $GLOBALS['__filters'][ $hook ] );
+	}
+}
+if ( ! function_exists( 'apply_filters' ) ) {
+	function apply_filters( string $hook, $value, ...$args ) {
+		$cbs = $GLOBALS['__filters'][ $hook ] ?? array();
+		ksort( $cbs );
+		foreach ( $cbs as $bucket ) {
+			foreach ( $bucket as $cb ) {
+				$value = call_user_func_array( $cb, array_merge( array( $value ), $args ) );
+			}
+		}
+		return $value;
+	}
+}
+if ( ! function_exists( 'add_action' ) ) {
+	function add_action( string $hook, callable $cb, int $priority = 10, int $accepted_args = 1 ): void {
+		add_filter( $hook, $cb, $priority, $accepted_args );
+	}
+}
+if ( ! function_exists( 'do_action' ) ) {
+	function do_action( string $hook, ...$args ): void {
+		$cbs = $GLOBALS['__filters'][ $hook ] ?? array();
+		ksort( $cbs );
+		foreach ( $cbs as $bucket ) {
+			foreach ( $bucket as $cb ) {
+				call_user_func_array( $cb, $args );
+			}
+		}
+	}
+}
+if ( ! function_exists( 'wp_get_ability' ) ) {
+	function wp_get_ability( string $name ) { return $GLOBALS['__abilities'][ $name ] ?? null; }
+}
+if ( ! function_exists( 'wp_has_ability' ) ) {
+	function wp_has_ability( string $name ): bool { return isset( $GLOBALS['__abilities'][ $name ] ); }
+}
+if ( ! function_exists( 'wp_register_ability' ) ) {
+	function wp_register_ability( string $name, array $args ) {
+		$GLOBALS['__abilities'][ $name ] = new WP_Ability( $name, $args );
+		return $GLOBALS['__abilities'][ $name ];
+	}
+}
+if ( ! function_exists( 'current_user_can' ) ) {
+	function current_user_can( $cap ): bool { unset( $cap ); return true; }
+}
+if ( ! function_exists( 'get_option' ) ) {
+	function get_option( string $option, $default = false ) {
+		return array_key_exists( $option, $GLOBALS['__options'] ) ? $GLOBALS['__options'][ $option ] : $default;
+	}
+}
+if ( ! function_exists( 'add_option' ) ) {
+	function add_option( string $option, $value = '', $deprecated = '', $autoload = null ): bool {
+		unset( $deprecated, $autoload );
+		if ( array_key_exists( $option, $GLOBALS['__options'] ) ) {
+			return false;
+		}
+		$GLOBALS['__options'][ $option ] = $value;
+		return true;
+	}
+}
+if ( ! function_exists( 'update_option' ) ) {
+	function update_option( string $option, $value, $autoload = null ): bool {
+		unset( $autoload );
+		$GLOBALS['__options'][ $option ] = $value;
+		return true;
+	}
+}
+if ( ! function_exists( 'delete_option' ) ) {
+	function delete_option( string $option ): bool {
+		if ( array_key_exists( $option, $GLOBALS['__options'] ) ) {
+			unset( $GLOBALS['__options'][ $option ] );
+			return true;
+		}
+		return false;
+	}
+}
+
+// ── The Action Scheduler function-shim, WITH the real 8,000-char args guard ──────
+// AS enforces a hard 8,000-char limit on the JSON-encoded action args and THROWS
+// when exceeded. This shim reproduces that exact behavior so the payload bug is
+// caught for real: an inline branch descriptor (the pre-fix payload) trips it; a
+// small store ref (the post-fix payload) does not. A "force fail" mode models an
+// enqueue that fails for other reasons (AS down) for the fail-loud test.
+
+final class AS_Limit_Shim {
+	/** Action Scheduler's real hard limit on the encoded args column. */
+	public const ARGS_LIMIT = 8000;
+
+	/** @var array<int,array{id:int,hook:string,args:array<mixed>,group:string}> */
+	public static array $queue = array();
+	/** @var array<int,bool> */
+	public static array $claimed = array();
+	private static int $seq = 0;
+	/** When true, every enqueue "fails" the way AS's runner swallows — throws. */
+	public static bool $force_fail = false;
+
+	public static function reset(): void {
+		self::$queue      = array();
+		self::$claimed    = array();
+		self::$seq        = 0;
+		self::$force_fail = false;
+	}
+
+	public static function enqueue( string $hook, array $args, string $group ): int {
+		if ( self::$force_fail ) {
+			throw new \RuntimeException( 'ActionScheduler queue is unavailable (simulated).' );
+		}
+		$encoded = wp_json_encode_shim( $args );
+		if ( strlen( $encoded ) > self::ARGS_LIMIT ) {
+			// This is the exact failure the real bug hit.
+			throw new \InvalidArgumentException(
+				sprintf(
+					'ActionScheduler_Action::$args too long. It should not be more than %d characters when encoded as JSON (was %d).',
+					self::ARGS_LIMIT,
+					strlen( $encoded )
+				)
+			);
+		}
+		$id            = ++self::$seq;
+		self::$queue[] = array(
+			'id'    => $id,
+			'hook'  => $hook,
+			'args'  => $args,
+			'group' => $group,
+		);
+		return $id;
+	}
+
+	public static function claim( int $id ): bool {
+		if ( ! empty( self::$claimed[ $id ] ) ) {
+			return false;
+		}
+		self::$claimed[ $id ] = true;
+		return true;
+	}
+
+	/** @return array<int,array{id:int,hook:string,args:array<mixed>,group:string}> */
+	public static function actions_for( string $hook ): array {
+		return array_values(
+			array_filter(
+				self::$queue,
+				static function ( array $action ) use ( $hook ): bool {
+					return $action['hook'] === $hook;
+				}
+			)
+		);
+	}
+
+	public static function fire( int $id ): bool {
+		if ( ! self::claim( $id ) ) {
+			return false;
+		}
+		foreach ( self::$queue as $action ) {
+			if ( $action['id'] === $id ) {
+				do_action( $action['hook'], ...$action['args'] );
+				return true;
+			}
+		}
+		return false;
+	}
+}
+
+function wp_json_encode_shim( $value ): string {
+	$encoded = json_encode( $value );
+	return false === $encoded ? '' : $encoded;
+}
+
+if ( ! function_exists( 'as_enqueue_async_action' ) ) {
+	function as_enqueue_async_action( string $hook, array $args = array(), string $group = '' ) {
+		return AS_Limit_Shim::enqueue( $hook, $args, $group );
+	}
+}
+
+function smoke_assert( $expected, $actual, string $name, array &$failures, int &$passes ): void {
+	if ( $expected === $actual ) {
+		++$passes;
+		echo "  PASS {$name}\n";
+		return;
+	}
+	$failures[] = $name;
+	echo "  FAIL {$name}\n";
+	echo '    expected: ' . var_export( $expected, true ) . "\n";
+	echo '    actual:   ' . var_export( $actual, true ) . "\n";
+}
+
+function smoke_assert_true( $actual, string $name, array &$failures, int &$passes ): void {
+	smoke_assert( true, (bool) $actual, $name, $failures, $passes );
+}
+
+require_once __DIR__ . '/../src/Workflows/class-wp-agent-workflow-bindings.php';
+require_once __DIR__ . '/../src/Workflows/class-wp-agent-workflow-spec-validator.php';
+require_once __DIR__ . '/../src/Workflows/class-wp-agent-workflow-spec.php';
+require_once __DIR__ . '/../src/Workflows/class-wp-agent-workflow-run-result.php';
+require_once __DIR__ . '/../src/Workflows/class-wp-agent-workflow-store.php';
+require_once __DIR__ . '/../src/Workflows/class-wp-agent-workflow-run-recorder.php';
+require_once __DIR__ . '/../src/Abilities/class-wp-agent-ability-dispatcher.php';
+require_once __DIR__ . '/../src/Runtime/interface-wp-agent-run-control-store.php';
+require_once __DIR__ . '/../src/Runtime/class-wp-agent-option-run-control-store.php';
+require_once __DIR__ . '/../src/Runtime/class-wp-agent-run-control.php';
+require_once __DIR__ . '/../src/Workflows/class-wp-agent-workflow-run-context.php';
+require_once __DIR__ . '/../src/Workflows/interface-wp-agent-workflow-branch-executor.php';
+require_once __DIR__ . '/../src/Workflows/class-wp-agent-workflow-step-executor.php';
+require_once __DIR__ . '/../src/Workflows/class-wp-agent-workflow-runner.php';
+require_once __DIR__ . '/../src/Workflows/register-agents-workflow-abilities.php';
+require_once __DIR__ . '/../src/Workflows/class-wp-agent-workflow-reconcile-lock.php';
+require_once __DIR__ . '/../src/Workflows/register-reconcile-workflow-branch.php';
+require_once __DIR__ . '/../src/Workflows/class-wp-agent-workflow-action-scheduler-bridge.php';
+require_once __DIR__ . '/../src/Workflows/class-wp-agent-workflow-branch-store.php';
+require_once __DIR__ . '/../src/Workflows/class-wp-agent-workflow-action-scheduler-branch-executor.php';
+require_once __DIR__ . '/../src/Workflows/register-workflow-branch-executor.php';
+
+use AgentsAPI\AI\Workflows\WP_Agent_Workflow_Run_Result;
+use AgentsAPI\AI\Workflows\WP_Agent_Workflow_Run_Recorder;
+use AgentsAPI\AI\Workflows\WP_Agent_Workflow_Runner;
+use AgentsAPI\AI\Workflows\WP_Agent_Workflow_Spec;
+use AgentsAPI\AI\Workflows\WP_Agent_Workflow_Action_Scheduler_Branch_Executor;
+use AgentsAPI\AI\Workflows\WP_Agent_Workflow_Branch_Store;
+
+final class Payload_Smoke_Recorder implements WP_Agent_Workflow_Run_Recorder {
+	/** @var array<string,array<string,mixed>> */
+	public array $rows = array();
+
+	public function start( WP_Agent_Workflow_Run_Result $result ) {
+		$this->rows[ $result->get_run_id() ] = $result->to_array();
+		return $result->get_run_id();
+	}
+	public function update( WP_Agent_Workflow_Run_Result $result ) {
+		$this->rows[ $result->get_run_id() ] = $result->to_array();
+		return true;
+	}
+	public function find( string $run_id ): ?WP_Agent_Workflow_Run_Result {
+		return isset( $this->rows[ $run_id ] )
+			? WP_Agent_Workflow_Run_Result::from_array( $this->rows[ $run_id ] )
+			: null;
+	}
+	public function recent( array $args = array() ): array {
+		unset( $args );
+		return array_map(
+			array( WP_Agent_Workflow_Run_Result::class, 'from_array' ),
+			array_values( $this->rows )
+		);
+	}
+}
+
+function payload_register_ability( string $name, \Closure $handler ): void {
+	$GLOBALS['__abilities'][ $name ] = new WP_Ability( $name, array( 'execute_callback' => $handler ) );
+}
+
+payload_register_ability(
+	'demo/role-worker',
+	static function ( array $input ): array {
+		return array( 'fragment' => strtoupper( (string) ( $input['label'] ?? 'X' ) ) );
+	}
+);
+payload_register_ability(
+	'demo/aggregate',
+	static function ( array $input ): array {
+		return array( 'final_bundle' => 'FUSED[' . (string) ( $input['headline'] ?? '' ) . '|' . (string) ( $input['body'] ?? '' ) . ']' );
+	}
+);
+
+/**
+ * A realistic multi-page brief: a shared context well over the 8,000-char AS
+ * args limit. This is the payload that broke the inline design.
+ *
+ * @return array<string,mixed>
+ */
+function payload_large_context(): array {
+	$page = str_repeat( 'Design intent, spec, and brief prose for one page of the site forge output. ', 40 );
+	$pages = array();
+	for ( $i = 1; $i <= 6; $i++ ) {
+		$pages[ 'page_' . $i ] = array(
+			'title'   => 'Page ' . $i,
+			'brief'   => $page,
+			'spec'    => $page,
+			'intent'  => $page,
+		);
+	}
+	return array( 'brief' => $pages, 'marker' => 'M' );
+}
+
+function payload_roles_spec(): WP_Agent_Workflow_Spec {
+	return WP_Agent_Workflow_Spec::from_array(
+		array(
+			'id'    => 'demo/payload-roles',
+			'steps' => array(
+				array(
+					'id'       => 'scatter',
+					'type'     => 'parallel',
+					'context'  => payload_large_context(),
+					'branches' => array(
+						array(
+							'role'          => 'headline',
+							'required'      => true,
+							'is_aggregator' => false,
+							'steps'         => array(
+								array( 'id' => 'h', 'type' => 'ability', 'ability' => 'demo/role-worker', 'args' => array( 'label' => 'head' ) ),
+							),
+						),
+						array(
+							'role'          => 'body',
+							'required'      => true,
+							'is_aggregator' => false,
+							'steps'         => array(
+								array( 'id' => 'b', 'type' => 'ability', 'ability' => 'demo/role-worker', 'args' => array( 'label' => 'body' ) ),
+							),
+						),
+						array(
+							'role'          => 'fuse',
+							'required'      => true,
+							'is_aggregator' => true,
+							'steps'         => array(
+								array(
+									'id'      => 'agg',
+									'type'    => 'ability',
+									'ability' => 'demo/aggregate',
+									'args'    => array(
+										'headline' => '${vars.branch_outputs.headline.fragment}',
+										'body'     => '${vars.branch_outputs.body.fragment}',
+									),
+								),
+							),
+						),
+					),
+				),
+			),
+		)
+	);
+}
+
+// ═════════════════════════════════════════════════════════════════════════════
+// BUG 1 — a >8KB shared context enqueues SMALL args and runs end-to-end.
+// ═════════════════════════════════════════════════════════════════════════════
+// Sanity: prove the context really is bigger than the AS args limit, so the
+// pre-fix inline payload WOULD have thrown.
+
+AS_Limit_Shim::reset();
+$GLOBALS['__options'] = array();
+$recorder = new Payload_Smoke_Recorder();
+remove_all_filters( 'wp_agent_workflow_run_recorder' );
+add_filter( 'wp_agent_workflow_run_recorder', static function () use ( $recorder ) { return $recorder; } );
+
+$context_bytes = strlen( wp_json_encode_shim( payload_large_context() ) );
+smoke_assert_true( $context_bytes > AS_Limit_Shim::ARGS_LIMIT, "bug1 setup: shared context ({$context_bytes} bytes) exceeds AS args limit (8000)", $failures, $passes );
+
+// With the offload, dispatch enqueues without throwing even though the context is
+// huge. (Pre-fix, run() would return a failed run whose parallel step errored with
+// the "args too long" enqueue throw.)
+$run = ( new WP_Agent_Workflow_Runner( $recorder ) )->run( payload_roles_spec(), array(), array( 'run_id' => 'pay-A' ) );
+smoke_assert( WP_Agent_Workflow_Run_Result::STATUS_SUSPENDED, $run->get_status(), 'bug1: run SUSPENDED (dispatch did NOT throw on a >8KB context)', $failures, $passes );
+
+$branch_actions = AS_Limit_Shim::actions_for( WP_Agent_Workflow_Action_Scheduler_Branch_Executor::BRANCH_HOOK );
+smoke_assert( 2, count( $branch_actions ), 'bug1: one AS action enqueued per sibling branch', $failures, $passes );
+
+// THE payload assertion: every enqueued AS args payload is SMALL — a reference,
+// well under the 8,000-char limit — regardless of the multi-KB context.
+$max_args = 0;
+foreach ( $branch_actions as $action ) {
+	$max_args = max( $max_args, strlen( wp_json_encode_shim( $action['args'] ) ) );
+}
+smoke_assert_true( $max_args < 1000, "bug1: AS args are small (max {$max_args} bytes, well under 8000)", $failures, $passes );
+
+// The full descriptor is retrievable from the store and rehydrates the shared
+// context (re-seated from the run-scoped row).
+$first_payload = $branch_actions[0]['args'][0] ?? array();
+$rehydrated    = WP_Agent_Workflow_Branch_Store::get_branch(
+	(string) ( $first_payload['store_ref'] ?? '' ),
+	(string) ( $first_payload['context_ref'] ?? '' )
+);
+smoke_assert_true( is_array( $rehydrated['branch_vars']['context']['brief'] ?? null ), 'bug1: store rehydrates the full >8KB shared context into the descriptor', $failures, $passes );
+
+// End-to-end: fire branch actions + resume → run SUCCEEDED with the real
+// aggregated output. The branch action rehydrated from the store and ran.
+foreach ( $branch_actions as $action ) {
+	AS_Limit_Shim::fire( $action['id'] );
+}
+foreach ( AS_Limit_Shim::actions_for( WP_Agent_Workflow_Action_Scheduler_Branch_Executor::RESUME_HOOK ) as $action ) {
+	AS_Limit_Shim::fire( $action['id'] );
+}
+$final = $recorder->find( 'pay-A' );
+smoke_assert( WP_Agent_Workflow_Run_Result::STATUS_SUCCEEDED, $final->get_status(), 'bug1: run SUCCEEDED end-to-end (branch action rehydrated from store and ran)', $failures, $passes );
+smoke_assert( 'FUSED[HEAD|BODY]', $final->get_output()['steps']['scatter']['final']['final_bundle'] ?? '', 'bug1: aggregate fused the rehydrated branch outputs', $failures, $passes );
+
+// Cleanup discipline: the run's stored branch payloads are released on resume.
+$leftover = 0;
+foreach ( array_keys( $GLOBALS['__options'] ) as $opt ) {
+	if ( str_starts_with( (string) $opt, 'agents_wf_branch_' ) ) {
+		++$leftover;
+	}
+}
+smoke_assert( 0, $leftover, 'bug1: branch store rows cleaned up on resume (no orphans)', $failures, $passes );
+
+// ═════════════════════════════════════════════════════════════════════════════
+// BUG 2 — an enqueue failure FAILS LOUD, never a phantom ref=0 suspend.
+// ═════════════════════════════════════════════════════════════════════════════
+
+AS_Limit_Shim::reset();
+$GLOBALS['__options']  = array();
+AS_Limit_Shim::$force_fail = true; // every enqueue throws (AS unavailable).
+$recorder2 = new Payload_Smoke_Recorder();
+remove_all_filters( 'wp_agent_workflow_run_recorder' );
+add_filter( 'wp_agent_workflow_run_recorder', static function () use ( $recorder2 ) { return $recorder2; } );
+
+// dispatch() directly: it must return a WP_Error, not a phantom ref=0 handle.
+$executor  = new WP_Agent_Workflow_Action_Scheduler_Branch_Executor();
+$dispatched = $executor->dispatch(
+	array(
+		array( 'key' => 'headline', 'run_id' => 'pay-fail', 'step_id' => 'scatter', 'required' => true, 'steps' => array( array( 'id' => 'h', 'type' => 'ability', 'ability' => 'demo/role-worker' ) ), 'branch_vars' => array( 'context' => array() ) ),
+	),
+	array( '_workflow_run_id' => 'pay-fail', '_workflow_step_id' => 'scatter', 'shared_context' => array() )
+);
+smoke_assert_true( is_wp_error( $dispatched ), 'bug2: dispatch() returns a WP_Error when the enqueue fails (no phantom ref=0 handle)', $failures, $passes );
+smoke_assert( 'workflow_branch_dispatch_enqueue_failed', is_wp_error( $dispatched ) ? $dispatched->get_error_code() : '', 'bug2: WP_Error carries the descriptive dispatch-failure code', $failures, $passes );
+
+// The full run path: a failed enqueue must FAIL the run fast — never SUSPENDED.
+$run2 = ( new WP_Agent_Workflow_Runner( $recorder2 ) )->run( payload_roles_spec(), array(), array( 'run_id' => 'pay-fail-run' ) );
+smoke_assert_true( WP_Agent_Workflow_Run_Result::STATUS_SUSPENDED !== $run2->get_status(), 'bug2: run did NOT suspend against un-enqueued branches (no silent stuck-suspend)', $failures, $passes );
+smoke_assert( WP_Agent_Workflow_Run_Result::STATUS_FAILED, $run2->get_status(), 'bug2: run FAILED fast when dispatch could not enqueue', $failures, $passes );
+
+// No orphan store rows from the failed dispatch.
+$leftover2 = 0;
+foreach ( array_keys( $GLOBALS['__options'] ) as $opt ) {
+	if ( str_starts_with( (string) $opt, 'agents_wf_branch_' ) ) {
+		++$leftover2;
+	}
+}
+smoke_assert( 0, $leftover2, 'bug2: failed dispatch cleaned up its stored rows (no orphans)', $failures, $passes );
+
+echo "Passed: {$passes}, Failed: " . count( $failures ) . "\n";
+exit( count( $failures ) > 0 ? 1 : 0 );


### PR DESCRIPTION
## The bugs

The Action Scheduler branch executor's `dispatch()` packed each branch's **full self-contained descriptor** — including the shared immutable `context` (design intent, spec, brief) — **inline** into the AS action `args`, and **duplicated** that context into every branch. Action Scheduler enforces a hard **8,000-char limit** on its `args` column, so on any realistically-sized workflow the per-branch payload blew past the limit and every enqueue threw. A real 6-page Site Forge fanout measured:

- shared context per branch: **5,910 bytes**
- full branch descriptor per branch: **6,219 bytes**
- per-branch AS args payload: **~13,034 bytes** → ~5KB over the 8,000 cap → all 6 enqueues threw.

**Bug 1 — oversized inline branch payload.** The inline descriptor scaled with context richness and was copied N times, breaking the async fanout on any non-trivial workflow.

**Bug 2 — silent stuck-suspend.** `dispatch()` called `as_enqueue_async_action()` with no size guard and no error handling. When the enqueue threw, AS's queue runner caught+logged+swallowed it, so `dispatch()` returned a phantom `ref => 0` handle for a branch that was never enqueued. The run then **suspended against a non-existent branch and hung** draining an empty queue until its budget expired (observed: a 1800s stuck-suspend). The failure never surfaced to the caller.

## The fixes

**Store-offload (Bug 1).** New table-free, option-backed `WP_Agent_Workflow_Branch_Store` (same no-new-tables discipline as the reconcile lock and the `metadata._suspension` frame). `dispatch()` persists each descriptor to the store and enqueues AS args that carry only a small, stable reference — `{ run_id, handle_id, store_ref, context_ref }` — whose size does **not** scale with context. The shared context is stored **once per run** (run-scoped) rather than duplicated into every branch. The branch action rehydrates the full descriptor from the store, re-seating the run-scoped shared context, and runs exactly as before. Stored rows are released on resume (and on a failed dispatch) so no orphan option rows linger. Persistence is pluggable via `wp_agent_workflow_branch_store_*` filters.

**Fail-loud dispatch (Bug 2).** The enqueue seam now normalizes both a throw and a non-positive id to a failure, and `dispatch()` returns a descriptive `WP_Error` on **any** branch's enqueue failure (cleaning up already-stored rows first). The runner treats a `WP_Error` dispatch as a hard step failure, so the run **fails fast** instead of phantom-suspending. A partial dispatch (some branches enqueued, one failed) also fails cleanly rather than suspending against a partial branch set. This keeps failing loud for any future enqueue failure (AS down, etc.).

## Verification

New `tests/workflow-async-branch-payload-smoke.php` drives the real executor + runner + reconcile/resume + store, shimming only Action Scheduler (with its real 8,000-char args guard):

- **Bug 1:** a >8KB shared context (55,110 bytes) — asserts the AS args stay small (max 193 bytes), the full descriptor is retrievable from the store, and the branch rehydrates + runs end-to-end to `SUCCEEDED` with the correct aggregate. **Fails before** the fix (run `FAILED` with "args too long", 0 actions enqueued); **passes after**.
- **Bug 2:** an enqueue failure — asserts `dispatch()` returns a `WP_Error` (no phantom `ref=0`) and the run `FAILED` fast, never `SUSPENDED`. **Fails before** (uncaught throw / phantom handle → silent hang in production); **passes after**.

All existing workflow tests stay green (`workflow-as-branch`, `workflow-parallel-async`, `workflow-parallel`, `workflow-reconcile-race`, runner/validator/lifecycle). Full `composer smoke` (2,973 assertions) green, `composer phpstan` (level max) clean, `php -l` clean.

Refs #390

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Claude Opus 4.8)
- **Used for:** Root-cause analysis, the store-offload + fail-loud implementation, and the regression test.