### PR TITLE
feat: add wp_agent_can_access_agent host access filter for list/check symmetry

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -128,6 +128,7 @@
       "php tests/routine-smoke.php",
       "php tests/event-trigger-smoke.php",
       "php tests/subagents-smoke.php",
+      "php tests/access-decision-filter-smoke.php",
       "php tests/no-product-imports-smoke.php"
     ],
     "test": [

--- a/src/Auth/class-wp-agent-access.php
+++ b/src/Auth/class-wp-agent-access.php
@@ -121,6 +121,13 @@ if ( ! class_exists( 'WP_Agent_Access' ) ) {
 		/**
 		 * List registered agents accessible to a principal.
 		 *
+		 * Iterates every registered agent through the same
+		 * {@see WP_Agent_WordPress_Authorization_Policy::can_access_agent()}
+		 * decision used by the check path. This guarantees that
+		 * `agents/list-accessible-agents` and `agents/can-access-agent` can
+		 * never disagree: the list is literally the set of agents for which
+		 * the check returns true.
+		 *
 		 * @param AgentsAPI\AI\WP_Agent_Execution_Principal $principal    Execution principal.
 		 * @param string                                    $minimum_role Minimum access role.
 		 * @param array<string,mixed>                       $context      Host-owned request context.
@@ -131,29 +138,26 @@ if ( ! class_exists( 'WP_Agent_Access' ) ) {
 				return array();
 			}
 
-			$agent_ids = array();
-			$store     = self::get_store( $context );
-			if ( $store instanceof WP_Agent_Access_Store && $principal->acting_user_id > 0 ) {
-				$agent_ids = array_merge( $agent_ids, $store->get_agent_ids_for_user( $principal->acting_user_id, $minimum_role, $principal->workspace_id ) );
-			}
+			$store  = self::get_store( $context );
+			$policy = new WP_Agent_WordPress_Authorization_Policy( $store );
 
-			if ( $store instanceof WP_Agent_Principal_Access_Store ) {
-				foreach ( self::access_principals_for( $principal, $context ) as $access_principal ) {
-					$agent_ids = array_merge( $agent_ids, $store->get_agent_ids_for_principal( $access_principal, $minimum_role, $principal->workspace_id ) );
+			$agents = array();
+			$seen   = array();
+
+			$registered = function_exists( 'wp_get_agents' ) ? wp_get_agents() : array();
+			foreach ( $registered as $agent ) {
+				$slug = sanitize_title( $agent->get_slug() );
+				if ( '' === $slug || isset( $seen[ $slug ] ) ) {
+					continue;
 				}
-			}
 
-			if ( null === $principal->audience_id && self::CURRENT_USER_EFFECTIVE_AGENT_ID !== $principal->effective_agent_id ) {
-				$agent_ids[] = $principal->effective_agent_id;
-			}
+				$seen[ $slug ] = true;
 
-			$agent_ids = array_values( array_unique( array_filter( array_map( 'sanitize_title', $agent_ids ) ) ) );
-			$agents    = array();
-			foreach ( $agent_ids as $agent_id ) {
-				$agent = function_exists( 'wp_get_agent' ) ? wp_get_agent( $agent_id ) : null;
-				if ( $agent instanceof WP_Agent ) {
-					$agents[] = self::agent_to_access_summary( $agent );
+				if ( ! $policy->can_access_agent( $principal, $slug, $minimum_role, $context ) ) {
+					continue;
 				}
+
+				$agents[] = self::agent_to_access_summary( $agent );
 			}
 
 			return $agents;

--- a/src/Auth/class-wp-agent-wordpress-authorization-policy.php
+++ b/src/Auth/class-wp-agent-wordpress-authorization-policy.php
@@ -55,6 +55,11 @@ if ( ! class_exists( 'WP_Agent_WordPress_Authorization_Policy' ) ) {
 		/**
 		 * Check whether a principal can access an agent at a minimum role.
 		 *
+		 * The store-derived decision — including the effective-agent
+		 * short-circuit — is wrapped in the {@see 'wp_agent_can_access_agent'}
+		 * filter so hosts can tighten as well as widen access without
+		 * materializing grant rows.
+		 *
 		 * @param AgentsAPI\AI\WP_Agent_Execution_Principal $principal    Execution principal.
 		 * @param string                               $agent_id     Agent identifier.
 		 * @param string                               $minimum_role Minimum access role.
@@ -65,6 +70,42 @@ if ( ! class_exists( 'WP_Agent_WordPress_Authorization_Policy' ) ) {
 				return false;
 			}
 
+			$allowed = $this->resolve_default_access_decision( $principal, $agent_id, $minimum_role, $context );
+
+			if ( function_exists( 'apply_filters' ) ) {
+				/**
+				 * Filters the final agent access decision.
+				 *
+				 * Hosts that derive access from live state (capabilities, roles,
+				 * memberships) can grant or deny access without materializing
+				 * grant rows. The filter wraps the store-derived decision —
+				 * including the effective-agent short-circuit — so hosts can
+				 * tighten as well as widen access.
+				 *
+				 * @param bool                                       $allowed      Default store-derived decision.
+				 * @param AgentsAPI\AI\WP_Agent_Execution_Principal  $principal    Execution principal.
+				 * @param string                                     $agent_id     Agent identifier.
+				 * @param string                                     $minimum_role Minimum access role.
+				 * @param array<string,mixed>                        $context      Host-owned authorization context.
+				 */
+				$allowed = (bool) apply_filters( 'wp_agent_can_access_agent', $allowed, $principal, $agent_id, $minimum_role, $context );
+			}
+
+			return $allowed;
+		}
+
+		/**
+		 * Resolve the default (store-derived) access decision before host filtering.
+		 *
+		 * Includes the effective-agent short-circuit so the host filter can
+		 * tighten as well as widen the decision.
+		 *
+		 * @param AgentsAPI\AI\WP_Agent_Execution_Principal $principal    Execution principal.
+		 * @param string                                     $agent_id     Agent identifier.
+		 * @param string                                     $minimum_role Minimum access role.
+		 * @param array<string,mixed>                        $context      Host-owned authorization context.
+		 */
+		private function resolve_default_access_decision( AgentsAPI\AI\WP_Agent_Execution_Principal $principal, string $agent_id, string $minimum_role, array $context ): bool {
 			if ( $principal->effective_agent_id === $agent_id ) {
 				return true;
 			}

--- a/tests/access-decision-filter-smoke.php
+++ b/tests/access-decision-filter-smoke.php
@@ -1,0 +1,320 @@
+<?php
+/**
+ * Pure-PHP smoke test for the wp_agent_can_access_agent host access filter.
+ *
+ * Covers:
+ *  - Default behavior unchanged when nothing hooks the filter.
+ *  - A hooked filter can grant access with no store row.
+ *  - A hooked filter can deny despite a store grant.
+ *  - List and check agree in both directions.
+ *  - The filter can tighten the effective-agent short-circuit.
+ *
+ * Run with: php tests/access-decision-filter-smoke.php
+ *
+ * @package AgentsAPI\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+$failures = array();
+$passes   = 0;
+
+echo "access-decision-filter-smoke\n";
+
+require_once __DIR__ . '/agents-api-smoke-helpers.php';
+
+$GLOBALS['__agents_api_smoke_current_user_id'] = 7;
+
+if ( ! function_exists( 'get_current_user_id' ) ) {
+	function get_current_user_id(): int {
+		return (int) $GLOBALS['__agents_api_smoke_current_user_id'];
+	}
+}
+
+if ( ! function_exists( 'is_user_logged_in' ) ) {
+	function is_user_logged_in(): bool {
+		return get_current_user_id() > 0;
+	}
+}
+
+if ( ! function_exists( 'wp_has_ability_category' ) ) {
+	function wp_has_ability_category( string $category ): bool {
+		return isset( $GLOBALS['__agents_api_smoke_categories'][ $category ] );
+	}
+}
+
+if ( ! function_exists( 'wp_register_ability_category' ) ) {
+	function wp_register_ability_category( string $category, array $args ): void {
+		$GLOBALS['__agents_api_smoke_categories'][ $category ] = $args;
+	}
+}
+
+if ( ! function_exists( 'wp_has_ability' ) ) {
+	function wp_has_ability( string $ability ): bool {
+		return isset( $GLOBALS['__agents_api_smoke_abilities'][ $ability ] );
+	}
+}
+
+if ( ! function_exists( 'wp_register_ability' ) ) {
+	function wp_register_ability( string $ability, array $args ): void {
+		$GLOBALS['__agents_api_smoke_abilities'][ $ability ] = $args;
+	}
+}
+
+agents_api_smoke_require_module();
+
+// -----------------------------------------------------------------------
+// Register three test agents.
+// -----------------------------------------------------------------------
+add_action(
+	'wp_agents_api_init',
+	static function (): void {
+		wp_register_agent(
+			'alpha-agent',
+			array(
+				'label'       => 'Alpha Agent',
+				'description' => 'Has a store grant.',
+			)
+		);
+		wp_register_agent(
+			'beta-agent',
+			array(
+				'label'       => 'Beta Agent',
+				'description' => 'No store grant; filter-granted.',
+			)
+		);
+		wp_register_agent(
+			'gamma-agent',
+			array(
+				'label'       => 'Gamma Agent',
+				'description' => 'No store grant; filter-granted.',
+			)
+		);
+	}
+);
+
+do_action( 'init' );
+
+// -----------------------------------------------------------------------
+// Store with a single grant for alpha-agent (user 7, operator, site:42).
+// -----------------------------------------------------------------------
+$grant = new WP_Agent_Access_Grant( 'alpha-agent', 7, WP_Agent_Access_Grant::ROLE_OPERATOR, 'site:42' );
+
+$access_store = new class( $grant ) implements WP_Agent_Access_Store {
+	public function __construct( private WP_Agent_Access_Grant $grant ) {}
+
+	public function grant_access( WP_Agent_Access_Grant $grant ): WP_Agent_Access_Grant {
+		$this->grant = $grant;
+		return $grant;
+	}
+
+	public function revoke_access( string $agent_id, int $user_id, ?string $workspace_id = null ): bool {
+		return $this->grant->agent_id === $agent_id && $this->grant->user_id === $user_id && $this->grant->workspace_id === $workspace_id;
+	}
+
+	public function get_access( string $agent_id, int $user_id, ?string $workspace_id = null ): ?WP_Agent_Access_Grant {
+		return $this->grant->agent_id === $agent_id && $this->grant->user_id === $user_id && $this->grant->workspace_id === $workspace_id ? $this->grant : null;
+	}
+
+	public function get_agent_ids_for_user( int $user_id, ?string $minimum_role = null, ?string $workspace_id = null ): array {
+		if ( $this->grant->user_id !== $user_id || $this->grant->workspace_id !== $workspace_id ) {
+			return array();
+		}
+
+		return null === $minimum_role || $this->grant->role_meets( $minimum_role ) ? array( $this->grant->agent_id ) : array();
+	}
+
+	public function get_users_for_agent( string $agent_id, ?string $workspace_id = null ): array {
+		return $this->grant->agent_id === $agent_id && $this->grant->workspace_id === $workspace_id ? array( $this->grant ) : array();
+	}
+};
+
+add_filter(
+	'wp_agent_access_store',
+	static function ( $store ) use ( $access_store ) {
+		return $store instanceof WP_Agent_Access_Store ? $store : $access_store;
+	}
+);
+
+$context = array( 'workspace_id' => 'site:42', 'access_store' => $access_store );
+
+$principal = AgentsAPI\AI\WP_Agent_Execution_Principal::user_session(
+	7,
+	'test-user',
+	AgentsAPI\AI\WP_Agent_Execution_Principal::REQUEST_CONTEXT_REST,
+	array( 'source' => 'smoke-test' ),
+	'site:42'
+);
+
+// Helper: extract slugs from an accessible-agents list.
+function access_decision_filter_slugs( array $agents ): array {
+	return array_column( $agents, 'slug' );
+}
+
+// Helper: assert list/check agreement for a single agent.
+function access_decision_filter_assert_agreement( AgentsAPI\AI\WP_Agent_Execution_Principal $principal, string $agent_id, array $context, string $label, array &$failures, int &$passes ): void {
+	$can    = WP_Agent_Access::can_principal_access_agent( $principal, $agent_id, WP_Agent_Access_Grant::ROLE_VIEWER, $context );
+	$list   = WP_Agent_Access::list_accessible_agents_for_principal( $principal, WP_Agent_Access_Grant::ROLE_VIEWER, $context );
+	$listed = in_array( $agent_id, access_decision_filter_slugs( $list ), true );
+	agents_api_smoke_assert_equals( $can, $listed, $label, $failures, $passes );
+}
+
+// =======================================================================
+// Phase 1: Default behavior — no wp_agent_can_access_agent filter hooked.
+// =======================================================================
+
+agents_api_smoke_assert_equals( true, WP_Agent_Access::can_principal_access_agent( $principal, 'alpha-agent', WP_Agent_Access_Grant::ROLE_VIEWER, $context ), 'default: store grant allows alpha at viewer', $failures, $passes );
+agents_api_smoke_assert_equals( true, WP_Agent_Access::can_principal_access_agent( $principal, 'alpha-agent', WP_Agent_Access_Grant::ROLE_OPERATOR, $context ), 'default: store grant allows alpha at operator', $failures, $passes );
+agents_api_smoke_assert_equals( false, WP_Agent_Access::can_principal_access_agent( $principal, 'alpha-agent', WP_Agent_Access_Grant::ROLE_ADMIN, $context ), 'default: store grant denies alpha above role', $failures, $passes );
+agents_api_smoke_assert_equals( false, WP_Agent_Access::can_principal_access_agent( $principal, 'beta-agent', WP_Agent_Access_Grant::ROLE_VIEWER, $context ), 'default: no grant denies beta', $failures, $passes );
+agents_api_smoke_assert_equals( false, WP_Agent_Access::can_principal_access_agent( $principal, 'gamma-agent', WP_Agent_Access_Grant::ROLE_VIEWER, $context ), 'default: no grant denies gamma', $failures, $passes );
+
+$default_list   = WP_Agent_Access::list_accessible_agents_for_principal( $principal, WP_Agent_Access_Grant::ROLE_VIEWER, $context );
+$default_slugs  = access_decision_filter_slugs( $default_list );
+agents_api_smoke_assert_equals( true, in_array( 'alpha-agent', $default_slugs, true ), 'default: list includes alpha', $failures, $passes );
+agents_api_smoke_assert_equals( false, in_array( 'beta-agent', $default_slugs, true ), 'default: list excludes beta', $failures, $passes );
+agents_api_smoke_assert_equals( false, in_array( 'gamma-agent', $default_slugs, true ), 'default: list excludes gamma', $failures, $passes );
+
+// =======================================================================
+// Hook the filter with a mutable override map.
+// =======================================================================
+
+$filter_overrides = array();
+
+add_filter(
+	'wp_agent_can_access_agent',
+	static function ( $allowed, $p, string $agent_id, string $minimum_role, array $ctx ) use ( &$filter_overrides ) {
+		if ( array_key_exists( $agent_id, $filter_overrides ) ) {
+			return $filter_overrides[ $agent_id ];
+		}
+		return $allowed;
+	},
+	10,
+	5
+);
+
+// =======================================================================
+// Phase 2: Filter grants beta (no store row).
+// =======================================================================
+
+$filter_overrides = array( 'beta-agent' => true );
+
+agents_api_smoke_assert_equals( true, WP_Agent_Access::can_principal_access_agent( $principal, 'beta-agent', WP_Agent_Access_Grant::ROLE_VIEWER, $context ), 'filter grants beta: check returns true with no store row', $failures, $passes );
+agents_api_smoke_assert_equals( true, WP_Agent_Access::can_principal_access_agent( $principal, 'alpha-agent', WP_Agent_Access_Grant::ROLE_VIEWER, $context ), 'filter grants beta: alpha still allowed (passthrough)', $failures, $passes );
+agents_api_smoke_assert_equals( false, WP_Agent_Access::can_principal_access_agent( $principal, 'gamma-agent', WP_Agent_Access_Grant::ROLE_VIEWER, $context ), 'filter grants beta: gamma still denied (passthrough)', $failures, $passes );
+
+$grant_list  = WP_Agent_Access::list_accessible_agents_for_principal( $principal, WP_Agent_Access_Grant::ROLE_VIEWER, $context );
+$grant_slugs = access_decision_filter_slugs( $grant_list );
+agents_api_smoke_assert_equals( true, in_array( 'alpha-agent', $grant_slugs, true ), 'filter grants beta: list includes alpha', $failures, $passes );
+agents_api_smoke_assert_equals( true, in_array( 'beta-agent', $grant_slugs, true ), 'filter grants beta: list includes beta', $failures, $passes );
+agents_api_smoke_assert_equals( false, in_array( 'gamma-agent', $grant_slugs, true ), 'filter grants beta: list excludes gamma', $failures, $passes );
+
+access_decision_filter_assert_agreement( $principal, 'beta-agent', $context, 'list/check agree: beta granted by filter', $failures, $passes );
+
+// =======================================================================
+// Phase 3: Filter denies alpha (despite store grant).
+// =======================================================================
+
+$filter_overrides = array( 'alpha-agent' => false );
+
+agents_api_smoke_assert_equals( false, WP_Agent_Access::can_principal_access_agent( $principal, 'alpha-agent', WP_Agent_Access_Grant::ROLE_VIEWER, $context ), 'filter denies alpha: check returns false despite store grant', $failures, $passes );
+agents_api_smoke_assert_equals( false, WP_Agent_Access::can_principal_access_agent( $principal, 'alpha-agent', WP_Agent_Access_Grant::ROLE_OPERATOR, $context ), 'filter denies alpha: check returns false at operator too', $failures, $passes );
+
+$deny_list  = WP_Agent_Access::list_accessible_agents_for_principal( $principal, WP_Agent_Access_Grant::ROLE_VIEWER, $context );
+$deny_slugs = access_decision_filter_slugs( $deny_list );
+agents_api_smoke_assert_equals( false, in_array( 'alpha-agent', $deny_slugs, true ), 'filter denies alpha: list excludes alpha despite store grant', $failures, $passes );
+
+access_decision_filter_assert_agreement( $principal, 'alpha-agent', $context, 'list/check agree: alpha denied by filter', $failures, $passes );
+
+// =======================================================================
+// Phase 4: Bidirectional agreement — grant beta+gamma, deny alpha.
+// =======================================================================
+
+$filter_overrides = array(
+	'alpha-agent' => false,
+	'beta-agent'  => true,
+	'gamma-agent' => true,
+);
+
+$bidir_list  = WP_Agent_Access::list_accessible_agents_for_principal( $principal, WP_Agent_Access_Grant::ROLE_VIEWER, $context );
+$bidir_slugs = access_decision_filter_slugs( $bidir_list );
+
+foreach ( array( 'alpha-agent', 'beta-agent', 'gamma-agent' ) as $agent_id ) {
+	access_decision_filter_assert_agreement( $principal, $agent_id, $context, "bidirectional agreement: list/check match for {$agent_id}", $failures, $passes );
+}
+
+agents_api_smoke_assert_equals( false, in_array( 'alpha-agent', $bidir_slugs, true ), 'bidirectional: alpha excluded', $failures, $passes );
+agents_api_smoke_assert_equals( true, in_array( 'beta-agent', $bidir_slugs, true ), 'bidirectional: beta included', $failures, $passes );
+agents_api_smoke_assert_equals( true, in_array( 'gamma-agent', $bidir_slugs, true ), 'bidirectional: gamma included', $failures, $passes );
+
+// =======================================================================
+// Phase 5: Filter can tighten the effective-agent short-circuit.
+// =======================================================================
+
+$sc_principal = AgentsAPI\AI\WP_Agent_Execution_Principal::user_session(
+	7,
+	'beta-agent',
+	AgentsAPI\AI\WP_Agent_Execution_Principal::REQUEST_CONTEXT_REST,
+	array( 'source' => 'smoke-test' ),
+	'site:42'
+);
+
+// Without override, short-circuit grants access to beta (effective agent).
+$filter_overrides = array();
+agents_api_smoke_assert_equals( true, WP_Agent_Access::can_principal_access_agent( $sc_principal, 'beta-agent', WP_Agent_Access_Grant::ROLE_VIEWER, $context ), 'short-circuit: effective agent id grants access by default', $failures, $passes );
+
+$sc_default_list  = WP_Agent_Access::list_accessible_agents_for_principal( $sc_principal, WP_Agent_Access_Grant::ROLE_VIEWER, $context );
+$sc_default_slugs = access_decision_filter_slugs( $sc_default_list );
+agents_api_smoke_assert_equals( true, in_array( 'beta-agent', $sc_default_slugs, true ), 'short-circuit: list includes effective agent by default', $failures, $passes );
+
+// With override, host can deny the short-circuit.
+$filter_overrides = array( 'beta-agent' => false );
+agents_api_smoke_assert_equals( false, WP_Agent_Access::can_principal_access_agent( $sc_principal, 'beta-agent', WP_Agent_Access_Grant::ROLE_VIEWER, $context ), 'short-circuit: filter can deny effective agent id', $failures, $passes );
+
+$sc_deny_list  = WP_Agent_Access::list_accessible_agents_for_principal( $sc_principal, WP_Agent_Access_Grant::ROLE_VIEWER, $context );
+$sc_deny_slugs = access_decision_filter_slugs( $sc_deny_list );
+agents_api_smoke_assert_equals( false, in_array( 'beta-agent', $sc_deny_slugs, true ), 'short-circuit: list excludes denied effective agent', $failures, $passes );
+
+// =======================================================================
+// Phase 6: Ability functions agree through the full path.
+// =======================================================================
+
+$filter_overrides = array(
+	'alpha-agent' => false,
+	'beta-agent'  => true,
+	'gamma-agent' => true,
+);
+
+$GLOBALS['__agents_api_smoke_current_user_id'] = 7;
+
+do_action( 'wp_abilities_api_categories_init' );
+do_action( 'wp_abilities_api_init' );
+
+$ability_input = array(
+	'minimum_role' => WP_Agent_Access_Grant::ROLE_VIEWER,
+	'workspace_id' => 'site:42',
+);
+
+$ability_list = AgentsAPI\AI\Auth\agents_list_accessible_agents( $ability_input );
+$ability_slugs = array_column( $ability_list['agents'] ?? array(), 'slug' );
+
+foreach ( array( 'alpha-agent', 'beta-agent', 'gamma-agent' ) as $agent_id ) {
+	$can_result  = AgentsAPI\AI\Auth\agents_can_access_agent(
+		array(
+			'agent'        => $agent_id,
+			'minimum_role' => WP_Agent_Access_Grant::ROLE_VIEWER,
+			'workspace_id' => 'site:42',
+		)
+	);
+	$can_allowed = (bool) ( $can_result['allowed'] ?? false );
+	$listed      = in_array( $agent_id, $ability_slugs, true );
+	agents_api_smoke_assert_equals( $can_allowed, $listed, "ability list/check agree: {$agent_id}", $failures, $passes );
+}
+
+agents_api_smoke_assert_equals( false, in_array( 'alpha-agent', $ability_slugs, true ), 'ability: alpha excluded', $failures, $passes );
+agents_api_smoke_assert_equals( true, in_array( 'beta-agent', $ability_slugs, true ), 'ability: beta included', $failures, $passes );
+agents_api_smoke_assert_equals( true, in_array( 'gamma-agent', $ability_slugs, true ), 'ability: gamma included', $failures, $passes );
+
+agents_api_smoke_finish( 'Access decision filter', $failures, $passes );


### PR DESCRIPTION
## Problem

`agents/can-access-agent` and `agents/list-accessible-agents` resolve access exclusively through the `WP_Agent_Access_Store` / `WP_Agent_Principal_Access_Store` contracts (explicit grant rows). There is no seam for the host to contribute an access decision that isn't materialized as a grant row.

Hosts that derive agent access from live state — a WordPress capability, a role, an org membership, a subscription — cannot express that through the substrate. They end up with **two divergent access systems**:

1. The host's own filter/policy surface (applied on the host's internal paths).
2. The substrate's store-only path (applied by every consumer that goes through the abilities).

Consumers of the abilities (chat widgets, MCP clients, REST callers) silently get answer #2, which disagrees with answer #1.

### Production impact

On a live site, the host bridges WordPress capability checks into its own access filter, and an integration plugin grants a team role access to an agent through it. The frontend chat widget resolves visibility via `agents/list-accessible-agents` → store-only. Result: of **~47 team members** who should see the agent, only the **3 with explicit grant rows** ever did. The capability bridge was dead code on every ability-driven surface, and nobody noticed for weeks because both paths *exist* and both *look* authoritative.

## Solution

### 1. `wp_agent_can_access_agent` filter on the check path

`WP_Agent_WordPress_Authorization_Policy::can_access_agent()` now wraps its **final** decision — including the `$principal->effective_agent_id === $agent_id` short-circuit — in a filter:

```php
$allowed = (bool) apply_filters(
    'wp_agent_can_access_agent',
    $allowed,        // store-derived decision (incl. short-circuit)
    $principal,      // WP_Agent_Execution_Principal
    $agent_id,       // string
    $minimum_role,   // string
    $context         // array<string,mixed>
);
```

The store-derived logic is extracted into `resolve_default_access_decision()` (private). Input validation (empty agent_id, invalid role) remains an early return — not filtered — since an invalid input is not a meaningful access decision for a host to override.

The filter wraps the short-circuit so hosts can **tighten** as well as **widen**: a host can deny access to the effective agent itself, not just override store-grant results.

Guarded with `function_exists( 'apply_filters' )` following the existing codebase pattern (see `WP_Agent_Access::get_store()`, `WP_Agent_Access::access_principals_for()`).

### 2. List path: per-agent reuse of the same decision filter

`WP_Agent_Access::list_accessible_agents_for_principal()` is rewritten to iterate every registered agent (via `wp_get_agents()`) through the **same** `can_access_agent()` decision used by the check path. This guarantees list/check symmetry **by construction**: the list is literally the set of agents for which the check returns true.

**Design choice: per-agent reuse, not a list-level filter.**

A list-level filter (`wp_agent_accessible_agents` on the resolved array) would require hosts to hook **two** filters consistently — one for check, one for list. If they hook only one (or hook them differently), list and check diverge. That is the exact class of bug this PR fixes. Per-agent reuse means the host hooks **one** filter and both abilities agree, always.

The candidate set is all registered agents (from the in-memory registry, no DB cost). For each, `can_access_agent()` runs the store lookup + filter. When no filter is hooked, `can_access_agent()` returns the store-derived decision, so only store-granted agents pass — same result as before, just resolved per-agent instead of via a bulk `get_agent_ids_for_user` query. The number of registered agents is typically small (single digits to low dozens), so the per-agent cost is negligible.

### 3. Behavior changes

- **No behavior change** for hosts that don't hook the filter. All existing smoke tests pass unmodified.
- **Edge case**: an audience principal whose `effective_agent_id` matches a registered agent will now see that agent in the list (via the short-circuit in `can_access_agent`). Previously, the list path explicitly excluded `effective_agent_id` for audience principals. This is a **correctness fix**: the check path already returned `true` for that agent (short-circuit), so the list was disagreeing with the check. The list now agrees.

## Tests

New smoke test `tests/access-decision-filter-smoke.php` (35 assertions) covers:

- **Default behavior unchanged** when nothing hooks the filter (store grants work, non-granted agents denied).
- **Filter grants access with no store row** — a hooked filter returns `true` for an agent with no grant; both check and list reflect it.
- **Filter denies despite a store grant** — a hooked filter returns `false` for an agent with a grant; both check and list reflect it.
- **List/check agreement in both directions** — for every registered agent, `can_access_agent` result matches list membership.
- **Short-circuit tightening** — the filter can deny the `effective_agent_id` short-circuit; list excludes the denied effective agent.
- **Ability functions** — `agents_can_access_agent` and `agents_list_accessible_agents` agree through the full ability path.

## Verification

- `composer test` — all smoke tests pass (including existing `agents-access-ability-smoke` and `authorization-smoke` with no regressions).
- `composer phpstan` — clean (0 errors).
- `no-product-imports-smoke` — passes (no product vocabulary, no host/plugin/vendor references).
- `homeboy review` — audit and lint stages pass. (Test stage failed due to a WP Codebox CLI infrastructure issue — missing Node module — not a code issue; GitHub Actions CI is the real gate.)

Fixes #417