### PR TITLE
fix: scope chat run control by workspace

### DIFF
--- a/agents-api.php
+++ b/agents-api.php
@@ -230,6 +230,7 @@ require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-runtime-tool-continua
 require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-runtime-tool-lifecycle.php';
 require_once AGENTS_API_PATH . 'src/Runtime/register-runtime-tool-lifecycle-abilities.php';
 require_once AGENTS_API_PATH . 'src/Runtime/interface-wp-agent-run-control-store.php';
+require_once AGENTS_API_PATH . 'src/Runtime/interface-wp-agent-workspace-run-control-store.php';
 require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-option-run-control-store.php';
 require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-run-control.php';
 require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-run-result-envelope.php';

--- a/composer.json
+++ b/composer.json
@@ -110,6 +110,7 @@
       "php tests/canonical-run-lifecycle-smoke.php",
       "php tests/channels-smoke.php",
       "php tests/chat-run-control-smoke.php",
+      "php tests/chat-run-control-multisite-smoke.php",
       "php tests/external-chat-run-bridge-fixture-smoke.php",
       "php tests/task-execution-smoke.php",
       "php tests/frontend-chat-rest-smoke.php",

--- a/src/Channels/register-agents-chat-ability.php
+++ b/src/Channels/register-agents-chat-ability.php
@@ -129,6 +129,12 @@ function agents_chat_dispatch( array $input ) {
 		$input['principal'] = $principal->to_array();
 	}
 
