### PR TITLE
Workflow branch executor: return truthful async runner dispatch result

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -123,6 +123,7 @@
       "php tests/workflow-scoped-drain-smoke.php",
       "php tests/workflow-async-branch-payload-smoke.php",
       "php tests/workflow-async-loopback-target-smoke.php",
+      "php tests/workflow-async-runner-dispatch-result-smoke.php",
       "php tests/workflow-reconcile-race-smoke.php",
       "php tests/workflow-lifecycle-smoke.php",
       "php tests/agents-workflow-ability-smoke.php",

--- a/src/Workflows/class-wp-agent-workflow-action-scheduler-branch-executor.php
+++ b/src/Workflows/class-wp-agent-workflow-action-scheduler-branch-executor.php
@@ -422,10 +422,10 @@ final class WP_Agent_Workflow_Action_Scheduler_Branch_Executor implements WP_Age
 	 * branches keep running in their own worker PIDs and the caller polls the
 	 * recorder.
 	 *
-	 * A no-op (returns 0) on a runtime without loopback/admin-ajax, where the run
-	 * falls back to AS's own WP-Cron runner or the caller's budget — acceptable
-	 * degradation, never fabricated behavior. When request_multiple is unavailable it
-	 * degrades to serial non-blocking POSTs (AS's own dispatch shape).
+		 * A no-op (returns 0) on a runtime without loopback/admin-ajax, where the run
+		 * falls back to AS's own WP-Cron runner or the caller's budget — acceptable
+		 * degradation, never fabricated behavior. When request_multiple is unavailable it
+		 * degrades to serial non-blocking POSTs (AS's own dispatch shape).
 	 *
 	 * @since 0.5.0
 	 *
@@ -523,10 +523,10 @@ final class WP_Agent_Workflow_Action_Scheduler_Branch_Executor implements WP_Age
 					}
 				}
 
-				// Even if every response object was an early-close exception, the workers
-				// may still have accepted and begun the queue run (we do not await the
-				// branch). Report at least the attempts so callers see the dispatch fired.
-				return $fired > 0 ? $fired : $workers;
+				// Count only loopbacks the runtime accepted. Connection-refused/transport
+				// failures mean no queue runner was reached, so callers must see 0 and fall
+				// back to another claim path instead of receiving fabricated success.
+				return $fired;
 			}
 		}
 

