### PR TITLE
fix: gate branch concurrency on in-flight (pending + in-progress), not pending alone

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -114,6 +114,7 @@
       "php tests/workflow-parallel-smoke.php",
       "php tests/workflow-parallel-async-smoke.php",
       "php tests/workflow-as-branch-smoke.php",
+      "php tests/workflow-branch-concurrency-gate-smoke.php",
       "php tests/workflow-async-branch-payload-smoke.php",
       "php tests/workflow-reconcile-race-smoke.php",
       "php tests/workflow-lifecycle-smoke.php",

--- a/src/Workflows/class-wp-agent-workflow-action-scheduler-branch-executor.php
+++ b/src/Workflows/class-wp-agent-workflow-action-scheduler-branch-executor.php
@@ -248,46 +248,74 @@ final class WP_Agent_Workflow_Action_Scheduler_Branch_Executor implements WP_Age
 	}
 
 	/**
-	 * Count PENDING branch actions on this executor's OWN branch hook (live, no
-	 * memoization).
+	 * Count the branch actions still IN FLIGHT for an active fan-out on this
+	 * executor's OWN branch hook — PENDING *plus* IN-PROGRESS — live, no memoization.
 	 *
 	 * This is the gate that scopes the AS concurrency raise to an in-flight fan-out.
-	 * It counts pending actions on {@see self::BRANCH_HOOK} specifically (not the
-	 * whole {@see self::GROUP} group), so the elevated concurrency policy keys off
-	 * THIS executor's own parallel branches and never touches unrelated AS workload.
+	 * It counts actions on {@see self::BRANCH_HOOK} specifically (not the whole
+	 * {@see self::GROUP} group), so the elevated concurrency policy keys off THIS
+	 * executor's own parallel branches and never touches unrelated AS workload.
+	 *
+	 * WHY IN-PROGRESS COUNTS, NOT JUST PENDING. The whole point of the fan-out is N
+	 * branches running AT ONCE. But the instant a worker claims a branch, that
+	 * action transitions PENDING -> in-progress, so a pending-only count collapses
+	 * toward 0 the moment claiming starts — even though every branch is still in
+	 * flight. If the gate keyed off pending alone, the first worker to claim a branch
+	 * would drop the count enough to revert both concurrency filters to the AS
+	 * defaults (`concurrent_batches` 1, `batch_size` 25), and
+	 * `has_maximum_concurrent_batches()` (get_claim_count 1 >= concurrent_batches 1)
+	 * would then BLOCK any further worker from claiming the remaining pending
+	 * branches while that first branch runs its multi-minute AI call. The fan-out
+	 * would drain SERIALLY — one branch at a time, ~the branch duration apart —
+	 * defeating the entire mechanism. Compounded by the intentional 3600s long-branch
+	 * reaper window ({@see register-workflow-branch-executor.php}), a single
+	 * in-progress branch could hold the one claim slot for up to an hour.
+	 *
+	 * Counting PENDING + IN-PROGRESS keeps the ceiling raised to cover EVERY branch
+	 * still in flight, so while some branches are running additional workers can still
+	 * claim the ones that are pending — the ceiling stays open until the last branch
+	 * leaves the in-flight set (both counts drain to 0), at which point the filters
+	 * pass through unchanged and every other AS workload sees stock behavior.
 	 *
 	 * The count is read LIVE on every call rather than memoized per request. The two
 	 * concurrency filters fire more than once within a single queue-runner request —
 	 * `has_maximum_concurrent_batches()` at the top of `run()`, and again on shutdown
 	 * when the worker considers self-chaining `maybe_dispatch()` — and between those
-	 * calls the pending set changes as branches move PENDING -> in-progress ->
-	 * complete. A request-static cache would pin the FIRST-observed value: if a
-	 * worker's first read happened to catch a moment when peers had momentarily
-	 * claimed every branch (pending 0), the gate would revert both filters to the AS
-	 * defaults (`concurrent_batches` 1, `batch_size` 25) for the rest of that
-	 * request, so a later `run()` in the same worker could claim a batch of 25 and
-	 * drain them serially — the exact serialization this policy exists to prevent.
-	 * Reading live keeps the gate honest. The query is a single indexed lookup
-	 * bounded to MAX_BRANCH_CONCURRENCY ids, so it is cheap enough to run per filter
-	 * application.
+	 * calls the in-flight set changes as branches move PENDING -> in-progress ->
+	 * complete. A request-static cache would pin the FIRST-observed value and go stale
+	 * as the set drains, so a later `run()` in the same worker could see the wrong
+	 * ceiling and either over- or under-claim. Reading live keeps the gate honest. The
+	 * query is a small indexed lookup bounded to 2*MAX_BRANCH_CONCURRENCY ids, so it
+	 * is cheap enough to run per filter application.
 	 *
 	 * Returns 0 when Action Scheduler's query API is unavailable (a runtime without
 	 * AS), which makes both concurrency filters pass their value through untouched.
 	 *
 	 * @since 0.5.0
 	 *
-	 * @return int Pending branch-action count (0..MAX_BRANCH_CONCURRENCY).
+	 * @return int In-flight branch-action count (pending + in-progress).
 	 */
