### PR TITLE
Expose compact tool observability in chat metadata

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -83,6 +83,7 @@
       "php tests/provider-turn-adapter-smoke.php",
       "php tests/default-provider-turn-adapter-smoke.php",
       "php tests/default-agents-chat-handler-smoke.php",
+      "php tests/tool-observability-smoke.php",
       "php tests/ability-tool-executor-smoke.php",
       "php tests/ability-tool-ceiling-smoke.php",
       "php tests/ability-tool-capability-denied-event-smoke.php",

--- a/src/Channels/register-agents-chat-ability.php
+++ b/src/Channels/register-agents-chat-ability.php
@@ -565,7 +565,53 @@ function agents_chat_output_schema(): array {
 			),
 			'metadata'   => array(
 				'type'        => 'object',
-				'description' => 'Runtime-specific metadata (token usage, model, latency, tool calls). Opaque to the dispatcher.',
+				'description' => 'Runtime metadata. The default handler exposes `agents_api.tool_observability`, a content-redacted v1 tool lifecycle contract.',
+				'properties'  => array(
+					'agents_api' => array(
+						'type'       => 'object',
+						'properties' => array(
+							'tool_observability' => array(
+								'type'        => 'object',
+								'description' => 'Additive content-redacted tool observability. Calls are globally ordered and expose no argument values, result content, hashes, raw errors, paths, or arbitrary runtime metadata.',
+								'required'    => array( 'version', 'calls' ),
+								'properties'  => array(
+									'version' => array( 'type' => 'integer', 'enum' => array( 1 ) ),
+									'calls'   => array(
+										'type'  => 'array',
+										'items' => array(
+											'type'       => 'object',
+											'required'   => array( 'sequence', 'turn', 'tool_call_id', 'tool_name', 'status', 'arguments' ),
+											'properties' => array(
+												'sequence'     => array( 'type' => 'integer' ),
+												'turn'         => array( 'type' => 'integer' ),
+												'tool_call_id' => array( 'type' => 'string' ),
+												'tool_name'    => array( 'type' => 'string' ),
+												'status'       => array( 'type' => 'string', 'enum' => array( 'pending', 'succeeded', 'failed', 'rejected' ) ),
+												'arguments'    => array(
+													'type'       => 'object',
+													'required'   => array( 'keys', 'count', 'redacted' ),
+													'properties' => array(
+														'keys'     => array( 'type' => 'array', 'items' => array( 'type' => 'string' ) ),
+														'count'    => array( 'type' => 'integer' ),
+														'redacted' => array( 'type' => 'boolean', 'enum' => array( true ) ),
+													),
+												),
+												'result'       => array(
+													'type'        => 'object',
+													'description' => 'Optional result shape only: type plus count for containers or byte size for strings.',
+												),
+												'error'        => array(
+													'type'        => 'object',
+													'description' => 'Agents API-owned normalized code and fixed safe message; never the executor or provider error.',
+												),
+											),
+										),
+									),
+								),
+							),
+						),
+					),
+				),
 			),
 		),
 	);

