### PR TITLE
fix: keep AS concurrency ceiling open for the terminal resume so a fan-out drains itself

### DIFF
--- a/src/Workflows/class-wp-agent-workflow-action-scheduler-branch-executor.php
+++ b/src/Workflows/class-wp-agent-workflow-action-scheduler-branch-executor.php
@@ -324,6 +324,64 @@ final class WP_Agent_Workflow_Action_Scheduler_Branch_Executor implements WP_Age
 	}
 
 	/**
+	 * Count the RESUME actions still IN FLIGHT — PENDING *plus* IN-PROGRESS — live,
+	 * no memoization. The terminal-reconcile companion to {@see self::branch_inflight_count()}.
+	 *
+	 * WHY THIS EXISTS — RESUME STARVATION. A parallel fan-out ends with ONE resume
+	 * action ({@see self::RESUME_HOOK}) that agents-api enqueues when the last branch
+	 * reconciles ({@see self::maybe_defer_resume()}); running it drives the suspended
+	 * run to terminal and fires the run-completed hook a caller finalizes on. The
+	 * branch-concurrency raise ({@see register-workflow-branch-executor.php}) keys off
+	 * {@see self::branch_inflight_count()} alone, which counts ONLY branch actions.
+	 * The instant the last branch completes that count hits 0 and the ceiling reverts
+	 * to the AS default (1) — but the resume action is now PENDING and DUE, and it is
+	 * NOT a branch, so nothing keeps a claim slot open for it.
+	 *
+	 * That is fine when the queue is otherwise idle. It is NOT fine when ANY claim is
+	 * still outstanding — for example a still-in-progress branch from an UNRELATED
+	 * earlier fan-out held by AS's long-branch reaper window (up to the 3600s
+	 * `action_scheduler_failure_period` this plugin sets). AS's WP-Cron runner gate,
+	 * `has_maximum_concurrent_batches()`, compares the GLOBAL claim count against the
+	 * ceiling (`get_claim_count() >= concurrent_batches`). With the ceiling back at 1
+	 * and even a single stale claim outstanding the gate stays shut, so the queue
+	 * runner claims NOTHING and the due resume sits unclaimed — the run never
+	 * finalizes — until that stale claim is finally reaped (observed: ~51 minutes).
+	 *
+	 * Counting the in-flight resume lets the concurrency filter add a slot for it
+	 * (see that filter), so the ceiling exceeds the outstanding-claim count by one and
+	 * AS's gate opens far enough for the WP-Cron runner to claim the resume even while
+	 * unrelated stale claims linger. Scoped to RESUME_HOOK so it only opens the extra
+	 * slot when one of THIS executor's own fan-outs has a resume waiting; when none
+	 * does the count is 0 and the ceiling is untouched.
+	 *
+	 * @since 0.5.0
+	 *
+	 * @return int In-flight resume-action count (pending + in-progress).
+	 */
+	public static function resume_inflight_count(): int {
+		if ( ! function_exists( 'as_get_scheduled_actions' ) || ! class_exists( '\ActionScheduler_Store' ) ) {
+			return 0;
+		}
+
+		// A run has exactly one resume action, but several runs can be in flight at
+		// once, so bound the query to MAX_BRANCH_CONCURRENCY — the same order of
+		// magnitude as the branch count. Callers only need "how many extra slots".
+		$ids = as_get_scheduled_actions(
+			array(
+				'hook'     => self::RESUME_HOOK,
+				'status'   => array(
+					\ActionScheduler_Store::STATUS_PENDING,
+					\ActionScheduler_Store::STATUS_RUNNING,
+				),
+				'per_page' => self::MAX_BRANCH_CONCURRENCY,
+			),
+			'ids'
+		);
+
+		return is_array( $ids ) ? count( $ids ) : 0;
+	}
+
+	/**
 	 * Trigger Action Scheduler's async-request queue runner: fire N CONCURRENT
 	 * loopback HTTP requests to admin-ajax.php so AS spawns N separate native-PHP
 	 * worker processes, each of which runs a queue batch. This is the mechanism that

--- a/src/Workflows/register-workflow-branch-executor.php
+++ b/src/Workflows/register-workflow-branch-executor.php
@@ -195,6 +195,24 @@ add_filter( 'action_scheduler_timeout_period', $agents_workflow_branch_reaper_wi
 //    behavior (concurrent_batches 1, batch_size 25). The elevated policy exists only
 //    for the span of a fan-out (seconds to a few minutes).
 //
+//    RESUME NEEDS A SLOT TOO — the terminal-drain gap. A fan-out ends with ONE resume
+//    action (RESUME_HOOK, enqueued when the last branch reconciles) that drives the
+//    suspended run to terminal. It is NOT a branch, so the branch-only in-flight count
+//    drops to 0 the moment the last branch completes and the ceiling reverts to the AS
+//    default of 1 — right as the resume becomes pending and DUE. When any claim is still
+//    outstanding (e.g. a still-in-progress branch from an UNRELATED earlier fan-out held
+//    by the 3600s long-branch reaper window above), AS's `has_maximum_concurrent_batches()`
+//    (get_claim_count >= concurrent_batches) then stays shut against a ceiling of 1, so
+//    the WP-Cron runner claims NOTHING and the due resume sits unclaimed — the run never
+//    finalizes — until that unrelated claim is finally reaped (observed: ~51 minutes).
+//    Adding the in-flight resume count
+//    ({@see WP_Agent_Workflow_Action_Scheduler_Branch_Executor::resume_inflight_count()})
+//    to the raise gives the resume its own slot on top of the branches: the ceiling
+//    exceeds the outstanding-claim count by one and the gate opens far enough for the
+//    runner to claim the resume even while unrelated stale claims linger. When no fan-out
+//    is active (both counts 0) the raise is inert and every other AS workload sees stock
+//    behavior.
+//
 //    concurrent_batches only ever RAISES (max of incoming and target) so it never
 //    lowers another plugin's already-higher ceiling. Priority 100 so it runs after
 //    most callers. Registered UNCONDITIONALLY (not gated on is_available()) for the
@@ -210,13 +228,31 @@ add_filter(
 	 */
 	static function ( $batches ) {
 		$incoming = is_numeric( $batches ) ? (int) $batches : 1;
-		$inflight = WP_Agent_Workflow_Action_Scheduler_Branch_Executor::branch_inflight_count();
-		if ( $inflight < 1 ) {
+		$branches = WP_Agent_Workflow_Action_Scheduler_Branch_Executor::branch_inflight_count();
+		$resumes  = WP_Agent_Workflow_Action_Scheduler_Branch_Executor::resume_inflight_count();
+		if ( $branches < 1 && $resumes < 1 ) {
 			return $incoming;
 		}
-		$target = min( $inflight, WP_Agent_Workflow_Action_Scheduler_Branch_Executor::MAX_BRANCH_CONCURRENCY );
-		// Only ever RAISE — never lower a ceiling another plugin set higher.
-		return max( $incoming, $target );
+
+		$max = WP_Agent_Workflow_Action_Scheduler_Branch_Executor::MAX_BRANCH_CONCURRENCY;
+
+		// Branch ceiling: enough slots for every in-flight branch (capped at MAX),
+		// never lowering a higher ceiling another plugin set. This is the existing
+		// parallel-branch behavior.
+		$branch_ceiling = max( $incoming, min( $branches, $max ) );
+
+		// Resume headroom is ADDITIVE on top of the branch ceiling — the resume needs
+		// a slot BEYOND the branches and beyond any UNRELATED claims that are already
+		// consuming the branch ceiling. If it merely matched the ceiling it would be
+		// starved: AS's has_maximum_concurrent_batches() compares the GLOBAL claim
+		// count against the ceiling, so a lone due resume with even one unrelated claim
+		// outstanding would sit at claim_count >= ceiling and never be admitted. Adding
+		// the resume count lifts the ceiling above the outstanding claims so the WP-Cron
+		// runner is admitted and claims the resume. Bounded (a fan-out has one resume;
+		// concurrent fan-outs are bounded by MAX) so the raise stays sane.
+		$resume_headroom = min( $resumes, $max );
+
+		return $branch_ceiling + $resume_headroom;
 	},
 	100
 );

