### PR TITLE
Prepare Composer bootstrap and parallel docs for v0.6.0

### DIFF
--- a/agents-api.php
+++ b/agents-api.php
@@ -25,9 +25,67 @@ if ( defined( '__PHPSTAN_RUNNING__' ) ) {
 	return;
 }
 
-defined( 'ABSPATH' ) || exit;
+// Composer evaluates this file through its `files` autoloader. Loading a
+// project's autoloader before WordPress is bootstrapped must remain harmless.
+if ( ! defined( 'ABSPATH' ) ) {
+	return;
+}
 
 if ( defined( 'AGENTS_API_LOADED' ) ) {
+	// A newer bundled or Composer copy can add symbols after an older copy has
+	// registered the runtime. Load each class or interface only when its symbol is
+	// absent, without repeating registration side effects.
+	$agents_api_load_symbol_file = static function ( string $file ): void {
+		$namespace = '';
+		$tokens    = token_get_all( (string) file_get_contents( $file ) );
+		$count     = count( $tokens );
+
+		for ( $index = 0; $index < $count; ++$index ) {
+			$token = $tokens[ $index ];
+			if ( ! is_array( $token ) ) {
+				continue;
+			}
+
+			if ( T_NAMESPACE === $token[0] ) {
+				$namespace = '';
+				for ( ++$index; $index < $count; ++$index ) {
+					$namespace_token = $tokens[ $index ];
+					if ( ';' === $namespace_token || '{' === $namespace_token ) {
+						break;
+					}
+					if ( is_array( $namespace_token ) ) {
+						$namespace .= $namespace_token[1];
+					}
+				}
+				continue;
+			}
+
+			if ( ! in_array( $token[0], array( T_CLASS, T_INTERFACE, T_TRAIT ), true ) ) {
+				continue;
+			}
+
+			for ( ++$index; $index < $count; ++$index ) {
+				$symbol_token = $tokens[ $index ];
+				if ( is_array( $symbol_token ) && T_STRING === $symbol_token[0] ) {
+					$namespace = trim( $namespace );
+					$symbol    = '' === $namespace ? $symbol_token[1] : $namespace . '\\' . $symbol_token[1];
+					if ( ! class_exists( $symbol, false ) && ! interface_exists( $symbol, false ) && ! trait_exists( $symbol, false ) ) {
+						require_once $file;
+					}
+					return;
+				}
+			}
+		}
+	};
+
+	$agents_api_symbol_files = array_merge(
+		glob( __DIR__ . '/src/*/{class,interface}-*.php', GLOB_BRACE ) ?: array(),
+		array( __DIR__ . '/src/Channels/register-default-agents-chat-handler.php' )
+	);
+	foreach ( $agents_api_symbol_files as $agents_api_symbol_file ) {
+		$agents_api_load_symbol_file( $agents_api_symbol_file );
+	}
+
 	return;
 }
 

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,9 @@
   "require": {
     "php": ">=8.1"
   },
