### PR TITLE
Fix workflow foreground drain isolation

### DIFF
--- a/src/Workflows/class-wp-agent-workflow-action-scheduler-branch-executor.php
+++ b/src/Workflows/class-wp-agent-workflow-action-scheduler-branch-executor.php
@@ -21,9 +21,10 @@
  * This is a DIFFERENT Action Scheduler use-case from the cron bridge
  * ({@see WP_Agent_Workflow_Action_Scheduler_Bridge}), which schedules ONE
  * recurring action per workflow trigger under `wp_agent_workflow_run_scheduled`.
- * This executor enqueues ONE async action PER BRANCH under a distinct hook,
- * plus one RESUME action per suspended run. Both reuse GROUP `agents-api` so an
- * operator has a single group to reason about; the hooks keep them separate.
+	 * This executor enqueues ONE async action PER BRANCH under a distinct hook,
+	 * plus one RESUME action per suspended run. New runs use one durable group per
+	 * run so foreground awaiters cannot claim another run's work; legacy in-flight
+	 * runs without a mapping retain GROUP `agents-api` across upgrades.
  *
  * The runner owns the suspend/resume state machine and the reconcile entry
  * point ({@see agents_reconcile_workflow_branch()}); this executor owns only the
@@ -38,6 +39,9 @@ namespace AgentsAPI\AI\Workflows;
 defined( 'ABSPATH' ) || exit;
 
 final class WP_Agent_Workflow_Action_Scheduler_Branch_Executor implements WP_Agent_Workflow_Branch_Executor {
+
+	/** Option prefix mapping newly dispatched runs to their isolated AS group. */
+	private const RUN_GROUP_PREFIX = 'agents_wf_as_group_';
 
 	/**
 	 * Stable executor id stamped on every frame + handle so reconcile and the
@@ -100,6 +104,23 @@ final class WP_Agent_Workflow_Action_Scheduler_Branch_Executor implements WP_Age
 	 */
 	public static function is_available(): bool {
 		return function_exists( 'as_enqueue_async_action' );
+	}
+
+	/**
+	 * Resolve the durable queue group for a run.
+	 *
+	 * Runs dispatched before run-group isolation have no mapping and deliberately
+	 * retain the legacy shared group so an upgrade cannot strand in-flight actions.
+	 *
+	 * @since 0.5.2
+	 */
+	public static function group_for_run( string $run_id ): string {
+		if ( '' === $run_id || ! function_exists( 'get_option' ) ) {
+			return self::GROUP;
+		}
+
+		$group = get_option( self::RUN_GROUP_PREFIX . md5( $run_id ), '' );
+		return is_string( $group ) && '' !== $group ? $group : self::GROUP;
 	}
 
 	/**
@@ -198,7 +219,8 @@ final class WP_Agent_Workflow_Action_Scheduler_Branch_Executor implements WP_Age
 				'context_ref' => $context_ref,
 			);
 
-			$action_id = self::enqueue_async_action( self::BRANCH_HOOK, array( $payload ), self::GROUP );
+			$group     = self::ensure_run_group( $run_id );
+			$action_id = self::enqueue_async_action( self::BRANCH_HOOK, array( $payload ), $group );
 
 			// FAIL LOUD: a non-positive action id means the enqueue did not durably
 			// persist the branch (AS's args-size guard threw, AS is down, etc.).
@@ -209,6 +231,7 @@ final class WP_Agent_Workflow_Action_Scheduler_Branch_Executor implements WP_Age
 			if ( $action_id <= 0 ) {
 				if ( '' !== $run_id ) {
 					WP_Agent_Workflow_Branch_Store::forget_run( $run_id );
+					self::forget_run_group( $run_id );
 				}
 				return new \WP_Error(
 					'workflow_branch_dispatch_enqueue_failed',
@@ -889,9 +912,10 @@ final class WP_Agent_Workflow_Action_Scheduler_Branch_Executor implements WP_Age
 	 * @param bool   $deferred    Whether resume is already deferred.
 	 * @param string $run_id      The suspended run id.
 	 * @param string $executor_id The frame's owning executor id.
+	 * @param mixed  $result      Current suspended run result.
 	 * @return bool True when this executor claimed the resume.
 	 */
-	public static function maybe_defer_resume( bool $deferred, string $run_id, string $executor_id ): bool {
+	public static function maybe_defer_resume( bool $deferred, string $run_id, string $executor_id, $result = null ): bool {
 		if ( $deferred ) {
 			return true;
 		}
@@ -904,13 +928,23 @@ final class WP_Agent_Workflow_Action_Scheduler_Branch_Executor implements WP_Age
 			return false;
 		}
 
-		self::enqueue_async_action(
+		$suspension = is_object( $result ) && method_exists( $result, 'get_suspension' )
+			? self::string_keyed_array( (array) $result->get_suspension() )
+			: array();
+		$action_id = self::enqueue_async_action(
 			self::RESUME_HOOK,
-			array( array( 'run_id' => $run_id ) ),
-			self::GROUP
+			array(
+				array(
+					'run_id'        => $run_id,
+					'suspension_id' => self::suspension_id( $suspension ),
+				),
+			),
+			self::group_for_run( $run_id )
 		);
 
-		return true;
+		// If durable enqueue fails, return false so reconcile resumes inline rather
+		// than stranding a suspended run with no resume action.
+		return $action_id > 0;
 	}
 
 	/**
@@ -922,7 +956,7 @@ final class WP_Agent_Workflow_Action_Scheduler_Branch_Executor implements WP_Age
 	 *
 	 * @since 0.5.0
 	 *
-	 * @param array<mixed> $payload Action payload: { run_id }.
+	 * @param array<mixed> $payload Action payload: { run_id, suspension_id }.
 	 * @return void
 	 */
 	public static function run_resume_action( array $payload ): void {
@@ -941,16 +975,37 @@ final class WP_Agent_Workflow_Action_Scheduler_Branch_Executor implements WP_Age
 			// Already resumed (or gone). The claimed action is a no-op. This is
 			// the second-of-two simultaneous finishers being deduped by AS's
 			// claim + this SUSPENDED re-check.
+			if ( null !== $result ) {
+				WP_Agent_Workflow_Branch_Store::forget_run( $run_id );
+				self::forget_run_group( $run_id );
+			}
+			return;
+		}
+
+		$expected_suspension = self::string_value( $payload['suspension_id'] ?? '' );
+		if ( '' === $expected_suspension && self::GROUP !== self::group_for_run( $run_id ) ) {
+			// Tokenless actions predate suspension generations. They remain valid only
+			// for genuinely legacy runs that also lack a run-group mapping; once such a
+			// run advances into a new fan-out, its new mapping blocks delayed old actions.
+			return;
+		}
+		if ( '' !== $expected_suspension && ! hash_equals( $expected_suspension, self::suspension_id( $result->get_suspension() ) ) ) {
+			// A delayed duplicate from an earlier fan-out must not resume through the
+			// current, newer suspension generation.
 			return;
 		}
 
 		$runner = agents_workflow_resolve_runner( $recorder );
 		$runner->resume( $run_id );
 
-		// The run has resolved (the suspension frame was cleared by resume). Release
-		// this run's stored branch payloads so no orphan option rows linger — same
-		// cleanup discipline the suspension frame follows.
-		WP_Agent_Workflow_Branch_Store::forget_run( $run_id );
+		// resume() can reach another parallel step and suspend again. Keep the shared
+		// group mapping and branch-store index until the run is truly terminal so the
+		// next foreground await claims the new fan-out in the same isolated scope.
+		$current = $recorder->find( $run_id );
+		if ( null !== $current && ! $current->is_suspended() ) {
+			WP_Agent_Workflow_Branch_Store::forget_run( $run_id );
+			self::forget_run_group( $run_id );
+		}
 	}
 
 	// ── Internals ────────────────────────────────────────────────────────────
@@ -991,6 +1046,53 @@ final class WP_Agent_Workflow_Action_Scheduler_Branch_Executor implements WP_Age
 			unset( $error );
 			return 0;
 		}
