### PR TITLE
Execute accepted Docs Agent helpers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,14 +53,14 @@ jobs:
         uses: actions/checkout@v6.0.3
         with:
           repository: Automattic/docs-agent
-          ref: d1bf324154b4604099ae3209f64519386caf1f48
+          ref: 305928a4ab2bddea759cf3d88077215ed687f75f
           path: .docs-agent-producer
 
       - name: Checkout WP Codebox producer schema
         uses: actions/checkout@v6.0.3
         with:
           repository: Automattic/wp-codebox
-          ref: 0227ca7551d8cd98f14242b31e142b50f78dff13
+          ref: a6fe2d208e990a8d04104aa74aacbb8d1539fbc1
           path: .wp-codebox-producer
 
       - name: Set up PHP

--- a/.github/workflows/docs-agent.yml
+++ b/.github/workflows/docs-agent.yml
@@ -20,7 +20,7 @@ concurrency:
 jobs:
   docs-agent:
     name: Maintain Technical Documentation
-    uses: Automattic/docs-agent/.github/workflows/maintain-docs.yml@d1bf324154b4604099ae3209f64519386caf1f48
+    uses: Automattic/docs-agent/.github/workflows/maintain-docs.yml@305928a4ab2bddea759cf3d88077215ed687f75f
     with:
       audience: technical
       run_kind: maintenance

--- a/docs/docs-agent-workflow.md
+++ b/docs/docs-agent-workflow.md
@@ -7,7 +7,7 @@ Agents API publishes its canonical documentation updates through the repository-
 The consumer workflow is named **Docs Agent** and dispatches the reusable Docs Agent workflow from Automattic/docs-agent at the exact pinned revision:
 
 ```text
-Automattic/docs-agent/.github/workflows/maintain-docs.yml@d1bf324154b4604099ae3209f64519386caf1f48
+Automattic/docs-agent/.github/workflows/maintain-docs.yml@305928a4ab2bddea759cf3d88077215ed687f75f
 ```
 
 The workflow contract is intentionally narrow:
@@ -33,8 +33,8 @@ DOCS_AGENT_DIR=/path/to/docs-agent WP_CODEBOX_DIR=/path/to/wp-codebox php tests/
 
 The required producer checkouts are:
 
-- Docs Agent revision `d1bf324154b4604099ae3209f64519386caf1f48`.
-- WP Codebox reusable-workflow producer revision `0227ca7551d8cd98f14242b31e142b50f78dff13`; packaged runtime release `v0.12.29` resolves to `bc982947ec33c78160125026e16d357b7ece3ea1`.
+- Docs Agent revision `305928a4ab2bddea759cf3d88077215ed687f75f`.
+- WP Codebox reusable-workflow and helper revision `a6fe2d208e990a8d04104aa74aacbb8d1539fbc1`; packaged runtime release `v0.12.29` resolves to `bc982947ec33c78160125026e16d357b7ece3ea1`.
 
 At that Docs Agent revision, the `technical:maintenance` lane maps to the native package:
 
@@ -47,7 +47,7 @@ with agent slug `technical-docs-maintenance-agent`, package-source revision `a39
 Docs Agent then calls WP Codebox's reusable workflow:
 
 ```text
