### PR TITLE
Fix parallel smoke test: stub do_action for the run-completed hook

### DIFF
--- a/tests/workflow-parallel-smoke.php
+++ b/tests/workflow-parallel-smoke.php
@@ -87,6 +87,17 @@ if ( ! function_exists( 'add_action' ) ) {
 		add_filter( $hook, $cb, $priority, $accepted_args );
 	}
 }
+if ( ! function_exists( 'do_action' ) ) {
+	function do_action( string $hook, ...$args ): void {
+		$cbs = $GLOBALS['__filters'][ $hook ] ?? array();
+		ksort( $cbs );
+		foreach ( $cbs as $bucket ) {
+			foreach ( $bucket as $cb ) {
+				call_user_func_array( $cb, $args );
+			}
+		}
+	}
+}
 if ( ! function_exists( 'wp_get_ability' ) ) {
 	function wp_get_ability( string $name ) {
 		return $GLOBALS['__abilities'][ $name ] ?? null;


### PR DESCRIPTION
#397 added `do_action( 'wp_agent_workflow_run_completed', … )` at the runner's terminal funnel. `tests/workflow-parallel-smoke.php` defines its own inline WordPress stubs but only had `add_filter`/`apply_filters`/`add_action` — not `do_action` — so `run()` under those stubs hit "Call to undefined function do_action()" and the smoke job fataled (exit 255). This adds the missing `do_action` stub (dispatching callbacks registered via the existing `add_action`/`add_filter` stubs).

Production code is correct — WordPress provides `do_action`; only this test's harness lacked the stub. All workflow smoke tests pass locally after the fix.

Fixes the `PHP smoke tests` failure introduced by #397.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Opus 4.8 via Claude Code
- **Used for:** Diagnosing the missing-stub CI failure and adding the do_action stub.