### PR TITLE
Fix async runner response accounting

### DIFF
--- a/src/Workflows/class-wp-agent-workflow-action-scheduler-branch-executor.php
+++ b/src/Workflows/class-wp-agent-workflow-action-scheduler-branch-executor.php
@@ -517,9 +517,14 @@ final class WP_Agent_Workflow_Action_Scheduler_Branch_Executor implements WP_Age
 			if ( is_array( $results ) ) {
 				$fired = 0;
 				foreach ( $results as $result ) {
-					// A successful loopback returns a Requests Response; a torn-down one
-					// returns an exception. Count the ones the runtime accepted.
-					if ( $result instanceof \WpOrg\Requests\Response ) {
+					// A transport response alone does not prove the queue runner accepted
+					// the request: protected origins can return 403/5xx without executing
+					// Action Scheduler. Count only successful HTTP responses.
+					if (
+						$result instanceof \WpOrg\Requests\Response
+						&& $result->status_code >= 200
+						&& $result->status_code < 300
+					) {
 						++$fired;
 					}
 				}

--- a/tests/workflow-async-runner-dispatch-result-smoke.php
+++ b/tests/workflow-async-runner-dispatch-result-smoke.php
@@ -8,7 +8,9 @@
  */
 
 namespace WpOrg\Requests {
-	class Response {}
+	class Response {
+		public function __construct( public int $status_code ) {}
+	}
 
 	class Requests {
 		/** @var array<int,mixed> */
@@ -122,13 +124,25 @@ namespace {
 
 	Requests::$results = array(
 		new \RuntimeException( 'cURL error 7: Failed to connect to 127.0.0.1 port 443' ),
-		new Response(),
-		new Response(),
+		new Response( 200 ),
+		new Response( 204 ),
 	);
 	smoke_assert(
 		2,
 		WP_Agent_Workflow_Action_Scheduler_Branch_Executor::trigger_async_runner( 3 ),
 		'mixed parallel loopbacks report only accepted dispatches',
+		$failures,
+		$passes
+	);
+
+	Requests::$results = array(
+		new Response( 403 ),
+		new Response( 503 ),
+	);
+	smoke_assert(
+		0,
+		WP_Agent_Workflow_Action_Scheduler_Branch_Executor::trigger_async_runner( 2 ),
+		'rejected HTTP responses report 0 accepted dispatches',
 		$failures,
 		$passes
 	);


### PR DESCRIPTION
## Summary
Count only successful HTTP responses as accepted Action Scheduler loopback dispatches. Protected origins can return `403` or `5xx` without executing the queue runner; those responses must return zero so callers can use another server-side worker path.

## How to test
1. Run `php tests/workflow-async-runner-dispatch-result-smoke.php`.
2. Verify transport failures report `0`.
3. Verify mixed transport failures plus `200`/`204` report `2`.
4. Verify `403`/`503` report `0`.

Closes #453.

## AI assistance
- **AI assistance:** Yes
- **Tool:** OpenCode
- **Used for:** Diagnosed a protected-runtime dispatch mismatch and added focused response-accounting coverage. Chris reviews and owns the change.