-Automattic/wp-codebox/.github/workflows/run-agent-task.yml@0227ca7551d8cd98f14242b31e142b50f78dff13
+Automattic/wp-codebox/.github/workflows/run-agent-task.yml@a6fe2d208e990a8d04104aa74aacbb8d1539fbc1
 ```
 
 The contract test verifies that this WP Codebox producer exposes the `wp-codebox/reusable-workflow-interface/v1` schema and preserves the release, external-package, runtime-source, target repository, writable path, verification, drift-check, publication, access-repository, and allowed-repository chain. The completion contract requires one evidence-backed report item for the `workflow-run-awaiter` source delta and rejects a no-change disposition until that known drift is documented. WP Codebox returns the reviewer-safe result projection and stages the validated completion report as a declared command artifact.

--- a/tests/docs-agent-native-workflow-contract.php
+++ b/tests/docs-agent-native-workflow-contract.php
@@ -12,9 +12,9 @@
 
 declare( strict_types=1 );
 
-const AGENTS_API_DOCS_AGENT_REVISION          = 'd1bf324154b4604099ae3209f64519386caf1f48';
+const AGENTS_API_DOCS_AGENT_REVISION          = '305928a4ab2bddea759cf3d88077215ed687f75f';
 const AGENTS_API_WP_CODEBOX_RELEASE_REF       = 'v0.12.29';
-const AGENTS_API_WP_CODEBOX_PRODUCER_REVISION = '0227ca7551d8cd98f14242b31e142b50f78dff13';
+const AGENTS_API_WP_CODEBOX_PRODUCER_REVISION = 'a6fe2d208e990a8d04104aa74aacbb8d1539fbc1';
 
 $root     = dirname( __DIR__ );
 $failures = array();
@@ -122,6 +122,7 @@ foreach ( array( 'contents: write', 'pull-requests: write', 'issues: write' ) as
 
 agents_api_docs_agent_contract_match( $docs_workflow, '~technical:maintenance\)\s+package_path="bundles/technical-docs-agent/native/technical-docs-maintenance-agent\.agent\.json"\s+agent_slug="technical-docs-maintenance-agent"\s+package_digest="sha256-bytes-v1:975c7b0a0a7aff52897c52be5ac903a7fb110ea3c33e16227f8694c74c932519"\s+lane_requires_pr=false~s', 'Docs Agent #167 technical maintenance lane must map to its exact native package.', $failures );
 agents_api_docs_agent_contract_match( $docs_workflow, '~uses:\s*Automattic/wp-codebox/\.github/workflows/run-agent-task\.yml@' . AGENTS_API_WP_CODEBOX_PRODUCER_REVISION . '~', 'Docs Agent must pin the accepted WP Codebox producer.', $failures );
+agents_api_docs_agent_contract_match( $docs_workflow, '~wp_codebox_workflow_ref:\s*' . AGENTS_API_WP_CODEBOX_PRODUCER_REVISION . '~', 'Docs Agent must execute helpers from the accepted WP Codebox producer.', $failures );
 agents_api_docs_agent_contract_match( $docs_workflow, '~wp_codebox_release_ref:\s*' . preg_quote( AGENTS_API_WP_CODEBOX_RELEASE_REF, '~' ) . '.*?external_package_source:\s*\$\{\{ needs\.prepare\.outputs\.external_package_source \}\}.*?runtime_sources:\s*\$\{\{ needs\.prepare\.outputs\.runtime_sources \}\}.*?target_repo:\s*\$\{\{ github\.repository \}\}.*?writable_paths:\s*\$\{\{ inputs\.writable_paths \}\}.*?verification_commands:\s*\$\{\{ needs\.prepare\.outputs\.verification_commands \}\}.*?drift_checks:\s*\$\{\{ needs\.prepare\.outputs\.drift_checks \}\}.*?success_requires_pr:\s*\$\{\{ needs\.prepare\.outputs\.success_requires_pr == \'true\' \}\}.*?access_token_repos:\s*\$\{\{ needs\.prepare\.outputs\.access_token_repos \}\}.*?allowed_repos:\s*\$\{\{ needs\.prepare\.outputs\.allowed_repos \}\}~s', 'Docs Agent must preserve the WP Codebox release, external-package, runtime-source, target, writable, verification, publication, and access chain.', $failures );
 agents_api_docs_agent_contract_match( $docs_workflow, '~OPENAI_API_KEY:\s*\$\{\{ secrets\.OPENAI_API_KEY \}\}\s+ACCESS_TOKEN:\s*\$\{\{ github\.token \}\}\s+EXTERNAL_PACKAGE_SOURCE_POLICY:\s*\$\{\{ secrets\.EXTERNAL_PACKAGE_SOURCE_POLICY \}\}~s', 'Docs Agent must forward caller credentials and its built-in publication token.', $failures );
 


### PR DESCRIPTION
## Summary
- pin Docs Agent `305928a4`, which executes accepted WP Codebox helper commits
- pin WP Codebox helper revision `a6fe2d20` in producer validation
- preserve the workflow-run-awaiter completion delta

## How to test
1. Check out Docs Agent `305928a4ab2bddea759cf3d88077215ed687f75f` and WP Codebox `a6fe2d208e990a8d04104aa74aacbb8d1539fbc1`.
2. Run `DOCS_AGENT_DIR=/path/to/docs-agent WP_CODEBOX_DIR=/path/to/wp-codebox php tests/docs-agent-native-workflow-contract.php`.
3. Run `actionlint .github/workflows/*.yml`.

## Compatibility
This updates immutable workflow provenance only. Agents API runtime behavior and source-delta semantics are unchanged.

Depends on https://github.com/Automattic/docs-agent/pull/171

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with GPT-5.6-sol
- **Used for:** Updated immutable producer integration and assertions with Chris reviewing and owning the change.