--- a/tests/workflow-async-runner-dispatch-result-smoke.php
+++ b/tests/workflow-async-runner-dispatch-result-smoke.php
@@ -1,0 +1,140 @@
+<?php
+/**
+ * Pure-PHP smoke test for async-runner dispatch result honesty.
+ *
+ * Run with: php tests/workflow-async-runner-dispatch-result-smoke.php
+ *
+ * @package AgentsAPI\Tests
+ */
+
+namespace WpOrg\Requests {
+	class Response {}
+
+	class Requests {
+		/** @var array<int,mixed> */
+		public static array $results = array();
+
+		/**
+		 * @param array<int,array<string,mixed>> $requests
+		 * @param array<string,mixed>            $options
+		 * @return array<int,mixed>
+		 */
+		public static function request_multiple( array $requests, array $options ): array {
+			unset( $requests, $options );
+			return self::$results;
+		}
+	}
+}
+
+namespace AgentsAPI\AI\Workflows {
+	if ( ! class_exists( WP_Agent_Workflow_Action_Scheduler_Bridge::class ) ) {
+		final class WP_Agent_Workflow_Action_Scheduler_Bridge {
+			public const GROUP = 'agents-api';
+		}
+	}
+}
+
+namespace {
+	defined( 'ABSPATH' ) || define( 'ABSPATH', __DIR__ . '/' );
+
+	$failures = array();
+	$passes   = 0;
+
+	echo "workflow-async-runner-dispatch-result-smoke\n";
+
+	if ( ! class_exists( 'ActionScheduler' ) ) {
+		class ActionScheduler {
+			public static function is_initialized(): bool {
+				return true;
+			}
+		}
+	}
+
+	if ( ! function_exists( 'admin_url' ) ) {
+		function admin_url( string $path = '' ): string {
+			return 'https://example.test/wp-admin/' . ltrim( $path, '/' );
+		}
+	}
+
+	if ( ! function_exists( 'wp_create_nonce' ) ) {
+		function wp_create_nonce( string $action ): string {
+			return 'nonce-' . $action;
+		}
+	}
+
+	if ( ! function_exists( 'add_query_arg' ) ) {
+		function add_query_arg( array $args, string $url ): string {
+			$separator = false === strpos( $url, '?' ) ? '?' : '&';
+			return $url . $separator . http_build_query( $args );
+		}
+	}
+
+	if ( ! function_exists( 'esc_url_raw' ) ) {
+		function esc_url_raw( string $url ): string {
+			return $url;
+		}
+	}
+
+	if ( ! function_exists( 'apply_filters' ) ) {
+		function apply_filters( string $hook, $value ) {
+			unset( $hook );
+			return $value;
+		}
+	}
+
+	if ( ! function_exists( 'wp_parse_url' ) ) {
+		function wp_parse_url( string $url, int $component = -1 ) {
+			return parse_url( $url, $component );
+		}
+	}
+
+	function smoke_assert( $expected, $actual, string $name, array &$failures, int &$passes ): void {
+		if ( $expected === $actual ) {
+			++$passes;
+			echo "  PASS {$name}\n";
+			return;
+		}
+
+		$failures[] = $name;
+		echo "  FAIL {$name}\n";
+		echo '    expected: ' . var_export( $expected, true ) . "\n";
+		echo '    actual:   ' . var_export( $actual, true ) . "\n";
+	}
+
+	require_once __DIR__ . '/../src/Workflows/interface-wp-agent-workflow-branch-executor.php';
+	require_once __DIR__ . '/../src/Workflows/class-wp-agent-workflow-action-scheduler-branch-executor.php';
+
+	use AgentsAPI\AI\Workflows\WP_Agent_Workflow_Action_Scheduler_Branch_Executor;
+	use WpOrg\Requests\Requests;
+	use WpOrg\Requests\Response;
+
+	Requests::$results = array(
+		new \RuntimeException( 'cURL error 7: Failed to connect to 127.0.0.1 port 443' ),
+		new \RuntimeException( 'cURL error 7: Failed to connect to 127.0.0.1 port 443' ),
+	);
+	smoke_assert(
+		0,
+		WP_Agent_Workflow_Action_Scheduler_Branch_Executor::trigger_async_runner( 2 ),
+		'all failed parallel loopbacks report 0 accepted dispatches',
+		$failures,
+		$passes
+	);
+
+	Requests::$results = array(
+		new \RuntimeException( 'cURL error 7: Failed to connect to 127.0.0.1 port 443' ),
+		new Response(),
+		new Response(),
+	);
+	smoke_assert(
+		2,
+		WP_Agent_Workflow_Action_Scheduler_Branch_Executor::trigger_async_runner( 3 ),
+		'mixed parallel loopbacks report only accepted dispatches',
+		$failures,
+		$passes
+	);
+
+	echo "\n{$passes} passing" . ( $failures ? ', ' . count( $failures ) . ' failing' : '' ) . "\n";
+	if ( $failures ) {
+		exit( 1 );
+	}
+}


### PR DESCRIPTION
## Problem
`trigger_async_runner()` returned the full worker count even when every loopback request failed, fabricating dispatch success; callers could not fall back.

## Fix
Count only accepted loopback responses from `Requests::request_multiple()`; return 0 when all fail. New smoke test covering all-failed and mixed cases.

## Context
Discovered on a WP Cloud runtime with no reachable loopback (connection refused on 127.0.0.1:80/443) and DISABLE_WP_CRON=true, where Action Scheduler jobs stayed pending forever while the executor reported success. Downstream consumer fix lands separately in the wp-build repo (GHE chubes4/wp-build#1149).

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude (Anthropic claude-fable-5) via OpenCode; subagent fleet drafted the fix
- **Used for:** Root-cause investigation on the runtime, drafting the fix and smoke tests