### PR TITLE
feat: safe-by-default tool curation — write-capable tools opt-in for autonomous principals

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,6 +46,7 @@
       "php tests/tool-executor-registry-smoke.php",
       "php tests/tool-result-error-type-smoke.php",
       "php tests/runtime-tool-policy-smoke.php",
+      "php tests/write-capable-default-smoke.php",
       "php tests/runtime-tool-lifecycle-abilities-smoke.php",
       "php tests/tool-tier-resolver-smoke.php",
       "php tests/action-policy-resolver-smoke.php",

--- a/src/Tools/class-wp-agent-tool-policy-filter.php
+++ b/src/Tools/class-wp-agent-tool-policy-filter.php
@@ -186,6 +186,22 @@ if ( ! class_exists( 'WP_Agent_Tool_Policy_Filter' ) ) {
 		}
 
 		/**
+		 * Default write-capable category slugs.
+		 *
+		 * Generic classification vocabulary — not consumer tool names. The
+		 * substrate classifies by declared nature (the `write`/`mutating` tool
+		 * flag) or by membership in one of these generic category slugs.
+		 * Consumers and Core can extend or replace this set via the
+		 * `agents_api_write_capable_categories` filter.
+		 */
+		private const DEFAULT_WRITE_CAPABLE_CATEGORIES = array(
+			'write',
+			'publishing',
+			'mutating',
+			'destructive',
+		);
+
+		/**
 		 * Whether a declaration represents a caller-provided runtime tool.
 		 *
 		 * @param array<string, mixed> $tool Tool definition.
@@ -194,6 +210,97 @@ if ( ! class_exists( 'WP_Agent_Tool_Policy_Filter' ) ) {
 		public function is_runtime_tool( array $tool ): bool {
 			return true === ( $tool['runtime_tool'] ?? false )
 				|| 'client' === ( $tool['executor'] ?? null );
+		}
+
+		/**
+		 * Return the filterable set of write-capable category slugs.
+		 *
+		 * The built-in list is intentionally conservative and generic. Extend
+		 * it through the `agents_api_write_capable_categories` filter rather
+		 * than hardcoding consumer vocabulary in the substrate.
+		 *
+		 * @param array<string, mixed> $context Runtime context.
+		 * @return string[] Write-capable category slugs.
+		 */
+		public function write_capable_categories( array $context = array() ): array {
+			$categories = self::DEFAULT_WRITE_CAPABLE_CATEGORIES;
+
+			if ( function_exists( 'apply_filters' ) ) {
+				$filtered = apply_filters( 'agents_api_write_capable_categories', $categories, $context, $this );
+				if ( is_array( $filtered ) ) {
+					$categories = $filtered;
+				}
+			}
+
+			return $this->string_list( $categories );
+		}
+
+		/**
+		 * Whether a tool declaration is classified as write-capable.
+		 *
+		 * A tool is write-capable when it declares a `write` or `mutating`
+		 * flag set to true (the layer-pure path — the tool declares its own
+		 * nature), OR when one of its categories matches a write-capable
+		 * category slug.
+		 *
+		 * @param array<string, mixed> $tool        Tool definition.
+		 * @param string[]             $categories  Write-capable category slugs.
+		 * @return bool Whether the tool is write-capable.
+		 */
+		public function is_write_capable_tool( array $tool, array $categories = array() ): bool {
+			if ( true === ( $tool['write'] ?? false ) || true === ( $tool['mutating'] ?? false ) ) {
+				return true;
+			}
+
+			return $this->tool_matches_categories( $tool, $this->string_list( $categories ) );
+		}
+
+		/**
+		 * Exclude write-capable tools unless explicitly opted in or preserved.
+		 *
+		 * Applied only in non-interactive runtime modes as a safe default.
+		 * Read-only tools, mandatory plumbing, and explicitly opted-in tools
+		 * are unaffected.
+		 *
+		 * @param array<string, array<string, mixed>> $tools              Tool definitions keyed by tool name.
+		 * @param string[]            $allowed_tools      Tool names explicitly allowed.
+		 * @param string[]            $allowed_categories Tool categories explicitly allowed.
+		 * @param string[]            $write_categories   Write-capable category slugs.
+		 * @param callable|null       $preserve_tool      Optional callback for mandatory tools.
+		 * @return array<string, array<string, mixed>> Filtered tools.
+		 */
+		public function filter_write_capable_by_policy_opt_in( array $tools, array $allowed_tools, array $allowed_categories, array $write_categories, ?callable $preserve_tool = null ): array {
+			$allowed_tools      = $this->string_list( $allowed_tools );
+			$allowed_categories = $this->string_list( $allowed_categories );
+			$write_categories   = $this->string_list( $write_categories );
+
+			if ( empty( $write_categories ) ) {
+				return $tools;
+			}
+
+			$filtered = array();
+			foreach ( $tools as $name => $tool ) {
+				if ( ! $this->is_write_capable_tool( $tool, $write_categories ) ) {
+					$filtered[ $name ] = $tool;
+					continue;
+				}
+
+				if ( in_array( $name, $allowed_tools, true ) ) {
+					$filtered[ $name ] = $tool;
+					continue;
+				}
+
+				if ( $this->tool_matches_categories( $tool, $allowed_categories ) ) {
+					$filtered[ $name ] = $tool;
+					continue;
+				}
+
+				if ( $preserve_tool && $preserve_tool( $tool, $name ) ) {
+					$filtered[ $name ] = $tool;
+				}
+			}
+
+			return $filtered;
 		}
 
 		/**

--- a/src/Tools/class-wp-agent-tool-policy-filter.php
+++ b/src/Tools/class-wp-agent-tool-policy-filter.php
@@ -258,9 +258,12 @@ if ( ! class_exists( 'WP_Agent_Tool_Policy_Filter' ) ) {
 		/**
 		 * Exclude write-capable tools unless explicitly opted in or preserved.
 		 *
-		 * Applied only in non-interactive runtime modes as a safe default.
-		 * Read-only tools, mandatory plumbing, and explicitly opted-in tools
-		 * are unaffected.
+		 * Applied only for autonomous principals (no human in the loop) as a
+		 * tool-surface CURATION default — see
+		 * {@see WP_Agent_Tool_Policy::is_autonomous_principal_context()}.
+		 * This is defense-in-depth, NOT the enforcement boundary; capability
+		 * enforcement is tracked in #412. Read-only tools, mandatory
+		 * plumbing, and explicitly opted-in tools are unaffected.
 		 *
 		 * @param array<string, array<string, mixed>> $tools              Tool definitions keyed by tool name.
 		 * @param string[]            $allowed_tools      Tool names explicitly allowed.

--- a/src/Tools/class-wp-agent-tool-policy.php
+++ b/src/Tools/class-wp-agent-tool-policy.php
@@ -19,29 +19,17 @@ if ( ! class_exists( 'WP_Agent_Tool_Policy' ) ) {
 		/**
 		 * Canonical interactive runtime mode.
 		 *
-		 * The substrate's OWN interactive vocabulary. The tool policy treats
-		 * any context carrying `interactive => true` OR one of the recognized
-		 * interactive mode markers as a human-in-the-loop flow; every other
-		 * value is non-interactive. See {@see INTERACTIVE_MODES}.
+		 * Default value for the generic tool `mode` filter
+		 * ({@see WP_Agent_Tool_Policy_Filter::filter_by_mode()}), which lets
+		 * tools declare the modes they are available in. This is a
+		 * substrate-native interactive surface and is intentionally kept.
+		 *
+		 * NOTE: The write-capable curation gate does NOT key off this mode.
+		 * It keys off the execution principal's autonomy instead — see
+		 * {@see is_autonomous_principal_context()}. Mode-name coupling was
+		 * removed from the gate so the substrate names no consumer modes.
 		 */
 		public const RUNTIME_CHAT = 'chat';
-
-		/**
-		 * Substrate-recognized interactive runtime mode markers.
-		 *
-		 * This is the substrate's complete interactive vocabulary. It is
-		 * intentionally NOT a list of automation/non-interactive mode names:
-		 * the substrate is mode-name-neutral and never names consumer
-		 * product modes (pipeline, system, editor, ...). A context is
-		 * non-interactive when it carries no recognized interactive signal,
-		 * so the write-capable safe default applies without the substrate
-		 * having to enumerate the consumer's automation modes.
-		 *
-		 * Consumers keep their own product-shaped mode vocabulary and map
-		 * onto this axis at the call site, either by setting the explicit
-		 * `interactive` flag or by passing one of these mode markers.
-		 */
-		private const INTERACTIVE_MODES = array( self::RUNTIME_CHAT, 'interactive', 'rest' );
 
 		/**
 		 * @var WP_Agent_Tool_Policy_Filter
@@ -118,7 +106,7 @@ if ( ! class_exists( 'WP_Agent_Tool_Policy' ) ) {
 				$preserve_tool
 			);
 
-			if ( $this->is_non_interactive_context( $context ) && ! $this->allows_ambient_write_tools( $context, $policies ) ) {
+			if ( $this->is_autonomous_principal_context( $context ) && ! $this->allows_ambient_write_tools( $context, $policies ) ) {
 				$tools = $this->filter->filter_write_capable_by_policy_opt_in(
 					$tools,
 					$runtime_opt_in['tools'],
@@ -269,6 +257,34 @@ if ( ! class_exists( 'WP_Agent_Tool_Policy' ) ) {
 		}
 
 		/**
+		 * Convert scalar/Stringable input to a non-negative integer.
+		 *
+		 * @param mixed $value Raw value.
+		 * @return int Integer value (0 for non-stringable/negative input).
+		 */
+		private function int_value( $value ): int {
+			if ( is_int( $value ) ) {
+				return $value < 0 ? 0 : $value;
+			}
+
+			if ( is_bool( $value ) ) {
+				return $value ? 1 : 0;
+			}
+
+			if ( is_float( $value ) ) {
+				return $value > 0 ? (int) $value : 0;
+			}
+
+			if ( is_string( $value ) || $value instanceof Stringable ) {
+				$int = (int) (string) $value;
+
+				return $int < 0 ? 0 : $int;
+			}
+
+			return 0;
+		}
+
+		/**
 		 * Keep only string-keyed entries from a policy map.
 		 *
 		 * @param array<mixed,mixed> $values Raw map.
@@ -342,37 +358,99 @@ if ( ! class_exists( 'WP_Agent_Tool_Policy' ) ) {
 		}
 
 		/**
-		 * Whether the runtime context is non-interactive (no human in the loop).
+		 * Whether the runtime context is driven by an autonomous principal.
 		 *
-		 * The substrate models only the interactive-vs-non-interactive axis.
-		 * It never enumerates consumer-specific automation mode names. A
-		 * context is interactive when it sets the explicit `interactive` flag
-		 * to true OR carries a mode the substrate recognizes as interactive
-		 * ({@see INTERACTIVE_MODES}) — mirroring the consent policy's
-		 * interactive detection. Anything else is non-interactive, so the
-		 * write-capable safe default applies. Consumers keep their own
-		 * product-shaped mode vocabulary and map onto this axis at the call
-		 * site.
+		 * TOOL-SURFACE CURATION (defense-in-depth), NOT the enforcement
+		 * boundary. This gate only decides whether write-capable tools are
+		 * *offered* to the model. It reduces prompt surface and stops an
+		 * autonomous agent from even trying a write tool. The actual
+		 * security boundary is capability-ceiling ENFORCEMENT at
+		 * ability/tool execution — tracked in #412. Consumers must not
+		 * treat this listing gate as authorization.
+		 *
+		 * Autonomy is read from the execution principal — which the
+		 * substrate already models precisely — instead of a mode/interactive
+		 * string. The substrate therefore names no consumer modes here. A
+		 * principal is autonomous when EITHER:
+		 *
+		 *   - its `auth_source` is an automation source
+		 *     (`system` / `runtime` / `agent_token`), OR
+		 *   - it has no human backing it (`acting_user_id` === 0).
+		 *
+		 * The principal is resolved from, in order: a `principal` entry on
+		 * the context (a {@see \AgentsAPI\AI\WP_Agent_Execution_Principal}
+		 * instance or its array shape), or flat `auth_source` /
+		 * `acting_user_id` fields on the context root. When no principal
+		 * information is present at all, the gate falls back SAFE: autonomy
+		 * is assumed and the gate engages. Prefer the principal at the call
+		 * site; the fallback exists so an unannotated context cannot
+		 * silently expose write tools.
 		 *
 		 * @param array<string, mixed> $context Runtime context.
-		 * @return bool Whether the context is non-interactive.
+		 * @return bool Whether the principal is autonomous (gate engages).
 		 */