+	$run_context = WP_Agent_Chat_Run_Control::context_from_input( $input );
+	if ( is_wp_error( $run_context ) ) {
+		do_action( 'agents_chat_dispatch_failed', $run_context->get_error_code(), $input );
+		return $run_context;
+	}
+
 	$run_id = agents_chat_optional_string( $input['run_id'] ?? null );
 	if ( null === $run_id ) {
 		$input['run_id'] = WP_Agent_Chat_Run_Control::generate_run_id();
@@ -171,14 +177,18 @@ function agents_chat_dispatch( array $input ) {
 	$session_id = agents_chat_optional_string( $input['session_id'] ?? null );
 	$agent      = agents_chat_optional_string( $input['agent'] ?? null ) ?? '';
 	if ( null !== $session_id ) {
-		WP_Agent_Chat_Run_Control::start_run( $run_id, $session_id, array( 'agent' => $agent ) );
+		try {
+			WP_Agent_Chat_Run_Control::start_run( $run_id, $session_id, array( 'agent' => $agent ), $run_context['workspace'], $run_context['owner'] );
+		} catch ( \RuntimeException $error ) {
+			return new \WP_Error( 'agents_chat_run_workspace_unsupported', $error->getMessage() );
+		}
 	}
 
 	$result = call_user_func( $handler, $input );
 
 	if ( is_wp_error( $result ) ) {
 		if ( null !== $session_id ) {
-			WP_Agent_Chat_Run_Control::finish_run( $run_id, WP_Agent_Chat_Run_Control::STATUS_FAILED );
+			WP_Agent_Chat_Run_Control::finish_run( $run_id, WP_Agent_Chat_Run_Control::STATUS_FAILED, $run_context['workspace'] );
 		}
 
 		/** This action is documented above. */
@@ -189,7 +199,7 @@ function agents_chat_dispatch( array $input ) {
 
 	if ( ! is_array( $result ) ) {
 		if ( null !== $session_id ) {
-			WP_Agent_Chat_Run_Control::finish_run( $run_id, WP_Agent_Chat_Run_Control::STATUS_FAILED );
+			WP_Agent_Chat_Run_Control::finish_run( $run_id, WP_Agent_Chat_Run_Control::STATUS_FAILED, $run_context['workspace'] );
 		}
 
 		/** This action is documented above. */
@@ -210,11 +220,11 @@ function agents_chat_dispatch( array $input ) {
 	$resolved_session_id = agents_chat_optional_string( $result['session_id'] ?? null ) ?? $session_id;
 	if ( null !== $resolved_session_id ) {
 		if ( null === $session_id ) {
-			WP_Agent_Chat_Run_Control::start_run( $result_run_id, $resolved_session_id, array( 'agent' => $agent ) );
+			WP_Agent_Chat_Run_Control::start_run( $result_run_id, $resolved_session_id, array( 'agent' => $agent ), $run_context['workspace'], $run_context['owner'] );
 		}
 
 		$status = WP_Agent_Run_Outcome::run_control_status( $result );
-		WP_Agent_Chat_Run_Control::finish_run( $result_run_id, $status );
+		WP_Agent_Chat_Run_Control::finish_run( $result_run_id, $status, $run_context['workspace'] );
 	}
 
 	return $result;
@@ -331,6 +341,7 @@ function agents_chat_input_schema(): array {
 		'type'       => 'object',
 		'required'   => array( 'agent', 'message' ),
 		'properties' => array(
+			'workspace'             => agents_chat_workspace_schema(),
 			'agent'                 => array(
 				'type'        => 'string',
 				'description' => 'Slug or ID of the registered agent that should handle this turn.',
@@ -437,6 +448,18 @@ function agents_chat_input_schema(): array {
 					),
 				),
 			),
+		),
+	);
+}
+
+/** @return array<string,mixed> */
+function agents_chat_workspace_schema(): array {
+	return array(
+		'type'       => 'object',
+		'required'   => array( 'workspace_type', 'workspace_id' ),
+		'properties' => array(
+			'workspace_type' => array( 'type' => 'string' ),
+			'workspace_id'   => array( 'type' => 'string' ),
 		),
 	);
 }

--- a/src/Channels/register-agents-chat-run-control-abilities.php
+++ b/src/Channels/register-agents-chat-run-control-abilities.php
@@ -10,6 +10,7 @@ namespace AgentsAPI\AI\Channels;
 use AgentsAPI\AI\WP_Agent_Chat_Run_Control;
 use AgentsAPI\AI\WP_Agent_Filter_Run_Control_Adapter;
 use AgentsAPI\AI\WP_Agent_Run_Control;
+use AgentsAPI\Core\Workspace\WP_Agent_Workspace_Scope;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -96,6 +97,14 @@ add_action(
  * @return array<string, mixed>|\WP_Error
  */
 function agents_get_chat_run( array $input ) {
+	$context = WP_Agent_Chat_Run_Control::context_from_input( $input );
+	if ( is_wp_error( $context ) ) {
+		return $context;
+	}
+	if ( $context['workspace'] instanceof WP_Agent_Workspace_Scope ) {
+		$input['workspace'] = $context['workspace']->to_array();
+	}
+
 	$result = agents_chat_run_control_adapter()->get_run( $input );
 	if ( null !== $result ) {
 		if ( is_wp_error( $result ) ) {
@@ -106,7 +115,11 @@ function agents_get_chat_run( array $input ) {
 		return is_wp_error( $result ) ? $result : agents_chat_run_observer_payload( $result, $input );
 	}
 
-	$run                  = WP_Agent_Chat_Run_Control::get_run( agents_chat_run_control_string( $input['run_id'] ?? '' ) );
+	try {
+		$run = WP_Agent_Chat_Run_Control::get_run( agents_chat_run_control_string( $input['run_id'] ?? '' ), $context['workspace'], $context['owner'] );
+	} catch ( \RuntimeException $error ) {
+		return new \WP_Error( 'agents_chat_run_workspace_unsupported', $error->getMessage() );
+	}
 	$requested_session_id = agents_chat_run_control_string( $input['session_id'] ?? '' );
 	if ( null !== $run && agents_chat_run_control_string( $run['session_id'] ?? '' ) !== $requested_session_id ) {
 		return agents_chat_run_control_no_handler( 'agents_chat_run_not_found', 'No chat run was found for the requested session_id and run_id.' );
@@ -123,7 +136,33 @@ function agents_get_chat_run( array $input ) {
  * @return array<string, mixed>|\WP_Error
  */
 function agents_list_chat_run_events( array $input ) {
-	$result = agents_chat_run_events_normalize_result( agents_chat_run_control_adapter()->list_events( $input ) );
+	$context = WP_Agent_Chat_Run_Control::context_from_input( $input );
+	if ( is_wp_error( $context ) ) {
+		return $context;
+	}
+	if ( $context['workspace'] instanceof WP_Agent_Workspace_Scope ) {
+		$input['workspace'] = $context['workspace']->to_array();
+	}
+
+	$result = agents_chat_run_control_adapter()->list_events( $input );
+	if ( is_wp_error( $result ) && 'agents_chat_run_events_no_handler' === $result->get_error_code() ) {
+		try {
+			$result = WP_Agent_Chat_Run_Control::list_events(
+				agents_chat_run_control_string( $input['run_id'] ?? '' ),
+				agents_chat_run_control_string( $input['cursor'] ?? '' ),
+				agents_chat_run_control_int( $input['limit'] ?? 100 ),
+				$context['workspace'],
+				$context['owner']
+			);
+		} catch ( \RuntimeException $error ) {
+			return new \WP_Error( 'agents_chat_run_workspace_unsupported', $error->getMessage() );
+		}
+		if ( null === $result ) {
+			return agents_chat_run_control_no_handler( 'agents_chat_run_not_found', 'No chat run was found for the requested run_id.' );
+		}
+	}
+
+	$result = agents_chat_run_events_normalize_result( $result );
 	return is_wp_error( $result ) ? $result : agents_chat_run_observer_payload( $result, $input );
 }
 
@@ -132,11 +171,23 @@ function agents_list_chat_run_events( array $input ) {
  * @return array<string, mixed>|\WP_Error
  */
 function agents_cancel_chat_run( array $input ) {
+	$context = WP_Agent_Chat_Run_Control::context_from_input( $input );
+	if ( is_wp_error( $context ) ) {
+		return $context;
+	}
+	if ( $context['workspace'] instanceof WP_Agent_Workspace_Scope ) {
+		$input['workspace'] = $context['workspace']->to_array();
+	}
+
 	$result = agents_chat_run_control_adapter()->cancel_run( $input );
 	if ( null !== $result ) {
 		$result = is_wp_error( $result ) ? $result : agents_chat_run_control_normalize_result( $result, 'agents_chat_run_invalid_cancel_result' );
 	} else {
-		$run                  = WP_Agent_Chat_Run_Control::get_run( agents_chat_run_control_string( $input['run_id'] ?? '' ) );
+		try {
+			$run = WP_Agent_Chat_Run_Control::get_run( agents_chat_run_control_string( $input['run_id'] ?? '' ), $context['workspace'], $context['owner'] );
+		} catch ( \RuntimeException $error ) {
+			return new \WP_Error( 'agents_chat_run_workspace_unsupported', $error->getMessage() );
+		}
 		$requested_session_id = agents_chat_run_control_string( $input['session_id'] ?? '' );
 		if ( null === $run ) {
 			return agents_chat_run_control_no_handler( 'agents_chat_run_not_found', 'No chat run was found for the requested run_id.' );
@@ -145,7 +196,7 @@ function agents_cancel_chat_run( array $input ) {
 			return agents_chat_run_control_no_handler( 'agents_chat_run_not_found', 'No chat run was found for the requested session_id and run_id.' );
 		}
 
-		$result = WP_Agent_Chat_Run_Control::request_cancel( agents_chat_run_control_string( $input['run_id'] ?? '' ) );
+		$result = WP_Agent_Chat_Run_Control::request_cancel( agents_chat_run_control_string( $input['run_id'] ?? '' ), $context['workspace'], $context['owner'] );
 		if ( null === $result ) {
 			return agents_chat_run_control_no_handler( 'agents_chat_run_not_found', 'No chat run was found for the requested run_id.' );
 		}
@@ -174,13 +225,21 @@ function agents_cancel_chat_run( array $input ) {
  * @return array<string, mixed>|\WP_Error
  */
 function agents_queue_chat_message( array $input ) {
+	$context = WP_Agent_Chat_Run_Control::context_from_input( $input );
+	if ( is_wp_error( $context ) ) {
+		return $context;
+	}
+	if ( $context['workspace'] instanceof WP_Agent_Workspace_Scope ) {
+		$input['workspace'] = $context['workspace']->to_array();
+	}
+
 	$handler = apply_filters( 'wp_agent_chat_message_queue_handler', null, $input );
 	if ( is_callable( $handler ) ) {
 		$result = agents_chat_run_control_normalize_result( call_user_func( $handler, $input ), 'agents_chat_message_queue_invalid_result' );
 	} else {
 		try {
-			$result = WP_Agent_Chat_Run_Control::queue_message( $input );
-		} catch ( \InvalidArgumentException $error ) {
+			$result = WP_Agent_Chat_Run_Control::queue_message( $input, $context['workspace'], $context['owner'] );
+		} catch ( \InvalidArgumentException|\RuntimeException $error ) {
 			return new \WP_Error( 'agents_chat_message_queue_invalid_result', $error->getMessage() );
 		}
 	}
@@ -198,7 +257,6 @@ function agents_queue_chat_message( array $input ) {
 
 	return $result;
 }
-
 
 /**
  * @param array<string, mixed> $input Ability input.
@@ -291,6 +349,13 @@ function agents_chat_run_current_user_owns_session( array $input ): bool {
  */
 function agents_chat_run_control_request_scope( array $input ): array {
 	$scope = array();
+	if ( is_array( $input['workspace'] ?? null ) ) {
+		foreach ( array( 'workspace_id', 'workspace_type' ) as $key ) {
+			if ( isset( $input['workspace'][ $key ] ) && is_scalar( $input['workspace'][ $key ] ) ) {
+				$scope[ $key ] = (string) $input['workspace'][ $key ];
+			}
+		}
+	}
 	foreach ( array( 'workspace_id', 'workspace_type', 'request_context', 'client_id', 'audience_id' ) as $key ) {
 		if ( isset( $input[ $key ] ) && is_scalar( $input[ $key ] ) ) {
 			$scope[ $key ] = (string) $input[ $key ];
@@ -412,6 +477,7 @@ function agents_chat_run_id_input_schema(): array {
 		'type'       => 'object',
 		'required'   => array( 'session_id', 'run_id' ),
 		'properties' => array(
+			'workspace'     => agents_chat_workspace_schema(),
 			'session_id'    => array( 'type' => 'string' ),
 			'run_id'        => array( 'type' => 'string' ),
 			'session_owner' => agents_chat_session_owner_schema(),

--- a/src/Channels/register-default-agents-chat-handler.php
+++ b/src/Channels/register-default-agents-chat-handler.php
@@ -177,6 +177,8 @@ class WP_Agent_Default_Chat_Handler {
 		$loop_options = array(
 			'system_prompt' => $system_prompt,
 			'max_turns'     => $max_turns,
+			'workspace'     => self::workspace_from_input( $input ),
+			'principal'     => $input['principal'] ?? null,
 			'context'       => array(
 				'session_id'             => $session_id,
 				'agent_slug'             => $agent_slug,
@@ -485,7 +487,7 @@ class WP_Agent_Default_Chat_Handler {
 		}
 
 		try {
-			$workspace = WP_Agent_Workspace_Scope::from_parts( 'site', self::default_workspace_id() );
+			$workspace = self::workspace_from_input( $input ) ?? WP_Agent_Workspace_Scope::from_parts( 'site', self::default_workspace_id() );
 		} catch ( \Throwable $error ) {
 			unset( $error );
 			return '';
@@ -505,6 +507,20 @@ class WP_Agent_Default_Chat_Handler {
 		}
 
 		return $session_id;
+	}
+
+	/** @param array<string,mixed> $input Canonical chat input. */
+	private static function workspace_from_input( array $input ): ?WP_Agent_Workspace_Scope {
+		if ( ! is_array( $input['workspace'] ?? null ) ) {
+			return null;
+		}
+
+		try {
+			return WP_Agent_Workspace_Scope::from_array( $input['workspace'] );
+		} catch ( \InvalidArgumentException $error ) {
+			unset( $error );
+			return null;
+		}
 	}
 
 	/**

--- a/src/Runtime/class-wp-agent-chat-run-control.php
+++ b/src/Runtime/class-wp-agent-chat-run-control.php
@@ -7,6 +7,8 @@
 
 namespace AgentsAPI\AI;
 
+use AgentsAPI\Core\Workspace\WP_Agent_Workspace_Scope;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -41,6 +43,77 @@ class WP_Agent_Chat_Run_Control {
 			self::STATUS_BUDGET_EXCEEDED,
 			self::STATUS_STALLED,
 			self::STATUS_INTERRUPTED,
+		);
+	}
+
+	/**
+	 * Resolve and bind canonical workspace and principal ownership.
+	 *
+	 * @param array<mixed> $input Ability input.
+	 * @return array{workspace:?WP_Agent_Workspace_Scope,owner:?array{type:string,key:string}}|\WP_Error
+	 */
+	public static function context_from_input( array $input ) {
+		$workspace = null;
+		if ( array_key_exists( 'workspace', $input ) ) {
+			if ( ! is_array( $input['workspace'] ) ) {
+				return new \WP_Error( 'agents_chat_run_invalid_workspace', 'workspace must be a canonical workspace object.' );
+			}
+			try {
+				$workspace = WP_Agent_Workspace_Scope::from_array( WP_Agent_Run_Control::string_keyed_array( $input['workspace'] ) );
+			} catch ( \InvalidArgumentException $error ) {
+				return new \WP_Error( 'agents_chat_run_invalid_workspace', $error->getMessage() );
+			}
+		}
+
+		$principal = null;
+		try {
+			if ( ( $input['principal'] ?? null ) instanceof WP_Agent_Execution_Principal ) {
+				$principal = $input['principal'];
+			} elseif ( is_array( $input['principal'] ?? null ) ) {
+				$principal = WP_Agent_Execution_Principal::from_array( WP_Agent_Run_Control::string_keyed_array( $input['principal'] ) );
+			} else {
+				$request_context                    = WP_Agent_Run_Control::string_keyed_array( $input );
+				$request_context['request_context'] = WP_Agent_Execution_Principal::REQUEST_CONTEXT_REST;
+				$principal                         = WP_Agent_Execution_Principal::resolve( $request_context );
+			}
+		} catch ( \Throwable $error ) {
+			return new \WP_Error( 'agents_chat_run_invalid_principal', $error->getMessage() );
+		}
+
+		if ( ! $principal instanceof WP_Agent_Execution_Principal ) {
+			$user_id = function_exists( 'get_current_user_id' ) ? (int) get_current_user_id() : 0;
+			if ( $user_id > 0 ) {
+				$agent     = self::string_value( $input['agent'] ?? '__wordpress_user__' );
+				$principal = WP_Agent_Execution_Principal::user_session( $user_id, '' !== $agent ? $agent : '__wordpress_user__' );
+			}
+		}
+
+		$owner         = $principal instanceof WP_Agent_Execution_Principal ? $principal->conversation_owner() : null;
+		$claimed_owner = is_array( $input['session_owner'] ?? null ) ? WP_Agent_Run_Control::string_keyed_array( $input['session_owner'] ) : null;
+		if ( is_array( $claimed_owner ) ) {
+			$claimed_owner = array(
+				'type' => sanitize_key( self::string_value( $claimed_owner['type'] ?? '' ) ),
+				'key'  => trim( self::string_value( $claimed_owner['key'] ?? '' ) ),
+			);
+			if ( '' === $claimed_owner['type'] || '' === $claimed_owner['key'] ) {
+				return new \WP_Error( 'agents_chat_run_invalid_owner', 'session_owner type and key are required.' );
+			}
+			if ( is_array( $owner ) && $claimed_owner !== $owner ) {
+				return new \WP_Error( 'agents_chat_run_owner_forbidden', 'session_owner must match the authenticated conversation principal.' );
+			}
+			$owner = $owner ?? $claimed_owner;
+		}
+
+		if ( $workspace instanceof WP_Agent_Workspace_Scope && ! is_array( $owner ) ) {
+			return new \WP_Error( 'agents_chat_run_owner_required', 'Explicit workspace run control requires an authenticated conversation owner.' );
+		}
+		if ( $workspace instanceof WP_Agent_Workspace_Scope && ! WP_Agent_Run_Control::supports_workspace_state() ) {
+			return new \WP_Error( 'agents_chat_run_workspace_unsupported', 'The registered run-control store does not support explicit workspaces.' );
+		}
+
+		return array(
+			'workspace' => $workspace,
+			'owner'     => $owner,
 		);
 	}
 
@@ -108,16 +181,19 @@ class WP_Agent_Chat_Run_Control {
 	 * @param string              $run_id     Run ID.
 	 * @param string              $session_id Session ID.
 	 * @param array<string,mixed> $metadata   Run metadata.
+	 * @param array<string,mixed>|null $owner Canonical conversation owner.
 	 * @return array<string,mixed> Normalized run.
 	 */
-	public static function start_run( string $run_id, string $session_id, array $metadata = array() ): array {
+	public static function start_run( string $run_id, string $session_id, array $metadata = array(), ?WP_Agent_Workspace_Scope $workspace = null, ?array $owner = null ): array {
 		return self::normalize_run( WP_Agent_Run_Control::start_run(
 			self::OPTION_KEY,
 			$run_id,
 			array(
 				'session_id' => $session_id,
 				'metadata'   => $metadata,
-			)
+				'_owner'     => self::owner_fingerprint( $owner ),
+			),
+			$workspace
 		) );
 	}
 
@@ -128,8 +204,8 @@ class WP_Agent_Chat_Run_Control {
 	 * @param string $status Terminal status.
 	 * @return array<string,mixed>|null Normalized run, or null when absent.
 	 */
-	public static function finish_run( string $run_id, string $status = self::STATUS_COMPLETED ): ?array {
-		$run = WP_Agent_Run_Control::finish_run( self::OPTION_KEY, $run_id, $status );
+	public static function finish_run( string $run_id, string $status = self::STATUS_COMPLETED, ?WP_Agent_Workspace_Scope $workspace = null ): ?array {
+		$run = WP_Agent_Run_Control::finish_run( self::OPTION_KEY, $run_id, $status, $workspace );
 		return null === $run ? null : self::normalize_run( $run );
 	}
 
@@ -137,10 +213,15 @@ class WP_Agent_Chat_Run_Control {
 	 * Read a stored chat run.
 	 *
 	 * @param string $run_id Run ID.
+	 * @param array<string,mixed>|null $owner Canonical conversation owner.
 	 * @return array<string,mixed>|null Normalized run, or null when absent.
 	 */
-	public static function get_run( string $run_id ): ?array {
-		$run = WP_Agent_Run_Control::get_run( self::OPTION_KEY, $run_id );
+	public static function get_run( string $run_id, ?WP_Agent_Workspace_Scope $workspace = null, ?array $owner = null ): ?array {
+		if ( ! self::can_access_run( $run_id, $workspace, $owner ) ) {
+			return null;
+		}
+
+		$run = WP_Agent_Run_Control::get_run( self::OPTION_KEY, $run_id, $workspace );
 		return null === $run ? null : self::normalize_run( $run );
 	}
 
@@ -148,10 +229,15 @@ class WP_Agent_Chat_Run_Control {
 	 * Request cancellation of a stored chat run.
 	 *
 	 * @param string $run_id Run ID.
+	 * @param array<string,mixed>|null $owner Canonical conversation owner.
 	 * @return array<string,mixed>|null Normalized run, or null when absent.
 	 */
-	public static function request_cancel( string $run_id ): ?array {
-		$run = WP_Agent_Run_Control::request_cancel( self::OPTION_KEY, $run_id );
+	public static function request_cancel( string $run_id, ?WP_Agent_Workspace_Scope $workspace = null, ?array $owner = null ): ?array {
+		if ( ! self::can_access_run( $run_id, $workspace, $owner ) ) {
+			return null;
+		}
+
+		$run = WP_Agent_Run_Control::request_cancel( self::OPTION_KEY, $run_id, $workspace );
 		return null === $run ? null : self::normalize_run( $run );
 	}
 
@@ -160,10 +246,11 @@ class WP_Agent_Chat_Run_Control {
 	 *
 	 * @param string $run_id     Run ID.
 	 * @param string $session_id Session ID.
+	 * @param array<string,mixed>|null $owner Canonical conversation owner.
 	 * @return array<string,mixed>|null Interrupt message or null.
 	 */
-	public static function cancellation_interrupt_for_run( string $run_id, string $session_id = '' ): ?array {
-		$run = self::get_run( $run_id );
+	public static function cancellation_interrupt_for_run( string $run_id, string $session_id = '', ?WP_Agent_Workspace_Scope $workspace = null, ?array $owner = null ): ?array {
+		$run = self::get_run( $run_id, $workspace, $owner );
 		if ( null === $run || self::STATUS_CANCELLING !== $run['status'] ) {
 			return null;
 		}
@@ -177,9 +264,10 @@ class WP_Agent_Chat_Run_Control {
 	 * Queue a follow-up message for a chat session.
 	 *
 	 * @param array<string,mixed> $input Canonical queue input.
+	 * @param array<string,mixed>|null $owner Canonical conversation owner.
 	 * @return array<string,mixed> Queue result.
 	 */
-	public static function queue_message( array $input ): array {
+	public static function queue_message( array $input, ?WP_Agent_Workspace_Scope $workspace = null, ?array $owner = null ): array {
 		$session_id = trim( self::string_value( $input['session_id'] ?? null ) );
 		$run_id     = trim( self::string_value( $input['run_id'] ?? null ) );
 		if ( '' === $session_id ) {
@@ -196,13 +284,14 @@ class WP_Agent_Chat_Run_Control {
 			'attachments'       => is_array( $input['attachments'] ?? null ) ? $input['attachments'] : array(),
 			'client_context'    => is_array( $input['client_context'] ?? null ) ? $input['client_context'] : array(),
 			'created_at'        => self::now(),
+			'_owner'            => self::owner_fingerprint( $owner ),
 		);
 
-		$state                            = self::state();
+		$state                            = self::state( $workspace );
 		$state['queues'][ $session_id ]   = array_values( $state['queues'][ $session_id ] ?? array() );
 		$state['queues'][ $session_id ][] = $item;
 		$position                         = count( $state['queues'][ $session_id ] );
-		self::save_state( $state );
+		self::save_state( $state, $workspace );
 
 		return self::normalize_run( array(
 			'run_id'            => '' !== $run_id ? $run_id : self::generate_run_id(),
@@ -218,14 +307,35 @@ class WP_Agent_Chat_Run_Control {
 	 * Claim queued messages for a session.
 	 *
 	 * @param string $session_id Session ID.
+	 * @param array<string,mixed>|null $owner Canonical conversation owner.
 	 * @return array<int,array<string,mixed>> Queued items.
 	 */
-	public static function claim_queued_messages( string $session_id ): array {
-		$state = self::state();
-		$items = array_values( $state['queues'][ $session_id ] ?? array() );
+	public static function claim_queued_messages( string $session_id, ?WP_Agent_Workspace_Scope $workspace = null, ?array $owner = null ): array {
+		$state = self::state( $workspace );
+		$items = array_values( array_filter(
+			$state['queues'][ $session_id ] ?? array(),
+			static fn( array $item ): bool => self::owner_matches( $item['_owner'] ?? '', $owner )
+		) );
+		if ( count( $items ) !== count( $state['queues'][ $session_id ] ?? array() ) ) {
+			return array();
+		}
 		unset( $state['queues'][ $session_id ] );
-		self::save_state( $state );
-		return $items;
+		self::save_state( $state, $workspace );
+		return array_map( array( self::class, 'public_queue_item' ), $items );
+	}
+
+	/**
+	 * List lifecycle events for a principal-owned run.
+	 *
+	 * @param array<string,mixed>|null $owner Canonical conversation owner.
+	 * @return array<string,mixed>|null
+	 */
+	public static function list_events( string $run_id, string $cursor = '', int $limit = 100, ?WP_Agent_Workspace_Scope $workspace = null, ?array $owner = null ): ?array {
+		if ( ! self::can_access_run( $run_id, $workspace, $owner ) ) {
+			return null;
+		}
+
+		return WP_Agent_Run_Control::list_events( self::OPTION_KEY, $run_id, $cursor, $limit, $workspace );
 	}
 
 	/**
@@ -259,17 +369,9 @@ class WP_Agent_Chat_Run_Control {
 		);
 	}
 
-	/** @return array{runs:array<string,array<string,mixed>>,queues:array<string,array<int,array<string,mixed>>>} */
-	private static function state(): array {
-		$state = function_exists( 'get_option' ) ? get_option( self::OPTION_KEY, array() ) : array();
-		if ( ! is_array( $state ) ) {
-			$state = array();
-		}
-
-		return array(
-			'runs'   => self::stored_runs( $state['runs'] ?? array() ),
-			'queues' => self::stored_queues( $state['queues'] ?? array() ),
-		);
+	/** @return array{runs:array<string,array<string,mixed>>,queues:array<string,array<int,array<string,mixed>>>,events:array<string,array<int,array<string,mixed>>>} */
+	private static function state( ?WP_Agent_Workspace_Scope $workspace = null ): array {
+		return WP_Agent_Run_Control::state( self::OPTION_KEY, $workspace );
 	}
 
 	private static function string_value( mixed $value ): string {
@@ -280,71 +382,40 @@ class WP_Agent_Chat_Run_Control {
 		return is_int( $value ) || is_float( $value ) || is_string( $value ) || is_bool( $value ) ? (int) $value : 0;
 	}
 
-	/**
-	 * @param mixed $runs Raw stored runs.
-	 * @return array<string,array<string,mixed>>
-	 */
-	private static function stored_runs( mixed $runs ): array {
-		if ( ! is_array( $runs ) ) {
-			return array();
+	/** @param array{runs:array<string,array<string,mixed>>,queues:array<string,array<int,array<string,mixed>>>,events:array<string,array<int,array<string,mixed>>>} $state State to persist. */
+	private static function save_state( array $state, ?WP_Agent_Workspace_Scope $workspace = null ): void {
+		WP_Agent_Run_Control::save_state( self::OPTION_KEY, $state, $workspace );
+	}
+
+	/** @param array<string,mixed>|null $owner */
+	private static function owner_fingerprint( ?array $owner ): string {
+		if ( ! is_string( $owner['type'] ?? null ) || ! is_string( $owner['key'] ?? null ) ) {
+			return '';
 		}
 
-		$stored = array();
-		foreach ( $runs as $run_id => $run ) {
-			if ( is_string( $run_id ) && is_array( $run ) ) {
-				$stored[ $run_id ] = self::assoc_array( $run );
-			}
-		}
+		return hash( 'sha256', $owner['type'] . ':' . $owner['key'] );
+	}
 
-		return $stored;
+	/** @param array<string,mixed>|null $owner */
+	private static function owner_matches( mixed $stored, ?array $owner ): bool {
+		$stored = is_string( $stored ) ? $stored : '';
+		return '' === $stored || ( '' !== self::owner_fingerprint( $owner ) && hash_equals( $stored, self::owner_fingerprint( $owner ) ) );
+	}
+
+	/** @param array<string,mixed>|null $owner */
+	private static function can_access_run( string $run_id, ?WP_Agent_Workspace_Scope $workspace, ?array $owner ): bool {
+		$state = self::state( $workspace );
+		$run   = $state['runs'][ $run_id ] ?? null;
+		return is_array( $run ) && self::owner_matches( $run['_owner'] ?? '', $owner );
 	}
 
 	/**
-	 * @param mixed $queues Raw stored queues.
-	 * @return array<string,array<int,array<string,mixed>>>
-	 */
-	private static function stored_queues( mixed $queues ): array {
-		if ( ! is_array( $queues ) ) {
-			return array();
-		}
-
-		$stored = array();
-		foreach ( $queues as $session_id => $items ) {
-			if ( ! is_string( $session_id ) || ! is_array( $items ) ) {
-				continue;
-			}
-
-			$stored[ $session_id ] = array();
-			foreach ( $items as $item ) {
-				if ( is_array( $item ) ) {
-					$stored[ $session_id ][] = self::assoc_array( $item );
-				}
-			}
-		}
-
-		return $stored;
-	}
-
-	/**
-	 * @param array<mixed> $value Raw array.
+	 * @param array<string,mixed> $item Stored queue item.
 	 * @return array<string,mixed>
 	 */
-	private static function assoc_array( array $value ): array {
-		$assoc = array();
-		foreach ( $value as $field => $field_value ) {
-			if ( is_string( $field ) ) {
-				$assoc[ $field ] = $field_value;
-			}
-		}
-
-		return $assoc;
-	}
-
-	/** @param array<string,mixed> $state State to persist. */
-	private static function save_state( array $state ): void {
-		if ( function_exists( 'update_option' ) ) {
-			update_option( self::OPTION_KEY, $state, false );
-		}
+	private static function public_queue_item( array $item ): array {
+		unset( $item['_owner'] );
+		return $item;
 	}
 
 	private static function now(): string {

--- a/src/Runtime/class-wp-agent-conversation-loop.php
+++ b/src/Runtime/class-wp-agent-conversation-loop.php
@@ -113,6 +113,8 @@ class WP_Agent_Conversation_Loop {
 		$interrupt_source      = self::resolve_interrupt_source( $options );
 		$request               = self::resolve_request( $messages, $options );
 		$principal             = $request->principal();
+		$run_workspace         = $request->workspace();
+		$run_owner             = $principal instanceof WP_Agent_Execution_Principal ? $principal->conversation_owner() : null;
 		if ( $principal instanceof WP_Agent_Execution_Principal && ! isset( $context['principal'] ) ) {
 			// Thread the resolved execution principal into the run context so it
 			// reaches tool execution (turn context -> tool context -> executor).
@@ -134,7 +136,7 @@ class WP_Agent_Conversation_Loop {
 		self::emit_tool_declaration_diagnostics( $on_event, $rejected_declarations, $tool_declarations, $tool_executor );
 		$messages = self::normalize_messages( $messages );
 		if ( '' !== $run_id && '' !== $lock_session_id ) {
-			WP_Agent_Chat_Run_Control::start_run( $run_id, $lock_session_id, array( 'source' => 'conversation_loop' ) );
+			WP_Agent_Chat_Run_Control::start_run( $run_id, $lock_session_id, array( 'source' => 'conversation_loop' ), $run_workspace, $run_owner );
 		}
 		$events                = array();
 		$tool_results          = array();
@@ -190,7 +192,7 @@ class WP_Agent_Conversation_Loop {
 				$force_continue       = false;
 				$turn_context         = $context;
 				$turn_context['turn'] = $turn;
-				$interrupt            = self::check_runtime_cancellation( $run_id, $lock_session_id, $turn_context, $on_event );
+				$interrupt            = self::check_runtime_cancellation( $run_id, $lock_session_id, $turn_context, $on_event, $run_workspace, $run_owner );
 				if ( null !== $interrupt ) {
 					$messages[]  = $interrupt['message'];
 					$events[]    = self::interrupt_event( $interrupt );
@@ -229,7 +231,7 @@ class WP_Agent_Conversation_Loop {
 					);
 
 					if ( '' !== $run_id && '' !== $lock_session_id ) {
-						WP_Agent_Chat_Run_Control::finish_run( $run_id, WP_Agent_Chat_Run_Control::STATUS_FAILED );
+						WP_Agent_Chat_Run_Control::finish_run( $run_id, WP_Agent_Chat_Run_Control::STATUS_FAILED, $run_workspace );
 					}
 
 					self::persist_transcript( $transcript_persister, $messages, $options, $failure_result );
@@ -255,7 +257,7 @@ class WP_Agent_Conversation_Loop {
 					throw $error;
 				}
 
-				$interrupt = self::check_runtime_cancellation( $run_id, $lock_session_id, $turn_context, $on_event );
+				$interrupt = self::check_runtime_cancellation( $run_id, $lock_session_id, $turn_context, $on_event, $run_workspace, $run_owner );
 				if ( null !== $interrupt ) {
 					$messages[]  = $interrupt['message'];
 					$events[]    = self::interrupt_event( $interrupt );
@@ -291,7 +293,7 @@ class WP_Agent_Conversation_Loop {
 					) );
 
 					if ( '' !== $run_id && '' !== $lock_session_id ) {
-						WP_Agent_Chat_Run_Control::finish_run( $run_id, WP_Agent_Chat_Run_Control::STATUS_FAILED );
+						WP_Agent_Chat_Run_Control::finish_run( $run_id, WP_Agent_Chat_Run_Control::STATUS_FAILED, $run_workspace );
 					}
 
 					self::persist_transcript( $transcript_persister, $messages, $options, $failure_result );
@@ -316,7 +318,7 @@ class WP_Agent_Conversation_Loop {
 				// When mediation is enabled, the turn runner returns tool_calls
 				// and the loop handles execution. Otherwise, the caller-managed path applies.
 				if ( null !== $tool_executor && $mediation_enabled && isset( $result['tool_calls'] ) && is_array( $result['tool_calls'] ) ) {
-					$interrupt = self::check_runtime_cancellation( $run_id, $lock_session_id, $turn_context, $on_event );
+					$interrupt = self::check_runtime_cancellation( $run_id, $lock_session_id, $turn_context, $on_event, $run_workspace, $run_owner );
 					if ( null !== $interrupt ) {
 						$messages[]  = $interrupt['message'];
 						$events[]    = self::interrupt_event( $interrupt );
@@ -354,7 +356,7 @@ class WP_Agent_Conversation_Loop {
 					$approval_required     = $mediation_result['approval_required'] ?? null;
 					$runtime_tool_pending  = $mediation_result['runtime_tool_pending'] ?? null;
 					$stalled               = self::check_spin_detector( $spin_detector, $mediation_result['spin_signatures'], $turn_context, $on_event );
-					$interrupt             = self::check_runtime_cancellation( $run_id, $lock_session_id, $turn_context, $on_event );
+					$interrupt             = self::check_runtime_cancellation( $run_id, $lock_session_id, $turn_context, $on_event, $run_workspace, $run_owner );
 					if ( null !== $interrupt ) {
 						$messages[]  = $interrupt['message'];
 						$events[]    = self::interrupt_event( $interrupt );
@@ -454,7 +456,7 @@ class WP_Agent_Conversation_Loop {
 
 				$interrupt = self::check_interrupt_source( $interrupt_source, $messages, $options, $turn_context, $on_event );
 				if ( null === $interrupt ) {
-					$interrupt = self::check_runtime_cancellation( $run_id, $lock_session_id, $turn_context, $on_event );
+					$interrupt = self::check_runtime_cancellation( $run_id, $lock_session_id, $turn_context, $on_event, $run_workspace, $run_owner );
 				}
 				if ( null !== $interrupt ) {
 					$messages[] = $interrupt['message'];
@@ -534,7 +536,7 @@ class WP_Agent_Conversation_Loop {
 			$final_result = self::normalize_conversation_result( $final_result_data );
 
 			if ( '' !== $run_id && '' !== $lock_session_id ) {
-				WP_Agent_Chat_Run_Control::finish_run( $run_id, WP_Agent_Run_Outcome::run_control_status( $final_result ) );
+				WP_Agent_Chat_Run_Control::finish_run( $run_id, WP_Agent_Run_Outcome::run_control_status( $final_result ), $run_workspace );
 			}
 
 			self::persist_transcript( $transcript_persister, $messages, $options, $final_result );
@@ -1472,14 +1474,15 @@ class WP_Agent_Conversation_Loop {
 	 * Check canonical chat run-control cancellation state.
 	 *
 	 * @param array<string,mixed> $context Current turn context.
+	 * @param array<string,mixed>|null $owner Canonical conversation owner.
 	 * @return array{message: array<string, mixed>, metadata: array<string, mixed>, action: string}|null
 	 */
-	private static function check_runtime_cancellation( string $run_id, string $lock_session_id, array $context, ?callable $on_event ): ?array {
+	private static function check_runtime_cancellation( string $run_id, string $lock_session_id, array $context, ?callable $on_event, ?\AgentsAPI\Core\Workspace\WP_Agent_Workspace_Scope $workspace = null, ?array $owner = null ): ?array {
 		if ( '' === $run_id ) {
 			return null;
 		}
 
-		$interrupt_message = WP_Agent_Chat_Run_Control::cancellation_interrupt_for_run( $run_id, $lock_session_id );
+		$interrupt_message = WP_Agent_Chat_Run_Control::cancellation_interrupt_for_run( $run_id, $lock_session_id, $workspace, $owner );
 		if ( null === $interrupt_message ) {
 			return null;
 		}
@@ -1706,16 +1709,29 @@ class WP_Agent_Conversation_Loop {
 		}
 
 		$runtime_overrides = self::resolve_runtime_overrides( $options );
+		$principal         = $options['principal'] ?? ( is_array( $options['context'] ?? null ) ? ( $options['context']['principal'] ?? null ) : null );
+		if ( is_array( $principal ) ) {
+			try {
+				$principal = WP_Agent_Execution_Principal::from_array( self::normalize_assoc_array( $principal ) );
+			} catch ( \Throwable $error ) {
+				unset( $error );
+				$principal = null;
+			}
+		}
+		$workspace = $options['workspace'] ?? null;
+		if ( ! $workspace instanceof \AgentsAPI\Core\Workspace\WP_Agent_Workspace_Scope ) {
+			$workspace = null;
+		}
 
 		return new WP_Agent_Conversation_Request(
 			$messages,
 			array(),
-			null,
+			$principal instanceof WP_Agent_Execution_Principal ? $principal : null,
 			self::normalize_assoc_array( $options['context'] ?? array() ),
 			array(),
 			self::max_turns( $options['max_turns'] ?? 1 ),
 			false,
-			null,
+			$workspace,
 			$runtime_overrides
 		);
 	}

--- a/src/Runtime/class-wp-agent-option-run-control-store.php
+++ b/src/Runtime/class-wp-agent-option-run-control-store.php
@@ -7,12 +7,18 @@
 
 namespace AgentsAPI\AI;
 
+use AgentsAPI\Core\Workspace\WP_Agent_Workspace_Scope;
+
 defined( 'ABSPATH' ) || exit;
+
+if ( ! interface_exists( WP_Agent_Workspace_Run_Control_Store::class ) ) {
+	require_once __DIR__ . '/interface-wp-agent-workspace-run-control-store.php';
+}
 
 /**
  * Persists run-control state in WordPress options.
  */
-class WP_Agent_Option_Run_Control_Store implements WP_Agent_Run_Control_Store {
+class WP_Agent_Option_Run_Control_Store implements WP_Agent_Workspace_Run_Control_Store {
 
 	/**
 	 * @param string $store_key Store key.
@@ -39,6 +45,47 @@ class WP_Agent_Option_Run_Control_Store implements WP_Agent_Run_Control_Store {
 		if ( function_exists( 'update_option' ) ) {
 			update_option( $store_key, $state, false );
 		}
+	}
+
+	/**
+	 * Read explicit workspace state from the network-wide option table.
+	 *
+	 * Omitted workspaces continue through get_state() and remain site-local.
+	 *
+	 * @return array{runs:array<string,array<string,mixed>>,queues:array<string,array<int,array<string,mixed>>>,events:array<string,array<int,array<string,mixed>>>}
+	 */
+	public function get_workspace_state( string $store_key, WP_Agent_Workspace_Scope $workspace ): array {
+		if ( ! function_exists( 'get_site_option' ) ) {
+			throw new \RuntimeException( 'The run-control store cannot share explicit workspace state.' );
+		}
+
+		$state = get_site_option( $this->workspace_option_key( $store_key, $workspace ), array() );
+		if ( ! is_array( $state ) ) {
+			$state = array();
+		}
+
+		return array(
+			'runs'   => $this->stored_runs( $state['runs'] ?? array() ),
+			'queues' => $this->stored_queues( $state['queues'] ?? array() ),
+			'events' => $this->stored_queues( $state['events'] ?? array() ),
+		);
+	}
+
+	/**
+	 * Save explicit workspace state in the network-wide option table.
+	 *
+	 * @param array{runs:array<string,array<string,mixed>>,queues:array<string,array<int,array<string,mixed>>>,events:array<string,array<int,array<string,mixed>>>} $state State envelope.
+	 */
+	public function save_workspace_state( string $store_key, WP_Agent_Workspace_Scope $workspace, array $state ): void {
+		if ( ! function_exists( 'update_site_option' ) ) {
+			throw new \RuntimeException( 'The run-control store cannot share explicit workspace state.' );
+		}
+
+		update_site_option( $this->workspace_option_key( $store_key, $workspace ), $state );
+	}
+
+	private function workspace_option_key( string $store_key, WP_Agent_Workspace_Scope $workspace ): string {
+		return $store_key . '_workspace_' . hash( 'sha256', $workspace->key() );
 	}
 
 	/**

--- a/src/Runtime/class-wp-agent-run-control.php
+++ b/src/Runtime/class-wp-agent-run-control.php
@@ -7,6 +7,8 @@
 
 namespace AgentsAPI\AI;
 
+use AgentsAPI\Core\Workspace\WP_Agent_Workspace_Scope;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -234,7 +236,7 @@ class WP_Agent_Run_Control {
 	 * @param array<string,mixed> $run       Run fields.
 	 * @return array<string,mixed>
 	 */
-	public static function start_run( string $store_key, string $run_id, array $run = array() ): array {
+	public static function start_run( string $store_key, string $run_id, array $run = array(), ?WP_Agent_Workspace_Scope $workspace = null ): array {
 		$now = self::now();
 		$run = array_merge(
 			$run,
@@ -247,10 +249,10 @@ class WP_Agent_Run_Control {
 			)
 		);
 
-		$state                    = self::state( $store_key );
+		$state                    = self::state( $store_key, $workspace );
 		$state['runs'][ $run_id ] = $run;
 		$state                    = self::record_event_in_state( $state, $run_id, 'run_started', array( 'status' => self::STATUS_RUNNING ) );
-		self::save_state( $store_key, $state );
+		self::save_state( $store_key, $state, $workspace );
 
 		return self::normalize_run( $run );
 	}
@@ -283,8 +285,8 @@ class WP_Agent_Run_Control {
 	 * @param string $status    Terminal status.
 	 * @return array<string,mixed>|null
 	 */
-	public static function finish_run( string $store_key, string $run_id, string $status = self::STATUS_COMPLETED ): ?array {
-		$state = self::state( $store_key );
+	public static function finish_run( string $store_key, string $run_id, string $status = self::STATUS_COMPLETED, ?WP_Agent_Workspace_Scope $workspace = null ): ?array {
+		$state = self::state( $store_key, $workspace );
 		if ( ! isset( $state['runs'][ $run_id ] ) ) {
 			return null;
 		}
@@ -298,7 +300,7 @@ class WP_Agent_Run_Control {
 
 		$state['runs'][ $run_id ] = $run;
 		$state                    = self::record_event_in_state( $state, $run_id, 'run_finished', array( 'status' => $run['status'] ) );
-		self::save_state( $store_key, $state );
+		self::save_state( $store_key, $state, $workspace );
 
 		return self::normalize_run( $run );
 	}
@@ -308,8 +310,8 @@ class WP_Agent_Run_Control {
 	 *
 	 * @return array<string,mixed>|null
 	 */
-	public static function get_run( string $store_key, string $run_id ): ?array {
-		$state = self::state( $store_key );
+	public static function get_run( string $store_key, string $run_id, ?WP_Agent_Workspace_Scope $workspace = null ): ?array {
+		$state = self::state( $store_key, $workspace );
 		$run   = $state['runs'][ $run_id ] ?? null;
 		return is_array( $run ) ? self::normalize_run( $run ) : null;
 	}
@@ -319,8 +321,8 @@ class WP_Agent_Run_Control {
 	 *
 	 * @return array<string,mixed>|null
 	 */
-	public static function request_cancel( string $store_key, string $run_id ): ?array {
-		$state = self::state( $store_key );
+	public static function request_cancel( string $store_key, string $run_id, ?WP_Agent_Workspace_Scope $workspace = null ): ?array {
+		$state = self::state( $store_key, $workspace );
 		if ( ! isset( $state['runs'][ $run_id ] ) ) {
 			return null;
 		}
@@ -333,7 +335,7 @@ class WP_Agent_Run_Control {
 
 		$state['runs'][ $run_id ] = $run;
 		$state                    = self::record_event_in_state( $state, $run_id, 'cancel_requested', array( 'status' => $run['status'] ) );
-		self::save_state( $store_key, $state );
+		self::save_state( $store_key, $state, $workspace );
 
 		return self::normalize_run( $run );
 	}
@@ -346,13 +348,13 @@ class WP_Agent_Run_Control {
 	/**
 	 * @return array<string,mixed>|null
 	 */
-	public static function list_events( string $store_key, string $run_id, string $cursor = '', int $limit = 100 ): ?array {
-		$run = self::get_run( $store_key, $run_id );
+	public static function list_events( string $store_key, string $run_id, string $cursor = '', int $limit = 100, ?WP_Agent_Workspace_Scope $workspace = null ): ?array {
+		$run = self::get_run( $store_key, $run_id, $workspace );
 		if ( null === $run ) {
 			return null;
 		}
 
-		$state  = self::state( $store_key );
+		$state  = self::state( $store_key, $workspace );
 		$events = array_values( $state['events'][ $run_id ] ?? array() );
 		$offset = max( 0, self::int_value( $cursor ) );
 		$limit  = max( 1, min( 500, $limit ) );
@@ -385,16 +387,37 @@ class WP_Agent_Run_Control {
 		self::$store = null;
 	}
 
+	public static function supports_workspace_state(): bool {
+		return self::store() instanceof WP_Agent_Workspace_Run_Control_Store;
+	}
+
 	/** @return array{runs:array<string,array<string,mixed>>,queues:array<string,array<int,array<string,mixed>>>,events:array<string,array<int,array<string,mixed>>>} */
-	public static function state( string $store_key ): array {
-		return self::store()->get_state( $store_key );
+	public static function state( string $store_key, ?WP_Agent_Workspace_Scope $workspace = null ): array {
+		$store = self::store();
+		if ( null === $workspace ) {
+			return $store->get_state( $store_key );
+		}
+		if ( ! $store instanceof WP_Agent_Workspace_Run_Control_Store ) {
+			throw new \RuntimeException( 'The registered run-control store does not support explicit workspaces.' );
+		}
+
+		return $store->get_workspace_state( $store_key, $workspace );
 	}
 
 	/**
 	 * @param array{runs:array<string,array<string,mixed>>,queues:array<string,array<int,array<string,mixed>>>,events:array<string,array<int,array<string,mixed>>>} $state
 	 */
-	public static function save_state( string $store_key, array $state ): void {
-		self::store()->save_state( $store_key, $state );
+	public static function save_state( string $store_key, array $state, ?WP_Agent_Workspace_Scope $workspace = null ): void {
+		$store = self::store();
+		if ( null === $workspace ) {
+			$store->save_state( $store_key, $state );
+			return;
+		}
+		if ( ! $store instanceof WP_Agent_Workspace_Run_Control_Store ) {
+			throw new \RuntimeException( 'The registered run-control store does not support explicit workspaces.' );
+		}
+
+		$store->save_workspace_state( $store_key, $workspace, $state );
 	}
 
 	public static function now(): string {

--- a/src/Runtime/interface-wp-agent-workspace-run-control-store.php
+++ b/src/Runtime/interface-wp-agent-workspace-run-control-store.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Workspace-aware run-control store contract.
+ *
+ * @package AgentsAPI
+ */
+
+namespace AgentsAPI\AI;
+
+use AgentsAPI\Core\Workspace\WP_Agent_Workspace_Scope;
+
+defined( 'ABSPATH' ) || exit;
+
+if ( ! interface_exists( WP_Agent_Run_Control_Store::class ) ) {
+	require_once __DIR__ . '/interface-wp-agent-run-control-store.php';
+}
+
+/**
+ * Optional store capability for state shared by a canonical workspace.
+ */
+interface WP_Agent_Workspace_Run_Control_Store extends WP_Agent_Run_Control_Store {
+
+	/**
+	 * @return array{runs:array<string,array<string,mixed>>,queues:array<string,array<int,array<string,mixed>>>,events:array<string,array<int,array<string,mixed>>>}
+	 */
+	public function get_workspace_state( string $store_key, WP_Agent_Workspace_Scope $workspace ): array;
+
+	/**
+	 * @param array{runs:array<string,array<string,mixed>>,queues:array<string,array<int,array<string,mixed>>>,events:array<string,array<int,array<string,mixed>>>} $state State envelope.
+	 */
+	public function save_workspace_state( string $store_key, WP_Agent_Workspace_Scope $workspace, array $state ): void;
+}

--- a/tests/agents-chat-ability-smoke.php
+++ b/tests/agents-chat-ability-smoke.php
@@ -164,6 +164,7 @@ smoke_assert( true, agents_chat_permission( array() ), 'permission_filter_widens
 $in = agents_chat_input_schema();
 smoke_assert( array( 'agent', 'message' ), $in['required'] ?? array(), 'input_schema_required_fields', $failures, $passes );
 smoke_assert( true, isset( $in['properties']['client_context'] ), 'input_schema_has_client_context', $failures, $passes );
+smoke_assert( true, isset( $in['properties']['workspace']['properties']['workspace_type'] ), 'input_schema_has_canonical_workspace', $failures, $passes );
 smoke_assert( true, isset( $in['properties']['session_owner'] ), 'input_schema_has_session_owner', $failures, $passes );
 smoke_assert( true, isset( $in['properties']['session_owner']['properties']['type'] ), 'session_owner_schema_has_type', $failures, $passes );
 smoke_assert( true, isset( $in['properties']['session_owner']['properties']['key'] ), 'session_owner_schema_has_key', $failures, $passes );

--- a/tests/chat-run-control-multisite-smoke.php
+++ b/tests/chat-run-control-multisite-smoke.php
@@ -1,0 +1,248 @@
+<?php
+/**
+ * Stateful multisite coverage for workspace-scoped chat run control.
+ *
+ * Run with: php tests/chat-run-control-multisite-smoke.php
+ *
+ * @package AgentsAPI\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+$failures = array();
+$passes   = 0;
+
+echo "chat-run-control-multisite-smoke\n";
+
+require_once __DIR__ . '/agents-api-smoke-helpers.php';
+
+$GLOBALS['__agents_api_smoke_abilities']    = array();
+$GLOBALS['__agents_api_smoke_categories']   = array();
+$GLOBALS['__agents_api_multisite_blog']     = 1;
+$GLOBALS['__agents_api_multisite_stack']    = array();
+$GLOBALS['__agents_api_multisite_options']  = array();
+$GLOBALS['__agents_api_multisite_network']  = array();
+$GLOBALS['__agents_api_multisite_user']     = 123;
+
+if ( ! class_exists( 'WP_Error' ) ) {
+	class WP_Error {
+		public function __construct( private string $code = '', private string $message = '', private array $data = array() ) {}
+		public function get_error_code(): string { return $this->code; }
+		public function get_error_message(): string { return $this->message; }
+		public function get_error_data(): array { return $this->data; }
+	}
+}
+
+function get_current_blog_id(): int {
+	return (int) $GLOBALS['__agents_api_multisite_blog'];
+}
+
+function switch_to_blog( int $blog_id ): bool {
+	$GLOBALS['__agents_api_multisite_stack'][] = get_current_blog_id();
+	$GLOBALS['__agents_api_multisite_blog']    = $blog_id;
+	return true;
+}
+
+function restore_current_blog(): bool {
+	if ( array() === $GLOBALS['__agents_api_multisite_stack'] ) {
+		return false;
+	}
+	$GLOBALS['__agents_api_multisite_blog'] = array_pop( $GLOBALS['__agents_api_multisite_stack'] );
+	return true;
+}
+
+function get_option( string $option, $default = false ) {
+	return $GLOBALS['__agents_api_multisite_options'][ get_current_blog_id() ][ $option ] ?? $default;
+}
+
+function update_option( string $option, $value, $autoload = null ): bool {
+	unset( $autoload );
+	$GLOBALS['__agents_api_multisite_options'][ get_current_blog_id() ][ $option ] = $value;
+	return true;
+}
+
+function get_site_option( string $option, $default = false ) {
+	return $GLOBALS['__agents_api_multisite_network'][ $option ] ?? $default;
+}
+
+function update_site_option( string $option, $value ): bool {
+	$GLOBALS['__agents_api_multisite_network'][ $option ] = $value;
+	return true;
+}
+
+function get_current_user_id(): int {
+	return (int) $GLOBALS['__agents_api_multisite_user'];
+}
+
+function current_user_can( string $capability ): bool {
+	return 'read' === $capability;
+}
+
+function sanitize_key( string $value ): string {
+	return (string) preg_replace( '/[^a-z0-9_-]/', '', strtolower( $value ) );
+}
+
+function wp_has_ability_category( string $category ): bool {
+	return isset( $GLOBALS['__agents_api_smoke_categories'][ $category ] );
+}
+
+function wp_register_ability_category( string $category, array $args ): void {
+	$GLOBALS['__agents_api_smoke_categories'][ $category ] = $args;
+}
+
+function wp_has_ability( string $ability ): bool {
+	return isset( $GLOBALS['__agents_api_smoke_abilities'][ $ability ] );
+}
+
+function wp_register_ability( string $ability, array $args ): void {
+	$GLOBALS['__agents_api_smoke_abilities'][ $ability ] = $args;
+}
+
+agents_api_smoke_require_module();
+
+use AgentsAPI\AI\WP_Agent_Chat_Run_Control;
+use AgentsAPI\AI\WP_Agent_Execution_Principal;
+use AgentsAPI\AI\WP_Agent_Run_Control;
+use AgentsAPI\AI\WP_Agent_Run_Control_Store;
+use AgentsAPI\Core\Workspace\WP_Agent_Workspace_Scope;
+use function AgentsAPI\AI\Channels\agents_cancel_chat_run;
+use function AgentsAPI\AI\Channels\agents_chat_dispatch;
+use function AgentsAPI\AI\Channels\agents_get_chat_run;
+use function AgentsAPI\AI\Channels\agents_list_chat_run_events;
+use function AgentsAPI\AI\Channels\agents_queue_chat_message;
+
+$workspace = array(
+	'workspace_type' => 'network',
+	'workspace_id'   => 'network-9',
+);
+$other_workspace = array(
+	'workspace_type' => 'network',
+	'workspace_id'   => 'network-10',
+);
+$principal = WP_Agent_Execution_Principal::user_session( 123, 'demo-agent' )->to_array();
+$other_principal = WP_Agent_Execution_Principal::user_session( 456, 'demo-agent' )->to_array();
+$owner = array( 'type' => 'user', 'key' => '123' );
+
+add_filter(
+	'wp_agent_chat_handler',
+	static fn() => static fn( array $input ): array => array(
+		'session_id' => (string) ( $input['session_id'] ?? 'network-session' ),
+		'run_id'     => (string) $input['run_id'],
+		'reply'      => 'pending',
+		'completed'  => false,
+		'status'     => 'runtime_tool_pending',
+	),
+	1,
+	2
+);
+
+$created = agents_chat_dispatch(
+	array(
+		'agent'         => 'demo-agent',
+		'message'       => 'start',
+		'session_id'    => 'network-session',
+		'workspace'     => $workspace,
+		'principal'     => $principal,
+		'session_owner' => $owner,
+	)
+);
+$run_id = is_array( $created ) ? (string) ( $created['run_id'] ?? '' ) : '';
+agents_api_smoke_assert_equals( false, $created instanceof WP_Error, 'run is created on the first subsite under an explicit workspace', $failures, $passes );
+
+$queued = agents_queue_chat_message(
+	array(
+		'agent'         => 'demo-agent',
+		'message'       => 'queued continuation',
+		'session_id'    => 'network-session',
+		'run_id'        => $run_id,
+		'workspace'     => $workspace,
+		'principal'     => $principal,
+		'session_owner' => $owner,
+	)
+);
+agents_api_smoke_assert_equals( 'queued', $queued['status'] ?? null, 'queue state is created on the first subsite', $failures, $passes );
+
+switch_to_blog( 2 );
+$control_input = array(
+	'session_id'    => 'network-session',
+	'run_id'        => $run_id,
+	'workspace'     => $workspace,
+	'principal'     => $principal,
+	'session_owner' => $owner,
+);
+$status = agents_get_chat_run( $control_input );
+$events = agents_list_chat_run_events( $control_input );
+agents_api_smoke_assert_equals( 'runtime_tool_pending', $status['status'] ?? null, 'second subsite reads workspace run status', $failures, $passes );
+agents_api_smoke_assert_equals( true, count( $events['events'] ?? array() ) >= 2, 'second subsite reads workspace run events', $failures, $passes );
+
+$claimed = WP_Agent_Chat_Run_Control::claim_queued_messages( 'network-session', WP_Agent_Workspace_Scope::from_array( $workspace ), $owner );
+agents_api_smoke_assert_equals( 'queued continuation', $claimed[0]['message'] ?? null, 'second subsite claims the workspace queue', $failures, $passes );
+
+$continued = agents_chat_dispatch(
+	array(
+		'agent'         => 'demo-agent',
+		'message'       => 'continue',
+		'session_id'    => 'network-session',
+		'workspace'     => $workspace,
+		'principal'     => $principal,
+		'session_owner' => $owner,
+	)
+);
+agents_api_smoke_assert_equals( 'network-session', $continued['session_id'] ?? null, 'second subsite continues the same workspace session', $failures, $passes );
+
+$cancelled = agents_cancel_chat_run( $control_input );
+agents_api_smoke_assert_equals( true, $cancelled['cancelled'] ?? null, 'second subsite cancels the workspace run', $failures, $passes );
+agents_api_smoke_assert_equals( 2, get_current_blog_id(), 'workspace operations preserve the caller blog context', $failures, $passes );
+
+$wrong_workspace = agents_get_chat_run( array_replace( $control_input, array( 'workspace' => $other_workspace ) ) );
+agents_api_smoke_assert_equals( 'agents_chat_run_not_found', $wrong_workspace instanceof WP_Error ? $wrong_workspace->get_error_code() : '', 'same run id is inaccessible in another workspace', $failures, $passes );
+
+$wrong_principal_input              = $control_input;
+$wrong_principal_input['principal'] = $other_principal;
+$wrong_principal_input['session_owner'] = array( 'type' => 'user', 'key' => '456' );
+$wrong_principal = agents_get_chat_run( $wrong_principal_input );
+agents_api_smoke_assert_equals( 'agents_chat_run_not_found', $wrong_principal instanceof WP_Error ? $wrong_principal->get_error_code() : '', 'wrong principal cannot inspect a workspace run', $failures, $passes );
+
+$forged_owner_input                  = $control_input;
+$forged_owner_input['session_owner'] = array( 'type' => 'user', 'key' => '456' );
+$forged_owner = agents_cancel_chat_run( $forged_owner_input );
+agents_api_smoke_assert_equals( 'agents_chat_run_owner_forbidden', $forged_owner instanceof WP_Error ? $forged_owner->get_error_code() : '', 'forged session ownership cannot cancel a run', $failures, $passes );
+
+$invalid_workspace = agents_get_chat_run( array_replace( $control_input, array( 'workspace' => array( 'workspace_type' => 'network' ) ) ) );
+agents_api_smoke_assert_equals( 'agents_chat_run_invalid_workspace', $invalid_workspace instanceof WP_Error ? $invalid_workspace->get_error_code() : '', 'malformed canonical workspaces are rejected', $failures, $passes );
+
+restore_current_blog();
+$legacy = WP_Agent_Chat_Run_Control::start_run( 'legacy-run', 'legacy-session', array(), null, $owner );
+switch_to_blog( 2 );
+$legacy_other_site = WP_Agent_Chat_Run_Control::get_run( 'legacy-run', null, $owner );
+agents_api_smoke_assert_equals( null, $legacy_other_site, 'omitted workspace state remains site-local', $failures, $passes );
+restore_current_blog();
+$legacy_origin = WP_Agent_Chat_Run_Control::get_run( 'legacy-run', null, $owner );
+agents_api_smoke_assert_equals( 'legacy-run', $legacy_origin['run_id'] ?? null, 'omitted workspace compatibility remains readable on its origin site', $failures, $passes );
+
+$unsupported_store = new class() implements WP_Agent_Run_Control_Store {
+	public function get_state( string $store_key ): array {
+		unset( $store_key );
+		return array( 'runs' => array(), 'queues' => array(), 'events' => array() );
+	}
+	public function save_state( string $store_key, array $state ): void {
+		unset( $store_key, $state );
+	}
+};
+WP_Agent_Run_Control::set_store( $unsupported_store );
+$unsupported = agents_queue_chat_message(
+	array(
+		'agent'         => 'demo-agent',
+		'message'       => 'unsupported',
+		'session_id'    => 'network-session',
+		'workspace'     => $workspace,
+		'principal'     => $principal,
+		'session_owner' => $owner,
+	)
+);
+agents_api_smoke_assert_equals( 'agents_chat_run_workspace_unsupported', $unsupported instanceof WP_Error ? $unsupported->get_error_code() : '', 'unsupported stores fail explicit workspace queueing truthfully', $failures, $passes );
+WP_Agent_Run_Control::reset_store();
+
+agents_api_smoke_finish( 'chat run-control multisite', $failures, $passes );

--- a/tests/chat-run-control-smoke.php
+++ b/tests/chat-run-control-smoke.php
@@ -286,7 +286,7 @@ agents_api_smoke_assert_equals( 'run-1', $interrupt['metadata']['run_id'] ?? nul
 
 $no_events_handler = AgentsAPI\AI\Channels\agents_list_chat_run_events( array( 'session_id' => 'session-events-1', 'run_id' => 'run-events-1' ) );
 agents_api_smoke_assert_equals( true, $no_events_handler instanceof WP_Error, 'run events require host handler', $failures, $passes );
-agents_api_smoke_assert_equals( 'agents_chat_run_events_no_handler', $no_events_handler->get_error_code(), 'run events no-handler error is explicit', $failures, $passes );
+agents_api_smoke_assert_equals( 'agents_chat_run_not_found', $no_events_handler->get_error_code(), 'run events report missing stored runs explicitly', $failures, $passes );
 
 add_filter(
 	'wp_agent_chat_run_events_handler',


### PR DESCRIPTION
## Summary
- validate and thread canonical workspace through chat dispatch, run status/events/cancel, queue claims, and conversation-loop cancellation
- add an optional workspace-aware run-control store capability, with explicit workspace state isolated in network options while omitted workspace remains site-local
- bind stored runs and queued messages to conversation-owner fingerprints and fail unsupported stores explicitly

## Tests
- `composer test`
- `composer phpstan`
- PHP syntax checks for all changed PHP files
- `homeboy review audit --placement local --profile pr --changed-since origin/main --json-summary` (no introduced findings)
- `homeboy review lint --placement local --changed-only --summary` attempted; Homeboy's bundled PHPCS installation fatals because `PHP_CodeSniffer\\Reports\\Report` is missing, and its bundled PHPStan is also corrupted. Repository PHPStan passes independently.

Fixes #449