### PR TITLE
Remove Data Machine-specific product blacklist entries

### DIFF
--- a/tests/default-agents-chat-handler-smoke.php
+++ b/tests/default-agents-chat-handler-smoke.php
@@ -3,7 +3,7 @@
  * Pure-PHP smoke test for the default agents/chat runtime handler.
  *
  * Proves that Agents API runs a real agent loop turn natively behind the
- * canonical `agents/chat` ability — no Data Machine, no external runtime — and
+ * canonical `agents/chat` ability — no product-specific or external runtime — and
  * that dispatch is provider-agnostic (driven only by the requested provider +
  * model through the wp-ai-client builder, here stubbed with a deterministic
  * fake provider that emits a tool call then a final assistant message).

--- a/tests/no-product-imports-smoke.php
+++ b/tests/no-product-imports-smoke.php
@@ -42,12 +42,6 @@ $forbidden_namespaces = array(
 );
 
 $forbidden_product_vocabulary = array(
-	'Data Machine',
-	'DataMachine',
-	'data machine',
-	'datamachine',
-	'data-machine',
-	'data_machine',
 	'Homeboy',
 	'homeboy',
 	'Acme Runner',


### PR DESCRIPTION
## Summary
Remove obsolete Data Machine-specific blacklist checks while retaining generic product-neutral boundaries.

## What changed
- Removed six Data Machine spellings from the forbidden product-vocabulary list and generalized the native chat-handler comment.

## How to test
1. Run `php tests/no-product-imports-smoke.php`; expect All 7 assertions pass..
2. Run `php tests/default-agents-chat-handler-smoke.php`; expect All 52 assertions pass..

## Compatibility
No runtime or extension compatibility impact; this changes test vocabulary and a comment only.

## Evidence
- CI expected: Agents API test suite
- Reviewer-resolvable source evidence: https://github.com/Automattic/agents-api/issues/433
- targeted-tests: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode via Homeboy
- **Model:** openai/gpt-5.6-terra
- **Used for:** Removed obsolete Data Machine-specific negative guards while preserving generic product-neutral and security contracts; Chris reviews and owns the change.

## Source relationships
- Closes Automattic/agents-api#433