--- a/tests/workflow-branch-concurrency-gate-smoke.php
+++ b/tests/workflow-branch-concurrency-gate-smoke.php
@@ -165,6 +165,7 @@ require_once __DIR__ . '/../src/Workflows/register-workflow-branch-executor.php'
 use AgentsAPI\AI\Workflows\WP_Agent_Workflow_Action_Scheduler_Branch_Executor;
 
 $branch_hook = WP_Agent_Workflow_Action_Scheduler_Branch_Executor::BRANCH_HOOK;
+$resume_hook = WP_Agent_Workflow_Action_Scheduler_Branch_Executor::RESUME_HOOK;
 $max         = WP_Agent_Workflow_Action_Scheduler_Branch_Executor::MAX_BRANCH_CONCURRENCY;
 
 /** Apply the real concurrent_batches filter against the incoming default (AS default 1). */
@@ -236,13 +237,14 @@ smoke_assert( 4, $concurrent_batches(), 'all in-progress: ceiling STAYS raised (
 smoke_assert( 1, $batch_size(), 'all in-progress: batch_size STAYS pinned to 1 (old gate would revert to 25)', $failures, $passes );
 
 // ═════════════════════════════════════════════════════════════════════════════
-// 5. Cap: a pathological in-flight count is bounded by MAX_BRANCH_CONCURRENCY.
+// 5. Cap: a pathological in-flight BRANCH count is bounded by MAX_BRANCH_CONCURRENCY
+//    (no resume in flight adds no headroom).
 // ═════════════════════════════════════════════════════════════════════════════
 
 AS_Query_Shim::reset();
 AS_Query_Shim::add( $branch_hook, ActionScheduler_Store::STATUS_PENDING, $max + 5 );
 AS_Query_Shim::add( $branch_hook, ActionScheduler_Store::STATUS_RUNNING, $max + 5 );
-smoke_assert( $max, $concurrent_batches(), 'cap: concurrent_batches never exceeds MAX_BRANCH_CONCURRENCY', $failures, $passes );
+smoke_assert( $max, $concurrent_batches(), 'cap: branch ceiling never exceeds MAX_BRANCH_CONCURRENCY', $failures, $passes );
 
 // ═════════════════════════════════════════════════════════════════════════════
 // 6. Only-ever-RAISE: a higher incoming ceiling from another plugin is preserved.
@@ -272,6 +274,52 @@ AS_Query_Shim::add( 'some_other_unrelated_hook', ActionScheduler_Store::STATUS_R
 smoke_assert( 0, WP_Agent_Workflow_Action_Scheduler_Branch_Executor::branch_inflight_count(), 'inflight=0 — unrelated AS hooks never open the branch gate', $failures, $passes );
 smoke_assert( 1, $concurrent_batches(), 'scoping: unrelated AS workload keeps stock concurrent_batches (1)', $failures, $passes );
 smoke_assert( 25, $batch_size(), 'scoping: unrelated AS workload keeps stock batch_size (25)', $failures, $passes );
+
+// ═════════════════════════════════════════════════════════════════════════════
+// 9. THE RESUME-STARVATION FIX. When every branch has completed, a fan-out ends
+//    with ONE resume action that drives the run to terminal. The resume is NOT a
+//    branch, so branch_inflight_count() drops to 0 — but resume_inflight_count()
+//    keeps the ceiling raised by one so the resume gets a claim slot. Without this,
+//    a lone due resume was starved whenever ANY unrelated claim lingered (observed
+//    ~51 min behind AS's long-branch reaper window).
+// ═════════════════════════════════════════════════════════════════════════════
+
+AS_Query_Shim::reset();
+AS_Query_Shim::add( $resume_hook, ActionScheduler_Store::STATUS_PENDING, 1 );
+smoke_assert( 0, WP_Agent_Workflow_Action_Scheduler_Branch_Executor::branch_inflight_count(), 'branches done: branch_inflight=0', $failures, $passes );
+smoke_assert( 1, WP_Agent_Workflow_Action_Scheduler_Branch_Executor::resume_inflight_count(), 'resume pending: resume_inflight=1', $failures, $passes );
+smoke_assert( 2, $concurrent_batches(), 'RESUME GUARD: ceiling raised to 2 (incoming default 1 + resume slot) so a due resume can win a claim', $failures, $passes );
+
+// The production starvation case, modeled exactly: the 5-page run finished (its
+// branches complete), the resume is pending and DUE, but TWO stale in-progress
+// branches from an UNRELATED earlier fan-out still hold claims (reaper window).
+// get_claim_count() (global) = 2; the OLD ceiling (branch_inflight only) was also 2
+// (those two stale in-progress branches), so has_maximum_concurrent_batches
+// (2 >= 2) stayed shut and the resume was stranded. With the resume counted, the
+// ceiling is 3, so 2 (claimed) < 3 → AS admits the runner and the resume drains.
+AS_Query_Shim::reset();
+AS_Query_Shim::add( $branch_hook, ActionScheduler_Store::STATUS_RUNNING, 2 ); // stale unrelated branches holding claims
+AS_Query_Shim::add( $resume_hook, ActionScheduler_Store::STATUS_PENDING, 1 ); // our due, stranded resume
+$stale_claims = 2;
+smoke_assert( 3, $concurrent_batches(), 'STARVATION REPRO: ceiling = 2 stale branches + 1 resume slot = 3', $failures, $passes );
+smoke_assert( true, $concurrent_batches() > $stale_claims, 'STARVATION FIX: ceiling (3) > global claim count (2) → AS gate opens, resume claimable', $failures, $passes );
+
+// A resume already IN-PROGRESS also counts (its own worker holds the slot); it must
+// not collapse the ceiling mid-drain.
+AS_Query_Shim::reset();
+AS_Query_Shim::add( $resume_hook, ActionScheduler_Store::STATUS_RUNNING, 1 );
+smoke_assert( 1, WP_Agent_Workflow_Action_Scheduler_Branch_Executor::resume_inflight_count(), 'resume in-progress also counts as in flight', $failures, $passes );
+
+// Scoping: a resume in flight does NOT pin batch_size (that gate is branch-only —
+// the resume is a single quick reconcile action, not one of N parallel branches).
+AS_Query_Shim::reset();
+AS_Query_Shim::add( $resume_hook, ActionScheduler_Store::STATUS_PENDING, 1 );
+smoke_assert( 25, $batch_size(), 'resume-only: batch_size stays at AS default (resume is not a fanned-out branch)', $failures, $passes );
+
+// No resume, no branches → resume slot never opens (blast radius).
+AS_Query_Shim::reset();
+smoke_assert( 0, WP_Agent_Workflow_Action_Scheduler_Branch_Executor::resume_inflight_count(), 'no fan-out: resume_inflight=0', $failures, $passes );
+smoke_assert( 1, $concurrent_batches(), 'no fan-out: no resume slot added, stock ceiling (1)', $failures, $passes );
 
 echo "Passed: {$passes}, Failed: " . count( $failures ) . "\n";
 exit( count( $failures ) > 0 ? 1 : 0 );


### PR DESCRIPTION
## Problem

A parallel workflow fan-out ends with **one** resume action (`RESUME_HOOK` = `wp_agent_workflow_run_resume`) that reconciles the completed branches, drives the suspended run to terminal, and fires the run-completed hook a caller finalizes on (e.g. Site Forge assembling its multi-page bundle).

The Action Scheduler concurrency raise that lets branches run in parallel keys off `branch_inflight_count()` alone, which counts **only** branch actions. The instant the last branch completes, that count hits 0 and the ceiling reverts to the AS default of `1` — exactly when the resume becomes pending and DUE.

That is fine on an idle queue. It is **not** fine when any unrelated claim is still outstanding, because AS's `has_maximum_concurrent_batches()` gate compares the **global** claim count against the ceiling:

```
get_claim_count() >= concurrent_batches   // ceiling back at 1 → gate SHUT on any 1 claim
```

The most common trigger is a still-in-progress branch from an **earlier** fan-out held by the 3600s long-branch reaper window this plugin itself sets (`action_scheduler_failure_period`). With the ceiling at 1 and even one such stale claim outstanding, the WP-Cron / heartbeat queue runner claims nothing, and the due resume sits unclaimed — **the run never finalizes** — until that unrelated claim is finally reaped.

## Live evidence (studio-native MySQL runtime)

A 5-page Site Forge generation: all 5 branches completed in parallel and the resume (`action_id=304`) became due at `04:10:33`. Two stale in-progress branches (`293`, `296`) from an earlier failed run each held a claim for the full ~3600s reaper window. `get_claim_count()` = 2 while the (branch-only) ceiling was also 2, so `2 >= 2` kept the gate shut.

Action 304 finally ran at `05:01:56` — the **exact second** the reaper failed the last stale branch (296) and released its claim — **~51 minutes late**. Claim-hold durations confirm the window: branch 293 held its claim 3605s, branch 296 held 3648s.

The completion hook + finalization then worked correctly; the only defect is the resume being **starved of a claim slot** by the concurrency gate.

## Fix

- Add `resume_inflight_count()` — pending + in-progress `RESUME_HOOK` actions (mirrors `branch_inflight_count()`).
- Make the `action_scheduler_queue_runner_concurrent_batches` filter add the resume count as **additive headroom** on top of the branch ceiling. A pending resume lifts the ceiling one above the outstanding-claim count, so AS admits the queue runner and the resume is claimed even while unrelated stale claims linger.

Scoped to `RESUME_HOOK` and inert when no fan-out is active, so all other AS workloads keep stock behavior (`concurrent_batches` 1, `batch_size` 25). `batch_size` is intentionally **not** pinned for a lone resume (it is a single quick reconcile action, not one of N parallel branches).

Modeled live against the exact production window:

| | ceiling | global claims | AS gate |
|---|---|---|---|
| pre-fix | 2 | 2 | **SHUT** (resume stranded) |
| post-fix | 3 | 2 | **OPEN** (resume drains) |

## Tests

`tests/workflow-branch-concurrency-gate-smoke.php` extended with the resume-starvation cases (now **30 assertions**, all green), including a direct model of the production scenario (2 stale branch claims + 1 pending resume). Full workflow smoke suite green; PHPStan clean; downstream Site Forge smoke tests (225 assertions) unaffected.

Deployed to the local studio-native MySQL runtime and confirmed live: with a pending resume, `resume_inflight_count() = 1`, ceiling raises to 2, and the WP-Cron gate reports OPEN.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Opus 4.8 via Claude Code
- **Used for:** Root-cause investigation against the live runtime, the fix, and smoke-test coverage.