-		private function is_non_interactive_context( array $context ): bool {
-			if ( true === ( $context['interactive'] ?? null ) ) {
-				return false;
+		private function is_autonomous_principal_context( array $context ): bool {
+			$signals = $this->principal_autonomy_signals( $context );
+
+			if ( ! $signals['present'] ) {
+				return true;
 			}
 
-			$mode = strtolower( $this->string_value( $context['mode'] ?? '' ) );
+			if ( 0 === $signals['acting_user_id'] ) {
+				return true;
+			}
 
-			return '' === $mode || ! in_array( $mode, self::INTERACTIVE_MODES, true );
+			return in_array( $signals['auth_source'], array( 'system', 'runtime', 'agent_token' ), true );
+		}
+
+		/**
+		 * Resolve principal autonomy signals from the runtime context.
+		 *
+		 * @param array<string, mixed> $context Runtime context.
+		 * @return array{auth_source: string, acting_user_id: int, present: bool} Resolved signals.
+		 */
+		private function principal_autonomy_signals( array $context ): array {
+			$principal = $context['principal'] ?? null;
+
+			if ( $principal instanceof AgentsAPI\AI\WP_Agent_Execution_Principal ) {
+				return array(
+					'auth_source'    => $principal->auth_source,
+					'acting_user_id' => $principal->acting_user_id,
+					'present'        => true,
+				);
+			}
+
+			if ( is_array( $principal ) && ( array_key_exists( 'auth_source', $principal ) || array_key_exists( 'acting_user_id', $principal ) ) ) {
+				return array(
+					'auth_source'    => $this->string_value( $principal['auth_source'] ?? '' ),
+					'acting_user_id' => $this->int_value( $principal['acting_user_id'] ?? 0 ),
+					'present'        => true,
+				);
+			}
+
+			if ( array_key_exists( 'auth_source', $context ) || array_key_exists( 'acting_user_id', $context ) ) {
+				return array(
+					'auth_source'    => $this->string_value( $context['auth_source'] ?? '' ),
+					'acting_user_id' => $this->int_value( $context['acting_user_id'] ?? 0 ),
+					'present'        => true,
+				);
+			}
+
+			return array(
+				'auth_source'    => '',
+				'acting_user_id' => 0,
+				'present'        => false,
+			);
 		}
 
 		/**
 		 * Whether the context or any policy fragment opts in to ambient write tools.
 		 *
-		 * When true, the write-capable safe-default gate is skipped entirely
+		 * When true, the write-capable curation gate is skipped entirely
 		 * for this resolution. This is the explicit escape hatch for consumers
-		 * that intentionally want ambient write tools in a non-interactive mode.
+		 * that intentionally want ambient write tools surfaced to an
+		 * autonomous principal (defense-in-depth curation only; capability
+		 * enforcement is tracked in #412).
 		 *
 		 * @param array<string, mixed>             $context  Runtime context.
 		 * @param array<int, array<string, mixed>> $policies Policy fragments.

--- a/src/Tools/class-wp-agent-tool-policy.php
+++ b/src/Tools/class-wp-agent-tool-policy.php
@@ -16,19 +16,32 @@ if ( ! class_exists( 'WP_Agent_Tool_Policy' ) ) {
 		public const MODE_ALLOW = 'allow';
 		public const MODE_DENY  = 'deny';
 
-		public const RUNTIME_CHAT     = 'chat';
-		public const RUNTIME_PIPELINE = 'pipeline';
-		public const RUNTIME_SYSTEM   = 'system';
+		/**
+		 * Canonical interactive runtime mode.
+		 *
+		 * The substrate's OWN interactive vocabulary. The tool policy treats
+		 * any context carrying `interactive => true` OR one of the recognized
+		 * interactive mode markers as a human-in-the-loop flow; every other
+		 * value is non-interactive. See {@see INTERACTIVE_MODES}.
+		 */
+		public const RUNTIME_CHAT = 'chat';
 
 		/**
-		 * Runtime modes without a human in the loop.
+		 * Substrate-recognized interactive runtime mode markers.
 		 *
-		 * In these modes, write-capable tools (declared via the `write`/
-		 * `mutating` tool flag or a write-capable category) are opt-in by
-		 * default rather than ambient. Interactive `chat` mode is excluded —
-		 * it is request-user-scoped and already access-gated.
+		 * This is the substrate's complete interactive vocabulary. It is
+		 * intentionally NOT a list of automation/non-interactive mode names:
+		 * the substrate is mode-name-neutral and never names consumer
+		 * product modes (pipeline, system, editor, ...). A context is
+		 * non-interactive when it carries no recognized interactive signal,
+		 * so the write-capable safe default applies without the substrate
+		 * having to enumerate the consumer's automation modes.
+		 *
+		 * Consumers keep their own product-shaped mode vocabulary and map
+		 * onto this axis at the call site, either by setting the explicit
+		 * `interactive` flag or by passing one of these mode markers.
 		 */
-		public const NON_INTERACTIVE_MODES = array( self::RUNTIME_PIPELINE, self::RUNTIME_SYSTEM );
+		private const INTERACTIVE_MODES = array( self::RUNTIME_CHAT, 'interactive', 'rest' );
 
 		/**
 		 * @var WP_Agent_Tool_Policy_Filter
@@ -105,7 +118,7 @@ if ( ! class_exists( 'WP_Agent_Tool_Policy' ) ) {
 				$preserve_tool
 			);
 
-			if ( $this->is_non_interactive_mode( $mode ) && ! $this->allows_ambient_write_tools( $context, $policies ) ) {
+			if ( $this->is_non_interactive_context( $context ) && ! $this->allows_ambient_write_tools( $context, $policies ) ) {
 				$tools = $this->filter->filter_write_capable_by_policy_opt_in(
 					$tools,
 					$runtime_opt_in['tools'],
@@ -329,13 +342,29 @@ if ( ! class_exists( 'WP_Agent_Tool_Policy' ) ) {
 		}
 
 		/**
-		 * Whether a runtime mode is non-interactive (no human in the loop).
+		 * Whether the runtime context is non-interactive (no human in the loop).
 		 *
-		 * @param string $mode Runtime mode.
-		 * @return bool Whether the mode is non-interactive.
+		 * The substrate models only the interactive-vs-non-interactive axis.
+		 * It never enumerates consumer-specific automation mode names. A
+		 * context is interactive when it sets the explicit `interactive` flag
+		 * to true OR carries a mode the substrate recognizes as interactive
+		 * ({@see INTERACTIVE_MODES}) — mirroring the consent policy's
+		 * interactive detection. Anything else is non-interactive, so the
+		 * write-capable safe default applies. Consumers keep their own
+		 * product-shaped mode vocabulary and map onto this axis at the call
+		 * site.
+		 *
+		 * @param array<string, mixed> $context Runtime context.
+		 * @return bool Whether the context is non-interactive.
 		 */
-		private function is_non_interactive_mode( string $mode ): bool {
-			return in_array( $mode, self::NON_INTERACTIVE_MODES, true );
+		private function is_non_interactive_context( array $context ): bool {
+			if ( true === ( $context['interactive'] ?? null ) ) {
+				return false;
+			}
+
+			$mode = strtolower( $this->string_value( $context['mode'] ?? '' ) );
+
+			return '' === $mode || ! in_array( $mode, self::INTERACTIVE_MODES, true );
 		}
 
 		/**

--- a/src/Tools/class-wp-agent-tool-policy.php
+++ b/src/Tools/class-wp-agent-tool-policy.php
@@ -21,6 +21,16 @@ if ( ! class_exists( 'WP_Agent_Tool_Policy' ) ) {
 		public const RUNTIME_SYSTEM   = 'system';
 
 		/**
+		 * Runtime modes without a human in the loop.
+		 *
+		 * In these modes, write-capable tools (declared via the `write`/
+		 * `mutating` tool flag or a write-capable category) are opt-in by
+		 * default rather than ambient. Interactive `chat` mode is excluded —
+		 * it is request-user-scoped and already access-gated.
+		 */
+		public const NON_INTERACTIVE_MODES = array( self::RUNTIME_PIPELINE, self::RUNTIME_SYSTEM );
+
+		/**
 		 * @var WP_Agent_Tool_Policy_Filter
 		 */
 		private WP_Agent_Tool_Policy_Filter $filter;
@@ -94,6 +104,16 @@ if ( ! class_exists( 'WP_Agent_Tool_Policy' ) ) {
 				$runtime_opt_in['categories'],
 				$preserve_tool
 			);
+
+			if ( $this->is_non_interactive_mode( $mode ) && ! $this->allows_ambient_write_tools( $context, $policies ) ) {
+				$tools = $this->filter->filter_write_capable_by_policy_opt_in(
+					$tools,
+					$runtime_opt_in['tools'],
+					$runtime_opt_in['categories'],
+					$this->filter->write_capable_categories( $context ),
+					$preserve_tool
+				);
+			}
 
 			$deny = $this->filter->string_list( $context['deny'] ?? array() );
 			foreach ( $policies as $policy ) {
@@ -306,6 +326,41 @@ if ( ! class_exists( 'WP_Agent_Tool_Policy' ) ) {
 				'tools'      => array_values( array_unique( $allowed_tools ) ),
 				'categories' => array_values( array_unique( $allowed_categories ) ),
 			);
+		}
+
+		/**
+		 * Whether a runtime mode is non-interactive (no human in the loop).
+		 *
+		 * @param string $mode Runtime mode.
+		 * @return bool Whether the mode is non-interactive.
+		 */
+		private function is_non_interactive_mode( string $mode ): bool {
+			return in_array( $mode, self::NON_INTERACTIVE_MODES, true );
+		}
+
+		/**
+		 * Whether the context or any policy fragment opts in to ambient write tools.
+		 *
+		 * When true, the write-capable safe-default gate is skipped entirely
+		 * for this resolution. This is the explicit escape hatch for consumers
+		 * that intentionally want ambient write tools in a non-interactive mode.
+		 *
+		 * @param array<string, mixed>             $context  Runtime context.
+		 * @param array<int, array<string, mixed>> $policies Policy fragments.
+		 * @return bool Whether ambient write tools are allowed.
+		 */
+		private function allows_ambient_write_tools( array $context, array $policies ): bool {
+			if ( true === ( $context['allow_write_tools'] ?? false ) ) {
+				return true;
+			}
+
+			foreach ( $policies as $policy ) {
+				if ( true === ( $policy['allow_write_tools'] ?? false ) ) {
+					return true;
+				}
+			}
+
+			return false;
 		}
 	}
 }

--- a/src/Transcripts/class-wp-agent-conversation-store.php
+++ b/src/Transcripts/class-wp-agent-conversation-store.php
@@ -57,7 +57,7 @@ interface WP_Agent_Conversation_Store {
 	 * @param int                      $user_id   WordPress user ID owning the session.
 	 * @param string                   $agent_slug Registered agent slug, or empty string for agent-less sessions.
 	 * @param array<mixed>                    $metadata  Arbitrary session metadata (JSON-serializable).
-	 * @param string                   $context   Execution mode ('chat', 'pipeline', 'system').
+	 * @param string                   $context   Execution mode. An opaque, consumer-defined string. The substrate treats `chat`/`interactive`/`rest` as interactive and every other value as non-interactive; it never enumerates consumer automation modes.
 	 * @return string Session ID (UUIDv4), or empty string on failure.
 	 */
 	public function create_session( WP_Agent_Workspace_Scope $workspace, int $user_id, string $agent_slug = '', array $metadata = array(), string $context = 'chat' ): string;

--- a/src/Transcripts/class-wp-agent-principal-conversation-store.php
+++ b/src/Transcripts/class-wp-agent-principal-conversation-store.php
@@ -34,7 +34,7 @@ interface WP_Agent_Principal_Conversation_Store extends WP_Agent_Conversation_St
 	 * @param array{type:string,key:string} $owner     Canonical principal owner.
 	 * @param string                       $agent_slug Registered agent slug, or empty string for agent-less sessions.
 	 * @param array<mixed>                        $metadata   Arbitrary session metadata (JSON-serializable).
-	 * @param string                       $context    Execution mode ('chat', 'pipeline', 'system').
+	 * @param string                       $context    Execution mode. An opaque, consumer-defined string. The substrate treats `chat`/`interactive`/`rest` as interactive and every other value as non-interactive; it never enumerates consumer automation modes.
 	 * @return string Session ID (UUIDv4), or empty string on failure.
 	 */
 	public function create_session_for_owner( WP_Agent_Workspace_Scope $workspace, array $owner, string $agent_slug = '', array $metadata = array(), string $context = 'chat' ): string;

--- a/tests/tool-policy-contracts-smoke.php
+++ b/tests/tool-policy-contracts-smoke.php
@@ -141,10 +141,18 @@ $resolved = $resolver->resolve(
 agents_api_smoke_assert_equals( array( 'client/read' ), array_keys( $resolved ), 'explicit deny removes mandatory provider tool', $failures, $passes );
 
 echo "\n[5] Runtime/client tools require explicit opt-in while non-runtime tools remain visible:\n";
+// This section exercises generic runtime-tool opt-in. It models an
+// interactive human session via a user principal so the write-capable
+// curation gate (now keyed off principal autonomy) stays out of the way:
+// the host `client/write` tool remains ambient and the assertions can
+// focus on runtime-tool opt-in behavior.
+$user_principal = AgentsAPI\AI\WP_Agent_Execution_Principal::user_session( 1, 'contracts-agent' );
+
 $resolved = $resolver->resolve(
 	$tools,
 	array(
-		'mode' => 'chat',
+		'mode'      => 'chat',
+		'principal' => $user_principal,
 	)
 );
 $resolved_names = array_keys( $resolved );
@@ -155,6 +163,7 @@ $resolved = $resolver->resolve(
 	$tools,
 	array(
 		'mode'         => 'chat',
+		'principal'    => $user_principal,
 		'agent_config' => array(
 			'tool_policy' => array(
 				'mode'  => 'allow',
@@ -171,6 +180,7 @@ $resolved = $resolver->resolve(
 	$tools,
 	array(
 		'mode'        => 'chat',
+		'principal'   => $user_principal,
 		'tool_policy' => array(
 			'mode'          => 'deny',
 			'tools'         => array( 'client/write' ),
@@ -186,6 +196,7 @@ $resolved = $resolver->resolve(
 	$tools,
 	array(
 		'mode'       => 'chat',
+		'principal'  => $user_principal,
 		'allow_only' => array( 'client/read', 'client/runtime' ),
 	)
 );
@@ -197,6 +208,7 @@ $resolved = $resolver->resolve(
 	$tools,
 	array(
 		'mode'        => 'chat',
+		'principal'   => $user_principal,
 		'tool_policy' => array(
 			'mode'               => 'deny',
 			'runtime_categories' => array( 'read' ),

--- a/tests/write-capable-default-smoke.php
+++ b/tests/write-capable-default-smoke.php
@@ -2,8 +2,15 @@
 /**
  * Pure-PHP smoke test for the safe-by-default write-capable tool policy.
  *
- * In non-interactive runtime modes (pipeline, system), write-capable tools
- * are opt-in rather than ambient. Interactive chat mode is unchanged.
+ * The substrate models only the interactive-vs-non-interactive axis. In a
+ * non-interactive context (no human in the loop), write-capable tools are
+ * opt-in rather than ambient. Interactive contexts are unchanged.
+ *
+ * The substrate never enumerates consumer automation mode names: a context
+ * is non-interactive when it carries no recognized interactive signal
+ * (`interactive => true` or a mode in chat/interactive/rest). Consumer mode
+ * strings like `pipeline`/`system` are opaque to the substrate and land as
+ * non-interactive simply because they are not interactive markers.
  *
  * Run with: php tests/write-capable-default-smoke.php
  *
@@ -22,8 +29,11 @@ echo "agents-api-write-capable-default-smoke\n";
 require_once __DIR__ . '/agents-api-smoke-helpers.php';
 agents_api_smoke_require_module();
 
-echo "\n[1] Safe-default contracts are available:\n";
-agents_api_smoke_assert_equals( true, defined( 'WP_Agent_Tool_Policy::NON_INTERACTIVE_MODES' ), 'NON_INTERACTIVE_MODES constant is declared', $failures, $passes );
+echo "\n[1] Safe-default contracts are available and the gate is mode-name neutral:\n";
+agents_api_smoke_assert_equals( false, defined( 'WP_Agent_Tool_Policy::NON_INTERACTIVE_MODES' ), 'NON_INTERACTIVE_MODES enumeration is gone (substrate is mode-name neutral)', $failures, $passes );
+agents_api_smoke_assert_equals( false, defined( 'WP_Agent_Tool_Policy::RUNTIME_PIPELINE' ), 'RUNTIME_PIPELINE consumer-mode constant is gone', $failures, $passes );
+agents_api_smoke_assert_equals( false, defined( 'WP_Agent_Tool_Policy::RUNTIME_SYSTEM' ), 'RUNTIME_SYSTEM consumer-mode constant is gone', $failures, $passes );
+agents_api_smoke_assert_equals( true, defined( 'WP_Agent_Tool_Policy::RUNTIME_CHAT' ), 'RUNTIME_CHAT interactive vocabulary is retained', $failures, $passes );
 agents_api_smoke_assert_equals( true, method_exists( 'WP_Agent_Tool_Policy_Filter', 'write_capable_categories' ), 'write_capable_categories method is available', $failures, $passes );
 agents_api_smoke_assert_equals( true, method_exists( 'WP_Agent_Tool_Policy_Filter', 'is_write_capable_tool' ), 'is_write_capable_tool method is available', $failures, $passes );
 agents_api_smoke_assert_equals( true, method_exists( 'WP_Agent_Tool_Policy_Filter', 'filter_write_capable_by_policy_opt_in' ), 'filter_write_capable_by_policy_opt_in method is available', $failures, $passes );
@@ -66,26 +76,35 @@ $tools = array(
 	),
 );
 
-echo "\n[2] Pipeline mode excludes write-capable tools by default while read tools survive:\n";
+echo "\n[2] An opaque consumer automation mode (e.g. 'pipeline') is non-interactive, so write-capable tools are gated while read tools survive:\n";
 $resolved = $resolver->resolve( $tools, array( 'mode' => 'pipeline' ) );
 $resolved_names = array_keys( $resolved );
 sort( $resolved_names );
 agents_api_smoke_assert_equals(
 	array( 'host/mandatory-fetch', 'host/read-meta' ),
 	$resolved_names,
-	'pipeline mode excludes every write-capable tool (category or flag) but keeps read and mandatory tools',
+	'an opaque consumer mode string excludes every write-capable tool (category or flag) but keeps read and mandatory tools',
 	$failures,
 	$passes
 );
 
 echo "\n[3] Declared write/mutating flag is gated exactly like category-classified tools:\n";
-agents_api_smoke_assert_equals( false, array_key_exists( 'host/write-post', $resolved ), 'write-category tool is excluded in pipeline mode', $failures, $passes );
-agents_api_smoke_assert_equals( false, array_key_exists( 'host/publish-post', $resolved ), 'publishing-category tool is excluded in pipeline mode', $failures, $passes );
-agents_api_smoke_assert_equals( false, array_key_exists( 'host/flagged-write', $resolved ), 'declared write-flag tool is excluded in pipeline mode', $failures, $passes );
-agents_api_smoke_assert_equals( false, array_key_exists( 'host/flagged-mutate', $resolved ), 'declared mutating-flag tool is excluded in pipeline mode', $failures, $passes );
+agents_api_smoke_assert_equals( false, array_key_exists( 'host/write-post', $resolved ), 'write-category tool is excluded in a non-interactive context', $failures, $passes );
+agents_api_smoke_assert_equals( false, array_key_exists( 'host/publish-post', $resolved ), 'publishing-category tool is excluded in a non-interactive context', $failures, $passes );
+agents_api_smoke_assert_equals( false, array_key_exists( 'host/flagged-write', $resolved ), 'declared write-flag tool is excluded in a non-interactive context', $failures, $passes );
+agents_api_smoke_assert_equals( false, array_key_exists( 'host/flagged-mutate', $resolved ), 'declared mutating-flag tool is excluded in a non-interactive context', $failures, $passes );
 agents_api_smoke_assert_equals( true, array_key_exists( 'host/read-meta', $resolved ), 'non-write read tool survives', $failures, $passes );
 
-echo "\n[4] Chat mode is unchanged — all tools remain visible:\n";
+echo "\n[4] The explicit interactive flag controls the gate, not the mode name:\n";
+$resolved = $resolver->resolve( $tools, array( 'mode' => 'pipeline', 'interactive' => true ) );
+agents_api_smoke_assert_equals( true, array_key_exists( 'host/write-post', $resolved ), 'interactive=true overrides an opaque automation mode and keeps write tools', $failures, $passes );
+agents_api_smoke_assert_equals( true, array_key_exists( 'host/flagged-write', $resolved ), 'interactive=true keeps declared write-flag tools', $failures, $passes );
+
+$resolved = $resolver->resolve( $tools, array( 'mode' => 'pipeline', 'interactive' => false ) );
+agents_api_smoke_assert_equals( false, array_key_exists( 'host/write-post', $resolved ), 'interactive=false keeps the gate engaged for an automation mode', $failures, $passes );
+agents_api_smoke_assert_equals( true, array_key_exists( 'host/read-meta', $resolved ), 'read tools still survive with interactive=false', $failures, $passes );
+
+echo "\n[5] Recognized interactive modes keep every tool regardless of write classification:\n";
 $resolved = $resolver->resolve( $tools, array( 'mode' => 'chat' ) );
 $resolved_names = array_keys( $resolved );
 sort( $resolved_names );
@@ -97,12 +116,31 @@ agents_api_smoke_assert_equals(
 	$passes
 );
 
-echo "\n[5] System mode also applies the safe default:\n";
-$resolved = $resolver->resolve( $tools, array( 'mode' => 'system' ) );
-agents_api_smoke_assert_equals( false, array_key_exists( 'host/write-post', $resolved ), 'write-category tool is excluded in system mode', $failures, $passes );
-agents_api_smoke_assert_equals( true, array_key_exists( 'host/read-meta', $resolved ), 'read tool survives in system mode', $failures, $passes );
+// 'interactive' and 'rest' are also substrate-recognized interactive markers.
+// Use a tool that declares them in its modes list so the mode filter does not
+// obscure the write-gate behavior under test.
+$interactive_marker_tools = array(
+	'host/write-iv' => array(
+		'name'       => 'host/write-iv',
+		'categories' => array( 'write' ),
+		'modes'      => array( 'interactive', 'rest' ),
+	),
+);
+$resolved = $resolver->resolve( $interactive_marker_tools, array( 'mode' => 'interactive' ) );
+agents_api_smoke_assert_equals( true, array_key_exists( 'host/write-iv', $resolved ), "'interactive' mode is a recognized interactive marker (write tool kept)", $failures, $passes );
 
-echo "\n[6] Explicit opt-in paths restore write tools in pipeline mode:\n";
+$resolved = $resolver->resolve( $interactive_marker_tools, array( 'mode' => 'rest' ) );
+agents_api_smoke_assert_equals( true, array_key_exists( 'host/write-iv', $resolved ), "'rest' mode is a recognized interactive marker (write tool kept)", $failures, $passes );
+
+echo "\n[6] Any other opaque consumer mode string lands as non-interactive too:\n";
+$resolved = $resolver->resolve( $tools, array( 'mode' => 'system' ) );
+agents_api_smoke_assert_equals( false, array_key_exists( 'host/write-post', $resolved ), "opaque 'system' mode is treated as non-interactive", $failures, $passes );
+agents_api_smoke_assert_equals( true, array_key_exists( 'host/read-meta', $resolved ), 'read tool survives in an opaque automation mode', $failures, $passes );
+
+$resolved = $resolver->resolve( $tools, array( 'mode' => 'editor' ) );
+agents_api_smoke_assert_equals( false, array_key_exists( 'host/write-post', $resolved ), "an unknown consumer mode like 'editor' is also non-interactive (not in the interactive set)", $failures, $passes );
+
+echo "\n[7] Explicit opt-in paths restore write tools in a non-interactive context:\n";
 $resolved = $resolver->resolve(
 	$tools,
 	array(
@@ -142,7 +180,7 @@ $resolved = $resolver->resolve(
 );
 agents_api_smoke_assert_equals( true, array_key_exists( 'host/flagged-write', $resolved ), 'runtime_tools opts a write-flag tool back in', $failures, $passes );
 
-echo "\n[7] Mandatory tools are preserved regardless of write classification:\n";
+echo "\n[8] Mandatory tools are preserved regardless of write classification:\n";
 $resolved = $resolver->resolve(
 	$tools,
 	array(
@@ -152,10 +190,10 @@ $resolved = $resolver->resolve(
 		),
 	)
 );
-agents_api_smoke_assert_equals( true, array_key_exists( 'host/publish-post', $resolved ), 'mandatory_tools preserves a write tool even in pipeline mode', $failures, $passes );
+agents_api_smoke_assert_equals( true, array_key_exists( 'host/publish-post', $resolved ), 'mandatory_tools preserves a write tool even in a non-interactive context', $failures, $passes );
 agents_api_smoke_assert_equals( true, array_key_exists( 'host/mandatory-fetch', $resolved ), 'declared-mandatory flag tool is preserved', $failures, $passes );
 
-echo "\n[8] allow_write_tools escape hatch disables the safe default:\n";
+echo "\n[9] allow_write_tools escape hatch disables the safe default:\n";
 $resolved = $resolver->resolve(
 	$tools,
 	array(
@@ -168,7 +206,7 @@ sort( $resolved_names );
 agents_api_smoke_assert_equals(
 	array( 'host/flagged-mutate', 'host/flagged-write', 'host/mandatory-fetch', 'host/publish-post', 'host/read-meta', 'host/write-post' ),
 	$resolved_names,
-	'context allow_write_tools flag restores ambient write tools in pipeline mode',
+	'context allow_write_tools flag restores ambient write tools in a non-interactive context',
 	$failures,
 	$passes
 );
@@ -186,7 +224,7 @@ $resolved = $resolver->resolve(
 );
 agents_api_smoke_assert_equals( true, array_key_exists( 'host/write-post', $resolved ), 'policy allow_write_tools flag restores ambient write tools', $failures, $passes );
 
-echo "\n[9] agents_api_write_capable_categories filter extends the classification set:\n";
+echo "\n[10] agents_api_write_capable_categories filter extends the classification set:\n";
 add_filter(
 	'agents_api_write_capable_categories',
 	static function ( array $categories ): array {
@@ -202,12 +240,12 @@ $sensitive_tools = array(
 	),
 );
 $resolved = $resolver->resolve( $sensitive_tools, array( 'mode' => 'pipeline' ) );
-agents_api_smoke_assert_equals( false, array_key_exists( 'host/sensitive-op', $resolved ), 'filtered-in write-capable category is gated in pipeline mode', $failures, $passes );
+agents_api_smoke_assert_equals( false, array_key_exists( 'host/sensitive-op', $resolved ), 'filtered-in write-capable category is gated in a non-interactive context', $failures, $passes );
 
 $resolved = $resolver->resolve( $sensitive_tools, array( 'mode' => 'chat' ) );
 agents_api_smoke_assert_equals( true, array_key_exists( 'host/sensitive-op', $resolved ), 'filtered-in category is still visible in chat mode', $failures, $passes );
 
-echo "\n[10] agents_api_resolved_tools final filter still runs after the write gate:\n";
+echo "\n[11] agents_api_resolved_tools final filter still runs after the write gate:\n";
 add_filter(
 	'agents_api_resolved_tools',
 	static function ( array $resolved_tools ) {

--- a/tests/write-capable-default-smoke.php
+++ b/tests/write-capable-default-smoke.php
@@ -1,17 +1,21 @@
 <?php
 /**
- * Pure-PHP smoke test for the safe-by-default write-capable tool policy.
+ * Pure-PHP smoke test for the safe-by-default write-capable tool curation.
  *
- * The substrate models only the interactive-vs-non-interactive axis. In a
- * non-interactive context (no human in the loop), write-capable tools are
- * opt-in rather than ambient. Interactive contexts are unchanged.
+ * The write-capable gate is TOOL-SURFACE CURATION (defense-in-depth), not
+ * the enforcement boundary. Capability-ceiling enforcement at ability/tool
+ * execution is tracked separately in #412. This listing gate only decides
+ * whether write-capable tools are *offered* to the model.
  *
- * The substrate never enumerates consumer automation mode names: a context
- * is non-interactive when it carries no recognized interactive signal
- * (`interactive => true` or a mode in chat/interactive/rest). Consumer mode
- * strings like `pipeline`/`system` are opaque to the substrate and land as
- * non-interactive simply because they are not interactive markers.
+ * The gate keys off the execution PRINCIPAL'S AUTONOMY — which the substrate
+ * already models precisely — instead of a mode/interactive string. A
+ * principal is autonomous when its `auth_source` is an automation source
+ * (system / runtime / agent_token) OR it has no human backing it
+ * (`acting_user_id` === 0). For autonomous principals, write-capable tools
+ * are opt-in rather than ambient. Human-backed principals (interactive user
+ * sessions) are unchanged.
  *
+ * The gate names NO consumer modes: a `mode` string does not move the gate.
  * Run with: php tests/write-capable-default-smoke.php
  *
  * @package AgentsAPI\Tests
@@ -29,11 +33,15 @@ echo "agents-api-write-capable-default-smoke\n";
 require_once __DIR__ . '/agents-api-smoke-helpers.php';
 agents_api_smoke_require_module();
 
-echo "\n[1] Safe-default contracts are available and the gate is mode-name neutral:\n";
+$principal_class = 'AgentsAPI\AI\WP_Agent_Execution_Principal';
+
+echo "\n[1] Curation contracts are available and the gate names no consumer modes:\n";
 agents_api_smoke_assert_equals( false, defined( 'WP_Agent_Tool_Policy::NON_INTERACTIVE_MODES' ), 'NON_INTERACTIVE_MODES enumeration is gone (substrate is mode-name neutral)', $failures, $passes );
+agents_api_smoke_assert_equals( false, defined( 'WP_Agent_Tool_Policy::INTERACTIVE_MODES' ), 'INTERACTIVE_MODES mode-marker list is gone from the write gate', $failures, $passes );
 agents_api_smoke_assert_equals( false, defined( 'WP_Agent_Tool_Policy::RUNTIME_PIPELINE' ), 'RUNTIME_PIPELINE consumer-mode constant is gone', $failures, $passes );
 agents_api_smoke_assert_equals( false, defined( 'WP_Agent_Tool_Policy::RUNTIME_SYSTEM' ), 'RUNTIME_SYSTEM consumer-mode constant is gone', $failures, $passes );
-agents_api_smoke_assert_equals( true, defined( 'WP_Agent_Tool_Policy::RUNTIME_CHAT' ), 'RUNTIME_CHAT interactive vocabulary is retained', $failures, $passes );
+agents_api_smoke_assert_equals( true, defined( 'WP_Agent_Tool_Policy::RUNTIME_CHAT' ), 'RUNTIME_CHAT is retained as the generic tool mode-filter default', $failures, $passes );
+agents_api_smoke_assert_equals( true, method_exists( 'WP_Agent_Tool_Policy', 'resolve' ), 'WP_Agent_Tool_Policy resolver is available', $failures, $passes );
 agents_api_smoke_assert_equals( true, method_exists( 'WP_Agent_Tool_Policy_Filter', 'write_capable_categories' ), 'write_capable_categories method is available', $failures, $passes );
 agents_api_smoke_assert_equals( true, method_exists( 'WP_Agent_Tool_Policy_Filter', 'is_write_capable_tool' ), 'is_write_capable_tool method is available', $failures, $passes );
 agents_api_smoke_assert_equals( true, method_exists( 'WP_Agent_Tool_Policy_Filter', 'filter_write_capable_by_policy_opt_in' ), 'filter_write_capable_by_policy_opt_in method is available', $failures, $passes );
@@ -76,75 +84,136 @@ $tools = array(
 	),
 );
 
-echo "\n[2] An opaque consumer automation mode (e.g. 'pipeline') is non-interactive, so write-capable tools are gated while read tools survive:\n";
-$resolved = $resolver->resolve( $tools, array( 'mode' => 'pipeline' ) );
+// A runtime principal (auth_source=runtime, acting_user_id=0) is autonomous.
+$autonomous_runtime = $principal_class::runtime( 'runtime-1', 'smoke-agent' );
+
+// An agent-token principal (auth_source=agent_token) is autonomous even when
+// it carries an acting user, because automation drives the loop.
+$autonomous_token = $principal_class::agent_token( 5, 'smoke-agent', 9 );
+
+// An audience principal (acting_user_id=0) is autonomous by the no-human signal.
+$autonomous_audience = $principal_class::audience( 'aud-1', 'smoke-agent' );
+
+// A user-session principal (auth_source=user, acting_user_id>0) is interactive.
+$interactive_user = $principal_class::user_session( 7, 'smoke-agent' );
+
+// An application-password principal is a human-bound session, not autonomous.
+$interactive_app_password = $principal_class::from_array(
+	array(
+		'acting_user_id'     => 7,
+		'effective_agent_id' => 'smoke-agent',
+		'auth_source'        => $principal_class::AUTH_SOURCE_APPLICATION_PASSWORD,
+		'request_context'    => $principal_class::REQUEST_CONTEXT_REST,
+	)
+);
+
+echo "\n[2] An autonomous runtime principal excludes every write-capable tool while read + mandatory survive:\n";
+$resolved       = $resolver->resolve( $tools, array( 'principal' => $autonomous_runtime ) );
 $resolved_names = array_keys( $resolved );
 sort( $resolved_names );
 agents_api_smoke_assert_equals(
 	array( 'host/mandatory-fetch', 'host/read-meta' ),
 	$resolved_names,
-	'an opaque consumer mode string excludes every write-capable tool (category or flag) but keeps read and mandatory tools',
+	'an autonomous runtime principal curates out every write-capable tool (category or flag) but keeps read and mandatory tools',
 	$failures,
 	$passes
 );
 
 echo "\n[3] Declared write/mutating flag is gated exactly like category-classified tools:\n";
-agents_api_smoke_assert_equals( false, array_key_exists( 'host/write-post', $resolved ), 'write-category tool is excluded in a non-interactive context', $failures, $passes );
-agents_api_smoke_assert_equals( false, array_key_exists( 'host/publish-post', $resolved ), 'publishing-category tool is excluded in a non-interactive context', $failures, $passes );
-agents_api_smoke_assert_equals( false, array_key_exists( 'host/flagged-write', $resolved ), 'declared write-flag tool is excluded in a non-interactive context', $failures, $passes );
-agents_api_smoke_assert_equals( false, array_key_exists( 'host/flagged-mutate', $resolved ), 'declared mutating-flag tool is excluded in a non-interactive context', $failures, $passes );
+agents_api_smoke_assert_equals( false, array_key_exists( 'host/write-post', $resolved ), 'write-category tool is excluded for an autonomous principal', $failures, $passes );
+agents_api_smoke_assert_equals( false, array_key_exists( 'host/publish-post', $resolved ), 'publishing-category tool is excluded for an autonomous principal', $failures, $passes );
+agents_api_smoke_assert_equals( false, array_key_exists( 'host/flagged-write', $resolved ), 'declared write-flag tool is excluded for an autonomous principal', $failures, $passes );
+agents_api_smoke_assert_equals( false, array_key_exists( 'host/flagged-mutate', $resolved ), 'declared mutating-flag tool is excluded for an autonomous principal', $failures, $passes );
 agents_api_smoke_assert_equals( true, array_key_exists( 'host/read-meta', $resolved ), 'non-write read tool survives', $failures, $passes );
 
-echo "\n[4] The explicit interactive flag controls the gate, not the mode name:\n";
-$resolved = $resolver->resolve( $tools, array( 'mode' => 'pipeline', 'interactive' => true ) );
-agents_api_smoke_assert_equals( true, array_key_exists( 'host/write-post', $resolved ), 'interactive=true overrides an opaque automation mode and keeps write tools', $failures, $passes );
-agents_api_smoke_assert_equals( true, array_key_exists( 'host/flagged-write', $resolved ), 'interactive=true keeps declared write-flag tools', $failures, $passes );
+echo "\n[4] Both autonomy signals engage the gate independently:\n";
+$resolved = $resolver->resolve( $tools, array( 'principal' => $autonomous_token ) );
+agents_api_smoke_assert_equals( false, array_key_exists( 'host/write-post', $resolved ), 'agent_token auth_source engages the gate even with an acting user', $failures, $passes );
 
-$resolved = $resolver->resolve( $tools, array( 'mode' => 'pipeline', 'interactive' => false ) );
-agents_api_smoke_assert_equals( false, array_key_exists( 'host/write-post', $resolved ), 'interactive=false keeps the gate engaged for an automation mode', $failures, $passes );
-agents_api_smoke_assert_equals( true, array_key_exists( 'host/read-meta', $resolved ), 'read tools still survive with interactive=false', $failures, $passes );
+$resolved = $resolver->resolve( $tools, array( 'principal' => $autonomous_audience ) );
+agents_api_smoke_assert_equals( false, array_key_exists( 'host/write-post', $resolved ), 'acting_user_id=0 engages the gate even for a non-automation auth source', $failures, $passes );
 
-echo "\n[5] Recognized interactive modes keep every tool regardless of write classification:\n";
-$resolved = $resolver->resolve( $tools, array( 'mode' => 'chat' ) );
+echo "\n[5] A human-backed principal keeps write tools regardless of the mode string:\n";
+$resolved = $resolver->resolve( $tools, array( 'principal' => $interactive_user ) );
 $resolved_names = array_keys( $resolved );
 sort( $resolved_names );
 agents_api_smoke_assert_equals(
 	array( 'host/flagged-mutate', 'host/flagged-write', 'host/mandatory-fetch', 'host/publish-post', 'host/read-meta', 'host/write-post' ),
 	$resolved_names,
-	'chat mode keeps every tool regardless of write classification',
+	'a user-session principal keeps every tool regardless of write classification',
 	$failures,
 	$passes
 );
 
-// 'interactive' and 'rest' are also substrate-recognized interactive markers.
-// Use a tool that declares them in its modes list so the mode filter does not
-// obscure the write-gate behavior under test.
-$interactive_marker_tools = array(
-	'host/write-iv' => array(
-		'name'       => 'host/write-iv',
-		'categories' => array( 'write' ),
-		'modes'      => array( 'interactive', 'rest' ),
-	),
-);
-$resolved = $resolver->resolve( $interactive_marker_tools, array( 'mode' => 'interactive' ) );
-agents_api_smoke_assert_equals( true, array_key_exists( 'host/write-iv', $resolved ), "'interactive' mode is a recognized interactive marker (write tool kept)", $failures, $passes );
-
-$resolved = $resolver->resolve( $interactive_marker_tools, array( 'mode' => 'rest' ) );
-agents_api_smoke_assert_equals( true, array_key_exists( 'host/write-iv', $resolved ), "'rest' mode is a recognized interactive marker (write tool kept)", $failures, $passes );
-
-echo "\n[6] Any other opaque consumer mode string lands as non-interactive too:\n";
-$resolved = $resolver->resolve( $tools, array( 'mode' => 'system' ) );
-agents_api_smoke_assert_equals( false, array_key_exists( 'host/write-post', $resolved ), "opaque 'system' mode is treated as non-interactive", $failures, $passes );
-agents_api_smoke_assert_equals( true, array_key_exists( 'host/read-meta', $resolved ), 'read tool survives in an opaque automation mode', $failures, $passes );
-
-$resolved = $resolver->resolve( $tools, array( 'mode' => 'editor' ) );
-agents_api_smoke_assert_equals( false, array_key_exists( 'host/write-post', $resolved ), "an unknown consumer mode like 'editor' is also non-interactive (not in the interactive set)", $failures, $passes );
-
-echo "\n[7] Explicit opt-in paths restore write tools in a non-interactive context:\n";
 $resolved = $resolver->resolve(
 	$tools,
 	array(
-		'mode'       => 'pipeline',
+		'principal' => $interactive_app_password,
+	)
+);
+agents_api_smoke_assert_equals( true, array_key_exists( 'host/write-post', $resolved ), 'an application-password (human-bound) principal keeps write tools', $failures, $passes );
+
+echo "\n[6] The gate keys off the principal, NOT the mode string (decisive contract):\n";
+$resolved = $resolver->resolve(
+	$tools,
+	array(
+		'principal' => $autonomous_runtime,
+		'mode'      => 'chat',
+	)
+);
+agents_api_smoke_assert_equals( false, array_key_exists( 'host/write-post', $resolved ), 'an autonomous principal is gated even in chat mode (mode does not rescue autonomy)', $failures, $passes );
+
+$resolved = $resolver->resolve(
+	$tools,
+	array(
+		'principal' => $interactive_user,
+		'mode'      => 'pipeline',
+	)
+);
+agents_api_smoke_assert_equals( true, array_key_exists( 'host/write-post', $resolved ), 'a user principal keeps write tools even in an opaque automation mode (mode does not create autonomy)', $failures, $passes );
+
+echo "\n[7] The principal may be supplied as an array shape or as flat context fields:\n";
+$resolved = $resolver->resolve(
+	$tools,
+	array(
+		'principal' => array(
+			'acting_user_id'     => 0,
+			'effective_agent_id' => 'smoke-agent',
+			'auth_source'        => 'system',
+			'request_context'    => 'runtime',
+		),
+	)
+);
+agents_api_smoke_assert_equals( false, array_key_exists( 'host/write-post', $resolved ), 'a system principal in array shape engages the gate', $failures, $passes );
+
+$resolved = $resolver->resolve(
+	$tools,
+	array(
+		'auth_source'    => 'runtime',
+		'acting_user_id' => 0,
+	)
+);
+agents_api_smoke_assert_equals( false, array_key_exists( 'host/write-post', $resolved ), 'flat auth_source/acting_user_id context fields engage the gate', $failures, $passes );
+
+$resolved = $resolver->resolve(
+	$tools,
+	array(
+		'auth_source'    => 'user',
+		'acting_user_id' => 7,
+	)
+);
+agents_api_smoke_assert_equals( true, array_key_exists( 'host/write-post', $resolved ), 'flat user fields keep write tools', $failures, $passes );
+
+echo "\n[8] Safe fallback: a context with no principal information is treated as autonomous:\n";
+$resolved = $resolver->resolve( $tools, array( 'mode' => 'pipeline' ) );
+agents_api_smoke_assert_equals( false, array_key_exists( 'host/write-post', $resolved ), 'a context with no principal falls back to autonomous (gate engages, safe)', $failures, $passes );
+agents_api_smoke_assert_equals( true, array_key_exists( 'host/read-meta', $resolved ), 'read tool survives in the no-principal fallback', $failures, $passes );
+
+echo "\n[9] Explicit opt-in paths restore write tools for an autonomous principal:\n";
+$resolved = $resolver->resolve(
+	$tools,
+	array(
+		'principal'  => $autonomous_runtime,
 		'allow_only' => array( 'host/write-post' ),
 	)
 );
@@ -153,7 +222,7 @@ agents_api_smoke_assert_equals( true, array_key_exists( 'host/write-post', $reso
 $resolved = $resolver->resolve(
 	$tools,
 	array(
-		'mode'        => 'pipeline',
+		'principal'          => $autonomous_runtime,
 		'runtime_categories' => array( 'publishing' ),
 	)
 );
@@ -162,7 +231,7 @@ agents_api_smoke_assert_equals( true, array_key_exists( 'host/publish-post', $re
 $resolved = $resolver->resolve(
 	$tools,
 	array(
-		'mode'        => 'pipeline',
+		'principal'   => $autonomous_runtime,
 		'tool_policy' => array(
 			'mode'  => 'allow',
 			'tools' => array( 'host/write-post' ),
@@ -174,30 +243,30 @@ agents_api_smoke_assert_equals( true, array_key_exists( 'host/write-post', $reso
 $resolved = $resolver->resolve(
 	$tools,
 	array(
-		'mode'        => 'pipeline',
-		'runtime_tools' => array( 'host/flagged-write' ),
+		'principal'      => $autonomous_runtime,
+		'runtime_tools'  => array( 'host/flagged-write' ),
 	)
 );
 agents_api_smoke_assert_equals( true, array_key_exists( 'host/flagged-write', $resolved ), 'runtime_tools opts a write-flag tool back in', $failures, $passes );
 
-echo "\n[8] Mandatory tools are preserved regardless of write classification:\n";
+echo "\n[10] Mandatory tools are preserved regardless of write classification:\n";
 $resolved = $resolver->resolve(
 	$tools,
 	array(
-		'mode'        => 'pipeline',
+		'principal'   => $autonomous_runtime,
 		'tool_policy' => array(
 			'mandatory_tools' => array( 'host/publish-post' ),
 		),
 	)
 );
-agents_api_smoke_assert_equals( true, array_key_exists( 'host/publish-post', $resolved ), 'mandatory_tools preserves a write tool even in a non-interactive context', $failures, $passes );
+agents_api_smoke_assert_equals( true, array_key_exists( 'host/publish-post', $resolved ), 'mandatory_tools preserves a write tool even for an autonomous principal', $failures, $passes );
 agents_api_smoke_assert_equals( true, array_key_exists( 'host/mandatory-fetch', $resolved ), 'declared-mandatory flag tool is preserved', $failures, $passes );
 
-echo "\n[9] allow_write_tools escape hatch disables the safe default:\n";
+echo "\n[11] allow_write_tools escape hatch disables the curation gate:\n";
 $resolved = $resolver->resolve(
 	$tools,
 	array(
-		'mode'               => 'pipeline',
+		'principal'          => $autonomous_runtime,
 		'allow_write_tools'  => true,
 	)
 );
@@ -206,7 +275,7 @@ sort( $resolved_names );
 agents_api_smoke_assert_equals(
 	array( 'host/flagged-mutate', 'host/flagged-write', 'host/mandatory-fetch', 'host/publish-post', 'host/read-meta', 'host/write-post' ),
 	$resolved_names,
-	'context allow_write_tools flag restores ambient write tools in a non-interactive context',
+	'context allow_write_tools flag restores ambient write tools for an autonomous principal',
 	$failures,
 	$passes
 );
@@ -214,7 +283,7 @@ agents_api_smoke_assert_equals(
 $resolved = $resolver->resolve(
 	$tools,
 	array(
-		'mode'        => 'pipeline',
+		'principal'    => $autonomous_runtime,
 		'agent_config' => array(
 			'tool_policy' => array(
 				'allow_write_tools' => true,
@@ -224,7 +293,7 @@ $resolved = $resolver->resolve(
 );
 agents_api_smoke_assert_equals( true, array_key_exists( 'host/write-post', $resolved ), 'policy allow_write_tools flag restores ambient write tools', $failures, $passes );
 
-echo "\n[10] agents_api_write_capable_categories filter extends the classification set:\n";
+echo "\n[12] agents_api_write_capable_categories filter extends the classification set:\n";
 add_filter(
 	'agents_api_write_capable_categories',
 	static function ( array $categories ): array {
@@ -239,13 +308,13 @@ $sensitive_tools = array(
 		'modes'      => array( 'chat', 'pipeline' ),
 	),
 );
-$resolved = $resolver->resolve( $sensitive_tools, array( 'mode' => 'pipeline' ) );
-agents_api_smoke_assert_equals( false, array_key_exists( 'host/sensitive-op', $resolved ), 'filtered-in write-capable category is gated in a non-interactive context', $failures, $passes );
+$resolved = $resolver->resolve( $sensitive_tools, array( 'principal' => $autonomous_runtime ) );
+agents_api_smoke_assert_equals( false, array_key_exists( 'host/sensitive-op', $resolved ), 'filtered-in write-capable category is gated for an autonomous principal', $failures, $passes );
 
-$resolved = $resolver->resolve( $sensitive_tools, array( 'mode' => 'chat' ) );
-agents_api_smoke_assert_equals( true, array_key_exists( 'host/sensitive-op', $resolved ), 'filtered-in category is still visible in chat mode', $failures, $passes );
+$resolved = $resolver->resolve( $sensitive_tools, array( 'principal' => $interactive_user ) );
+agents_api_smoke_assert_equals( true, array_key_exists( 'host/sensitive-op', $resolved ), 'filtered-in category is still visible for a user principal', $failures, $passes );
 
-echo "\n[11] agents_api_resolved_tools final filter still runs after the write gate:\n";
+echo "\n[13] agents_api_resolved_tools final filter still runs after the write gate:\n";
 add_filter(
 	'agents_api_resolved_tools',
 	static function ( array $resolved_tools ) {
@@ -253,7 +322,7 @@ add_filter(
 		return $resolved_tools;
 	}
 );
-$resolved = $resolver->resolve( array(), array( 'mode' => 'pipeline' ) );
+$resolved = $resolver->resolve( array(), array( 'principal' => $autonomous_runtime ) );
 agents_api_smoke_assert_equals( true, array_key_exists( 'host/filter-injected', $resolved ), 'resolved_tools final filter runs after write gate', $failures, $passes );
 
 agents_api_smoke_finish( 'Write-capable default', $failures, $passes );

--- a/tests/write-capable-default-smoke.php
+++ b/tests/write-capable-default-smoke.php
@@ -1,0 +1,221 @@
+<?php
+/**
+ * Pure-PHP smoke test for the safe-by-default write-capable tool policy.
+ *
+ * In non-interactive runtime modes (pipeline, system), write-capable tools
+ * are opt-in rather than ambient. Interactive chat mode is unchanged.
+ *
+ * Run with: php tests/write-capable-default-smoke.php
+ *
+ * @package AgentsAPI\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+$failures = array();
+$passes   = 0;
+
+echo "agents-api-write-capable-default-smoke\n";
+
+require_once __DIR__ . '/agents-api-smoke-helpers.php';
+agents_api_smoke_require_module();
+
+echo "\n[1] Safe-default contracts are available:\n";
+agents_api_smoke_assert_equals( true, defined( 'WP_Agent_Tool_Policy::NON_INTERACTIVE_MODES' ), 'NON_INTERACTIVE_MODES constant is declared', $failures, $passes );
+agents_api_smoke_assert_equals( true, method_exists( 'WP_Agent_Tool_Policy_Filter', 'write_capable_categories' ), 'write_capable_categories method is available', $failures, $passes );
+agents_api_smoke_assert_equals( true, method_exists( 'WP_Agent_Tool_Policy_Filter', 'is_write_capable_tool' ), 'is_write_capable_tool method is available', $failures, $passes );
+agents_api_smoke_assert_equals( true, method_exists( 'WP_Agent_Tool_Policy_Filter', 'filter_write_capable_by_policy_opt_in' ), 'filter_write_capable_by_policy_opt_in method is available', $failures, $passes );
+
+$resolver = new WP_Agent_Tool_Policy();
+
+$tools = array(
+	'host/read-meta'       => array(
+		'name'       => 'host/read-meta',
+		'categories' => array( 'read' ),
+		'modes'      => array( 'chat', 'pipeline', 'system' ),
+	),
+	'host/write-post'      => array(
+		'name'       => 'host/write-post',
+		'categories' => array( 'write' ),
+		'modes'      => array( 'chat', 'pipeline', 'system' ),
+	),
+	'host/publish-post'    => array(
+		'name'       => 'host/publish-post',
+		'categories' => array( 'publishing' ),
+		'modes'      => array( 'chat', 'pipeline', 'system' ),
+	),
+	'host/flagged-write'   => array(
+		'name'       => 'host/flagged-write',
+		'categories' => array( 'misc' ),
+		'modes'      => array( 'chat', 'pipeline', 'system' ),
+		'write'      => true,
+	),
+	'host/flagged-mutate'  => array(
+		'name'       => 'host/flagged-mutate',
+		'categories' => array( 'misc' ),
+		'modes'      => array( 'chat', 'pipeline', 'system' ),
+		'mutating'   => true,
+	),
+	'host/mandatory-fetch' => array(
+		'name'       => 'host/mandatory-fetch',
+		'categories' => array( 'plumbing' ),
+		'modes'      => array( 'chat', 'pipeline', 'system' ),
+		'mandatory'  => true,
+	),
+);
+
+echo "\n[2] Pipeline mode excludes write-capable tools by default while read tools survive:\n";
+$resolved = $resolver->resolve( $tools, array( 'mode' => 'pipeline' ) );
+$resolved_names = array_keys( $resolved );
+sort( $resolved_names );
+agents_api_smoke_assert_equals(
+	array( 'host/mandatory-fetch', 'host/read-meta' ),
+	$resolved_names,
+	'pipeline mode excludes every write-capable tool (category or flag) but keeps read and mandatory tools',
+	$failures,
+	$passes
+);
+
+echo "\n[3] Declared write/mutating flag is gated exactly like category-classified tools:\n";
+agents_api_smoke_assert_equals( false, array_key_exists( 'host/write-post', $resolved ), 'write-category tool is excluded in pipeline mode', $failures, $passes );
+agents_api_smoke_assert_equals( false, array_key_exists( 'host/publish-post', $resolved ), 'publishing-category tool is excluded in pipeline mode', $failures, $passes );
+agents_api_smoke_assert_equals( false, array_key_exists( 'host/flagged-write', $resolved ), 'declared write-flag tool is excluded in pipeline mode', $failures, $passes );
+agents_api_smoke_assert_equals( false, array_key_exists( 'host/flagged-mutate', $resolved ), 'declared mutating-flag tool is excluded in pipeline mode', $failures, $passes );
+agents_api_smoke_assert_equals( true, array_key_exists( 'host/read-meta', $resolved ), 'non-write read tool survives', $failures, $passes );
+
+echo "\n[4] Chat mode is unchanged — all tools remain visible:\n";
+$resolved = $resolver->resolve( $tools, array( 'mode' => 'chat' ) );
+$resolved_names = array_keys( $resolved );
+sort( $resolved_names );
+agents_api_smoke_assert_equals(
+	array( 'host/flagged-mutate', 'host/flagged-write', 'host/mandatory-fetch', 'host/publish-post', 'host/read-meta', 'host/write-post' ),
+	$resolved_names,
+	'chat mode keeps every tool regardless of write classification',
+	$failures,
+	$passes
+);
+
+echo "\n[5] System mode also applies the safe default:\n";
+$resolved = $resolver->resolve( $tools, array( 'mode' => 'system' ) );
+agents_api_smoke_assert_equals( false, array_key_exists( 'host/write-post', $resolved ), 'write-category tool is excluded in system mode', $failures, $passes );
+agents_api_smoke_assert_equals( true, array_key_exists( 'host/read-meta', $resolved ), 'read tool survives in system mode', $failures, $passes );
+
+echo "\n[6] Explicit opt-in paths restore write tools in pipeline mode:\n";
+$resolved = $resolver->resolve(
+	$tools,
+	array(
+		'mode'       => 'pipeline',
+		'allow_only' => array( 'host/write-post' ),
+	)
+);
+agents_api_smoke_assert_equals( true, array_key_exists( 'host/write-post', $resolved ), 'allow_only opts a write tool back in', $failures, $passes );
+
+$resolved = $resolver->resolve(
+	$tools,
+	array(
+		'mode'        => 'pipeline',
+		'runtime_categories' => array( 'publishing' ),
+	)
+);
+agents_api_smoke_assert_equals( true, array_key_exists( 'host/publish-post', $resolved ), 'runtime_categories opts a write-category tool back in', $failures, $passes );
+
+$resolved = $resolver->resolve(
+	$tools,
+	array(
+		'mode'        => 'pipeline',
+		'tool_policy' => array(
+			'mode'  => 'allow',
+			'tools' => array( 'host/write-post' ),
+		),
+	)
+);
+agents_api_smoke_assert_equals( true, array_key_exists( 'host/write-post', $resolved ), 'ALLOW-mode policy opts a write tool back in', $failures, $passes );
+
+$resolved = $resolver->resolve(
+	$tools,
+	array(
+		'mode'        => 'pipeline',
+		'runtime_tools' => array( 'host/flagged-write' ),
+	)
+);
+agents_api_smoke_assert_equals( true, array_key_exists( 'host/flagged-write', $resolved ), 'runtime_tools opts a write-flag tool back in', $failures, $passes );
+
+echo "\n[7] Mandatory tools are preserved regardless of write classification:\n";
+$resolved = $resolver->resolve(
+	$tools,
+	array(
+		'mode'        => 'pipeline',
+		'tool_policy' => array(
+			'mandatory_tools' => array( 'host/publish-post' ),
+		),
+	)
+);
+agents_api_smoke_assert_equals( true, array_key_exists( 'host/publish-post', $resolved ), 'mandatory_tools preserves a write tool even in pipeline mode', $failures, $passes );
+agents_api_smoke_assert_equals( true, array_key_exists( 'host/mandatory-fetch', $resolved ), 'declared-mandatory flag tool is preserved', $failures, $passes );
+
+echo "\n[8] allow_write_tools escape hatch disables the safe default:\n";
+$resolved = $resolver->resolve(
+	$tools,
+	array(
+		'mode'               => 'pipeline',
+		'allow_write_tools'  => true,
+	)
+);
+$resolved_names = array_keys( $resolved );
+sort( $resolved_names );
+agents_api_smoke_assert_equals(
+	array( 'host/flagged-mutate', 'host/flagged-write', 'host/mandatory-fetch', 'host/publish-post', 'host/read-meta', 'host/write-post' ),
+	$resolved_names,
+	'context allow_write_tools flag restores ambient write tools in pipeline mode',
+	$failures,
+	$passes
+);
+
+$resolved = $resolver->resolve(
+	$tools,
+	array(
+		'mode'        => 'pipeline',
+		'agent_config' => array(
+			'tool_policy' => array(
+				'allow_write_tools' => true,
+			),
+		),
+	)
+);
+agents_api_smoke_assert_equals( true, array_key_exists( 'host/write-post', $resolved ), 'policy allow_write_tools flag restores ambient write tools', $failures, $passes );
+
+echo "\n[9] agents_api_write_capable_categories filter extends the classification set:\n";
+add_filter(
+	'agents_api_write_capable_categories',
+	static function ( array $categories ): array {
+		$categories[] = 'sensitive';
+		return $categories;
+	}
+);
+$sensitive_tools = array(
+	'host/sensitive-op' => array(
+		'name'       => 'host/sensitive-op',
+		'categories' => array( 'sensitive' ),
+		'modes'      => array( 'chat', 'pipeline' ),
+	),
+);
+$resolved = $resolver->resolve( $sensitive_tools, array( 'mode' => 'pipeline' ) );
+agents_api_smoke_assert_equals( false, array_key_exists( 'host/sensitive-op', $resolved ), 'filtered-in write-capable category is gated in pipeline mode', $failures, $passes );
+
+$resolved = $resolver->resolve( $sensitive_tools, array( 'mode' => 'chat' ) );
+agents_api_smoke_assert_equals( true, array_key_exists( 'host/sensitive-op', $resolved ), 'filtered-in category is still visible in chat mode', $failures, $passes );
+
+echo "\n[10] agents_api_resolved_tools final filter still runs after the write gate:\n";
+add_filter(
+	'agents_api_resolved_tools',
+	static function ( array $resolved_tools ) {
+		$resolved_tools['host/filter-injected'] = array( 'name' => 'host/filter-injected' );
+		return $resolved_tools;
+	}
+);
+$resolved = $resolver->resolve( array(), array( 'mode' => 'pipeline' ) );
+agents_api_smoke_assert_equals( true, array_key_exists( 'host/filter-injected', $resolved ), 'resolved_tools final filter runs after write gate', $failures, $passes );
+
+agents_api_smoke_finish( 'Write-capable default', $failures, $passes );


### PR DESCRIPTION
## Summary

Addresses #408. Part of #412.

Makes **write-capable / mutating ability categories opt-in (not ambient)** for **autonomous principals** (no human in the loop), while leaving human-backed (interactive) principals unchanged. This is **tool-surface CURATION (defense-in-depth)** — it reduces prompt surface and stops an autonomous agent from even trying a write tool. It is **NOT the security boundary**: the real boundary is capability-ceiling ENFORCEMENT at ability/tool execution, tracked separately in **#412**.

**Production incident this prevents:** a pipeline agent silently published 224 junk posts by calling a generic publish ability it was never meant to reach. (Consumer-side emergency fix: Extra-Chill/data-machine#2853; this PR is the durable substrate curation layer.)

## Update (this push) — repositioned onto principal autonomy

The gate now keys off the **execution principal's autonomy**, which the substrate already models precisely, instead of a mode/interactive string (a weaker proxy). Per the deeper analysis in #412, the gate is also now explicitly documented as curation, not enforcement.

- **Deleted** `WP_Agent_Tool_Policy::INTERACTIVE_MODES` (the `chat`/`interactive`/`rest` mode-marker list) and the `is_non_interactive_context()` mode check entirely. The write-gate now names **zero** consumer modes.
- **Replaced** `is_non_interactive_context($context)` with `is_autonomous_principal_context($context)`, keyed off the principal.
- **Kept** `RUNTIME_CHAT = 'chat'` — it is still the default value for the **generic tool `mode` filter** (`filter_by_mode()`, a substrate-native interactive surface that lets tools declare the modes they are available in). The write-gate no longer touches it.
- **Documented** the gate as tool-surface CURATION (defense-in-depth); capability enforcement is #412.

### How autonomy is determined

A principal is **autonomous** when EITHER:

- its `auth_source` is an automation source (`system` / `runtime` / `agent_token`), **OR**
- it has no human backing it (`acting_user_id` === 0).

The principal is resolved, in order, from:

1. a `principal` entry on the context — a `WP_Agent_Execution_Principal` instance **or** its array shape (`to_array()`), **or**
2. flat `auth_source` / `acting_user_id` fields on the context root (mirrors how `WP_Agent_Action_Policy_Resolver` already reads `acting_user_id`).

When **no** principal information is present at all, the gate **falls back safe**: autonomy is assumed and the gate engages. Prefer the principal at the call site; the fallback exists so an unannotated context cannot silently expose write tools.

> The `system` / `runtime` / `agent_token` strings here are the principal's **authentication source** identifiers (substrate primitive constants on `WP_Agent_Execution_Principal::AUTH_SOURCE_*`), **not** consumer orchestration mode names. The gate contains zero consumer mode-name vocabulary.

### Why autonomy, not mode

The substrate already models who/what is driving the run via the principal. A mode string only describes the runtime surface (`chat`/`rest`/`cli`/…), not whether a human is accountable for the loop. Two examples the old mode-based gate got wrong:

- An **agent-token** principal driving an unattended loop is autonomous even though it may carry an `acting_user_id` — a mode-based gate that treats `rest` as "interactive" would surface write tools to it.
- A **user-session** principal in an opaque consumer mode is *not* autonomous — but the old gate gated them because the mode wasn't a recognized interactive marker.

Keying off autonomy fixes both. `git grep -nE "INTERACTIVE_MODES|'pipeline'|'system'|RUNTIME_PIPELINE|RUNTIME_SYSTEM|NON_INTERACTIVE" src/Tools/` now returns only the `auth_source` allow-list (`'system', 'runtime', 'agent_token'`).

## What's excluded by default (for autonomous principals)

Tools classified as **write-capable** are removed unless preserved or explicitly opted in. A tool is write-capable when **either**:

1. **It declares a per-tool flag** — `'write' => true` or `'mutating' => true` on the tool/ability-tool definition. (Layer-pure: the tool declares its own nature, the policy enforces the default. Mirrors the existing `action_policy` per-tool declaration precedent.)
2. **One of its categories matches a write-capable category** — built-in set is `['write', 'publishing', 'mutating', 'destructive']`, all generic classification vocabulary (not consumer tool names).

The substrate **never hardcodes consumer tool slugs** (e.g. `publish-wordpress`) and **never enumerates consumer mode names**. Classification is by declared nature or generic category.

## What's exempt (unchanged behavior)

| Path | Effect |
|------|--------|
| **Human-backed principal** (`auth_source` user/application_password with `acting_user_id` > 0) | Gate not applied. Request-user-scoped and already access-gated. |
| **Mandatory tools/categories** | `$preserve_tool` closure still exempts them — mandatory plumbing survives. |
| **Declared-mandatory tools** (`'mandatory' => true`) | Preserved. |
| **`allow_only`** | Names the write tool explicitly → kept. |
| **`runtime_tools`** | Names the write tool explicitly → kept. |
| **`runtime_categories`** | Category match → kept. |
| **ALLOW-mode named policy** (`mode: allow, tools: [...]`) | Named tool/category → kept. |

The gate reuses the existing `collect_runtime_tool_opt_in()` aggregate, so every opt-in path works **uniformly** — no parallel opt-in path was built.

## Escape hatches

| Mechanism | Effect |
|-----------|--------|
| Context key `'allow_write_tools' => true` | Disables the curation gate entirely for that resolution. |
| Policy fragment `'allow_write_tools' => true` | Same, via agent config / tool_policy / provider. |
| Filter `agents_api_write_capable_categories` | Extend or replace the built-in category set (Core/consumer). |

The final `agents_api_resolved_tools` filter still runs **after** the write gate, so host-level overrides compose on top.

## Where it sits in `resolve()`

```
filter_by_mode → access_checker → named policies → categories
→ allow_only → runtime opt-in → [WRITE-CAPABLE CURATION GATE] → deny → final filter
```

The gate runs after the runtime opt-in gate (so it can reuse the aggregated opt-in set) and before deny (so explicit deny always wins) and before the final filter (so hosts can still override the result).

## Smoke test

`tests/write-capable-default-smoke.php` (37 assertions) proves the gate keys off **principal autonomy**, not a mode string:

1. **Curation contracts + mode-name neutrality** → `INTERACTIVE_MODES` / `NON_INTERACTIVE_MODES` / `RUNTIME_PIPELINE` / `RUNTIME_SYSTEM` are **gone**; `RUNTIME_CHAT` retained (as the generic mode-filter default); filter methods present.
2. **Autonomous runtime principal** → every write-capable tool gated (category or flag); read + mandatory survive.
3. **Declared `write`/`mutating` flags** gated exactly like category-classified tools.
4. **Both autonomy signals independently engage the gate** → `agent_token` auth_source (even with an acting user) and `acting_user_id=0` (even for a non-automation auth source).
5. **Human-backed principals keep write tools** → user-session and application-password principals.
6. **The gate keys off the principal, NOT the mode (decisive contract)** → autonomous principal gated even in `chat` mode; user principal keeps write tools even in `pipeline` mode.
7. **Principal supplied as array shape OR flat context fields** → both supported.
8. **Safe fallback** → no principal in context → treated as autonomous (gate engages).
9. **`allow_only` / `runtime_categories` / ALLOW policy / `runtime_tools`** → write tool restored for an autonomous principal.
10. **`mandatory_tools`** → write tool preserved even for an autonomous principal.
11. **`allow_write_tools`** (context + policy) → ambient write tools restored.
12. **`agents_api_write_capable_categories` filter** → extended category gated for autonomous principal, visible for user principal.
13. **`agents_api_resolved_tools`** final filter still runs after the gate.

`tests/tool-policy-contracts-smoke.php` section [5] was updated to model an interactive user principal so the generic runtime-tool opt-in behavior stays in focus without the write curation gate interfering.

```
All 37 Write-capable default assertions passed.
```

Full suite: `composer smoke` (all existing tests still green) and `composer phpstan` (clean).

## Consumer impact: Data Machine needs zero changes

Data Machine (the primary consumer) requires **no code changes** for this repositioning. The curation gate is a **no-op for DM's tools**: every DM ability category is `datamachine-*` namespaced (`datamachine-publishing`, `datamachine-content`, …) and **no DM tool sets a `write`/`mutating` flag**. None of DM's tools match the substrate's generic write-capable set (`write`/`publishing`/`mutating`/`destructive`). DM's own pipeline write-gating (`filterPipelineWriteOptInTools`, which targets `requires_pipeline_opt_in` + `datamachine-publishing`) continues to own product-specific gating exactly as before. The substrate gate simply composes as defense-in-depth without dropping anything DM currently exposes.

When DM (or any consumer) wants the substrate to engage for an autonomous principal, it passes the execution principal into the resolver context — the substrate no longer guesses from a mode string.

## Relationship to #412

- **This PR (#411)** is **tool-list curation**: don't even *offer* write tools to an autonomous agent. Defense-in-depth only.
- **#412** is the actual enforcement boundary beneath it: enforce the capability ceiling at ability/tool execution so an autonomous principal cannot perform a write it isn't granted — even if a write tool is somehow offered or the acting user is privileged.

Shipping curation as if it were the security boundary would give Core sites a false sense of safety. This PR is explicitly scoped as curation, with enforcement tracked in #412.

## Notes

- No backward-compatibility shim is needed — `INTERACTIVE_MODES` was private and never imported by consumers; the only behavioral change is that the gate now engages on principal autonomy (with a safe no-principal fallback) instead of on a mode-string heuristic.
- The consumer-side emergency fix was Extra-Chill/data-machine#2853.
