### PR TITLE
Use Docs Agent #148 and WP Codebox v0.12.23

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,14 +53,14 @@ jobs:
         uses: actions/checkout@v6.0.3
         with:
           repository: Automattic/docs-agent
-          ref: 4c1043510ae71be4750cfde69777efc95ae0001e
+          ref: 37d2c49251bc402852d301d9d5b42a105413f13e
           path: .docs-agent-producer
 
       - name: Checkout WP Codebox producer schema
         uses: actions/checkout@v6.0.3
         with:
           repository: Automattic/wp-codebox
-          ref: v0.12.21
+          ref: v0.12.23
           path: .wp-codebox-producer
 
       - name: Set up PHP

--- a/.github/workflows/docs-agent.yml
+++ b/.github/workflows/docs-agent.yml
@@ -20,7 +20,7 @@ concurrency:
 jobs:
   docs-agent:
     name: Maintain Technical Documentation
-    uses: Automattic/docs-agent/.github/workflows/maintain-docs.yml@4c1043510ae71be4750cfde69777efc95ae0001e
+    uses: Automattic/docs-agent/.github/workflows/maintain-docs.yml@37d2c49251bc402852d301d9d5b42a105413f13e
     with:
       audience: technical
       run_kind: maintenance

--- a/tests/docs-agent-native-workflow-contract.php
+++ b/tests/docs-agent-native-workflow-contract.php
@@ -2,8 +2,8 @@
 /**
  * Validate the Docs Agent consumer against its pinned native producer chain.
  *
- * Run with DOCS_AGENT_DIR at Docs Agent #143's merge commit and WP_CODEBOX_DIR
- * at WP Codebox v0.12.21. This test intentionally fails without
+ * Run with DOCS_AGENT_DIR at Docs Agent #148's merge commit and WP_CODEBOX_DIR
+ * at WP Codebox v0.12.23. This test intentionally fails without
  * both checkouts because it verifies the producer interfaces, not just copies
  * of their expected values in this repository.
  *
@@ -12,9 +12,9 @@
 
 declare( strict_types=1 );
 
-const AGENTS_API_DOCS_AGENT_REVISION = '4c1043510ae71be4750cfde69777efc95ae0001e';
-const AGENTS_API_WP_CODEBOX_REF      = 'v0.12.21';
-const AGENTS_API_WP_CODEBOX_REVISION = 'b5b1fc7eef4367d5e403de3e373df91d3722965b';
+const AGENTS_API_DOCS_AGENT_REVISION = '37d2c49251bc402852d301d9d5b42a105413f13e';
+const AGENTS_API_WP_CODEBOX_REF      = 'v0.12.23';
+const AGENTS_API_WP_CODEBOX_REVISION = 'a2b02cd99ba645ba2250bf58c943bdd1eb13e690';
 
 $root     = dirname( __DIR__ );
 $failures = array();
@@ -103,7 +103,7 @@ if ( is_array( $schema ) ) {
 	}
 }
 
-agents_api_docs_agent_contract_match( $consumer_workflow, '~^\s*uses:\s*Automattic/docs-agent/\.github/workflows/maintain-docs\.yml@' . AGENTS_API_DOCS_AGENT_REVISION . '\s*$~m', 'Consumer must pin Docs Agent #143.', $failures );
+agents_api_docs_agent_contract_match( $consumer_workflow, '~^\s*uses:\s*Automattic/docs-agent/\.github/workflows/maintain-docs\.yml@' . AGENTS_API_DOCS_AGENT_REVISION . '\s*$~m', 'Consumer must pin Docs Agent #148.', $failures );
 agents_api_docs_agent_contract_match( $consumer_workflow, '~^\s*audience:\s*technical\s*$~m', 'Consumer audience must be technical.', $failures );
 agents_api_docs_agent_contract_match( $consumer_workflow, '~^\s*run_kind:\s*maintenance\s*$~m', 'Consumer run kind must be maintenance.', $failures );
 agents_api_docs_agent_contract_match( $consumer_workflow, '~^\s*base_ref:\s*main\s*$~m', 'Consumer target base must be main.', $failures );
@@ -119,8 +119,8 @@ foreach ( array( 'contents: write', 'pull-requests: write', 'issues: write' ) as
 	agents_api_docs_agent_contract_match( $consumer_workflow, '~^\s*' . preg_quote( $permission, '~' ) . '\s*$~m', "Consumer must grant {$permission} for built-in-token publication.", $failures );
 }
 
-agents_api_docs_agent_contract_match( $docs_workflow, '~technical:maintenance\)\s+package_path="bundles/technical-docs-agent/native/technical-docs-maintenance-agent\.agent\.json"\s+agent_slug="technical-docs-maintenance-agent"\s+package_digest="sha256-bytes-v1:6057aad4eb7c5f0320ccfbce9da93a5fa1d3fc521478b5571ed81c28129325aa"\s+success_requires_pr=false~s', 'Docs Agent #143 technical maintenance lane must map to its exact native package.', $failures );
-agents_api_docs_agent_contract_match( $docs_workflow, '~uses:\s*Automattic/wp-codebox/\.github/workflows/run-agent-task\.yml@' . preg_quote( AGENTS_API_WP_CODEBOX_REF, '~' ) . '~', 'Docs Agent must pin WP Codebox v0.12.21.', $failures );
+agents_api_docs_agent_contract_match( $docs_workflow, '~technical:maintenance\)\s+package_path="bundles/technical-docs-agent/native/technical-docs-maintenance-agent\.agent\.json"\s+agent_slug="technical-docs-maintenance-agent"\s+package_digest="sha256-bytes-v1:6057aad4eb7c5f0320ccfbce9da93a5fa1d3fc521478b5571ed81c28129325aa"\s+success_requires_pr=false~s', 'Docs Agent #148 technical maintenance lane must map to its exact native package.', $failures );
+agents_api_docs_agent_contract_match( $docs_workflow, '~uses:\s*Automattic/wp-codebox/\.github/workflows/run-agent-task\.yml@' . preg_quote( AGENTS_API_WP_CODEBOX_REF, '~' ) . '~', 'Docs Agent must pin WP Codebox v0.12.23.', $failures );
 agents_api_docs_agent_contract_match( $docs_workflow, '~wp_codebox_release_ref:\s*' . preg_quote( AGENTS_API_WP_CODEBOX_REF, '~' ) . '.*?external_package_source:\s*\$\{\{ needs\.prepare\.outputs\.external_package_source \}\}.*?runtime_sources:\s*\$\{\{ needs\.prepare\.outputs\.runtime_sources \}\}.*?target_repo:\s*\$\{\{ github\.repository \}\}.*?writable_paths:\s*\$\{\{ inputs\.writable_paths \}\}.*?verification_commands:\s*\$\{\{ needs\.prepare\.outputs\.verification_commands \}\}.*?drift_checks:\s*\$\{\{ needs\.prepare\.outputs\.drift_checks \}\}.*?success_requires_pr:\s*\$\{\{ needs\.prepare\.outputs\.success_requires_pr == \'true\' \}\}.*?access_token_repos:\s*\$\{\{ github\.repository \}\}.*?allowed_repos:\s*\'\["\$\{\{ github\.repository \}\}"\]\'~s', 'Docs Agent must preserve the WP Codebox release, external-package, runtime-source, target, writable, verification, publication, and access chain.', $failures );
 agents_api_docs_agent_contract_match( $docs_workflow, '~OPENAI_API_KEY:\s*\$\{\{ secrets\.OPENAI_API_KEY \}\}\s+ACCESS_TOKEN:\s*\$\{\{ github\.token \}\}\s+EXTERNAL_PACKAGE_SOURCE_POLICY:\s*\$\{\{ secrets\.EXTERNAL_PACKAGE_SOURCE_POLICY \}\}~s', 'Docs Agent must forward caller credentials and its built-in publication token.', $failures );
 


### PR DESCRIPTION
## Summary
Pin Agents API to merged Docs Agent #148 and repaired WP Codebox v0.12.23.

## What changed
- Update the reusable Docs Agent workflow pin and CI producer checkouts to immutable accepted revisions.
- Update the source-backed contract test and labels for Docs Agent #148 and WP Codebox v0.12.23.

## How to test
1. Run `DOCS_AGENT_DIR=/path/to/docs-agent-at-37d2c492 WP_CODEBOX_DIR=/path/to/wp-codebox-at-a2b02cd php tests/docs-agent-native-workflow-contract.php`; expect The native workflow contract passes..
2. Run `php -l tests/docs-agent-native-workflow-contract.php`; expect PHP reports no syntax errors..

## Compatibility
No public Agents API or extension contract changes. This updates CI/workflow producer pins only.

## Evidence
- Base unchanged since verification: main remains at b297c0561b7998448470513d5c323aed0a407059.
- CI expected: Agents API CI workflow contracts
- Reviewer-resolvable source evidence: https://github.com/Automattic/docs-agent/pull/148
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/8577
- Verified finalization base: main at b297c0561b7998448470513d5c323aed0a407059
- diff-check: Passed
- php-syntax: Passed
- producer-contract: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Model:** openai/gpt-5.6-sol
- **Used for:** Prepared the immutable consumer pin update and producer-contract assertions; Chris directed and verified the rollout.

## Source relationships
- Relates to Automattic/docs-agent#148