-	public static function pending_branch_count(): int {
+	public static function branch_inflight_count(): int {
 		if ( ! function_exists( 'as_get_scheduled_actions' ) || ! class_exists( '\ActionScheduler_Store' ) ) {
 			return 0;
 		}
 
+		// Query PENDING and IN-PROGRESS in one call. Passing an array of statuses to
+		// as_get_scheduled_actions() OR-matches them, so the returned ids are every
+		// branch action that is either waiting to be claimed or currently running —
+		// i.e. still in flight for this fan-out. per_page is bounded to twice
+		// MAX_BRANCH_CONCURRENCY because at the boundary the in-flight set can hold up
+		// to MAX_BRANCH_CONCURRENCY in-progress plus that many still pending; the
+		// callers only need to know whether the count is >= their target, so a bound
+		// that comfortably exceeds MAX_BRANCH_CONCURRENCY is sufficient.
 		$ids = as_get_scheduled_actions(
 			array(
 				'hook'     => self::BRANCH_HOOK,
-				'status'   => \ActionScheduler_Store::STATUS_PENDING,
-				'per_page' => self::MAX_BRANCH_CONCURRENCY,
+				'status'   => array(
+					\ActionScheduler_Store::STATUS_PENDING,
+					\ActionScheduler_Store::STATUS_RUNNING,
+				),
+				'per_page' => self::MAX_BRANCH_CONCURRENCY * 2,
 			),
 			'ids'
 		);

--- a/src/Workflows/register-workflow-branch-executor.php
+++ b/src/Workflows/register-workflow-branch-executor.php
@@ -160,9 +160,9 @@ add_filter( 'action_scheduler_timeout_period', $agents_workflow_branch_reaper_wi
 //    fan-out that is exactly wrong — N branches enqueued under BRANCH_HOOK would drain
 //    serially in one worker instead of N workers each running one branch. The two
 //    filters below flip that WHILE — and only while — this executor's own branches are
-//    pending:
+//    still IN FLIGHT:
 //
-//      - `concurrent_batches` is RAISED to the pending BRANCH count (capped at
+//      - `concurrent_batches` is RAISED to the IN-FLIGHT branch count (capped at
 //        MAX_BRANCH_CONCURRENCY) so up to N workers may each hold a claim at once.
 //      - `batch_size` is pinned to 1 so each of those workers claims exactly ONE
 //        branch and leaves the rest for its peers.
@@ -172,13 +172,28 @@ add_filter( 'action_scheduler_timeout_period', $agents_workflow_branch_reaper_wi
 //    MySQL each worker's stake_claim uses FOR UPDATE SKIP LOCKED, so the concurrent
 //    claims pick distinct branches.
 //
+//    IN FLIGHT = PENDING + IN-PROGRESS, NOT PENDING ALONE. The gate keys off
+//    {@see WP_Agent_Workflow_Action_Scheduler_Branch_Executor::branch_inflight_count()}
+//    — the count of branch actions that are pending OR in-progress — not the pending
+//    count alone. This is the crux of the fix. The instant a worker claims a branch it
+//    transitions PENDING -> in-progress, so a pending-only gate collapses toward 0 as
+//    soon as claiming starts: the first claim drops the count enough to revert both
+//    filters to the AS defaults (concurrent_batches 1, batch_size 25), and AS's
+//    `has_maximum_concurrent_batches()` (get_claim_count 1 >= concurrent_batches 1)
+//    then blocks any further worker from claiming the still-pending branches while that
+//    first branch runs its multi-minute AI call — the fan-out drains SERIALLY. Keying
+//    off pending + in-progress keeps the ceiling raised to cover every branch still in
+//    flight, so a second/third worker CAN claim a pending branch while the first is
+//    in-progress (get_claim_count < concurrent_batches, so the AS gate lets it
+//    through). The ceiling stays open until the LAST branch leaves the in-flight set.
+//
 //    BLAST RADIUS. Both filters are process-global — Action Scheduler has no per-group
 //    concurrency knob — so a naive permanent raise would change concurrency for ALL AS
 //    workloads. To keep the blast radius bounded, BOTH callbacks are GATED on this
-//    executor's OWN branches being pending ({@see pending_branch_count()}): when zero
-//    branches are pending they pass the incoming value through UNCHANGED, so every
-//    other AS workload keeps stock behavior (concurrent_batches 1, batch_size 25). The
-//    elevated policy exists only for the span of a fan-out (seconds to a few minutes).
+//    executor's OWN branches being in flight: when zero branches are in flight they
+//    pass the incoming value through UNCHANGED, so every other AS workload keeps stock
+//    behavior (concurrent_batches 1, batch_size 25). The elevated policy exists only
+//    for the span of a fan-out (seconds to a few minutes).
 //
 //    concurrent_batches only ever RAISES (max of incoming and target) so it never
 //    lowers another plugin's already-higher ceiling. Priority 100 so it runs after
@@ -195,11 +210,11 @@ add_filter(
 	 */
 	static function ( $batches ) {
 		$incoming = is_numeric( $batches ) ? (int) $batches : 1;
-		$pending  = WP_Agent_Workflow_Action_Scheduler_Branch_Executor::pending_branch_count();
-		if ( $pending < 1 ) {
+		$inflight = WP_Agent_Workflow_Action_Scheduler_Branch_Executor::branch_inflight_count();
+		if ( $inflight < 1 ) {
 			return $incoming;
 		}
-		$target = min( $pending, WP_Agent_Workflow_Action_Scheduler_Branch_Executor::MAX_BRANCH_CONCURRENCY );
+		$target = min( $inflight, WP_Agent_Workflow_Action_Scheduler_Branch_Executor::MAX_BRANCH_CONCURRENCY );
 		// Only ever RAISE — never lower a ceiling another plugin set higher.
 		return max( $incoming, $target );
 	},
@@ -213,10 +228,10 @@ add_filter(
 	 * @return int
 	 */
 	static function ( $batch_size ) {
-		// Pin to 1 while branches are pending so each worker claims exactly one branch;
-		// otherwise pass the incoming value through so ordinary AS throughput (25) is
-		// untouched.
-		if ( WP_Agent_Workflow_Action_Scheduler_Branch_Executor::pending_branch_count() > 0 ) {
+		// Pin to 1 while branches are in flight (pending or in-progress) so each worker
+		// claims exactly one branch; otherwise pass the incoming value through so
+		// ordinary AS throughput (25) is untouched.
+		if ( WP_Agent_Workflow_Action_Scheduler_Branch_Executor::branch_inflight_count() > 0 ) {
 			return 1;
 		}
 		return is_numeric( $batch_size ) ? (int) $batch_size : 25;

--- a/tests/workflow-branch-concurrency-gate-smoke.php
+++ b/tests/workflow-branch-concurrency-gate-smoke.php
@@ -1,0 +1,277 @@
+<?php
+/**
+ * Pure-PHP smoke test for the Action Scheduler concurrency GATE that scopes the
+ * parallel branch fan-out — specifically that the gate stays OPEN while branches
+ * are IN-PROGRESS, not just while they are pending.
+ *
+ * Run with: php tests/workflow-branch-concurrency-gate-smoke.php
+ *
+ * ## What this proves (the regression this test locks down)
+ *
+ * The two filters in {@see register-workflow-branch-executor.php} raise
+ * `action_scheduler_queue_runner_concurrent_batches` to the in-flight branch
+ * count and pin `action_scheduler_queue_runner_batch_size` to 1 while a fan-out
+ * is in flight. Both gate on
+ * {@see WP_Agent_Workflow_Action_Scheduler_Branch_Executor::branch_inflight_count()}.
+ *
+ * The bug this guards against: the gate USED to key off the PENDING count alone.
+ * The instant workers claim their branches, those actions transition
+ * PENDING -> in-progress, so a pending-only count collapses toward 0 the moment
+ * claiming starts. Once it hit 0, BOTH filters reverted to the AS defaults
+ * (concurrent_batches 1, batch_size 25), and AS's has_maximum_concurrent_batches()
+ * (get_claim_count 1 >= concurrent_batches 1) then blocked any further worker from
+ * claiming the still-pending branches while the first ran its multi-minute AI
+ * call — the fan-out drained SERIALLY.
+ *
+ * The fix counts pending + in-progress, so the ceiling stays raised to cover
+ * every branch still in flight. The assertions below drive the two filters
+ * against a modeled AS action set at each phase of a fan-out and prove the
+ * ceiling stays open while branches are in-progress.
+ *
+ * This test shims Action Scheduler's QUERY api (`as_get_scheduled_actions` +
+ * `ActionScheduler_Store`) with a controllable in-memory action list, then
+ * applies the REAL filters registered by register-workflow-branch-executor.php.
+ * No WordPress, no Action Scheduler install required.
+ *
+ * @package AgentsAPI\Tests
+ */
+
+defined( 'ABSPATH' ) || define( 'ABSPATH', __DIR__ . '/' );
+
+$failures = array();
+$passes   = 0;
+
+echo "workflow-branch-concurrency-gate-smoke\n";
+
+// ── Minimal filter runtime ───────────────────────────────────────────────────
+
+$GLOBALS['__filters'] = array();
+
+if ( ! function_exists( 'add_filter' ) ) {
+	function add_filter( string $hook, callable $cb, int $priority = 10, int $accepted_args = 1 ): void {
+		unset( $accepted_args );
+		$GLOBALS['__filters'][ $hook ][ $priority ][] = $cb;
+	}
+}
+if ( ! function_exists( 'add_action' ) ) {
+	function add_action( string $hook, callable $cb, int $priority = 10, int $accepted_args = 1 ): void {
+		add_filter( $hook, $cb, $priority, $accepted_args );
+	}
+}
+if ( ! function_exists( 'apply_filters' ) ) {
+	function apply_filters( string $hook, $value, ...$args ) {
+		$cbs = $GLOBALS['__filters'][ $hook ] ?? array();
+		ksort( $cbs );
+		foreach ( $cbs as $bucket ) {
+			foreach ( $bucket as $cb ) {
+				$value = call_user_func_array( $cb, array_merge( array( $value ), $args ) );
+			}
+		}
+		return $value;
+	}
+}
+
+// ── Action Scheduler QUERY shim ──────────────────────────────────────────────
+// A controllable in-memory model of AS's action store, scoped to the branch hook.
+// The test seeds a set of branch actions each with a status and drives the real
+// gate against it. `as_get_scheduled_actions` OR-matches an array of statuses
+// exactly like AS's own DBStore (which builds `status IN (...)`), so the real
+// branch_inflight_count() query — { status: [PENDING, RUNNING] } — resolves here
+// the same way it would against a live AS install.
+
+if ( ! class_exists( '\ActionScheduler_Store' ) ) {
+	// A minimal stand-in carrying only the status constants the gate reads.
+	class ActionScheduler_Store {
+		const STATUS_PENDING  = 'pending';
+		const STATUS_RUNNING  = 'in-progress';
+		const STATUS_COMPLETE = 'complete';
+		const STATUS_FAILED   = 'failed';
+	}
+}
+
+final class AS_Query_Shim {
+	/** @var array<int,array{hook:string,status:string}> */
+	public static array $actions = array();
+
+	public static function reset(): void {
+		self::$actions = array();
+	}
+
+	/** Seed N actions on a hook with a given status. */
+	public static function add( string $hook, string $status, int $count ): void {
+		for ( $i = 0; $i < $count; $i++ ) {
+			self::$actions[] = array(
+				'hook'   => $hook,
+				'status' => $status,
+			);
+		}
+	}
+
+	/**
+	 * Model as_get_scheduled_actions( { hook, status, per_page }, 'ids' ). `status`
+	 * may be a single value or an array (OR-match), mirroring AS DBStore's
+	 * `status IN (...)`. Returns synthetic ids bounded by per_page.
+	 *
+	 * @param array<string,mixed> $query
+	 * @return array<int,int>
+	 */
+	public static function query( array $query ): array {
+		$hook     = (string) ( $query['hook'] ?? '' );
+		$statuses = $query['status'] ?? array();
+		$statuses = is_array( $statuses ) ? $statuses : array( $statuses );
+		$per_page = isset( $query['per_page'] ) ? (int) $query['per_page'] : PHP_INT_MAX;
+
+		$matched = array();
+		$id      = 0;
+		foreach ( self::$actions as $action ) {
+			++$id;
+			if ( $action['hook'] === $hook && in_array( $action['status'], $statuses, true ) ) {
+				$matched[] = $id;
+				if ( count( $matched ) >= $per_page ) {
+					break;
+				}
+			}
+		}
+		return $matched;
+	}
+}
+
+if ( ! function_exists( 'as_get_scheduled_actions' ) ) {
+	function as_get_scheduled_actions( array $query = array(), string $return_format = 'ids' ) {
+		unset( $return_format );
+		return AS_Query_Shim::query( $query );
+	}
+}
+
+function smoke_assert( $expected, $actual, string $name, array &$failures, int &$passes ): void {
+	if ( $expected === $actual ) {
+		++$passes;
+		echo "  PASS {$name}\n";
+		return;
+	}
+	$failures[] = $name;
+	echo "  FAIL {$name}\n";
+	echo '    expected: ' . var_export( $expected, true ) . "\n";
+	echo '    actual:   ' . var_export( $actual, true ) . "\n";
+}
+
+// ── Load the real executor + the real gate filters ───────────────────────────
+
+require_once __DIR__ . '/../src/Workflows/interface-wp-agent-workflow-branch-executor.php';
+require_once __DIR__ . '/../src/Workflows/class-wp-agent-workflow-action-scheduler-bridge.php';
+require_once __DIR__ . '/../src/Workflows/class-wp-agent-workflow-action-scheduler-branch-executor.php';
+require_once __DIR__ . '/../src/Workflows/register-workflow-branch-executor.php';
+
+use AgentsAPI\AI\Workflows\WP_Agent_Workflow_Action_Scheduler_Branch_Executor;
+
+$branch_hook = WP_Agent_Workflow_Action_Scheduler_Branch_Executor::BRANCH_HOOK;
+$max         = WP_Agent_Workflow_Action_Scheduler_Branch_Executor::MAX_BRANCH_CONCURRENCY;
+
+/** Apply the real concurrent_batches filter against the incoming default (AS default 1). */
+$concurrent_batches = static function (): int {
+	return (int) apply_filters( 'action_scheduler_queue_runner_concurrent_batches', 1 );
+};
+/** Apply the real batch_size filter against the incoming default (AS default 25). */
+$batch_size = static function (): int {
+	return (int) apply_filters( 'action_scheduler_queue_runner_batch_size', 25 );
+};
+
+// ═════════════════════════════════════════════════════════════════════════════
+// 1. No fan-out in flight → both filters pass through UNCHANGED (blast radius).
+// ═════════════════════════════════════════════════════════════════════════════
+
+AS_Query_Shim::reset();
+smoke_assert( 0, WP_Agent_Workflow_Action_Scheduler_Branch_Executor::branch_inflight_count(), 'inflight=0 when no branch actions exist', $failures, $passes );
+smoke_assert( 1, $concurrent_batches(), 'no fan-out: concurrent_batches passes through AS default (1)', $failures, $passes );
+smoke_assert( 25, $batch_size(), 'no fan-out: batch_size passes through AS default (25)', $failures, $passes );
+
+// ═════════════════════════════════════════════════════════════════════════════
+// 2. Fan-out just enqueued: all 4 branches PENDING, none claimed yet.
+// ═════════════════════════════════════════════════════════════════════════════
+
+AS_Query_Shim::reset();
+AS_Query_Shim::add( $branch_hook, ActionScheduler_Store::STATUS_PENDING, 4 );
+smoke_assert( 4, WP_Agent_Workflow_Action_Scheduler_Branch_Executor::branch_inflight_count(), 'inflight=4 with 4 pending branches', $failures, $passes );
+smoke_assert( 4, $concurrent_batches(), 'all pending: concurrent_batches RAISED to 4', $failures, $passes );
+smoke_assert( 1, $batch_size(), 'all pending: batch_size pinned to 1', $failures, $passes );
+
+// ═════════════════════════════════════════════════════════════════════════════
+// 3. THE REGRESSION. Claiming has started — 1 branch is IN-PROGRESS (running a
+//    multi-minute AI call), 3 still PENDING. Under the OLD pending-only gate the
+//    count here would be 3 (still fine); the killer case is when MORE than one has
+//    been claimed. Model the worst case: 3 IN-PROGRESS, only 1 PENDING left.
+//
+//    Old behavior (pending-only): inflight would read 1 → concurrent_batches
+//    collapses toward 1, and with 3 already claimed, has_maximum_concurrent_batches
+//    (get_claim_count 3 >= concurrent_batches 1) would BLOCK the 4th branch from
+//    being claimed until an in-progress one finishes → serial drain.
+//
+//    Fixed behavior (pending + in-progress): inflight reads 4 → concurrent_batches
+//    stays 4, so with 3 claimed the AS gate (3 < 4) still lets a worker claim the
+//    4th while the others run. The ceiling stays OPEN.
+// ═════════════════════════════════════════════════════════════════════════════
+
+AS_Query_Shim::reset();
+AS_Query_Shim::add( $branch_hook, ActionScheduler_Store::STATUS_RUNNING, 3 );
+AS_Query_Shim::add( $branch_hook, ActionScheduler_Store::STATUS_PENDING, 1 );
+smoke_assert( 4, WP_Agent_Workflow_Action_Scheduler_Branch_Executor::branch_inflight_count(), 'inflight=4 counts pending + in-progress (3 running + 1 pending)', $failures, $passes );
+smoke_assert( 4, $concurrent_batches(), 'REGRESSION GUARD: ceiling STAYS raised to 4 while 3 branches are in-progress (not collapsed to 1)', $failures, $passes );
+smoke_assert( 1, $batch_size(), 'REGRESSION GUARD: batch_size STAYS pinned to 1 while branches are in-progress', $failures, $passes );
+
+// The AS claim gate math the raised ceiling enables: a 4th worker CAN claim while
+// 3 are in-progress because get_claim_count (3) < concurrent_batches (4). Assert
+// the ceiling exceeds the already-claimed count so AS admits the next worker.
+$already_claimed = 3;
+smoke_assert( true, $concurrent_batches() > $already_claimed, 'AS gate math: concurrent_batches (4) > get_claim_count (3) → next worker admitted', $failures, $passes );
+
+// ═════════════════════════════════════════════════════════════════════════════
+// 4. All branches claimed, ZERO pending, all IN-PROGRESS. Under the OLD gate this
+//    was the collapse point (pending=0 → filters revert). The fix keeps them open.
+// ═════════════════════════════════════════════════════════════════════════════
+
+AS_Query_Shim::reset();
+AS_Query_Shim::add( $branch_hook, ActionScheduler_Store::STATUS_RUNNING, 4 );
+smoke_assert( 4, WP_Agent_Workflow_Action_Scheduler_Branch_Executor::branch_inflight_count(), 'inflight=4 with ALL branches in-progress, zero pending', $failures, $passes );
+smoke_assert( 4, $concurrent_batches(), 'all in-progress: ceiling STAYS raised (old pending-only gate would collapse to 1 here)', $failures, $passes );
+smoke_assert( 1, $batch_size(), 'all in-progress: batch_size STAYS pinned to 1 (old gate would revert to 25)', $failures, $passes );
+
+// ═════════════════════════════════════════════════════════════════════════════
+// 5. Cap: a pathological in-flight count is bounded by MAX_BRANCH_CONCURRENCY.
+// ═════════════════════════════════════════════════════════════════════════════
+
+AS_Query_Shim::reset();
+AS_Query_Shim::add( $branch_hook, ActionScheduler_Store::STATUS_PENDING, $max + 5 );
+AS_Query_Shim::add( $branch_hook, ActionScheduler_Store::STATUS_RUNNING, $max + 5 );
+smoke_assert( $max, $concurrent_batches(), 'cap: concurrent_batches never exceeds MAX_BRANCH_CONCURRENCY', $failures, $passes );
+
+// ═════════════════════════════════════════════════════════════════════════════
+// 6. Only-ever-RAISE: a higher incoming ceiling from another plugin is preserved.
+// ═════════════════════════════════════════════════════════════════════════════
+
+AS_Query_Shim::reset();
+AS_Query_Shim::add( $branch_hook, ActionScheduler_Store::STATUS_RUNNING, 2 );
+$raised = (int) apply_filters( 'action_scheduler_queue_runner_concurrent_batches', 6 );
+smoke_assert( 6, $raised, 'only-ever-RAISE: a higher incoming ceiling (6) is never lowered to inflight (2)', $failures, $passes );
+
+// ═════════════════════════════════════════════════════════════════════════════
+// 7. Terminal branches (complete/failed) are NOT in flight — fan-out is done.
+// ═════════════════════════════════════════════════════════════════════════════
+
+AS_Query_Shim::reset();
+AS_Query_Shim::add( $branch_hook, ActionScheduler_Store::STATUS_COMPLETE, 4 );
+smoke_assert( 0, WP_Agent_Workflow_Action_Scheduler_Branch_Executor::branch_inflight_count(), 'inflight=0 once every branch is terminal (complete)', $failures, $passes );
+smoke_assert( 1, $concurrent_batches(), 'fan-out done: concurrent_batches reverts to AS default (1)', $failures, $passes );
+smoke_assert( 25, $batch_size(), 'fan-out done: batch_size reverts to AS default (25)', $failures, $passes );
+
+// ═════════════════════════════════════════════════════════════════════════════
+// 8. Scoping: actions on a DIFFERENT hook never open the gate (blast radius).
+// ═════════════════════════════════════════════════════════════════════════════
+
+AS_Query_Shim::reset();
+AS_Query_Shim::add( 'some_other_unrelated_hook', ActionScheduler_Store::STATUS_RUNNING, 8 );
+smoke_assert( 0, WP_Agent_Workflow_Action_Scheduler_Branch_Executor::branch_inflight_count(), 'inflight=0 — unrelated AS hooks never open the branch gate', $failures, $passes );
+smoke_assert( 1, $concurrent_batches(), 'scoping: unrelated AS workload keeps stock concurrent_batches (1)', $failures, $passes );
+smoke_assert( 25, $batch_size(), 'scoping: unrelated AS workload keeps stock batch_size (25)', $failures, $passes );
+
+echo "Passed: {$passes}, Failed: " . count( $failures ) . "\n";
+exit( count( $failures ) > 0 ? 1 : 0 );


### PR DESCRIPTION
## Problem

The parallel branch fan-out is designed to run N page branches concurrently. When N branches are enqueued as Action Scheduler actions under `wp_agent_workflow_branch_run`, `register-workflow-branch-executor.php` raises `action_scheduler_queue_runner_concurrent_batches` to the branch count (capped at `MAX_BRANCH_CONCURRENCY`) and pins `batch_size` to 1, so N workers each claim ONE distinct branch (on MySQL, `stake_claim` uses `FOR UPDATE SKIP LOCKED`).

Both filters were gated on `pending_branch_count()`, which counted branch actions in status **`pending` only**.

**The race:** the instant a worker claims a branch, that action transitions `pending -> in-progress`, so the pending-only count collapses toward 0 as soon as claiming starts. Once it hit 0, both filters reverted to the Action Scheduler defaults (`concurrent_batches` 1, `batch_size` 25). Action Scheduler's `has_maximum_concurrent_batches()` (`get_claim_count() >= concurrent_batches`) then **blocked any further worker from claiming the still-pending branches** while an in-progress branch ran its multi-minute AI call. Compounded by the intentional 3600s long-branch reaper window, a single in-progress branch could hold the one claim slot for up to an hour.

**Net effect:** branches drained **serially** — one in-progress at a time, roughly the AI-call duration apart — even though the whole mechanism was built for parallel execution.

## Fix

Count the branches still **in flight** for the active fan-out — `pending + in-progress` — via a new `branch_inflight_count()` (which replaces `pending_branch_count()`), and gate both filters on it.

While branches are running, the ceiling stays raised to cover every in-flight branch, so additional workers keep claiming the pending ones (`get_claim_count() < concurrent_batches`) instead of the ceiling collapsing to 1 after the first claim. Once the last branch leaves the in-flight set the filters pass through unchanged again.

Preserved discipline (unchanged from the original design):
- **Live, never memoized** — the inflight count reads Action Scheduler live on every filter application; a request-static cache would go stale as the set drains.
- **Only ever RAISE** — `concurrent_batches` never lowers a ceiling another plugin set higher.
- **Pass-through when `inflight == 0`** — every other AS workload keeps stock behavior (`concurrent_batches` 1, `batch_size` 25); the elevated policy is scoped to `BRANCH_HOOK` only.
- **3600s reaper window untouched** — long branches legitimately run long; the fix is the concurrency gate, not the reaper.

`branch_inflight_count()` OR-matches `[STATUS_PENDING, STATUS_RUNNING]` in one `as_get_scheduled_actions()` query (AS DBStore builds `status IN (...)` — supported since Action Scheduler 3.3.0).

## Test

New `tests/workflow-branch-concurrency-gate-smoke.php` shims Action Scheduler's query API (`as_get_scheduled_actions` + `ActionScheduler_Store`) with a controllable action set and drives the **real** filters registered by `register-workflow-branch-executor.php`. It asserts, among other cases:

- **Regression guard:** with 3 branches `in-progress` and 1 `pending`, `concurrent_batches` **stays raised to 4** and `batch_size` **stays pinned to 1** — the exact case the old pending-only gate collapsed to `(1, 25)`.
- With ALL 4 branches `in-progress` and zero pending (the old collapse point), the ceiling still stays open.
- AS gate math: `concurrent_batches (4) > get_claim_count (3)` so the next worker is admitted.
- Cap at `MAX_BRANCH_CONCURRENCY`, only-ever-RAISE, pass-through when idle, terminal branches not counted, and unrelated AS hooks never open the gate.

### Results

```
$ php tests/workflow-branch-concurrency-gate-smoke.php
Passed: 21, Failed: 0

$ composer smoke        # full suite
exit 0 — 2994 PASS, 0 FAIL

$ composer phpstan      # level max
[OK] No errors
```

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Opus 4.8 via Claude Code
- **Used for:** Confirming the race by reading the executor + filter code, designing and implementing the `pending + in-progress` inflight gate, extending the documentation comments, and writing the regression test.
