### PR TITLE
fix: drop orphaned test-CI version_target from homeboy.json

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -12,10 +12,6 @@
     {
       "file": "agents-api.php",
       "pattern": "Version:\\s*([0-9.]+)"
-    },
-    {
-      "file": "tests/playground-ci/component/agents-api-docs-agent-driver.php",
-      "pattern": "Version:\\s*([0-9.]+)"
     }
   ]
 }


### PR DESCRIPTION
## Summary

The `homeboy.json` `version_targets` array carried a second entry pointing at `tests/playground-ci/component/agents-api-docs-agent-driver.php`. This file is **never** in the shipped build artifact: `.distignore` excludes `tests/`, so `build/agents-api.zip` contains zero test files. Homeboy requires every `version_target` to exist in the packaged artifact, so this orphaned target failed the deploy version-target check.

## Root cause

The test-CI target was added alongside the release-target config (commit d207dd5) and was orphaned from day one — the build has always excluded `tests/`. It surfaced now during the studio-native runtime deploy work.

## Fix

Remove the dead test-CI `version_target`. `agents-api.php` is the canonical, packaged version anchor (mirrors how studio-native's homeboy.json anchors on shipped `.php`/`style.css` files, not tests). Both files were kept in Version lockstep (0.5.0), so no version-source information is lost.

## Verification

`homeboy deploy studio-native-local-runtime agents-api --head --apply --dry-run` now plans cleanly: `status: planned`, `failed: 0`, resolves `local_version: 0.5.0` from `agents-api.php`, no version-target error.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Opus 4.8 via Claude Code
- **Used for:** Root-cause investigation of the orphaned version_target and the one-line config fix.