### PR TITLE
Handle HybridStore missing group claims in scoped drain

### DIFF
--- a/src/Workflows/class-wp-agent-workflow-scoped-drain.php
+++ b/src/Workflows/class-wp-agent-workflow-scoped-drain.php
@@ -356,8 +356,10 @@ final class WP_Agent_Workflow_Scoped_Drain {
 			$this->reset_stale_timeouts( $store );
 			// stake_claim( $max, $before_date, $hooks, $group ). Claiming over the
 			// scoped hooks + group means we only ever run THIS caller's scope — never
-			// an unrelated AS workload sharing the queue.
-			$claim = $store->stake_claim( $batch_size, null, $hooks, $group );
+			// an unrelated AS workload sharing the queue. HybridStore can transiently
+			// throw "group does not exist" while actions for that group are readable;
+			// in that case retry hook-scoped only rather than failing the foreground pump.
+			$claim = $this->stake_claim( $store, $batch_size, $hooks, $group );
 		} catch ( \Throwable $throwable ) {
 			unset( $throwable );
 			return array(
@@ -406,6 +408,29 @@ final class WP_Agent_Workflow_Scoped_Drain {
 			'warnings'    => $warnings,
 			'stop_reason' => $stop_reason,
 		);
+	}
+
+	/**
+	 * Stake a scoped claim, falling back to hook-only scope when HybridStore cannot
+	 * resolve an otherwise-readable group.
+	 *
+	 * @since 0.5.2
+	 *
+	 * @param object            $store      Action Scheduler store.
+	 * @param int               $batch_size Maximum actions to claim.
+	 * @param array<int,string> $hooks      Hook scope.
+	 * @param string            $group      Group scope.
+	 * @return object Action Scheduler claim.
+	 */
+	private function stake_claim( object $store, int $batch_size, array $hooks, string $group ): object {
+		try {
+			return $store->stake_claim( $batch_size, null, $hooks, $group );
+		} catch ( \InvalidArgumentException $error ) {
+			if ( '' === $group || false === stripos( $error->getMessage(), 'group' ) ) {
+				throw $error;
+			}
+			return $store->stake_claim( $batch_size, null, $hooks, '' );
+		}
 	}
 
 	/**

--- a/src/Workflows/class-wp-agent-workflow-scoped-drain.php
+++ b/src/Workflows/class-wp-agent-workflow-scoped-drain.php
@@ -345,6 +345,7 @@ final class WP_Agent_Workflow_Scoped_Drain {
 	 * @return array{processed:int,warnings:int,stop_reason:string} Batch result.
 	 */
 	private function run_batch( int $batch_size, array $hooks, string $group, float $deadline_at, string $execution_context ): array {
+		/** @var \ActionScheduler_Store $store */
 		$store       = \ActionScheduler_Store::instance();
 		$runner      = \ActionScheduler::runner();
 		$processed   = 0;
@@ -416,13 +417,13 @@ final class WP_Agent_Workflow_Scoped_Drain {
 	 *
 	 * @since 0.5.2
 	 *
-	 * @param object            $store      Action Scheduler store.
+	 * @param \ActionScheduler_Store $store Action Scheduler store.
 	 * @param int               $batch_size Maximum actions to claim.
 	 * @param array<int,string> $hooks      Hook scope.
 	 * @param string            $group      Group scope.
-	 * @return object Action Scheduler claim.
+	 * @return \ActionScheduler_ActionClaim Action Scheduler claim.
 	 */
-	private function stake_claim( object $store, int $batch_size, array $hooks, string $group ): object {
+	private function stake_claim( \ActionScheduler_Store $store, int $batch_size, array $hooks, string $group ): \ActionScheduler_ActionClaim {
 		try {
 			return $store->stake_claim( $batch_size, null, $hooks, $group );
 		} catch ( \InvalidArgumentException $error ) {


### PR DESCRIPTION
## Summary
- Retry scoped Action Scheduler claims without the group only when HybridStore throws a missing-group InvalidArgumentException.
- Preserve hook scoping, so workflow branch/resume drains remain limited to the Agents API hooks.
- Keeps normal group-scoped claims unchanged on stores that support them.

## Root cause
Live WP Cloud uses ActionScheduler_HybridStore. During foreground drain proof, branch actions were readable under the agents-api group, but stake_claim(..., hooks, agents-api) threw “The group agents-api does not exist”, so the scoped drain stopped with warning before processing pending branch actions.

## Verification
- php -l src/Workflows/class-wp-agent-workflow-scoped-drain.php
- php tests/workflow-scoped-drain-smoke.php
- php tests/workflow-parallel-async-smoke.php

## Related
- Follow-up for chubes4/wp-build#1028 / chubes4/wp-build#962.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** GPT-5.5 via opencode
- **Used for:** Interpreted live WP Cloud Action Scheduler evidence, implemented the HybridStore fallback, and ran focused verification.