+  "replace": {
+    "automattic/agents-api": "self.version"
+  },
   "autoload": {
     "files": [
       "agents-api.php"
@@ -22,6 +25,8 @@
   "scripts": {
     "phpstan": "phpstan analyse --no-progress --memory-limit=2G",
     "smoke": [
+      "php tests/composer-autoload-smoke.php",
+      "php tests/bootstrap-version-skew-smoke.php",
       "php tests/bootstrap-smoke.php",
       "php tests/message-envelope-smoke.php",
       "php tests/message-coalesce-smoke.php",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f4c85f0f4336b799e977e8cd64439162",
+    "content-hash": "0ef0c0aef9328305f2be261f0f021c07",
     "packages": [],
     "packages-dev": [
         {

--- a/docs/channels-workflows-operations.md
+++ b/docs/channels-workflows-operations.md
@@ -264,6 +264,8 @@ Default step handlers:
 
 The default `parallel` handler uses `wp_agent_workflow_step_executor` as its concurrency seam. When an executor is available, it dispatches branches out of band and returns a `_suspend` directive so the run can resume after reconciliation. Agents API ships an Action Scheduler branch executor that is selected when `as_enqueue_async_action()` exists; it enqueues one async action per branch, raises branch-specific Action Scheduler concurrency while branches are in flight, and triggers loopback runners for faster drain. Without Action Scheduler or a caller-supplied executor, `parallel` falls back to synchronous in-process branch execution.
 
+The Action Scheduler executor requires a store that supports concurrent writes for parallel branch execution. MySQL and MariaDB can provide that concurrency. SQLite uses a single database-wide writer lock, so Action Scheduler claims and branch execution serialize even when multiple workers are requested. SQLite remains correct for async branch completion, but it provides no parallel speedup. Consumers that require parallel execution should use MySQL or MariaDB; Agents API does not detect or warn about the active database engine at runtime.
+
 Consumers extend the runner through the constructor or the `wp_agent_workflow_step_handlers` filter. Product-specific steps such as `branch` or nested `workflow` belong in consumers.
 
 Recorder behavior is conservative: `start()` runs before input validation, per-step `update()` calls follow state changes, and recorder-start failure returns a failed run result without executing steps.

--- a/src/Workflows/class-wp-agent-workflow-action-scheduler-branch-executor.php
+++ b/src/Workflows/class-wp-agent-workflow-action-scheduler-branch-executor.php
@@ -389,8 +389,9 @@ final class WP_Agent_Workflow_Action_Scheduler_Branch_Executor implements WP_Age
 	 *
 	 * It replicates ActionScheduler_AsyncRequest_QueueRunner's own dispatch: a POST
 	 * to `admin-ajax.php?action=as_async_request_queue_runner` with the matching
-	 * nonce. On MySQL each warm worker's `stake_claim` uses FOR UPDATE SKIP LOCKED,
-	 * so concurrent workers claim DIFFERENT pending branch actions.
+	 * nonce. Stores that support concurrent writes can claim pending branch actions
+	 * from separate workers. SQLite serializes writes behind its single writer lock,
+	 * so it cannot provide parallel branch execution.
 	 *
 	 * Public so a caller awaiting a suspended run in the foreground can re-nudge the
 	 * pool during its poll (the loopback worker self-chain can lapse behind AS's

--- a/src/Workflows/register-workflow-branch-executor.php
+++ b/src/Workflows/register-workflow-branch-executor.php
@@ -168,9 +168,10 @@ add_filter( 'action_scheduler_timeout_period', $agents_workflow_branch_reaper_wi
 //        branch and leaves the rest for its peers.
 //
 //    Together (concurrent_batches=N + batch_size=1) they turn N running workers into N
-//    DISTINCT branches instead of one worker draining a batch of them serially. On
-//    MySQL each worker's stake_claim uses FOR UPDATE SKIP LOCKED, so the concurrent
-//    claims pick distinct branches.
+//    DISTINCT branches instead of one worker draining a batch of them serially on
+//    stores that support concurrent writes. SQLite has one database-wide writer,
+//    so it serializes Action Scheduler claims and cannot execute these branches in
+//    parallel.
 //
 //    IN FLIGHT = PENDING + IN-PROGRESS, NOT PENDING ALONE. The gate keys off
 //    {@see WP_Agent_Workflow_Action_Scheduler_Branch_Executor::branch_inflight_count()}

--- a/tests/bootstrap-version-skew-smoke.php
+++ b/tests/bootstrap-version-skew-smoke.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Regression for a newer Agents API copy following an older loaded copy.
+ *
+ * Run with: php tests/bootstrap-version-skew-smoke.php
+ *
+ * @package AgentsAPI\Tests
+ */
+
+require_once __DIR__ . '/agents-api-smoke-helpers.php';
+
+$root     = dirname( __DIR__ );
+$old_copy = sys_get_temp_dir() . '/agents-api-old-' . bin2hex( random_bytes( 8 ) );
+
+/** @param string $source Source directory. @param string $destination Destination directory. */
+function agents_api_copy_directory( string $source, string $destination ): void {
+	mkdir( $destination, 0777, true );
+	foreach ( new DirectoryIterator( $source ) as $entry ) {
+		if ( $entry->isDot() ) {
+			continue;
+		}
+
+		$target = $destination . '/' . $entry->getFilename();
+		if ( $entry->isDir() ) {
+			agents_api_copy_directory( $entry->getPathname(), $target );
+			continue;
+		}
+
+		copy( $entry->getPathname(), $target );
+	}
+}
+
+agents_api_copy_directory( $root . '/src', $old_copy . '/src' );
+$old_bootstrap = (string) file_get_contents( $root . '/agents-api.php' );
+$old_bootstrap = str_replace(
+	"require_once AGENTS_API_PATH . 'src/Channels/class-wp-agent-channel.php';\n",
+	'',
+	$old_bootstrap
+);
+file_put_contents( $old_copy . '/agents-api.php', $old_bootstrap );
+
+require $old_copy . '/agents-api.php';
+
+if ( class_exists( 'AgentsAPI\\AI\\Channels\\WP_Agent_Channel', false ) ) {
+	fwrite( STDERR, "FAIL: skew fixture unexpectedly loaded the newer class.\n" );
+	exit( 1 );
+}
+
+$hook_count = count( $GLOBALS['__agents_api_smoke_actions'] );
+require $root . '/agents-api.php';
+
+if ( ! class_exists( 'AgentsAPI\\AI\\Channels\\WP_Agent_Channel', false ) ) {
+	fwrite( STDERR, "FAIL: newer copy did not load its missing class.\n" );
+	exit( 1 );
+}
+
+if ( $hook_count !== count( $GLOBALS['__agents_api_smoke_actions'] ) ) {
+	fwrite( STDERR, "FAIL: newer copy repeated bootstrap side effects.\n" );
+	exit( 1 );
+}
+
+echo "PASS: newer copy tops up missing classes without repeating hooks.\n";

--- a/tests/composer-autoload-smoke.php
+++ b/tests/composer-autoload-smoke.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * CLI regression for Composer's files autoloader outside a WordPress request.
+ *
+ * Run with: php tests/composer-autoload-smoke.php
+ *
+ * @package AgentsAPI\Tests
+ */
+
+echo "agents-api-composer-autoload-smoke\n";
+
+require dirname( __DIR__ ) . '/vendor/autoload.php';
+
+if ( defined( 'AGENTS_API_LOADED' ) ) {
+	fwrite( STDERR, "FAIL: Composer autoload initialized Agents API outside WordPress.\n" );
+	exit( 1 );
+}
+
+echo "PASS: Composer autoload returns without WordPress.\n";


### PR DESCRIPTION
## Summary
- make Composer autoload harmless outside a bootstrapped WordPress process and preserve the old Composer package name through `replace: self.version`
- make repeated bootstrap loading idempotent per symbol so a newer copy can top up classes absent from an older copy without repeating runtime registration
- document that Action Scheduler parallel branches require concurrent-write storage and run correctly but serially on SQLite

Fixes #274.
Fixes #291.
Fixes #393.

#279 is a duplicate report of #291 and should close with the same fix.

## How to test
1. Run `composer install --no-interaction` from a fresh checkout.
2. Run `php tests/composer-autoload-smoke.php`; confirm Composer autoload returns and prints the post-autoload assertion outside WordPress.
3. Run `php tests/bootstrap-version-skew-smoke.php`; confirm an older first copy and newer second copy produce the union of symbols without redeclaration or duplicate hook registration.
4. Run `composer test`.
5. Run `composer phpstan`.
6. Run `composer validate --no-check-publish`.

## Backward compatibility
The public bootstrap constants, first-copy hook registration, WordPress load behavior, and existing unscoped Composer package remain supported. The old `automattic/agents-api` package name resolves through Composer replacement metadata. Repeated copies now add only missing symbols rather than silently freezing the oldest class set.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.6-sol)
- **Used for:** Implemented Composer/bootstrap compatibility fixes, realistic regression coverage, and corrected parallel-execution documentation with Chris directing and reviewing the release scope.