+	}
+
+	/** Persist and return the isolated group for a newly dispatched run. */
+	private static function ensure_run_group( string $run_id ): string {
+		$existing = self::group_for_run( $run_id );
+		if ( self::GROUP !== $existing || '' === $run_id || ! function_exists( 'update_option' ) || ! function_exists( 'get_option' ) ) {
+			return $existing;
+		}
+
+		$group = 'agents-api-run-' . md5( $run_id );
+		update_option( self::RUN_GROUP_PREFIX . md5( $run_id ), $group, false );
+
+		return self::group_for_run( $run_id );
+	}
+
+	/** Remove a terminal run's queue-group mapping. */
+	private static function forget_run_group( string $run_id ): void {
+		if ( '' !== $run_id && function_exists( 'delete_option' ) ) {
+			delete_option( self::RUN_GROUP_PREFIX . md5( $run_id ) );
+		}
+	}
+
+	/**
+	 * Derive a stable identity for one exact suspension generation.
+	 *
+	 * @param array<string,mixed> $suspension Suspension frame.
+	 */
+	private static function suspension_id( array $suspension ): string {
+		$handles = is_array( $suspension['handles'] ?? null ) ? $suspension['handles'] : array();
+		$ids     = array();
+		$step_index = is_numeric( $suspension['step_index'] ?? null ) ? (int) $suspension['step_index'] : 0;
+		foreach ( $handles as $handle ) {
+			if ( is_array( $handle ) ) {
+				$ids[] = self::string_value( $handle['id'] ?? '' );
+			}
+		}
+
+		return hash(
+			'sha256',
+			serialize(
+				array(
+					'step_index' => $step_index,
+					'step_id'    => self::string_value( $suspension['step_id'] ?? '' ),
+					'handles'    => $ids,
+				)
+			)
+		);
 	}
 
 	/**

--- a/src/Workflows/class-wp-agent-workflow-run-awaiter.php
+++ b/src/Workflows/class-wp-agent-workflow-run-awaiter.php
@@ -39,6 +39,13 @@ class WP_Agent_Workflow_Run_Awaiter {
 	 * @return array{schema:string,run_id:string,status:string,terminal:bool,reconnectable:bool,result:?array<string,mixed>,drain:array<string,int|string|bool>}|\WP_Error
 	 */
 	public function await( string $run_id, WP_Agent_Workflow_Run_Recorder $recorder, array $options = array() ) {
+		if ( ! isset( $options['group'] ) || ! is_scalar( $options['group'] ) || '' === (string) $options['group'] ) {
+			$options['group'] = WP_Agent_Workflow_Action_Scheduler_Branch_Executor::group_for_run( $run_id );
+		}
+		// A run await must never fall back to hook-only claims: that could execute a
+		// different run whose branch/resume hooks share this executor.
+		$options['allow_group_fallback'] = false;
+
 		$current = $recorder->find( $run_id );
 		if ( null === $current ) {
 			return new \WP_Error( 'agents_workflow_run_not_found', 'No workflow run was found for the requested run_id.' );

--- a/src/Workflows/class-wp-agent-workflow-scoped-drain.php
+++ b/src/Workflows/class-wp-agent-workflow-scoped-drain.php
@@ -144,6 +144,7 @@ final class WP_Agent_Workflow_Scoped_Drain {
 	 *     time_limit?:int,
 	 *     stop_before_timeout_ms?:int,
 	 *     stop_before_timeout?:int,
+	 *     allow_group_fallback?:bool,
 	 *     execution_context?:string,
 	 *     terminal_status_callback?:callable
 	 * } $options Drain options.
@@ -160,6 +161,7 @@ final class WP_Agent_Workflow_Scoped_Drain {
 		$stop_before_ms    = isset( $options['stop_before_timeout_ms'] )
 			? max( 0, (int) $options['stop_before_timeout_ms'] )
 			: max( 0, (int) ( $options['stop_before_timeout'] ?? 0 ) ) * 1000;
+		$allow_group_fallback = ! isset( $options['allow_group_fallback'] ) || (bool) $options['allow_group_fallback'];
 		$execution_context = (string) ( $options['execution_context'] ?? 'agents-api scoped drain' );
 		$terminal_callback = is_callable( $options['terminal_status_callback'] ?? null ) ? $options['terminal_status_callback'] : null;
 
@@ -236,7 +238,7 @@ final class WP_Agent_Workflow_Scoped_Drain {
 				}
 
 				$due_before = $this->due_pending_count( $hooks, $group );
-				$batch      = $this->run_batch( $current_batch, $hooks, $group, $deadline_at, $execution_context );
+				$batch      = $this->run_batch( $current_batch, $hooks, $group, $deadline_at, $execution_context, $allow_group_fallback );
 				++$batches;
 				$processed += (int) $batch['processed'];
 				$warnings  += (int) $batch['warnings'];
@@ -318,6 +320,9 @@ final class WP_Agent_Workflow_Scoped_Drain {
 				$drain_options[ $int_key ] = (int) $options[ $int_key ];
 			}
 		}
+		if ( isset( $options['allow_group_fallback'] ) ) {
+			$drain_options['allow_group_fallback'] = (bool) $options['allow_group_fallback'];
+		}
 		if ( isset( $options['execution_context'] ) && is_scalar( $options['execution_context'] ) ) {
 			$drain_options['execution_context'] = (string) $options['execution_context'];
 		}
@@ -342,9 +347,10 @@ final class WP_Agent_Workflow_Scoped_Drain {
 	 * @param string            $group             AS group.
 	 * @param float             $deadline_at       Unix timestamp (with microseconds); 0 = no deadline.
 	 * @param string            $execution_context AS execution context label.
+	 * @param bool              $allow_group_fallback Whether HybridStore may retry without the group.
 	 * @return array{processed:int,warnings:int,stop_reason:string} Batch result.
 	 */
-	private function run_batch( int $batch_size, array $hooks, string $group, float $deadline_at, string $execution_context ): array {
+	private function run_batch( int $batch_size, array $hooks, string $group, float $deadline_at, string $execution_context, bool $allow_group_fallback ): array {
 		/** @var \ActionScheduler_Store $store */
 		$store       = \ActionScheduler_Store::instance();
 		$runner      = \ActionScheduler::runner();
@@ -358,9 +364,10 @@ final class WP_Agent_Workflow_Scoped_Drain {
 			// stake_claim( $max, $before_date, $hooks, $group ). Claiming over the
 			// scoped hooks + group means we only ever run THIS caller's scope — never
 			// an unrelated AS workload sharing the queue. HybridStore can transiently
-			// throw "group does not exist" while actions for that group are readable;
-			// in that case retry hook-scoped only rather than failing the foreground pump.
-			$claim = $this->stake_claim( $store, $batch_size, $hooks, $group );
+			// throw "group does not exist" while actions for that group are readable.
+			// Generic callers may retry hook-scoped; run awaiters disable that fallback
+			// because hook-only claims would cross run boundaries.
+			$claim = $this->stake_claim( $store, $batch_size, $hooks, $group, $allow_group_fallback );
 		} catch ( \Throwable $throwable ) {
 			unset( $throwable );
 			return array(
@@ -421,13 +428,14 @@ final class WP_Agent_Workflow_Scoped_Drain {
 	 * @param int               $batch_size Maximum actions to claim.
 	 * @param array<int,string> $hooks      Hook scope.
 	 * @param string            $group      Group scope.
+	 * @param bool              $allow_group_fallback Whether to retry hook-only.
 	 * @return \ActionScheduler_ActionClaim Action Scheduler claim.
 	 */
-	private function stake_claim( \ActionScheduler_Store $store, int $batch_size, array $hooks, string $group ): \ActionScheduler_ActionClaim {
+	private function stake_claim( \ActionScheduler_Store $store, int $batch_size, array $hooks, string $group, bool $allow_group_fallback ): \ActionScheduler_ActionClaim {
 		try {
 			return $store->stake_claim( $batch_size, null, $hooks, $group );
 		} catch ( \InvalidArgumentException $error ) {
-			if ( '' === $group || false === stripos( $error->getMessage(), 'group' ) ) {
+			if ( ! $allow_group_fallback || '' === $group || false === stripos( $error->getMessage(), 'group' ) ) {
 				throw $error;
 			}
 			return $store->stake_claim( $batch_size, null, $hooks, '' );

--- a/src/Workflows/register-workflow-branch-executor.php
+++ b/src/Workflows/register-workflow-branch-executor.php
@@ -82,7 +82,7 @@ add_action(
 add_action(
 	WP_Agent_Workflow_Action_Scheduler_Branch_Executor::RESUME_HOOK,
 	/**
-	 * @param array<string,mixed> $payload Action payload: { run_id }.
+	 * @param array<string,mixed> $payload Action payload: { run_id, suspension_id }.
 	 */
 	static function ( $payload = array() ): void {
 		WP_Agent_Workflow_Action_Scheduler_Branch_Executor::run_resume_action( is_array( $payload ) ? $payload : array() );
@@ -99,17 +99,19 @@ add_filter(
 	 * @param bool   $deferred    Whether resume is already deferred.
 	 * @param string $run_id      The suspended run id.
 	 * @param string $executor_id The frame's owning executor id.
+	 * @param mixed  $result      Current suspended run result.
 	 * @return bool
 	 */
-	static function ( $deferred, $run_id, $executor_id ) {
+	static function ( $deferred, $run_id, $executor_id, $result ) {
 		return WP_Agent_Workflow_Action_Scheduler_Branch_Executor::maybe_defer_resume(
 			(bool) $deferred,
 			is_string( $run_id ) ? $run_id : '',
-			is_string( $executor_id ) ? $executor_id : ''
+			is_string( $executor_id ) ? $executor_id : '',
+			$result
 		);
 	},
 	10,
-	3
+	4
 );
 
 // 4. Long-branch reaping window. Action Scheduler's QueueCleaner marks any action

--- a/tests/workflow-as-branch-smoke.php
+++ b/tests/workflow-as-branch-smoke.php
@@ -138,6 +138,12 @@ if ( ! function_exists( 'update_option' ) ) {
 		return true;
 	}
 }
+if ( ! function_exists( 'delete_option' ) ) {
+	function delete_option( string $option ): bool {
+		unset( $GLOBALS['__options'][ $option ] );
+		return true;
+	}
+}
 
 // ── The Action Scheduler function-shim ───────────────────────────────────────
 // Records every async enqueue as a queued action with a unique, claimable id.
@@ -151,14 +157,19 @@ final class AS_Shim {
 	/** @var array<int,bool> id => claimed */
 	public static array $claimed = array();
 	private static int $seq = 0;
+	public static string $reject_hook = '';
 
 	public static function reset(): void {
 		self::$queue   = array();
 		self::$claimed = array();
 		self::$seq     = 0;
+		self::$reject_hook = '';
 	}
 
 	public static function enqueue( string $hook, array $args, string $group ): int {
+		if ( '' !== self::$reject_hook && self::$reject_hook === $hook ) {
+			return 0;
+		}
 		$id                = ++self::$seq;
 		self::$queue[]     = array(
 			'id'    => $id,
@@ -405,6 +416,9 @@ $tables_before = $recorder->tables();
 $run = ( new WP_Agent_Workflow_Runner( $recorder ) )->run( as_smoke_roles_spec(), array(), array( 'run_id' => 'as-A' ) );
 
 smoke_assert( WP_Agent_Workflow_Run_Result::STATUS_SUSPENDED, $run->get_status(), 'AS path: run SUSPENDED after dispatch', $failures, $passes );
+AS_Shim::$reject_hook = WP_Agent_Workflow_Action_Scheduler_Branch_Executor::RESUME_HOOK;
+smoke_assert( false, WP_Agent_Workflow_Action_Scheduler_Branch_Executor::maybe_defer_resume( false, 'as-A', WP_Agent_Workflow_Action_Scheduler_Branch_Executor::ID, $run ), 'resume enqueue failure falls back to inline reconcile instead of stranding the run', $failures, $passes );
+AS_Shim::$reject_hook = '';
 
 // DISPATCH WIRING: one BRANCH_HOOK action per sibling branch (2; aggregator is
 // deferred), each carrying its full descriptor in the payload, under the
@@ -413,8 +427,18 @@ $branch_actions = AS_Shim::actions_for( WP_Agent_Workflow_Action_Scheduler_Branc
 smoke_assert( 2, count( $branch_actions ), 'dispatch: one AS action enqueued per branch (2 siblings)', $failures, $passes );
 
 $first_payload = $branch_actions[0]['args'][0] ?? array();
-smoke_assert( 'agents-api', $branch_actions[0]['group'] ?? '', 'dispatch: branch action uses the agents-api group', $failures, $passes );
+$run_group     = WP_Agent_Workflow_Action_Scheduler_Branch_Executor::group_for_run( 'as-A' );
+smoke_assert_true( 'agents-api' !== $run_group, 'dispatch: a new run receives an isolated Action Scheduler group', $failures, $passes );
+smoke_assert( $run_group, $branch_actions[0]['group'] ?? '', 'dispatch: branch action uses its run-specific group', $failures, $passes );
+smoke_assert( $run_group, $branch_actions[1]['group'] ?? '', 'dispatch: sibling branches share the same run-specific group', $failures, $passes );
 smoke_assert( 'as-A', $first_payload['run_id'] ?? '', 'dispatch: payload carries run_id', $failures, $passes );
+
+$run_b = ( new WP_Agent_Workflow_Runner( $recorder ) )->run( as_smoke_roles_spec(), array(), array( 'run_id' => 'as-B' ) );
+$run_b_group = WP_Agent_Workflow_Action_Scheduler_Branch_Executor::group_for_run( 'as-B' );
+smoke_assert( WP_Agent_Workflow_Run_Result::STATUS_SUSPENDED, $run_b->get_status(), 'isolation: a second run suspends independently', $failures, $passes );
+smoke_assert_true( $run_group !== $run_b_group, 'isolation: concurrent runs receive different claim groups', $failures, $passes );
+$all_branch_actions = AS_Shim::actions_for( WP_Agent_Workflow_Action_Scheduler_Branch_Executor::BRANCH_HOOK );
+smoke_assert( $run_b_group, $all_branch_actions[2]['group'] ?? '', 'isolation: run B branches cannot be claimed through run A group', $failures, $passes );
 
 // PAYLOAD OFFLOAD (Bug 1): the AS args are now a SMALL reference — no inline
 // branch descriptor, no inline shared context. The heavy descriptor lives in the
@@ -460,6 +484,7 @@ $after_all = $recorder->find( 'as-A' );
 smoke_assert( WP_Agent_Workflow_Run_Result::STATUS_SUSPENDED, $after_all->get_status(), 'AS path: resume DEFERRED (still suspended until RESUME action fires)', $failures, $passes );
 $resume_actions = AS_Shim::actions_for( WP_Agent_Workflow_Action_Scheduler_Branch_Executor::RESUME_HOOK );
 smoke_assert( 1, count( $resume_actions ), 'AS path: exactly one RESUME action enqueued when all branches terminal', $failures, $passes );
+smoke_assert( $run_group, $resume_actions[0]['group'] ?? '', 'AS path: resume preserves the run-specific group across processes', $failures, $passes );
 
 // Fire the RESUME action → aggregate already spliced by reconcile, resume() runs
 // the sequential `after` step.
@@ -470,6 +495,7 @@ $out_steps = $final->get_output()['steps'] ?? array();
 smoke_assert( 'FUSED[HEAD|BODY]', $out_steps['scatter']['final']['final_bundle'] ?? '', 'AS path: aggregate fused REAL branch outputs (run_branch_steps ran demo/role-worker)', $failures, $passes );
 smoke_assert( 'GOT:FUSED[HEAD|BODY]', $out_steps['after']['consumed'] ?? '', 'AS path: sequential step consumed the aggregate on resume', $failures, $passes );
 smoke_assert( array(), $final->get_suspension(), 'table-free: frame DELETED on resume', $failures, $passes );
+smoke_assert( WP_Agent_Workflow_Action_Scheduler_Branch_Executor::GROUP, WP_Agent_Workflow_Action_Scheduler_Branch_Executor::group_for_run( 'as-A' ), 'terminal resume deletes the run-group mapping', $failures, $passes );
 smoke_assert( $tables_before, $recorder->tables(), 'table-free: NO new table after full run', $failures, $passes );
 
 // ═════════════════════════════════════════════════════════════════════════════
@@ -630,6 +656,59 @@ foreach ( AS_Shim::actions_for( WP_Agent_Workflow_Action_Scheduler_Branch_Execut
 $final4 = $recorder4->find( 'as-fail' );
 smoke_assert( WP_Agent_Workflow_Run_Result::STATUS_FAILED, $final4->get_status(), 'branch-action state machine: required branch failing in a REAL run_branch_steps → run FAILED on resume', $failures, $passes );
 smoke_assert( 'workflow_parallel_required_branch_failed', $final4->get_error()['code'] ?? '', 'branch-action state machine: real reconcile surfaces the required-branch failure code', $failures, $passes );
+
+// A resume can advance into another parallel step and suspend again. The run's
+// isolated group and branch-store rows must survive that intermediate resume.
+function as_smoke_two_fanout_spec(): WP_Agent_Workflow_Spec {
+	$fanout = static function ( string $id, string $label ): array {
+		return array(
+			'id'    => $id,
+			'type'  => 'parallel',
+			'as'    => 'item',
+			'items' => array( array( 'label' => $label ) ),
+			'steps' => array(
+				array( 'id' => $id . '-worker', 'type' => 'ability', 'ability' => 'demo/role-worker', 'args' => array( 'label' => $label ) ),
+			),
+		);
+	};
+
+	return WP_Agent_Workflow_Spec::from_array(
+		array(
+			'id'    => 'demo/as-two-fanouts',
+			'steps' => array( $fanout( 'first', 'one' ), $fanout( 'second', 'two' ) ),
+		)
+	);
+}
+
+AS_Shim::reset();
+$recorder5 = new AS_Smoke_Recorder();
+remove_all_filters( 'wp_agent_workflow_run_recorder' );
+add_filter( 'wp_agent_workflow_run_recorder', static function () use ( $recorder5 ) { return $recorder5; } );
+
+$run5       = ( new WP_Agent_Workflow_Runner( $recorder5 ) )->run( as_smoke_two_fanout_spec(), array(), array( 'run_id' => 'as-two' ) );
+$group5     = WP_Agent_Workflow_Action_Scheduler_Branch_Executor::group_for_run( 'as-two' );
+$branches5  = AS_Shim::actions_for( WP_Agent_Workflow_Action_Scheduler_Branch_Executor::BRANCH_HOOK );
+AS_Shim::fire( $branches5[0]['id'] );
+$resumes5 = AS_Shim::actions_for( WP_Agent_Workflow_Action_Scheduler_Branch_Executor::RESUME_HOOK );
+as_enqueue_async_action( WP_Agent_Workflow_Action_Scheduler_Branch_Executor::RESUME_HOOK, $resumes5[0]['args'], $resumes5[0]['group'] );
+AS_Shim::fire( $resumes5[0]['id'] );
+
+$stale_resumes5 = AS_Shim::actions_for( WP_Agent_Workflow_Action_Scheduler_Branch_Executor::RESUME_HOOK );
+AS_Shim::fire( $stale_resumes5[1]['id'] );
+
+$mid5      = $recorder5->find( 'as-two' );
+$branches5 = AS_Shim::actions_for( WP_Agent_Workflow_Action_Scheduler_Branch_Executor::BRANCH_HOOK );
+smoke_assert( WP_Agent_Workflow_Run_Result::STATUS_SUSPENDED, $mid5->get_status(), 'multi-fanout: intermediate resume suspends on the second fan-out', $failures, $passes );
+smoke_assert( 1, (int) ( $mid5->get_suspension()['step_index'] ?? 0 ), 'multi-fanout: delayed duplicate resume cannot skip the newer suspension generation', $failures, $passes );
+smoke_assert( $group5, WP_Agent_Workflow_Action_Scheduler_Branch_Executor::group_for_run( 'as-two' ), 'multi-fanout: intermediate resume preserves the run-group mapping', $failures, $passes );
+smoke_assert( $group5, $branches5[1]['group'] ?? '', 'multi-fanout: second fan-out stays in the original isolated group', $failures, $passes );
+
+AS_Shim::fire( $branches5[1]['id'] );
+$resumes5 = AS_Shim::actions_for( WP_Agent_Workflow_Action_Scheduler_Branch_Executor::RESUME_HOOK );
+AS_Shim::fire( $resumes5[2]['id'] );
+$final5 = $recorder5->find( 'as-two' );
+smoke_assert( WP_Agent_Workflow_Run_Result::STATUS_SUCCEEDED, $final5->get_status(), 'multi-fanout: second resume reaches terminal success', $failures, $passes );
+smoke_assert( WP_Agent_Workflow_Action_Scheduler_Branch_Executor::GROUP, WP_Agent_Workflow_Action_Scheduler_Branch_Executor::group_for_run( 'as-two' ), 'multi-fanout: terminal resume finally removes the group mapping', $failures, $passes );
 
 echo "Passed: {$passes}, Failed: " . count( $failures ) . "\n";
 exit( count( $failures ) > 0 ? 1 : 0 );

--- a/tests/workflow-run-awaiter-smoke.php
+++ b/tests/workflow-run-awaiter-smoke.php
@@ -61,11 +61,13 @@ final class Await_Smoke_Awaiter extends WP_Agent_Workflow_Run_Awaiter {
 	public int $drains = 0;
 	public string $next_status = WP_Agent_Workflow_Run_Result::STATUS_SUCCEEDED;
 	public string $stop_reason = 'terminal_status';
+	public array $last_options = array();
 
 	public function __construct() {}
 
 	protected function drain_suspended_run( string $run_id, WP_Agent_Workflow_Run_Recorder $recorder, array $options ): array {
 		++$this->drains;
+		$this->last_options = $options;
 		$current = $recorder->find( $run_id );
 		if ( null !== $current && WP_Agent_Workflow_Run_Result::STATUS_SUSPENDED !== $this->next_status ) {
 			$recorder->update( $current->with( array( 'status' => $this->next_status ) ) );
@@ -133,6 +135,11 @@ await_assert( false, $limited['terminal'], 'limit-exhausted suspended run is non
 await_assert( true, $limited['reconnectable'], 'limit-exhausted suspended run is reconnectable' );
 await_assert( 'limit', $limited['drain']['stop_reason'], 'limit stop is preserved' );
 await_assert( null, $limited['result'], 'nonterminal state has no terminal result' );
+await_assert( 'agents-api', $awaiter->last_options['group'] ?? '', 'legacy run without a persisted mapping drains through the backward-compatible shared group' );
+await_assert( false, $awaiter->last_options['allow_group_fallback'] ?? null, 'run await never widens a failed group claim to other runs sharing the hooks' );
+
+$awaiter->await( 'limited', $recorder, array( 'limit' => 1, 'group' => 'caller-supplied' ) );
+await_assert( 'caller-supplied', $awaiter->last_options['group'] ?? '', 'an explicit caller group remains authoritative' );
 
 $awaiter->stop_reason = 'time_limit';
 $budgeted = $awaiter->await( 'limited', $recorder, array( 'time_limit_ms' => 1 ) );

--- a/tests/workflow-scoped-drain-smoke.php
+++ b/tests/workflow-scoped-drain-smoke.php
@@ -116,10 +116,12 @@ function smoke_assert( $expected, $actual, string $name, array &$failures, int &
 final class Scoped_Drain_AS {
 	/** @var array<int,array{id:int,hook:string,group:string,status:string}> */
 	public static array $actions = array();
+	public static bool $throw_group_claim = false;
 	private static int $seq      = 0;
 
 	public static function reset(): void {
 		self::$actions = array();
+		self::$throw_group_claim = false;
 		self::$seq     = 0;
 	}
 
@@ -204,6 +206,9 @@ if ( ! class_exists( '\ActionScheduler_Store' ) ) {
 		 */
 		public function stake_claim( int $max = 10, $before = null, array $hooks = array(), string $group = '' ): ActionScheduler_ActionClaim {
 			unset( $before );
+			if ( '' !== $group && Scoped_Drain_AS::$throw_group_claim ) {
+				throw new InvalidArgumentException( 'group does not exist' );
+			}
 			$claimed = array();
 			foreach ( Scoped_Drain_AS::$actions as $id => $action ) {
 				if ( count( $claimed ) >= $max ) {
@@ -461,6 +466,21 @@ Scoped_Drain_AS::seed( $branch_hook, $group, 2 );
 smoke_assert( 3, Scoped_Drain_AS::count_status( ActionScheduler_Store::STATUS_PENDING ), 'scoping: 3 unrelated actions left PENDING (not drained)', $failures, $passes );
 smoke_assert( 0, $GLOBALS['__other_runs'], 'scoping: unrelated hook callback never ran', $failures, $passes );
 smoke_assert( 2, Scoped_Drain_AS::count_status( ActionScheduler_Store::STATUS_COMPLETE ), 'scoping: only the 2 in-scope branch actions completed', $failures, $passes );
+
+// A run awaiter disables HybridStore's hook-only fallback. If the requested
+// group cannot be claimed, refusing work is safer than claiming another run.
+Scoped_Drain_AS::reset();
+Scoped_Drain_AS::seed( $branch_hook, 'run-a', 1 );
+Scoped_Drain_AS::seed( $branch_hook, 'run-b', 1 );
+Scoped_Drain_AS::$throw_group_claim = true;
+$strict = ( new WP_Agent_Workflow_Scoped_Drain() )->drain(
+	array(
+		'group'                => 'run-a',
+		'allow_group_fallback' => false,
+	)
+);
+smoke_assert( 'warning', $strict['stop_reason'], 'strict run scope reports an unavailable group claim without widening scope', $failures, $passes );
+smoke_assert( 2, Scoped_Drain_AS::count_status( ActionScheduler_Store::STATUS_PENDING ), 'strict run scope leaves both runs pending instead of cross-claiming by hook', $failures, $passes );
 
 echo "Passed: {$passes}, Failed: " . count( $failures ) . "\n";
 exit( count( $failures ) > 0 ? 1 : 0 );


### PR DESCRIPTION
## Summary

- assign newly dispatched workflow runs durable run-specific Action Scheduler groups
- make foreground awaiters claim only the requested run, including strict HybridStore behavior
- preserve group and branch-store state across multiple fan-outs and guard resume actions by suspension generation
- retain the shared `agents-api` group for pre-upgrade in-flight runs without a mapping
- fall back to inline resume when durable resume enqueue fails

## Verification

- `composer test`
- `composer phpstan`
- `php tests/workflow-as-branch-smoke.php`
- `php tests/workflow-run-awaiter-smoke.php`
- `php tests/workflow-scoped-drain-smoke.php`

Fixes #455