### PR TITLE
Hydrate Docs Agent verification dependencies

### DIFF
--- a/.github/workflows/docs-agent.yml
+++ b/.github/workflows/docs-agent.yml
@@ -29,6 +29,7 @@ jobs:
       writable_paths: README.md,docs/**
       verification_commands: |
         [
+          "composer install --no-interaction --prefer-dist --no-progress",
           "composer test",
           "php tests/no-product-imports-smoke.php"
         ]

--- a/docs/docs-agent-workflow.md
+++ b/docs/docs-agent-workflow.md
@@ -17,7 +17,7 @@ The workflow contract is intentionally narrow:
 - `base_ref: main`
 - `docs_branch: docs-agent/agents-api-docs-upkeep`
 - `writable_paths: README.md,docs/**`
-- `verification_commands`: `composer test`, then `php tests/no-product-imports-smoke.php`
+- `verification_commands`: `composer install --no-interaction --prefer-dist --no-progress`, `composer test`, then `php tests/no-product-imports-smoke.php`
 - `drift_checks`: `git diff --check`
 
 The workflow prompt tells the technical lane to maintain source-grounded developer documentation for the public, product-neutral Agents API substrate. Documentation updates are expected to stay inside `README.md` and `docs/**`.
@@ -67,6 +67,7 @@ The producer chain still uses a publication token: at the pinned Docs Agent revi
 For normal documentation maintenance runs, the configured consumer verification is the same command chain in `.github/workflows/docs-agent.yml`:
 
 ```sh
+composer install --no-interaction --prefer-dist --no-progress
 composer test
 php tests/no-product-imports-smoke.php
 git diff --check

--- a/tests/docs-agent-native-workflow-contract.php
+++ b/tests/docs-agent-native-workflow-contract.php
@@ -109,7 +109,7 @@ agents_api_docs_agent_contract_match( $consumer_workflow, '~^\s*run_kind:\s*main
 agents_api_docs_agent_contract_match( $consumer_workflow, '~^\s*base_ref:\s*main\s*$~m', 'Consumer target base must be main.', $failures );
 agents_api_docs_agent_contract_match( $consumer_workflow, '~^\s*docs_branch:\s*docs-agent/agents-api-docs-upkeep\s*$~m', 'Consumer publication branch must be stable and exact.', $failures );
 agents_api_docs_agent_contract_match( $consumer_workflow, '~^\s*writable_paths:\s*README\.md,docs/\*\*\s*$~m', 'Consumer writable paths must be README.md,docs/**.', $failures );
-agents_api_docs_agent_contract_match( $consumer_workflow, '~"composer test"\s*,\s*"php tests/no-product-imports-smoke\.php"~s', 'Consumer verification commands must include the test chain.', $failures );
+agents_api_docs_agent_contract_match( $consumer_workflow, '~"composer install --no-interaction --prefer-dist --no-progress"\s*,\s*"composer test"\s*,\s*"php tests/no-product-imports-smoke\.php"~s', 'Consumer verification commands must hydrate dependencies before the test chain.', $failures );
 agents_api_docs_agent_contract_match( $consumer_workflow, '~"git diff --check"~', 'Consumer drift check must run git diff --check.', $failures );
 agents_api_docs_agent_contract_match( $consumer_workflow, '~^\s*OPENAI_API_KEY:\s*\$\{\{ secrets\.OPENAI_API_KEY \}\}\s*$~m', 'Consumer must forward OPENAI_API_KEY.', $failures );
 agents_api_docs_agent_contract_match( $consumer_workflow, '~^\s*EXTERNAL_PACKAGE_SOURCE_POLICY:\s*\$\{\{ secrets\.EXTERNAL_PACKAGE_SOURCE_POLICY \}\}\s*$~m', 'Consumer must forward EXTERNAL_PACKAGE_SOURCE_POLICY.', $failures );


### PR DESCRIPTION
## Summary

- install locked Composer dependencies before running the Docs Agent verification suite
- assert the complete dependency-hydration and test sequence in the native producer-chain contract
- document the clean-checkout verification recipe

## Root cause

The Docs Agent workflow verified a fresh target checkout with `composer test`, but the first smoke test requires `vendor/autoload.php`. Managed local worktrees had already run `composer install`, masking the missing hosted setup step. A clean checkout deterministically failed with exit code `255`.

- Failed hosted reproduction: https://github.com/Automattic/agents-api/actions/runs/29688244614
- Successful hosted rerun: https://github.com/Automattic/agents-api/actions/runs/29688417403

The successful durable result records dependency installation, `composer test`, the product-neutrality smoke test, and `git diff --check` all exiting `0`. The maintenance pass correctly returned success with no documentation PR because the inspected docs were current.

## How to test

1. Start from a fresh checkout with no `vendor/` directory.
2. Run `composer install --no-interaction --prefer-dist --no-progress`.
3. Run `composer test`.
4. Run `php tests/no-product-imports-smoke.php`.
5. Check out Docs Agent at `06a7e92e0f4d265d09bbdb6dae1ec78fd8e7c825` and WP Codebox at `v0.12.29`.
6. Run `DOCS_AGENT_DIR=/path/to/docs-agent WP_CODEBOX_DIR=/path/to/wp-codebox php tests/docs-agent-native-workflow-contract.php`.
7. Run `actionlint .github/workflows/*.yml`.
8. Run `git diff --check origin/main...HEAD`.

## Compatibility

No Agents API runtime, PHP API, extension path, Docs Agent producer pin, permissions, secret mapping, writable path, or publication behavior changes. The workflow now explicitly hydrates the dependencies its existing verification command requires.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with OpenAI GPT-5.6 Sol
- **Model:** openai/gpt-5.6-sol
- **Used for:** Diagnosed the hosted clean-checkout failure, added the consumer-owned dependency hydration step and deterministic contract assertion, and verified the repaired hosted workflow. Chris reviewed and owns the change.