--- a/src/Channels/register-default-agents-chat-handler.php
+++ b/src/Channels/register-default-agents-chat-handler.php
@@ -566,10 +566,11 @@ class WP_Agent_Default_Chat_Handler {
 	private static function to_canonical_output( string $session_id, array $result ): array {
 		$metadata = array_filter(
 			array(
-				'status'      => is_string( $result['status'] ?? null ) ? $result['status'] : null,
-				'turn_count'  => isset( $result['turn_count'] ) ? self::int_value( $result['turn_count'] ) : null,
-				'usage'       => is_array( $result['usage'] ?? null ) ? $result['usage'] : null,
-				'run_outcome' => is_array( $result['run_outcome'] ?? null ) ? $result['run_outcome'] : null,
+				'status'             => is_string( $result['status'] ?? null ) ? $result['status'] : null,
+				'turn_count'         => isset( $result['turn_count'] ) ? self::int_value( $result['turn_count'] ) : null,
+				'usage'              => is_array( $result['usage'] ?? null ) ? $result['usage'] : null,
+				'run_outcome'        => is_array( $result['run_outcome'] ?? null ) ? $result['run_outcome'] : null,
+				'tool_observability' => is_array( $result['tool_observability'] ?? null ) ? $result['tool_observability'] : null,
 			),
 			static fn( $value ): bool => null !== $value
 		);

--- a/src/Runtime/class-wp-agent-conversation-loop.php
+++ b/src/Runtime/class-wp-agent-conversation-loop.php
@@ -880,8 +880,9 @@ class WP_Agent_Conversation_Loop {
 				$tool_call_id,
 				$turn,
 				array(
-					'status'  => ! empty( $exec_result['success'] ) ? 'success' : 'error',
-					'success' => (bool) ( $exec_result['success'] ?? false ),
+					'status'   => ! empty( $exec_result['success'] ) ? 'success' : 'error',
+					'success'  => (bool) ( $exec_result['success'] ?? false ),
+					'rejected' => 'reject' === $mediator_decision['action'],
 				)
 			);
 

--- a/src/Runtime/class-wp-agent-conversation-result.php
+++ b/src/Runtime/class-wp-agent-conversation-result.php
@@ -30,6 +30,7 @@ class WP_Agent_Conversation_Result {
 	public const OUTCOME_STOP_NATURAL                = WP_Agent_Run_Outcome::STOP_NATURAL;
 	public const OUTCOME_STOP_MAX_TURNS              = WP_Agent_Run_Outcome::STOP_MAX_TURNS;
 	public const OUTCOME_STOP_PROVIDER_ERROR         = WP_Agent_Run_Outcome::STOP_PROVIDER_ERROR;
+	public const TOOL_OBSERVABILITY_VERSION          = 1;
 
 	/**
 	 * Validate and normalize a loop result.
@@ -252,9 +253,139 @@ class WP_Agent_Conversation_Result {
 			throw self::invalid( 'runtime_tool_pending', 'must be an array when present' );
 		}
 
+		$result['tool_observability'] = self::tool_observability( $result['tool_events'], $result['tool_execution_results'] );
 		$result['run_outcome'] = WP_Agent_Run_Outcome::normalize( $result['run_outcome'] ?? null, $result );
 
 		return $result;
+	}
+
+	/**
+	 * Project internal tool lifecycle data to a compact content-redacted contract.
+	 *
+	 * @param array<mixed> $events  Ordered tool lifecycle events.
+	 * @param array<mixed> $results Tool execution results.
+	 * @return array{version:int,calls:array<int,array<string,mixed>>}
+	 */
+	private static function tool_observability( array $events, array $results ): array {
+		$calls       = array();
+		$pending     = array();
+		$result_uses = array();
+
+		foreach ( $events as $event ) {
+			if ( ! is_array( $event ) ) {
+				continue;
+			}
+
+			$type         = $event['type'] ?? '';
+			$tool_call_id = $event['tool_call_id'] ?? '';
+			if ( ! is_string( $type ) || ! is_string( $tool_call_id ) || '' === $tool_call_id ) {
+				continue;
+			}
+
+			if ( 'tool_call' === $type ) {
+				$metadata   = is_array( $event['metadata'] ?? null ) ? $event['metadata'] : array();
+				$parameters = is_array( $metadata['parameters'] ?? null ) ? $metadata['parameters'] : array();
+				$keys       = array_map( 'strval', array_keys( $parameters ) );
+				$calls[]    = array(
+					'sequence'     => count( $calls ) + 1,
+					'turn'         => is_int( $event['turn_count'] ?? null ) ? $event['turn_count'] : 0,
+					'tool_call_id' => $tool_call_id,
+					'tool_name'    => is_string( $event['tool_name'] ?? null ) ? $event['tool_name'] : '',
+					'status'       => 'pending',
+					'arguments'    => array(
+						'keys'     => $keys,
+						'count'    => count( $keys ),
+						'redacted' => true,
+					),
+				);
+				$pending[ $tool_call_id ][] = count( $calls ) - 1;
+				continue;
+			}
+
+			if ( ! in_array( $type, array( 'tool_result', 'pending' ), true ) || empty( $pending[ $tool_call_id ] ) ) {
+				continue;
+			}
+
+			if ( 'pending' === $type ) {
+				continue;
+			}
+			$call_index = (int) array_shift( $pending[ $tool_call_id ] );
+
+			$metadata = is_array( $event['metadata'] ?? null ) ? $event['metadata'] : array();
+			$rejected = true === ( $metadata['rejected'] ?? false );
+			$succeeded = true === ( $metadata['success'] ?? false );
+			$calls[ $call_index ]['status'] = $rejected ? 'rejected' : ( $succeeded ? 'succeeded' : 'failed' );
+
+			$result = self::matching_tool_result( $results, $tool_call_id, $result_uses );
+			if ( is_array( $result ) ) {
+				$execution_result = is_array( $result['result'] ?? null ) ? $result['result'] : array();
+				$canonical_name   = $execution_result['tool_name'] ?? null;
+				if ( is_string( $canonical_name ) && '' !== $canonical_name ) {
+					$calls[ $call_index ]['tool_name'] = $canonical_name;
+				}
+
+				if ( $succeeded && array_key_exists( 'result', $execution_result ) ) {
+					$calls[ $call_index ]['result'] = self::result_shape( $execution_result['result'] );
+				}
+			}
+
+			if ( ! $succeeded ) {
+				$calls[ $call_index ]['error'] = $rejected
+					? array( 'code' => 'agents_api_tool_call_rejected', 'message' => 'Tool call was rejected.' )
+					: array( 'code' => 'agents_api_tool_execution_failed', 'message' => 'Tool execution failed.' );
+			}
+		}
+
+		return array(
+			'version' => self::TOOL_OBSERVABILITY_VERSION,
+			'calls'   => $calls,
+		);
+	}
+
+	/**
+	 * Find the next execution result for a tool-call id.
+	 *
+	 * @param array<mixed>       $results Tool results.
+	 * @param string             $tool_call_id Tool call id.
+	 * @param array<string, int> $uses Per-id result offsets.
+	 * @return array<mixed>|null
+	 */
+	private static function matching_tool_result( array $results, string $tool_call_id, array &$uses ): ?array {
+		$offset = $uses[ $tool_call_id ] ?? 0;
+		$match  = 0;
+		foreach ( $results as $result ) {
+			if ( ! is_array( $result ) || $tool_call_id !== ( $result['tool_call_id'] ?? null ) ) {
+				continue;
+			}
+			if ( $match === $offset ) {
+				$uses[ $tool_call_id ] = $offset + 1;
+				return $result;
+			}
+			++$match;
+		}
+
+		return null;
+	}
+
+	/**
+	 * Describe a result without exposing its content.
+	 *
+	 * @param mixed $value Result value.
+	 * @return array<string,int|string>
+	 */
+	private static function result_shape( $value ): array {
+		if ( is_array( $value ) ) {
+			return array(
+				'type'  => array_is_list( $value ) ? 'array' : 'object',
+				'count' => count( $value ),
+			);
+		}
+
+		if ( is_string( $value ) ) {
+			return array( 'type' => 'string', 'size' => strlen( $value ) );
+		}
+
+		return array( 'type' => strtolower( gettype( $value ) ) );
 	}
 
 	/**

--- a/tests/agents-chat-ability-smoke.php
+++ b/tests/agents-chat-ability-smoke.php
@@ -186,6 +186,8 @@ smoke_assert( true, isset( $in['properties']['principal']['properties']['auth_so
 
 $out_schema = agents_chat_output_schema();
 smoke_assert( array( 'session_id', 'reply' ), $out_schema['required'] ?? array(), 'output_schema_required_fields', $failures, $passes );
+smoke_assert( array( 1 ), $out_schema['properties']['metadata']['properties']['agents_api']['properties']['tool_observability']['properties']['version']['enum'] ?? array(), 'output_schema_documents_tool_observability_v1', $failures, $passes );
+smoke_assert( array( 'pending', 'succeeded', 'failed', 'rejected' ), $out_schema['properties']['metadata']['properties']['agents_api']['properties']['tool_observability']['properties']['calls']['items']['properties']['status']['enum'] ?? array(), 'output_schema_documents_tool_statuses', $failures, $passes );
 
 // 9. Runtime principal input is normalized before dispatch and has a scoped permission filter.
 smoke_reset_chat_filters();

--- a/tests/conversation-loop-tool-execution-smoke.php
+++ b/tests/conversation-loop-tool-execution-smoke.php
@@ -246,6 +246,7 @@ agents_api_smoke_assert_equals( 'Duplicate tool call rejected.', $reject_result[
 agents_api_smoke_assert_equals( 'duplicate_tool_call', $reject_result['tool_audit_events'][0]['error_type'] ?? '', 'reject decision records audit error type', $failures, $passes );
 agents_api_smoke_assert_equals( array( 'tool_call', 'tool_result' ), array_column( $reject_result['tool_events'], 'type' ), 'reject decision records canonical tool events', $failures, $passes );
 agents_api_smoke_assert_equals( 'error', $reject_result['tool_events'][1]['status'] ?? '', 'reject decision records error tool event status', $failures, $passes );
+agents_api_smoke_assert_equals( 'rejected', $reject_result['tool_observability']['calls'][0]['status'] ?? '', 'tool observability distinguishes mediator rejection from execution failure', $failures, $passes );
 
 $executor->executed = array();
 $replace_result     = AgentsAPI\AI\WP_Agent_Conversation_Loop::run(
@@ -350,6 +351,8 @@ $multi_result = AgentsAPI\AI\WP_Agent_Conversation_Loop::run(
 agents_api_smoke_assert_equals( 2, count( $executor->executed ), 'tool executor was called twice across turns', $failures, $passes );
 agents_api_smoke_assert_equals( 3, $turn_count, 'loop ran three turns (two with tools, one without)', $failures, $passes );
 agents_api_smoke_assert_equals( 2, count( $multi_result['tool_execution_results'] ), 'result contains two tool execution results', $failures, $passes );
+agents_api_smoke_assert_equals( array( 'tool-call-1-1', 'tool-call-2-1' ), array_column( $multi_result['tool_observability']['calls'] ?? array(), 'tool_call_id' ), 'tool observability preserves generated fallback ids across turns', $failures, $passes );
+agents_api_smoke_assert_equals( array( 1, 2 ), array_column( $multi_result['tool_observability']['calls'] ?? array(), 'sequence' ), 'tool observability assigns global call sequence across turns', $failures, $passes );
 
 echo "\n[4] Tool validation errors are returned as error results without crashing:\n";
 $executor->executed = array();
@@ -644,6 +647,7 @@ agents_api_smoke_assert_equals( false, $pending_result['completed'] ?? true, 'pe
 agents_api_smoke_assert_equals( 'client/summarize', $pending_result['runtime_tool_pending']['tool_name'] ?? '', 'pending request carries tool name', $failures, $passes );
 agents_api_smoke_assert_equals( 'client-call-1', $pending_result['runtime_tool_pending']['tool_call_id'] ?? '', 'pending request carries tool call id', $failures, $passes );
 agents_api_smoke_assert_equals( array( 'tool_call', AgentsAPI\AI\WP_Agent_Runtime_Tool_Request::STATUS_PENDING ), array_column( $pending_result['tool_events'], 'type' ), 'pending request is recorded in canonical tool events', $failures, $passes );
+agents_api_smoke_assert_equals( 'pending', $pending_result['tool_observability']['calls'][0]['status'] ?? '', 'tool observability records pending runtime calls', $failures, $passes );
 agents_api_smoke_assert_equals( AgentsAPI\AI\WP_Agent_Conversation_Result::OUTCOME_STATUS_PENDING_RUNTIME_TOOL, $pending_result['run_outcome']['status'] ?? '', 'pending runtime tool run outcome is pending', $failures, $passes );
 agents_api_smoke_assert_equals( AgentsAPI\AI\WP_Agent_Runtime_Tool_Request::STATUS_PENDING, $pending_result['run_outcome']['stop_reason'] ?? '', 'pending runtime tool run outcome stop reason is pending', $failures, $passes );
 

--- a/tests/default-agents-chat-handler-smoke.php
+++ b/tests/default-agents-chat-handler-smoke.php
@@ -438,6 +438,13 @@ namespace {
 	agents_api_smoke_assert_equals( true, in_array( 'user', $canonical_roles, true ), 'canonical messages include the user turn', $failures, $passes );
 	agents_api_smoke_assert_equals( true, in_array( 'assistant', $canonical_roles, true ), 'canonical messages include the assistant reply', $failures, $passes );
 	agents_api_smoke_assert_equals( true, ! in_array( 'tool', $canonical_roles, true ), 'canonical messages omit raw tool envelopes', $failures, $passes );
+	$tool_observability = $output['metadata']['agents_api']['tool_observability'] ?? array();
+	agents_api_smoke_assert_equals( 1, $tool_observability['version'] ?? null, 'canonical metadata projects tool observability v1', $failures, $passes );
+	agents_api_smoke_assert_equals( 'call-1', $tool_observability['calls'][0]['tool_call_id'] ?? '', 'canonical metadata preserves the provider tool call id', $failures, $passes );
+	agents_api_smoke_assert_equals( 'succeeded', $tool_observability['calls'][0]['status'] ?? '', 'canonical metadata projects the terminal tool status', $failures, $passes );
+	agents_api_smoke_assert_equals( array( 'query' ), $tool_observability['calls'][0]['arguments']['keys'] ?? array(), 'canonical metadata exposes argument keys without values', $failures, $passes );
+	$tool_observability_json = json_encode( $tool_observability );
+	agents_api_smoke_assert_equals( false, is_string( $tool_observability_json ) && str_contains( $tool_observability_json, 'risotto' ), 'canonical tool observability omits argument values', $failures, $passes );
 
 	echo "\n[1b] Runtime-bundle agents declare their toolset as `enabled_tools` and the loop wires it:\n";
 	// Native runtime agent bundles place their toolset under

--- a/tests/tool-observability-smoke.php
+++ b/tests/tool-observability-smoke.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * Pure-PHP smoke tests for the content-redacted tool observability contract.
+ *
+ * @package AgentsAPI\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+$failures = array();
+$passes   = 0;
+
+echo "agents-api-tool-observability-smoke\n";
+
+require_once __DIR__ . '/agents-api-smoke-helpers.php';
+require_once __DIR__ . '/../agents-api.php';
+
+$call_event = static function ( string $id, string $name, int $turn, array $parameters ): array {
+	return array(
+		'type'         => 'tool_call',
+		'tool_name'    => $name,
+		'tool_call_id' => $id,
+		'turn_count'   => $turn,
+		'status'       => 'called',
+		'metadata'     => array( 'status' => 'called', 'parameters' => $parameters, 'parameters_sha256' => 'sha256:parameter-secret' ),
+	);
+};
+$terminal_event = static function ( string $id, string $name, int $turn, bool $success, bool $rejected = false ): array {
+	return array(
+		'type'         => 'tool_result',
+		'tool_name'    => $name,
+		'tool_call_id' => $id,
+		'turn_count'   => $turn,
+		'status'       => $success ? 'success' : 'error',
+		'metadata'     => array( 'status' => $success ? 'success' : 'error', 'success' => $success, 'rejected' => $rejected, 'raw_error' => 'RAW_ERROR_SENTINEL' ),
+	);
+};
+$execution_result = static function ( string $id, string $event_name, string $canonical_name, int $turn, bool $success, $payload ): array {
+	$result = array(
+		'success'   => $success,
+		'tool_name' => $canonical_name,
+		'metadata'  => array( 'extension_secret' => 'ARBITRARY_METADATA_SENTINEL' ),
+	);
+	if ( $success ) {
+		$result['result'] = $payload;
+	} else {
+		$result['error'] = 'RAW_EXECUTOR_ERROR_SENTINEL';
+	}
+
+	return array(
+		'tool_name'           => $event_name,
+		'tool_call_id'        => $id,
+		'result'              => $result,
+		'parameters'          => array( 'path' => 'RAW_PATH_SENTINEL', 'token' => 'RAW_PARAMETER_SENTINEL' ),
+		'parameters_sha256'   => 'sha256:parameter-secret',
+		'parameters_redacted' => true,
+		'turn_count'          => $turn,
+	);
+};
+
+$provider_id = 'provider-call-id';
+$fallback_id = 'tool-call-2-1';
+$result      = AgentsAPI\AI\WP_Agent_Conversation_Result::normalize(
+	array(
+		'messages'               => array( AgentsAPI\AI\WP_Agent_Message::text( 'assistant', 'safe reply' ) ),
+		'tool_events'            => array(
+			$call_event( $provider_id, 'provider_alias', 1, array( 'query' => 'RAW_PARAMETER_SENTINEL', 'limit' => 10 ) ),
+			$terminal_event( $provider_id, 'provider_alias', 1, true ),
+			$call_event( $fallback_id, 'workspace/read', 2, array( 'path' => 'RAW_PATH_SENTINEL' ) ),
+			$terminal_event( $fallback_id, 'workspace/read', 2, false ),
+			$call_event( 'rejected-id', 'workspace/write', 2, array( 'content' => 'RAW_CONTENT_SENTINEL' ) ),
+			$terminal_event( 'rejected-id', 'workspace/write', 2, false, true ),
+			$call_event( 'pending-id', 'browser/open', 3, array( 'url' => 'RAW_URL_SENTINEL' ) ),
+			array(
+				'type'         => 'pending',
+				'tool_name'    => 'browser/open',
+				'tool_call_id' => 'pending-id',
+				'turn_count'   => 3,
+				'status'       => 'pending',
+				'metadata'     => array( 'status' => 'pending', 'request_id' => 'PRIVATE_REQUEST_SENTINEL' ),
+			),
+		),
+		'tool_execution_results' => array(
+			$execution_result( $provider_id, 'provider_alias', 'catalog/search', 1, true, array( 'items' => array( 'RAW_RESULT_SENTINEL' ), 'source' => 'RAW_SOURCE_SENTINEL' ) ),
+			$execution_result( $fallback_id, 'workspace/read', 'workspace/read', 2, false, null ),
+			$execution_result( 'rejected-id', 'workspace/write', 'workspace/write', 2, false, null ),
+		),
+		'tool_observability'     => array( 'version' => 999, 'calls' => array( 'MALICIOUS_INPUT_SENTINEL' ) ),
+	)
+);
+
+$observability = $result['tool_observability'] ?? array();
+$calls         = $observability['calls'] ?? array();
+
+agents_api_smoke_assert_equals( 1, $observability['version'] ?? null, 'contract is version 1', $failures, $passes );
+agents_api_smoke_assert_equals( array( 1, 2, 3, 4 ), array_column( $calls, 'sequence' ), 'calls retain global order across turns', $failures, $passes );
+agents_api_smoke_assert_equals( array( 1, 2, 2, 3 ), array_column( $calls, 'turn' ), 'calls retain source turn numbers', $failures, $passes );
+agents_api_smoke_assert_equals( array( $provider_id, $fallback_id, 'rejected-id', 'pending-id' ), array_column( $calls, 'tool_call_id' ), 'provider and fallback ids are preserved', $failures, $passes );
+agents_api_smoke_assert_equals( array( 'succeeded', 'failed', 'rejected', 'pending' ), array_column( $calls, 'status' ), 'all terminal and pending statuses normalize once per call', $failures, $passes );
+agents_api_smoke_assert_equals( 'catalog/search', $calls[0]['tool_name'] ?? '', 'successful result supplies the canonical tool name', $failures, $passes );
+agents_api_smoke_assert_equals( array( 'keys' => array( 'query', 'limit' ), 'count' => 2, 'redacted' => true ), $calls[0]['arguments'] ?? array(), 'arguments expose keys, count, and redaction marker only', $failures, $passes );
+agents_api_smoke_assert_equals( array( 'type' => 'object', 'count' => 2 ), $calls[0]['result'] ?? array(), 'successful results expose shape only', $failures, $passes );
+agents_api_smoke_assert_equals( array( 'code' => 'agents_api_tool_execution_failed', 'message' => 'Tool execution failed.' ), $calls[1]['error'] ?? array(), 'failure uses an Agents API-owned safe error', $failures, $passes );
+agents_api_smoke_assert_equals( array( 'code' => 'agents_api_tool_call_rejected', 'message' => 'Tool call was rejected.' ), $calls[2]['error'] ?? array(), 'rejection uses an Agents API-owned safe error', $failures, $passes );
+agents_api_smoke_assert_equals( false, isset( $calls[3]['error'] ), 'pending calls do not fabricate an error', $failures, $passes );
+
+$public_json = json_encode( $observability );
+foreach ( array( 'RAW_', 'SENTINEL', 'sha256:', 'parameters_sha256', 'extension_secret', 'request_id', 'MALICIOUS_INPUT' ) as $forbidden ) {
+	agents_api_smoke_assert_equals( false, is_string( $public_json ) && str_contains( $public_json, $forbidden ), 'contract omits forbidden content: ' . $forbidden, $failures, $passes );
+}
+
+agents_api_smoke_finish( 'Agents API tool observability', $failures, $passes );


### PR DESCRIPTION
## Summary
- Finalized Homeboy agent-task cook run `cook-agents-api-426-tool-observability-attempt-1-ab4f666a` into review-ready branch `feat/tool-observability-final`.

## Proof provenance
- **Proof runner:** Homeboy agent-task cook loop
- **Proof ID:** `agent-task-finalization:cook-agents-api-426-tool-observability-attempt-1-ab4f666a`
- **Homeboy run ID:** `cook-agents-api-426-tool-observability-attempt-1-ab4f666a`
- **Manual proof:** none recorded by this Homeboy finalization

## Publication intent
- **Schema:** `homeboy/agent-task-publication-intent/v1`
- **Action:** `review_request`
- **Target kind:** `code_review`
- **Adapter:** `github_pull_request`
- **Base:** `main`
- **Head:** `feat/tool-observability-final`

## Source refs
- https://github.com/Automattic/agents-api/issues/426
- https://github.com/Extra-Chill/homeboy/pull/8204
- https://github.com/Extra-Chill/homeboy/pull/8211
- https://github.com/Extra-Chill/homeboy/pull/8221

## Attempt summary
Accepted Homeboy repair resolved configured DMC provider, promoted the retained candidate, and both complete Agents API gates passed; independent security review found no issues.

## Gate results
- smoke-suite: passed (targeted)
- phpstan: passed (targeted)

## Verification capability
- `targeted_checks_run`: `composer test`, `composer phpstan`
- `targeted_checks_unavailable`: none recorded
- `ci_expected`: `Agents API repository CI`
- `manual_reviewer_check`: Inspect metadata.agents_api.tool_observability and confirm no raw argument values, result bodies, hashes, runtime metadata, or executor errors are exposed.

## CI-equivalent coverage
- **CI-equivalent required gate:** CI-equivalent required gate was not recorded; targeted proof must not be treated as full CI coverage

## Changed files
- composer.json
- src/Channels/register-agents-chat-ability.php
- src/Channels/register-default-agents-chat-handler.php
- src/Runtime/class-wp-agent-conversation-loop.php
- src/Runtime/class-wp-agent-conversation-result.php
- tests/agents-chat-ability-smoke.php
- tests/conversation-loop-tool-execution-smoke.php
- tests/default-agents-chat-handler-smoke.php
- tests/tool-observability-smoke.php

## Artifact refs
- none recorded

## Final status
- **Status:** review-ready
- **Base:** `main`
- **Head:** `feat/tool-observability-final`
- **Merge/deploy:** not performed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Model:** openai/gpt-5.6-terra
- **Used for:** Designed, implemented, security-reviewed, and verified the compact content-redacted tool observability contract; Chris reviews and owns the change.
