### PR TITLE
fix: serialize chat run state mutations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,3 +80,45 @@ jobs:
         with:
           # With no paths, actionlint discovers and reads every workflow file.
           args: -no-color
+
+  option-store-concurrency:
+    name: Option-store concurrency
+    runs-on: ubuntu-latest
+    services:
+      mariadb:
+        image: mariadb:11.4
+        env:
+          MARIADB_DATABASE: agents_api_test
+          MARIADB_USER: agents_api
+          MARIADB_PASSWORD: agents_api
+          MARIADB_ROOT_PASSWORD: root
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="healthcheck.sh --connect --innodb_initialized"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=10
+
+    steps:
+      - uses: actions/checkout@v6.0.3
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.1'
+          extensions: mysqli, pcntl
+          coverage: none
+
+      - name: Download WordPress database layer
+        run: |
+          curl --fail --silent --show-error https://wordpress.org/latest.tar.gz | tar -xz -C /tmp
+
+      - name: Run option-store concurrency tests
+        env:
+          AGENTS_API_WP_ROOT: /tmp/wordpress
+          AGENTS_API_DB_HOST: 127.0.0.1:3306
+          AGENTS_API_DB_NAME: agents_api_test
+          AGENTS_API_DB_USER: agents_api
+          AGENTS_API_DB_PASSWORD: agents_api
+        run: php tests/run-control-option-store-integration.php

--- a/agents-api.php
+++ b/agents-api.php
@@ -231,6 +231,8 @@ require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-runtime-tool-lifecycl
 require_once AGENTS_API_PATH . 'src/Runtime/register-runtime-tool-lifecycle-abilities.php';
 require_once AGENTS_API_PATH . 'src/Runtime/interface-wp-agent-run-control-store.php';
 require_once AGENTS_API_PATH . 'src/Runtime/interface-wp-agent-workspace-run-control-store.php';
+require_once AGENTS_API_PATH . 'src/Runtime/interface-wp-agent-atomic-run-control-store.php';
+require_once AGENTS_API_PATH . 'src/Runtime/interface-wp-agent-atomic-workspace-run-control-store.php';
 require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-option-run-control-store.php';
 require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-run-control.php';
 require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-run-result-envelope.php';

--- a/src/Channels/register-agents-chat-ability.php
+++ b/src/Channels/register-agents-chat-ability.php
@@ -140,6 +140,8 @@ function agents_chat_dispatch( array $input ) {
 		$input['run_id'] = WP_Agent_Chat_Run_Control::generate_run_id();
 		$run_id          = $input['run_id'];
 	}
+	$run_claim_token                = WP_Agent_Chat_Run_Control::generate_run_id( 'claim_' );
+	$input['_agents_run_claim_token'] = $run_claim_token;
 
 	/**
 	 * Filter the chat runtime handler.
@@ -178,7 +180,7 @@ function agents_chat_dispatch( array $input ) {
 	$agent      = agents_chat_optional_string( $input['agent'] ?? null ) ?? '';
 	if ( null !== $session_id ) {
 		try {
-			$started = WP_Agent_Chat_Run_Control::start_run( $run_id, $session_id, array( 'agent' => $agent ), $run_context['workspace'], $run_context['owner'], $run_context['conversation_store'] );
+			$started = WP_Agent_Chat_Run_Control::start_run( $run_id, $session_id, array( 'agent' => $agent, '_claim_token' => $run_claim_token ), $run_context['workspace'], $run_context['owner'], $run_context['conversation_store'] );
 		} catch ( \RuntimeException $error ) {
 			return new \WP_Error( 'agents_chat_run_workspace_unsupported', $error->getMessage() );
 		}
@@ -186,9 +188,20 @@ function agents_chat_dispatch( array $input ) {
 			do_action( 'agents_chat_dispatch_failed', $started->get_error_code(), $input );
 			return $started;
 		}
+	} else {
+		$pending = WP_Agent_Chat_Run_Control::claim_pending_run( $run_id, $run_claim_token, $run_context['workspace'], $run_context['owner'] );
+		if ( is_wp_error( $pending ) ) {
+			do_action( 'agents_chat_dispatch_failed', $pending->get_error_code(), $input );
+			return $pending;
+		}
 	}
 
-	$result = call_user_func( $handler, $input );
+	WP_Agent_Chat_Run_Control::activate_run_claim( $run_id, $run_claim_token );
+	try {
+		$result = call_user_func( $handler, $input );
+	} finally {
+		WP_Agent_Chat_Run_Control::deactivate_run_claim( $run_id, $run_claim_token );
+	}
 
 	if ( is_wp_error( $result ) ) {
 		if ( null !== $session_id ) {
@@ -219,12 +232,15 @@ function agents_chat_dispatch( array $input ) {
 	if ( null === agents_chat_optional_string( $result['run_id'] ?? null ) ) {
 		$result['run_id'] = $input['run_id'];
 	}
+	if ( null === $session_id ) {
+		$result['run_id'] = $run_id;
+	}
 
 	$result_run_id       = agents_chat_optional_string( $result['run_id'] ?? null ) ?? $run_id;
 	$resolved_session_id = agents_chat_optional_string( $result['session_id'] ?? null ) ?? $session_id;
 	if ( null !== $resolved_session_id ) {
 		if ( null === $session_id ) {
-			$started = WP_Agent_Chat_Run_Control::start_run( $result_run_id, $resolved_session_id, array( 'agent' => $agent ), $run_context['workspace'], $run_context['owner'], $run_context['conversation_store'] );
+			$started = WP_Agent_Chat_Run_Control::start_run( $result_run_id, $resolved_session_id, array( 'agent' => $agent, '_claim_token' => $run_claim_token ), $run_context['workspace'], $run_context['owner'], $run_context['conversation_store'] );
 			if ( is_wp_error( $started ) ) {
 				do_action( 'agents_chat_dispatch_failed', $started->get_error_code(), $input );
 				return $started;
@@ -232,7 +248,11 @@ function agents_chat_dispatch( array $input ) {
 		}
 
 		$status = WP_Agent_Run_Outcome::run_control_status( $result );
-		WP_Agent_Chat_Run_Control::finish_run( $result_run_id, $status, $run_context['workspace'] );
+		$finished = WP_Agent_Chat_Run_Control::finish_run( $result_run_id, $status, $run_context['workspace'] );
+		if ( is_wp_error( $finished ) ) {
+			do_action( 'agents_chat_dispatch_failed', $finished->get_error_code(), $input );
+			return $finished;
+		}
 	}
 
 	return $result;

--- a/src/Channels/register-agents-chat-run-control-abilities.php
+++ b/src/Channels/register-agents-chat-run-control-abilities.php
@@ -197,6 +197,9 @@ function agents_cancel_chat_run( array $input ) {
 		}
 
 		$result = WP_Agent_Chat_Run_Control::request_cancel( agents_chat_run_control_string( $input['run_id'] ?? '' ), $context['workspace'], $context['owner'] );
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
 		if ( null === $result ) {
 			return agents_chat_run_control_no_handler( 'agents_chat_run_not_found', 'No chat run was found for the requested run_id.' );
 		}

--- a/src/Channels/register-default-agents-chat-handler.php
+++ b/src/Channels/register-default-agents-chat-handler.php
@@ -183,6 +183,7 @@ class WP_Agent_Default_Chat_Handler {
 				'session_id'             => $session_id,
 				'agent_slug'             => $agent_slug,
 				'run_id'                 => $runtime_context['run_id'],
+				'_agents_run_claim_token' => $input['_agents_run_claim_token'] ?? '',
 				'principal'              => $input['principal'] ?? null,
 				'conversation_store'     => $store,
 				'tool_executor_registry' => $executor_registry,

--- a/src/Runtime/class-wp-agent-chat-run-control.php
+++ b/src/Runtime/class-wp-agent-chat-run-control.php
@@ -30,6 +30,8 @@ class WP_Agent_Chat_Run_Control {
 	public const STATUS_STALLED              = 'stalled';
 	public const STATUS_INTERRUPTED          = 'interrupted';
 	private const OPTION_KEY                 = 'agents_api_chat_run_control';
+	/** @var array<string,string> */
+	private static array $active_claim_tokens = array();
 
 	/** @return string[] */
 	public static function statuses(): array {
@@ -123,8 +125,18 @@ class WP_Agent_Chat_Run_Control {
 	/**
 	 * Generate an opaque client-addressable run ID.
 	 */
-	public static function generate_run_id(): string {
-		return WP_Agent_Run_Control::generate_run_id();
+	public static function generate_run_id( string $prefix = 'run_' ): string {
+		return WP_Agent_Run_Control::generate_run_id( $prefix );
+	}
+
+	public static function activate_run_claim( string $run_id, string $claim_token ): void {
+		self::$active_claim_tokens[ $run_id ] = $claim_token;
+	}
+
+	public static function deactivate_run_claim( string $run_id, string $claim_token ): void {
+		if ( isset( self::$active_claim_tokens[ $run_id ] ) && hash_equals( self::$active_claim_tokens[ $run_id ], $claim_token ) ) {
+			unset( self::$active_claim_tokens[ $run_id ] );
+		}
 	}
 
 	/**
@@ -192,23 +204,129 @@ class WP_Agent_Chat_Run_Control {
 		if ( $canonical_owner instanceof \WP_Error ) {
 			return $canonical_owner;
 		}
-
-		$state    = self::state( $workspace );
-		$existing = $state['runs'][ $run_id ] ?? null;
-		if ( is_array( $existing ) && ( $session_id !== self::string_value( $existing['session_id'] ?? '' ) || ! self::fingerprint_matches( $existing['_owner'] ?? null, $canonical_owner ) ) ) {
-			return new \WP_Error( 'agents_chat_run_owner_forbidden', 'The run_id is already bound to another session or owner.' );
+		$claim_token = trim( self::string_value( $metadata['_claim_token'] ?? '' ) );
+		if ( '' === $claim_token && 'conversation_loop' === self::string_value( $metadata['source'] ?? '' ) ) {
+			$claim_token = self::$active_claim_tokens[ $run_id ] ?? '';
 		}
+		unset( $metadata['_claim_token'] );
 
-		return self::normalize_run( WP_Agent_Run_Control::start_run(
-			self::OPTION_KEY,
-			$run_id,
-			array(
-				'session_id' => $session_id,
-				'metadata'   => $metadata,
-				'_owner'     => $canonical_owner,
-			),
-			$workspace
-		) );
+		try {
+			$result = self::mutate_state(
+				static function ( array $state ) use ( $run_id, $session_id, $metadata, $canonical_owner, $claim_token ): array {
+					$existing = $state['runs'][ $run_id ] ?? null;
+					if ( is_array( $existing ) && ! self::fingerprint_matches( $existing['_owner'] ?? null, $canonical_owner ) ) {
+						return array(
+							'state'  => $state,
+							'result' => new \WP_Error( 'agents_chat_run_owner_forbidden', 'The run_id is already bound to another session or owner.' ),
+						);
+					}
+					if ( is_array( $existing ) ) {
+						$stored_claim = self::string_value( $existing['_claim_token'] ?? '' );
+						if ( '' !== $claim_token && '' !== $stored_claim && hash_equals( $stored_claim, $claim_token ) ) {
+							if ( ! empty( $existing['_session_pending'] ) ) {
+								$existing['session_id'] = $session_id;
+								$existing['metadata']   = $metadata;
+								$existing['updated_at'] = self::now();
+								unset( $existing['_session_pending'] );
+								$state['runs'][ $run_id ] = $existing;
+								return array( 'state' => $state, 'result' => self::normalize_run( $existing ) );
+							}
+							if ( $session_id !== self::string_value( $existing['session_id'] ?? '' ) ) {
+								return array(
+									'state'  => $state,
+									'result' => new \WP_Error( 'agents_chat_run_owner_forbidden', 'The run_id is already bound to another session or owner.' ),
+								);
+							}
+							return array( 'state' => $state, 'result' => self::normalize_run( $existing ) );
+						}
+						if ( $session_id !== self::string_value( $existing['session_id'] ?? '' ) ) {
+							return array(
+								'state'  => $state,
+								'result' => new \WP_Error( 'agents_chat_run_owner_forbidden', 'The run_id is already bound to another session or owner.' ),
+							);
+						}
+						return array(
+							'state'  => $state,
+							'result' => new \WP_Error( 'agents_chat_run_already_started', 'The run_id has already been claimed for execution.' ),
+						);
+					}
+
+					$now = self::now();
+					$run = array(
+						'run_id'       => $run_id,
+						'session_id'   => $session_id,
+						'status'       => self::STATUS_RUNNING,
+						'started_at'   => $now,
+						'updated_at'   => $now,
+						'metadata'     => $metadata,
+						'_owner'       => $canonical_owner,
+						'_claim_token' => $claim_token,
+					);
+					$state['runs'][ $run_id ] = $run;
+					$state = self::record_event( $state, $run_id, 'run_started', array( 'status' => self::STATUS_RUNNING ) );
+					return array(
+						'state'  => $state,
+						'result' => self::normalize_run( $run ),
+					);
+				},
+				$workspace,
+				'' === $canonical_owner
+			);
+		} catch ( \RuntimeException $error ) {
+			return self::atomic_unavailable( $error );
+		}
+		if ( $result instanceof \WP_Error ) {
+			return $result;
+		}
+		if ( ! is_array( $result ) ) {
+			throw new \RuntimeException( 'Atomic chat run creation returned an invalid result.' );
+		}
+		return self::normalize_run( WP_Agent_Run_Control::string_keyed_array( $result ) );
+	}
+
+	/**
+	 * Reserve a run before a handler creates and returns its canonical session.
+	 *
+	 * @param array<string,mixed>|null $owner Canonical conversation owner.
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	public static function claim_pending_run( string $run_id, string $claim_token, ?WP_Agent_Workspace_Scope $workspace = null, ?array $owner = null ) {
+		$fingerprint = self::owner_fingerprint( $owner );
+		if ( $workspace instanceof WP_Agent_Workspace_Scope && '' === $fingerprint ) {
+			return new \WP_Error( 'agents_chat_run_owner_required', 'Explicit workspace run control requires an authenticated conversation owner.' );
+		}
+		try {
+			$result = self::mutate_state(
+				static function ( array $state ) use ( $run_id, $claim_token, $fingerprint ): array {
+					if ( isset( $state['runs'][ $run_id ] ) ) {
+						return array( 'state' => $state, 'result' => new \WP_Error( 'agents_chat_run_already_started', 'The run_id has already been claimed for execution.' ) );
+					}
+					$now = self::now();
+					$run = array(
+						'run_id'           => $run_id,
+						'session_id'       => 'pending:' . $run_id,
+						'status'           => self::STATUS_RUNNING,
+						'started_at'       => $now,
+						'updated_at'       => $now,
+						'metadata'         => array(),
+						'_owner'           => $fingerprint,
+						'_claim_token'     => $claim_token,
+						'_session_pending' => true,
+					);
+					$state['runs'][ $run_id ] = $run;
+					$state = self::record_event( $state, $run_id, 'run_started', array( 'status' => self::STATUS_RUNNING ) );
+					return array( 'state' => $state, 'result' => self::normalize_run( $run ) );
+				},
+				$workspace,
+				'' === $fingerprint
+			);
+		} catch ( \RuntimeException $error ) {
+			return self::atomic_unavailable( $error );
+		}
+		if ( $result instanceof \WP_Error ) {
+			return $result;
+		}
+		return is_array( $result ) ? self::normalize_run( WP_Agent_Run_Control::string_keyed_array( $result ) ) : new \WP_Error( 'agents_chat_run_atomic_unavailable', 'Atomic pending run claim returned an invalid result.' );
 	}
 
 	/**
@@ -216,11 +334,33 @@ class WP_Agent_Chat_Run_Control {
 	 *
 	 * @param string $run_id Run ID.
 	 * @param string $status Terminal status.
-	 * @return array<string,mixed>|null Normalized run, or null when absent.
+	 * @return array<string,mixed>|null|\WP_Error Normalized run, null when absent, or a storage error.
 	 */
-	public static function finish_run( string $run_id, string $status = self::STATUS_COMPLETED, ?WP_Agent_Workspace_Scope $workspace = null ): ?array {
-		$run = WP_Agent_Run_Control::finish_run( self::OPTION_KEY, $run_id, $status, $workspace );
-		return null === $run ? null : self::normalize_run( $run );
+	public static function finish_run( string $run_id, string $status = self::STATUS_COMPLETED, ?WP_Agent_Workspace_Scope $workspace = null ) {
+		$allow_legacy = null === $workspace && ( ! class_exists( '\wpdb' ) || self::run_is_unowned( $run_id, $workspace ) );
+		try {
+			$result = self::mutate_state(
+			static function ( array $state ) use ( $run_id, $status ): array {
+				$run = $state['runs'][ $run_id ] ?? null;
+				if ( ! is_array( $run ) ) {
+					return array( 'state' => $state, 'result' => null );
+				}
+				$run['status']     = self::normalize_status( $status );
+				$run['updated_at'] = self::now();
+				if ( self::STATUS_CANCELLED === $run['status'] ) {
+					$run['cancelled'] = true;
+				}
+				$state['runs'][ $run_id ] = $run;
+				$state = self::record_event( $state, $run_id, 'run_finished', array( 'status' => $run['status'] ) );
+				return array( 'state' => $state, 'result' => self::normalize_run( $run ) );
+			},
+				$workspace,
+				$allow_legacy
+			);
+		} catch ( \RuntimeException $error ) {
+			return self::atomic_unavailable( $error );
+		}
+		return is_array( $result ) ? self::normalize_run( WP_Agent_Run_Control::string_keyed_array( $result ) ) : null;
 	}
 
 	/**
@@ -244,15 +384,35 @@ class WP_Agent_Chat_Run_Control {
 	 *
 	 * @param string $run_id Run ID.
 	 * @param array<string,mixed>|null $owner Canonical conversation owner.
-	 * @return array<string,mixed>|null Normalized run, or null when absent.
+	 * @return array<string,mixed>|null|\WP_Error Normalized run, null when absent, or a storage error.
 	 */
-	public static function request_cancel( string $run_id, ?WP_Agent_Workspace_Scope $workspace = null, ?array $owner = null ): ?array {
+	public static function request_cancel( string $run_id, ?WP_Agent_Workspace_Scope $workspace = null, ?array $owner = null ) {
 		if ( ! self::can_access_run( $run_id, $workspace, $owner ) ) {
 			return null;
 		}
 
-		$run = WP_Agent_Run_Control::request_cancel( self::OPTION_KEY, $run_id, $workspace );
-		return null === $run ? null : self::normalize_run( $run );
+		try {
+			$result = self::mutate_state(
+			static function ( array $state ) use ( $run_id, $owner ): array {
+				$run = $state['runs'][ $run_id ] ?? null;
+				if ( ! is_array( $run ) || ! self::owner_matches( $run['_owner'] ?? '', $owner ) ) {
+					return array( 'state' => $state, 'result' => null );
+				}
+				$terminal          = in_array( self::normalize_status( $run['status'] ?? '' ), array( self::STATUS_COMPLETED, self::STATUS_FAILED, self::STATUS_CANCELLED, self::STATUS_BUDGET_EXCEEDED, self::STATUS_STALLED, self::STATUS_INTERRUPTED ), true );
+				$run['status']     = $terminal ? self::normalize_status( $run['status'] ?? '' ) : self::STATUS_CANCELLING;
+				$run['cancelled']  = ! $terminal;
+				$run['updated_at'] = self::now();
+				$state['runs'][ $run_id ] = $run;
+				$state = self::record_event( $state, $run_id, 'cancel_requested', array( 'status' => $run['status'] ) );
+				return array( 'state' => $state, 'result' => self::normalize_run( $run ) );
+			},
+				$workspace,
+				null === $workspace && '' === self::owner_fingerprint( $owner )
+			);
+		} catch ( \RuntimeException $error ) {
+			return self::atomic_unavailable( $error );
+		}
+		return is_array( $result ) ? self::normalize_run( WP_Agent_Run_Control::string_keyed_array( $result ) ) : null;
 	}
 
 	/**
@@ -287,39 +447,58 @@ class WP_Agent_Chat_Run_Control {
 			throw new \InvalidArgumentException( 'session_id must be a non-empty string' );
 		}
 
-		$target = self::queue_target( $input, $workspace, $owner, $conversation_store );
-		if ( $target instanceof \WP_Error ) {
-			return $target;
+		$canonical_owner = self::session_owner_fingerprint( $session_id, $workspace, $owner, $conversation_store );
+		if ( $canonical_owner instanceof \WP_Error ) {
+			return $canonical_owner;
 		}
-		$run_id = $target['run_id'];
 
-		$queued_id = 'queued_' . str_replace( 'run_', '', self::generate_run_id() );
-		$item      = array(
-			'queued_message_id' => $queued_id,
-			'session_id'        => $session_id,
-			'run_id'            => $run_id,
-			'agent'             => sanitize_title( self::string_value( $input['agent'] ?? null ) ),
-			'message'           => self::string_value( $input['message'] ?? null ),
-			'attachments'       => is_array( $input['attachments'] ?? null ) ? $input['attachments'] : array(),
-			'client_context'    => is_array( $input['client_context'] ?? null ) ? $input['client_context'] : array(),
-			'created_at'        => self::now(),
-			'_owner'            => $target['owner_fingerprint'],
-		);
-
-		$state                            = self::state( $workspace );
-		$state['queues'][ $session_id ]   = array_values( $state['queues'][ $session_id ] ?? array() );
-		$state['queues'][ $session_id ][] = $item;
-		$position                         = count( $state['queues'][ $session_id ] );
-		self::save_state( $state, $workspace );
-
-		return self::normalize_run( array(
-			'run_id'            => $run_id,
-			'session_id'        => $session_id,
-			'status'            => self::STATUS_QUEUED,
-			'updated_at'        => self::now(),
-			'queued_message_id' => $queued_id,
-			'position'          => $position,
-		) );
+		try {
+			$result = self::mutate_state(
+			static function ( array $state ) use ( $input, $session_id, $canonical_owner ): array {
+				$target = self::queue_target_from_state( $input, $state, $canonical_owner );
+				if ( $target instanceof \WP_Error ) {
+					return array( 'state' => $state, 'result' => $target );
+				}
+				$queued_id = 'queued_' . str_replace( 'run_', '', self::generate_run_id() );
+				$item = array(
+					'queued_message_id' => $queued_id,
+					'session_id'        => $session_id,
+					'run_id'            => $target['run_id'],
+					'agent'             => sanitize_title( self::string_value( $input['agent'] ?? null ) ),
+					'message'           => self::string_value( $input['message'] ?? null ),
+					'attachments'       => is_array( $input['attachments'] ?? null ) ? $input['attachments'] : array(),
+					'client_context'    => is_array( $input['client_context'] ?? null ) ? $input['client_context'] : array(),
+					'created_at'        => self::now(),
+					'_owner'            => $canonical_owner,
+				);
+				$state['queues'][ $session_id ]   = array_values( $state['queues'][ $session_id ] ?? array() );
+				$state['queues'][ $session_id ][] = $item;
+				$position = count( $state['queues'][ $session_id ] );
+				return array(
+					'state'  => $state,
+					'result' => self::normalize_run( array(
+						'run_id'            => $target['run_id'],
+						'session_id'        => $session_id,
+						'status'            => self::STATUS_QUEUED,
+						'updated_at'        => self::now(),
+						'queued_message_id' => $queued_id,
+						'position'          => $position,
+					) ),
+				);
+			},
+				$workspace,
+				'' === $canonical_owner
+			);
+		} catch ( \RuntimeException $error ) {
+			return self::atomic_unavailable( $error );
+		}
+		if ( $result instanceof \WP_Error ) {
+			return $result;
+		}
+		if ( ! is_array( $result ) ) {
+			throw new \RuntimeException( 'Atomic chat queue mutation returned an invalid result.' );
+		}
+		return self::normalize_run( WP_Agent_Run_Control::string_keyed_array( $result ) );
 	}
 
 	/**
@@ -327,22 +506,43 @@ class WP_Agent_Chat_Run_Control {
 	 *
 	 * @param string $session_id Session ID.
 	 * @param array<string,mixed>|null $owner Canonical conversation owner.
-	 * @return array<int,array<string,mixed>> Queued items.
+	 * @return array<int,array<string,mixed>>|\WP_Error Queued items or a storage error.
 	 */
-	public static function claim_queued_messages( string $session_id, ?WP_Agent_Workspace_Scope $workspace = null, ?array $owner = null, ?WP_Agent_Conversation_Store $conversation_store = null ): array {
+	public static function claim_queued_messages( string $session_id, ?WP_Agent_Workspace_Scope $workspace = null, ?array $owner = null, ?WP_Agent_Conversation_Store $conversation_store = null ): array|\WP_Error {
 		$canonical_owner = self::session_owner_fingerprint( $session_id, $workspace, $owner, $conversation_store );
 		if ( $canonical_owner instanceof \WP_Error ) {
-			return array();
+			return $canonical_owner;
 		}
 
-		$state = self::state( $workspace );
-		$items = array_values( array_filter(
-			$state['queues'][ $session_id ] ?? array(),
-			static fn( array $item ): bool => self::fingerprint_matches( $item['_owner'] ?? null, $canonical_owner )
-		) );
-		unset( $state['queues'][ $session_id ] );
-		self::save_state( $state, $workspace );
-		return array_map( array( self::class, 'public_queue_item' ), $items );
+		try {
+			$result = self::mutate_state(
+			static function ( array $state ) use ( $session_id, $canonical_owner ): array {
+				$items = array_values( array_filter(
+					$state['queues'][ $session_id ] ?? array(),
+					static fn( array $item ): bool => self::fingerprint_matches( $item['_owner'] ?? null, $canonical_owner )
+				) );
+				unset( $state['queues'][ $session_id ] );
+				return array(
+					'state'  => $state,
+					'result' => array_map( array( self::class, 'public_queue_item' ), $items ),
+				);
+			},
+				$workspace,
+				'' === $canonical_owner
+			);
+		} catch ( \RuntimeException $error ) {
+			return self::atomic_unavailable( $error );
+		}
+		if ( ! is_array( $result ) ) {
+			return array();
+		}
+		$items = array();
+		foreach ( $result as $item ) {
+			if ( is_array( $item ) ) {
+				$items[] = WP_Agent_Run_Control::string_keyed_array( $item );
+			}
+		}
+		return $items;
 	}
 
 	/**
@@ -413,11 +613,6 @@ class WP_Agent_Chat_Run_Control {
 		return is_int( $value ) || is_float( $value ) || is_string( $value ) || is_bool( $value ) ? (int) $value : 0;
 	}
 
-	/** @param array{runs:array<string,array<string,mixed>>,queues:array<string,array<int,array<string,mixed>>>,events:array<string,array<int,array<string,mixed>>>} $state State to persist. */
-	private static function save_state( array $state, ?WP_Agent_Workspace_Scope $workspace = null ): void {
-		WP_Agent_Run_Control::save_state( self::OPTION_KEY, $state, $workspace );
-	}
-
 	/** @param array<string,mixed>|null $owner */
 	private static function owner_fingerprint( ?array $owner ): string {
 		if ( ! is_string( $owner['type'] ?? null ) || ! is_string( $owner['key'] ?? null ) ) {
@@ -448,12 +643,21 @@ class WP_Agent_Chat_Run_Control {
 	 */
 	private static function queue_target( array $input, ?WP_Agent_Workspace_Scope $workspace, ?array $owner, ?WP_Agent_Conversation_Store $conversation_store ) {
 		$session_id      = trim( self::string_value( $input['session_id'] ?? null ) );
-		$run_id          = trim( self::string_value( $input['run_id'] ?? null ) );
-		$state           = self::state( $workspace );
 		$canonical_owner = self::session_owner_fingerprint( $session_id, $workspace, $owner, $conversation_store );
 		if ( $canonical_owner instanceof \WP_Error ) {
 			return $canonical_owner;
 		}
+		return self::queue_target_from_state( $input, self::state( $workspace ), $canonical_owner );
+	}
+
+	/**
+	 * @param array<string,mixed> $input Queue input.
+	 * @param array{runs:array<string,array<string,mixed>>,queues:array<string,array<int,array<string,mixed>>>,events:array<string,array<int,array<string,mixed>>>} $state Stored state.
+	 * @return array{run_id:string,owner_fingerprint:string}|\WP_Error
+	 */
+	private static function queue_target_from_state( array $input, array $state, string $canonical_owner ) {
+		$session_id = trim( self::string_value( $input['session_id'] ?? null ) );
+		$run_id     = trim( self::string_value( $input['run_id'] ?? null ) );
 
 		if ( '' !== $run_id ) {
 			$candidate = $state['runs'][ $run_id ] ?? null;
@@ -482,6 +686,57 @@ class WP_Agent_Chat_Run_Control {
 			'run_id'            => $run_id,
 			'owner_fingerprint' => $canonical_owner,
 		);
+	}
+
+	/**
+	 * @param array{runs:array<string,array<string,mixed>>,queues:array<string,array<int,array<string,mixed>>>,events:array<string,array<int,array<string,mixed>>>} $state
+	 * @param array<string,mixed> $metadata
+	 * @return array{runs:array<string,array<string,mixed>>,queues:array<string,array<int,array<string,mixed>>>,events:array<string,array<int,array<string,mixed>>>}
+	 */
+	private static function record_event( array $state, string $run_id, string $type, array $metadata ): array {
+		$events = array_values( $state['events'][ $run_id ] ?? array() );
+		$events[] = array(
+			'id'         => (string) count( $events ),
+			'type'       => $type,
+			'created_at' => self::now(),
+			'metadata'   => $metadata,
+		);
+		$state['events'][ $run_id ] = $events;
+		return $state;
+	}
+
+	private static function atomic_unavailable( \RuntimeException $error ): \WP_Error {
+		return new \WP_Error( 'agents_chat_run_atomic_unavailable', $error->getMessage() );
+	}
+
+	/**
+	 * @param callable(array{runs:array<string,array<string,mixed>>,queues:array<string,array<int,array<string,mixed>>>,events:array<string,array<int,array<string,mixed>>>}):array{state:array{runs:array<string,array<string,mixed>>,queues:array<string,array<int,array<string,mixed>>>,events:array<string,array<int,array<string,mixed>>>},result:mixed} $mutation
+	 */
+	private static function mutate_state( callable $mutation, ?WP_Agent_Workspace_Scope $workspace, bool $allow_unowned_site_legacy ): mixed {
+		$store = WP_Agent_Run_Control::store();
+		if ( null === $workspace && method_exists( $store, 'mutate_state' ) ) {
+			try {
+				return $store->mutate_state( self::OPTION_KEY, $mutation );
+			} catch ( \RuntimeException $error ) {
+				if ( ! $allow_unowned_site_legacy || class_exists( '\wpdb' ) ) {
+					throw $error;
+				}
+			}
+		}
+		if ( $workspace instanceof WP_Agent_Workspace_Scope && method_exists( $store, 'mutate_workspace_state' ) ) {
+			return $store->mutate_workspace_state( self::OPTION_KEY, $workspace, $mutation );
+		}
+		if ( null === $workspace && $allow_unowned_site_legacy ) {
+			$mutated = $mutation( self::state() );
+			WP_Agent_Run_Control::save_state( self::OPTION_KEY, $mutated['state'] );
+			return $mutated['result'];
+		}
+		throw new \RuntimeException( 'The registered run-control store does not support atomic chat state mutation.' );
+	}
+
+	private static function run_is_unowned( string $run_id, ?WP_Agent_Workspace_Scope $workspace ): bool {
+		$run = self::state( $workspace )['runs'][ $run_id ] ?? null;
+		return is_array( $run ) && '' === self::string_value( $run['_owner'] ?? '' );
 	}
 
 	/**

--- a/src/Runtime/class-wp-agent-conversation-loop.php
+++ b/src/Runtime/class-wp-agent-conversation-loop.php
@@ -136,7 +136,7 @@ class WP_Agent_Conversation_Loop {
 		$messages = self::normalize_messages( $messages );
 		if ( '' !== $run_id && '' !== $lock_session_id ) {
 			$conversation_store = ( $context['conversation_store'] ?? null ) instanceof \AgentsAPI\Core\Database\Chat\WP_Agent_Conversation_Store ? $context['conversation_store'] : null;
-			$started            = WP_Agent_Chat_Run_Control::start_run( $run_id, $lock_session_id, array( 'source' => 'conversation_loop' ), $run_workspace, $run_owner, $conversation_store );
+			$started            = WP_Agent_Chat_Run_Control::start_run( $run_id, $lock_session_id, array( 'source' => 'conversation_loop', '_claim_token' => WP_Agent_Run_Control::string_value( $context['_agents_run_claim_token'] ?? '' ) ), $run_workspace, $run_owner, $conversation_store );
 			if ( is_wp_error( $started ) ) {
 				self::emit_event( $on_event, 'failed', array( 'error' => $started->get_error_message() ) );
 				return self::run_control_failure_result( $messages, $started );
@@ -541,7 +541,11 @@ class WP_Agent_Conversation_Loop {
 			$final_result = self::normalize_conversation_result( $final_result_data );
 
 			if ( '' !== $run_id && '' !== $lock_session_id ) {
-				WP_Agent_Chat_Run_Control::finish_run( $run_id, WP_Agent_Run_Outcome::run_control_status( $final_result ), $run_workspace );
+				$finished = WP_Agent_Chat_Run_Control::finish_run( $run_id, WP_Agent_Run_Outcome::run_control_status( $final_result ), $run_workspace );
+				if ( is_wp_error( $finished ) ) {
+					self::emit_event( $on_event, 'failed', array( 'error' => $finished->get_error_message() ) );
+					return self::run_control_failure_result( $messages, $finished );
+				}
 			}
 
 			self::persist_transcript( $transcript_persister, $messages, $options, $final_result );

--- a/src/Runtime/class-wp-agent-option-run-control-store.php
+++ b/src/Runtime/class-wp-agent-option-run-control-store.php
@@ -11,14 +11,24 @@ use AgentsAPI\Core\Workspace\WP_Agent_Workspace_Scope;
 
 defined( 'ABSPATH' ) || exit;
 
-if ( ! interface_exists( WP_Agent_Workspace_Run_Control_Store::class ) ) {
-	require_once __DIR__ . '/interface-wp-agent-workspace-run-control-store.php';
+if ( ! interface_exists( WP_Agent_Atomic_Workspace_Run_Control_Store::class ) ) {
+	require_once __DIR__ . '/interface-wp-agent-atomic-workspace-run-control-store.php';
 }
 
 /**
  * Persists run-control state in WordPress options.
  */
-class WP_Agent_Option_Run_Control_Store implements WP_Agent_Workspace_Run_Control_Store {
+class WP_Agent_Option_Run_Control_Store implements WP_Agent_Atomic_Workspace_Run_Control_Store {
+
+	private const LOCK_PREFIX       = '_agents_api_run_lock_';
+	private const LOCK_WAIT_SECONDS = 5.0;
+	private const LOCK_TTL_SECONDS  = 15.0;
+
+	private ?\wpdb $database;
+
+	public function __construct( ?\wpdb $database = null ) {
+		$this->database = $database;
+	}
 
 	/**
 	 * @param string $store_key Store key.
@@ -44,6 +54,29 @@ class WP_Agent_Option_Run_Control_Store implements WP_Agent_Workspace_Run_Contro
 	public function save_state( string $store_key, array $state ): void {
 		if ( function_exists( 'update_option' ) ) {
 			update_option( $store_key, $state, false );
+		}
+	}
+
+	public function mutate_state( string $store_key, callable $mutation ): mixed {
+		$db         = $this->database();
+		$table      = $db->options;
+		$lock_key   = $this->lock_option_key( 'site:' . $table . ':' . $store_key );
+		$lock_value = $this->acquire_lock( $db, $table, $lock_key );
+
+		try {
+			$state   = $this->read_option_state( $db, $table, $store_key );
+			$mutated = $this->mutation_result( $mutation( $state ) );
+			$lock_value = $this->commit_under_lock(
+				$db,
+				$table,
+				$lock_key,
+				$lock_value,
+				fn() => $this->write_option_state( $db, $table, $store_key, $mutated['state'] )
+			);
+			$this->refresh_site_cache( $store_key, $mutated['state'] );
+			return $mutated['result'];
+		} finally {
+			$this->release_lock( $db, $table, $lock_key, $lock_value );
 		}
 	}
 
@@ -84,8 +117,322 @@ class WP_Agent_Option_Run_Control_Store implements WP_Agent_Workspace_Run_Contro
 		update_site_option( $this->workspace_option_key( $store_key, $workspace ), $state );
 	}
 
+	public function mutate_workspace_state( string $store_key, WP_Agent_Workspace_Scope $workspace, callable $mutation ): mixed {
+		$db         = $this->database();
+		$option_key = $this->workspace_option_key( $store_key, $workspace );
+		if ( function_exists( 'is_multisite' ) && ! is_multisite() ) {
+			return $this->mutate_state( $option_key, $mutation );
+		}
+		$lock_table = $this->main_options_table( $db );
+		$lock_key   = $this->lock_option_key( 'workspace:' . $db->sitemeta . ':' . $this->network_id( $db ) . ':' . $option_key );
+		$lock_value = $this->acquire_lock( $db, $lock_table, $lock_key );
+
+		try {
+			$state   = $this->read_workspace_state( $db, $option_key );
+			$mutated = $this->mutation_result( $mutation( $state ) );
+			$lock_value = $this->commit_under_lock(
+				$db,
+				$lock_table,
+				$lock_key,
+				$lock_value,
+				fn() => $this->write_workspace_state( $db, $option_key, $mutated['state'] )
+			);
+			$this->refresh_workspace_cache( $this->network_id( $db ), $option_key, $mutated['state'] );
+			return $mutated['result'];
+		} finally {
+			$this->release_lock( $db, $lock_table, $lock_key, $lock_value );
+		}
+	}
+
 	private function workspace_option_key( string $store_key, WP_Agent_Workspace_Scope $workspace ): string {
 		return $store_key . '_workspace_' . hash( 'sha256', $workspace->key() );
+	}
+
+	private function database(): \wpdb {
+		if ( $this->database instanceof \wpdb ) {
+			return $this->database;
+		}
+
+		global $wpdb;
+		if ( ! $wpdb instanceof \wpdb ) {
+			throw new \RuntimeException( 'Atomic run-control mutation requires a WordPress database connection.' );
+		}
+
+		return $wpdb;
+	}
+
+	private function main_options_table( \wpdb $db ): string {
+		$network_id   = $this->network_id( $db );
+		$main_site_id = function_exists( 'get_main_site_id' ) ? (int) get_main_site_id( $network_id ) : 1;
+		return $db->get_blog_prefix( max( 1, $main_site_id ) ) . 'options';
+	}
+
+	private function network_id( \wpdb $db ): int {
+		return max( 1, (int) $db->siteid );
+	}
+
+	private function lock_option_key( string $scope ): string {
+		return self::LOCK_PREFIX . hash( 'sha256', $scope );
+	}
+
+	private function acquire_lock( \wpdb $db, string $table, string $lock_key ): string {
+		$token    = $this->lock_token();
+		$deadline = microtime( true ) + self::LOCK_WAIT_SECONDS;
+
+		do {
+			$lock_value = $this->lock_value( $token );
+			$created    = $this->lock_query( $db, $db->prepare( "INSERT IGNORE INTO %i (option_name, option_value, autoload) VALUES (%s, %s, 'no')", $table, $lock_key, $lock_value ) );
+			if ( 1 === $created ) {
+				return $lock_value;
+			}
+			if ( false === $created ) {
+				usleep( 50000 );
+				continue;
+			}
+
+			$current = $this->get_var( $db, $db->prepare( 'SELECT option_value FROM %i WHERE option_name = %s LIMIT 1', $table, $lock_key ) );
+			if ( is_string( $current ) && $this->lock_expired( $current ) ) {
+				$replaced = $this->lock_query( $db, $db->prepare( "UPDATE %i SET option_value = %s, autoload = 'no' WHERE option_name = %s AND option_value = %s", $table, $lock_value, $lock_key, $current ) );
+				if ( 1 === $replaced ) {
+					return $lock_value;
+				}
+				if ( false === $replaced ) {
+					usleep( 50000 );
+					continue;
+				}
+			}
+
+			usleep( 50000 );
+		} while ( microtime( true ) < $deadline );
+
+		throw new \RuntimeException( 'Atomic run-control lock acquisition timed out.' );
+	}
+
+	private function release_lock( \wpdb $db, string $table, string $lock_key, string $lock_value ): void {
+		$released = $this->query( $db, $db->prepare( 'DELETE FROM %i WHERE option_name = %s AND option_value = %s', $table, $lock_key, $lock_value ) );
+		if ( false === $released ) {
+			throw new \RuntimeException( 'Atomic run-control lock release failed.' );
+		}
+	}
+
+	private function commit_under_lock( \wpdb $db, string $table, string $lock_key, string $lock_value, callable $write ): string {
+		$decoded = json_decode( $lock_value, true );
+		if ( ! is_array( $decoded ) || ! is_string( $decoded['token'] ?? null ) ) {
+			throw new \RuntimeException( 'Atomic run-control lock token is invalid.' );
+		}
+		if ( false === $this->query( $db, 'START TRANSACTION' ) ) {
+			throw new \RuntimeException( 'Atomic run-control transaction could not start.' );
+		}
+		try {
+			$current = $this->get_var( $db, $db->prepare( 'SELECT option_value FROM %i WHERE option_name = %s FOR UPDATE', $table, $lock_key ) );
+			if ( ! is_string( $current ) || ! hash_equals( $lock_value, $current ) ) {
+				throw new \RuntimeException( 'Atomic run-control lock ownership was lost before state write.' );
+			}
+			$refreshed = $this->lock_value( $decoded['token'] );
+			$updated   = $this->query( $db, $db->prepare( "UPDATE %i SET option_value = %s, autoload = 'no' WHERE option_name = %s AND option_value = %s", $table, $refreshed, $lock_key, $lock_value ) );
+			if ( 1 !== $updated ) {
+				throw new \RuntimeException( 'Atomic run-control lock ownership was lost before state write.' );
+			}
+			$write();
+			if ( false === $this->query( $db, 'COMMIT' ) ) {
+				throw new \RuntimeException( 'Atomic run-control transaction could not commit.' );
+			}
+			return $refreshed;
+		} catch ( \Throwable $error ) {
+			$this->query( $db, 'ROLLBACK' );
+			throw $error;
+		}
+	}
+
+	private function lock_token(): string {
+		try {
+			return bin2hex( random_bytes( 16 ) );
+		} catch ( \Throwable $error ) {
+			unset( $error );
+			return hash( 'sha256', uniqid( '', true ) );
+		}
+	}
+
+	private function lock_value( string $token ): string {
+		$value = json_encode(
+			array(
+				'token'      => $token,
+				'expires_at' => microtime( true ) + self::LOCK_TTL_SECONDS,
+			)
+		);
+		if ( ! is_string( $value ) ) {
+			throw new \RuntimeException( 'Atomic run-control lock could not be encoded.' );
+		}
+		return $value;
+	}
+
+	private function lock_expired( string $lock_value ): bool {
+		$decoded = json_decode( $lock_value, true );
+		return ! is_array( $decoded ) || ! is_numeric( $decoded['expires_at'] ?? null ) || (float) $decoded['expires_at'] <= microtime( true );
+	}
+
+	/** @return array{runs:array<string,array<string,mixed>>,queues:array<string,array<int,array<string,mixed>>>,events:array<string,array<int,array<string,mixed>>>} */
+	private function read_option_state( \wpdb $db, string $table, string $store_key ): array {
+		$value = $this->get_var( $db, $db->prepare( 'SELECT option_value FROM %i WHERE option_name = %s LIMIT 1', $table, $store_key ) );
+		return $this->decode_state( $value );
+	}
+
+	/** @param array{runs:array<string,array<string,mixed>>,queues:array<string,array<int,array<string,mixed>>>,events:array<string,array<int,array<string,mixed>>>} $state */
+	private function write_option_state( \wpdb $db, string $table, string $store_key, array $state ): void {
+		$written = $this->query( $db, $db->prepare( "INSERT INTO %i (option_name, option_value, autoload) VALUES (%s, %s, 'no') ON DUPLICATE KEY UPDATE option_value = VALUES(option_value), autoload = 'no'", $table, $store_key, $this->serialize_value( $state ) ) );
+		if ( false === $written ) {
+			throw new \RuntimeException( 'Atomic run-control state write failed.' );
+		}
+	}
+
+	/** @return array{runs:array<string,array<string,mixed>>,queues:array<string,array<int,array<string,mixed>>>,events:array<string,array<int,array<string,mixed>>>} */
+	private function read_workspace_state( \wpdb $db, string $option_key ): array {
+		$value = $this->get_var( $db, $db->prepare( 'SELECT meta_value FROM %i WHERE site_id = %d AND meta_key = %s ORDER BY meta_id ASC LIMIT 1', $db->sitemeta, $this->network_id( $db ), $option_key ) );
+		return $this->decode_state( $value );
+	}
+
+	/** @param array{runs:array<string,array<string,mixed>>,queues:array<string,array<int,array<string,mixed>>>,events:array<string,array<int,array<string,mixed>>>} $state */
+	private function write_workspace_state( \wpdb $db, string $option_key, array $state ): void {
+		$value   = $this->serialize_value( $state );
+		$updated = $this->query( $db, $db->prepare( 'UPDATE %i SET meta_value = %s WHERE site_id = %d AND meta_key = %s', $db->sitemeta, $value, $this->network_id( $db ), $option_key ) );
+		if ( false === $updated ) {
+			throw new \RuntimeException( 'Atomic workspace run-control state write failed.' );
+		}
+		if ( 0 === $updated ) {
+			$existing = $this->get_var( $db, $db->prepare( 'SELECT meta_id FROM %i WHERE site_id = %d AND meta_key = %s LIMIT 1', $db->sitemeta, $this->network_id( $db ), $option_key ) );
+			if ( null !== $existing ) {
+				return;
+			}
+			$inserted = $this->query( $db, $db->prepare( 'INSERT INTO %i (site_id, meta_key, meta_value) VALUES (%d, %s, %s)', $db->sitemeta, $this->network_id( $db ), $option_key, $value ) );
+			if ( 1 !== $inserted ) {
+				throw new \RuntimeException( 'Atomic workspace run-control state creation failed.' );
+			}
+		}
+	}
+
+	private function serialize_value( mixed $value ): string {
+		$serialized = function_exists( 'maybe_serialize' ) ? maybe_serialize( $value ) : serialize( $value );
+		return is_string( $serialized ) ? $serialized : serialize( $serialized );
+	}
+
+	private function unserialize_value( mixed $value ): mixed {
+		if ( ! is_string( $value ) ) {
+			return array();
+		}
+		return function_exists( 'maybe_unserialize' ) ? maybe_unserialize( $value ) : @unserialize( $value );
+	}
+
+	/** @return array{runs:array<string,array<string,mixed>>,queues:array<string,array<int,array<string,mixed>>>,events:array<string,array<int,array<string,mixed>>>} */
+	private function decode_state( mixed $value ): array {
+		if ( null === $value ) {
+			return $this->normalize_state( array() );
+		}
+		$state = $this->unserialize_value( $value );
+		if ( ! is_array( $state ) || ! $this->valid_state_shape( $state ) ) {
+			throw new \RuntimeException( 'Atomic run-control state is corrupt.' );
+		}
+		return $this->normalize_state( $state );
+	}
+
+	/** @param array<mixed> $state */
+	private function valid_state_shape( array $state ): bool {
+		$runs   = $state['runs'] ?? array();
+		$queues = $state['queues'] ?? array();
+		$events = $state['events'] ?? array();
+		if ( ! is_array( $runs ) || ! is_array( $queues ) || ! is_array( $events ) ) {
+			return false;
+		}
+		foreach ( $runs as $run_id => $run ) {
+			if ( ! is_string( $run_id ) || ! is_array( $run ) ) {
+				return false;
+			}
+		}
+		foreach ( array( $queues, $events ) as $collection ) {
+			foreach ( $collection as $scope => $items ) {
+				if ( ! is_string( $scope ) || ! is_array( $items ) ) {
+					return false;
+				}
+				foreach ( $items as $item ) {
+					if ( ! is_array( $item ) ) {
+						return false;
+					}
+				}
+			}
+		}
+		return true;
+	}
+
+	/** @return array{runs:array<string,array<string,mixed>>,queues:array<string,array<int,array<string,mixed>>>,events:array<string,array<int,array<string,mixed>>>} */
+	private function normalize_state( mixed $state ): array {
+		$state = is_array( $state ) ? $state : array();
+		return array(
+			'runs'   => $this->stored_runs( $state['runs'] ?? array() ),
+			'queues' => $this->stored_queues( $state['queues'] ?? array() ),
+			'events' => $this->stored_queues( $state['events'] ?? array() ),
+		);
+	}
+
+	/** @return array{state:array{runs:array<string,array<string,mixed>>,queues:array<string,array<int,array<string,mixed>>>,events:array<string,array<int,array<string,mixed>>>},result:mixed} */
+	private function mutation_result( mixed $mutation ): array {
+		if ( ! is_array( $mutation ) || ! is_array( $mutation['state'] ?? null ) || ! array_key_exists( 'result', $mutation ) ) {
+			throw new \RuntimeException( 'Atomic run-control mutations must return state and result.' );
+		}
+		return array(
+			'state'  => $this->normalize_state( $mutation['state'] ),
+			'result' => $mutation['result'],
+		);
+	}
+
+	/** @param array{runs:array<string,array<string,mixed>>,queues:array<string,array<int,array<string,mixed>>>,events:array<string,array<int,array<string,mixed>>>} $state */
+	private function refresh_site_cache( string $store_key, array $state ): void {
+		if ( function_exists( 'wp_cache_delete' ) ) {
+			wp_cache_delete( $store_key, 'options' );
+			wp_cache_delete( 'notoptions', 'options' );
+			wp_cache_delete( 'alloptions', 'options' );
+		}
+		if ( function_exists( 'wp_cache_set' ) ) {
+			wp_cache_set( $store_key, $state, 'options' );
+		}
+	}
+
+	/** @param array{runs:array<string,array<string,mixed>>,queues:array<string,array<int,array<string,mixed>>>,events:array<string,array<int,array<string,mixed>>>} $state */
+	private function refresh_workspace_cache( int $network_id, string $option_key, array $state ): void {
+		if ( function_exists( 'wp_cache_delete' ) ) {
+			wp_cache_delete( $network_id . ':' . $option_key, 'site-options' );
+			wp_cache_delete( $network_id . ':notoptions', 'site-options' );
+		}
+		if ( function_exists( 'wp_cache_set' ) ) {
+			wp_cache_set( $network_id . ':' . $option_key, $state, 'site-options' );
+		}
+	}
+
+	/** @return int|bool */
+	private function query( \wpdb $db, ?string $query ) {
+		if ( ! is_string( $query ) ) {
+			throw new \RuntimeException( 'Atomic run-control query preparation failed.' );
+		}
+		return $db->query( $query );
+	}
+
+	private function get_var( \wpdb $db, ?string $query ): mixed {
+		if ( ! is_string( $query ) ) {
+			throw new \RuntimeException( 'Atomic run-control query preparation failed.' );
+		}
+		$value = $db->get_var( $query );
+		if ( '' !== $db->last_error ) {
+			throw new \RuntimeException( 'Atomic run-control state read failed: ' . $db->last_error );
+		}
+		return $value;
+	}
+
+	/** @return int|bool */
+	private function lock_query( \wpdb $db, ?string $query ) {
+		$previous = $db->suppress_errors( true );
+		try {
+			return $this->query( $db, $query );
+		} finally {
+			$db->suppress_errors( $previous );
+		}
 	}
 
 	/**

--- a/src/Runtime/class-wp-agent-run-control.php
+++ b/src/Runtime/class-wp-agent-run-control.php
@@ -420,6 +420,27 @@ class WP_Agent_Run_Control {
 		$store->save_workspace_state( $store_key, $workspace, $state );
 	}
 
+	/**
+	 * Serialize a read-modify-write mutation through the registered store.
+	 *
+	 * @param callable(array{runs:array<string,array<string,mixed>>,queues:array<string,array<int,array<string,mixed>>>,events:array<string,array<int,array<string,mixed>>>}):array{state:array{runs:array<string,array<string,mixed>>,queues:array<string,array<int,array<string,mixed>>>,events:array<string,array<int,array<string,mixed>>>},result:mixed} $mutation State mutation.
+	 * @return mixed Mutation result.
+	 */
+	public static function mutate_state( string $store_key, callable $mutation, ?WP_Agent_Workspace_Scope $workspace = null ): mixed {
+		$store = self::store();
+		if ( null === $workspace ) {
+			if ( ! $store instanceof WP_Agent_Atomic_Run_Control_Store ) {
+				throw new \RuntimeException( 'The registered run-control store does not support atomic state mutation.' );
+			}
+			return $store->mutate_state( $store_key, $mutation );
+		}
+		if ( ! $store instanceof WP_Agent_Atomic_Workspace_Run_Control_Store ) {
+			throw new \RuntimeException( 'The registered run-control store does not support atomic workspace state mutation.' );
+		}
+
+		return $store->mutate_workspace_state( $store_key, $workspace, $mutation );
+	}
+
 	public static function now(): string {
 		return gmdate( 'c' );
 	}

--- a/src/Runtime/interface-wp-agent-atomic-run-control-store.php
+++ b/src/Runtime/interface-wp-agent-atomic-run-control-store.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Atomic run-control store capability.
+ *
+ * @package AgentsAPI
+ */
+
+namespace AgentsAPI\AI;
+
+defined( 'ABSPATH' ) || exit;
+
+if ( ! interface_exists( __NAMESPACE__ . '\\WP_Agent_Run_Control_Store' ) ) {
+	require_once __DIR__ . '/interface-wp-agent-run-control-store.php';
+}
+
+/**
+ * Optional capability for serializing read-modify-write state mutations.
+ */
+interface WP_Agent_Atomic_Run_Control_Store extends WP_Agent_Run_Control_Store {
+
+	/**
+	 * @param callable(array{runs:array<string,array<string,mixed>>,queues:array<string,array<int,array<string,mixed>>>,events:array<string,array<int,array<string,mixed>>>}):array{state:array{runs:array<string,array<string,mixed>>,queues:array<string,array<int,array<string,mixed>>>,events:array<string,array<int,array<string,mixed>>>},result:mixed} $mutation State mutation.
+	 * @return mixed Mutation result.
+	 */
+	public function mutate_state( string $store_key, callable $mutation ): mixed;
+}

--- a/src/Runtime/interface-wp-agent-atomic-workspace-run-control-store.php
+++ b/src/Runtime/interface-wp-agent-atomic-workspace-run-control-store.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Atomic workspace run-control store capability.
+ *
+ * @package AgentsAPI
+ */
+
+namespace AgentsAPI\AI;
+
+use AgentsAPI\Core\Workspace\WP_Agent_Workspace_Scope;
+
+defined( 'ABSPATH' ) || exit;
+
+if ( ! interface_exists( __NAMESPACE__ . '\\WP_Agent_Atomic_Run_Control_Store' ) ) {
+	require_once __DIR__ . '/interface-wp-agent-atomic-run-control-store.php';
+}
+if ( ! interface_exists( __NAMESPACE__ . '\\WP_Agent_Workspace_Run_Control_Store' ) ) {
+	require_once __DIR__ . '/interface-wp-agent-workspace-run-control-store.php';
+}
+
+/**
+ * Optional capability for serializing workspace state mutations.
+ */
+interface WP_Agent_Atomic_Workspace_Run_Control_Store extends WP_Agent_Atomic_Run_Control_Store, WP_Agent_Workspace_Run_Control_Store {
+
+	/**
+	 * @param callable(array{runs:array<string,array<string,mixed>>,queues:array<string,array<int,array<string,mixed>>>,events:array<string,array<int,array<string,mixed>>>}):array{state:array{runs:array<string,array<string,mixed>>,queues:array<string,array<int,array<string,mixed>>>,events:array<string,array<int,array<string,mixed>>>},result:mixed} $mutation State mutation.
+	 * @return mixed Mutation result.
+	 */
+	public function mutate_workspace_state( string $store_key, WP_Agent_Workspace_Scope $workspace, callable $mutation ): mixed;
+}

--- a/tests/agents-chat-ability-smoke.php
+++ b/tests/agents-chat-ability-smoke.php
@@ -71,6 +71,8 @@ function smoke_assert( $expected, $actual, string $name, array &$failures, int &
 }
 
 agents_api_smoke_require_module();
+require_once __DIR__ . '/class-agents-api-memory-atomic-run-control-store.php';
+AgentsAPI\AI\WP_Agent_Run_Control::set_store( new Agents_API_Memory_Atomic_Run_Control_Store() );
 
 $conversation_store = new class() implements AgentsAPI\Core\Database\Chat\WP_Agent_Conversation_Store {
 	public function create_session( AgentsAPI\Core\Workspace\WP_Agent_Workspace_Scope $workspace, int $user_id, string $agent_slug = '', array $metadata = array(), string $context = 'chat' ): string {

--- a/tests/canonical-run-lifecycle-smoke.php
+++ b/tests/canonical-run-lifecycle-smoke.php
@@ -36,7 +36,7 @@ if ( ! function_exists( 'current_user_can' ) ) {
 
 agents_api_smoke_require_module();
 
-final class Agents_API_Smoke_Run_Control_Store implements AgentsAPI\AI\WP_Agent_Run_Control_Store {
+final class Agents_API_Smoke_Run_Control_Store implements AgentsAPI\AI\WP_Agent_Atomic_Run_Control_Store {
 	/** @var array<string,array{runs:array<string,array<string,mixed>>,queues:array<string,array<int,array<string,mixed>>>,events:array<string,array<int,array<string,mixed>>>}> */
 	private array $states = array();
 
@@ -54,6 +54,12 @@ final class Agents_API_Smoke_Run_Control_Store implements AgentsAPI\AI\WP_Agent_
 			'queues' => is_array( $state['queues'] ?? null ) ? $state['queues'] : array(),
 			'events' => is_array( $state['events'] ?? null ) ? $state['events'] : array(),
 		);
+	}
+
+	public function mutate_state( string $store_key, callable $mutation ): mixed {
+		$mutated = $mutation( $this->get_state( $store_key ) );
+		$this->save_state( $store_key, $mutated['state'] );
+		return $mutated['result'];
 	}
 }
 

--- a/tests/chat-run-control-multisite-smoke.php
+++ b/tests/chat-run-control-multisite-smoke.php
@@ -101,6 +101,7 @@ function wp_register_ability( string $ability, array $args ): void {
 }
 
 agents_api_smoke_require_module();
+require_once __DIR__ . '/class-agents-api-memory-atomic-run-control-store.php';
 
 use AgentsAPI\AI\WP_Agent_Chat_Run_Control;
 use AgentsAPI\AI\WP_Agent_Conversation_Loop;
@@ -115,6 +116,8 @@ use function AgentsAPI\AI\Channels\agents_chat_dispatch;
 use function AgentsAPI\AI\Channels\agents_get_chat_run;
 use function AgentsAPI\AI\Channels\agents_list_chat_run_events;
 use function AgentsAPI\AI\Channels\agents_queue_chat_message;
+
+WP_Agent_Run_Control::set_store( new Agents_API_Memory_Atomic_Run_Control_Store() );
 
 $workspace = array(
 	'workspace_type' => 'network',
@@ -323,7 +326,7 @@ $GLOBALS['__agents_api_multisite_user'] = 456;
 $foreign_cross_site = agents_queue_chat_message( $foreign_input );
 agents_api_smoke_assert_equals( 'agents_chat_run_not_found', $foreign_cross_site instanceof WP_Error ? $foreign_cross_site->get_error_code() : '', 'foreign enqueue remains denied from another subsite', $failures, $passes );
 $foreign_claim = WP_Agent_Chat_Run_Control::claim_queued_messages( 'network-session', WP_Agent_Workspace_Scope::from_array( $workspace ), $other_owner );
-agents_api_smoke_assert_equals( array(), $foreign_claim, 'foreign claim cannot consume the owner queue', $failures, $passes );
+agents_api_smoke_assert_equals( 'agents_chat_run_owner_forbidden', $foreign_claim instanceof WP_Error ? $foreign_claim->get_error_code() : '', 'foreign claim cannot consume the owner queue', $failures, $passes );
 $preserved_queue = WP_Agent_Run_Control::state( 'agents_api_chat_run_control', $workspace_scope )['queues']['network-session'] ?? array();
 agents_api_smoke_assert_equals( 'queued continuation', $preserved_queue[0]['message'] ?? null, 'foreign claim preserves the legitimate queue when foreign run is first', $failures, $passes );
 $GLOBALS['__agents_api_multisite_user'] = 123;
@@ -391,7 +394,7 @@ $mixed_state['queues']['network-session'][] = array(
 WP_Agent_Run_Control::save_state( 'agents_api_chat_run_control', $mixed_state, $workspace_scope );
 
 $mixed_foreign_claim = WP_Agent_Chat_Run_Control::claim_queued_messages( 'network-session', $workspace_scope, $other_owner );
-agents_api_smoke_assert_equals( array(), $mixed_foreign_claim, 'wrong owner cannot use mixed entries to consume the queue', $failures, $passes );
+agents_api_smoke_assert_equals( 'agents_chat_run_owner_forbidden', $mixed_foreign_claim instanceof WP_Error ? $mixed_foreign_claim->get_error_code() : '', 'wrong owner cannot use mixed entries to consume the queue', $failures, $passes );
 $mixed_preserved = WP_Agent_Run_Control::state( 'agents_api_chat_run_control', $workspace_scope )['queues']['network-session'] ?? array();
 agents_api_smoke_assert_equals( array( 'owner first', 'owner second' ), array_slice( array_column( $mixed_preserved, 'message' ), 0, 2 ), 'wrong-owner claim leaves legitimate entries intact beside corrupt rows', $failures, $passes );
 $mixed_claim = WP_Agent_Chat_Run_Control::claim_queued_messages( 'network-session', $workspace_scope, $owner );

--- a/tests/chat-run-control-smoke.php
+++ b/tests/chat-run-control-smoke.php
@@ -88,6 +88,8 @@ if ( ! function_exists( 'update_option' ) ) {
 }
 
 agents_api_smoke_require_module();
+require_once __DIR__ . '/class-agents-api-memory-atomic-run-control-store.php';
+AgentsAPI\AI\WP_Agent_Run_Control::set_store( new Agents_API_Memory_Atomic_Run_Control_Store() );
 
 $conversation_store = new class() implements AgentsAPI\Core\Database\Chat\WP_Agent_Conversation_Store {
 	public function create_session( AgentsAPI\Core\Workspace\WP_Agent_Workspace_Scope $workspace, int $user_id, string $agent_slug = '', array $metadata = array(), string $context = 'chat' ): string {

--- a/tests/class-agents-api-memory-atomic-run-control-store.php
+++ b/tests/class-agents-api-memory-atomic-run-control-store.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * In-memory atomic run-control store for pure-PHP smoke tests.
+ *
+ * @package AgentsAPI\Tests
+ */
+
+use AgentsAPI\AI\WP_Agent_Atomic_Workspace_Run_Control_Store;
+use AgentsAPI\Core\Workspace\WP_Agent_Workspace_Scope;
+
+final class Agents_API_Memory_Atomic_Run_Control_Store implements WP_Agent_Atomic_Workspace_Run_Control_Store {
+
+	/** @var array<string,array{runs:array<string,array<string,mixed>>,queues:array<string,array<int,array<string,mixed>>>,events:array<string,array<int,array<string,mixed>>>}> */
+	private array $states = array();
+
+	public function get_state( string $store_key ): array {
+		return $this->states[ $this->site_key( $store_key ) ] ?? $this->empty_state();
+	}
+
+	public function save_state( string $store_key, array $state ): void {
+		$this->states[ $this->site_key( $store_key ) ] = $state;
+	}
+
+	public function mutate_state( string $store_key, callable $mutation ): mixed {
+		$mutated = $mutation( $this->get_state( $store_key ) );
+		$this->save_state( $store_key, $mutated['state'] );
+		return $mutated['result'];
+	}
+
+	public function get_workspace_state( string $store_key, WP_Agent_Workspace_Scope $workspace ): array {
+		return $this->states[ $this->workspace_key( $store_key, $workspace ) ] ?? $this->empty_state();
+	}
+
+	public function save_workspace_state( string $store_key, WP_Agent_Workspace_Scope $workspace, array $state ): void {
+		$this->states[ $this->workspace_key( $store_key, $workspace ) ] = $state;
+	}
+
+	public function mutate_workspace_state( string $store_key, WP_Agent_Workspace_Scope $workspace, callable $mutation ): mixed {
+		$mutated = $mutation( $this->get_workspace_state( $store_key, $workspace ) );
+		$this->save_workspace_state( $store_key, $workspace, $mutated['state'] );
+		return $mutated['result'];
+	}
+
+	/** @return array{runs:array<string,array<string,mixed>>,queues:array<string,array<int,array<string,mixed>>>,events:array<string,array<int,array<string,mixed>>>} */
+	private function empty_state(): array {
+		return array( 'runs' => array(), 'queues' => array(), 'events' => array() );
+	}
+
+	private function site_key( string $store_key ): string {
+		$site_id = function_exists( 'get_current_blog_id' ) ? (string) get_current_blog_id() : 'default';
+		return 'site:' . $site_id . ':' . $store_key;
+	}
+
+	private function workspace_key( string $store_key, WP_Agent_Workspace_Scope $workspace ): string {
+		return 'workspace:' . $workspace->key() . ':' . $store_key;
+	}
+}

--- a/tests/default-agents-chat-handler-smoke.php
+++ b/tests/default-agents-chat-handler-smoke.php
@@ -360,6 +360,8 @@ namespace {
 	};
 
 	require_once __DIR__ . '/../agents-api.php';
+	require_once __DIR__ . '/class-agents-api-memory-atomic-run-control-store.php';
+	\AgentsAPI\AI\WP_Agent_Run_Control::set_store( new \Agents_API_Memory_Atomic_Run_Control_Store() );
 
 	class Agents_Chat_Runtime_Overlay_Executor implements \AgentsAPI\AI\Tools\WP_Agent_Tool_Executor {
 		/** @var array<int,array<string,mixed>> */

--- a/tests/run-control-option-store-integration.php
+++ b/tests/run-control-option-store-integration.php
@@ -1,0 +1,449 @@
+<?php
+/**
+ * MariaDB integration coverage for atomic option-store mutations.
+ *
+ * Requires AGENTS_API_WP_ROOT and AGENTS_API_DB_* environment variables.
+ *
+ * @package AgentsAPI\Tests
+ */
+
+$wp_root = rtrim( (string) getenv( 'AGENTS_API_WP_ROOT' ), '/' );
+if ( '' === $wp_root || ! is_file( $wp_root . '/wp-includes/class-wpdb.php' ) ) {
+	fwrite( STDERR, "AGENTS_API_WP_ROOT must point to a WordPress checkout.\n" );
+	exit( 1 );
+}
+if ( ! function_exists( 'pcntl_fork' ) ) {
+	fwrite( STDERR, "pcntl is required for two-connection integration tests.\n" );
+	exit( 1 );
+}
+
+define( 'ABSPATH', $wp_root . '/' );
+define( 'WPINC', 'wp-includes' );
+define( 'WP_DEBUG', false );
+define( 'WP_DEBUG_DISPLAY', false );
+define( 'SAVEQUERIES', false );
+define( 'MULTISITE', true );
+
+require_once $wp_root . '/wp-includes/class-wp-error.php';
+require_once $wp_root . '/wp-includes/plugin.php';
+require_once $wp_root . '/wp-includes/class-wpdb.php';
+require_once __DIR__ . '/../src/Workspace/class-wp-agent-workspace-scope.php';
+require_once __DIR__ . '/../src/Runtime/class-wp-agent-execution-principal.php';
+require_once __DIR__ . '/../src/Transcripts/class-wp-agent-conversation-store.php';
+require_once __DIR__ . '/../src/Transcripts/class-wp-agent-principal-conversation-store.php';
+require_once __DIR__ . '/../src/Transcripts/class-wp-agent-principal-conversation-session-reader.php';
+require_once __DIR__ . '/../src/Transcripts/class-wp-agent-conversation-sessions.php';
+require_once __DIR__ . '/../src/Runtime/interface-wp-agent-run-control-store.php';
+require_once __DIR__ . '/../src/Runtime/interface-wp-agent-workspace-run-control-store.php';
+require_once __DIR__ . '/../src/Runtime/interface-wp-agent-atomic-run-control-store.php';
+require_once __DIR__ . '/../src/Runtime/interface-wp-agent-atomic-workspace-run-control-store.php';
+require_once __DIR__ . '/../src/Runtime/class-wp-agent-option-run-control-store.php';
+require_once __DIR__ . '/../src/Runtime/class-wp-agent-run-control.php';
+require_once __DIR__ . '/../src/Runtime/class-wp-agent-message.php';
+require_once __DIR__ . '/../src/Runtime/class-wp-agent-chat-run-control.php';
+
+use AgentsAPI\AI\WP_Agent_Chat_Run_Control;
+use AgentsAPI\AI\WP_Agent_Option_Run_Control_Store;
+use AgentsAPI\AI\WP_Agent_Run_Control;
+use AgentsAPI\Core\Database\Chat\WP_Agent_Conversation_Store;
+use AgentsAPI\Core\Workspace\WP_Agent_Workspace_Scope;
+
+function is_wp_error( mixed $value ): bool {
+	return $value instanceof WP_Error;
+}
+
+function is_multisite(): bool {
+	return (bool) ( $GLOBALS['__agents_api_integration_multisite'] ?? true );
+}
+
+function sanitize_title( string $value ): string {
+	return strtolower( (string) preg_replace( '/[^a-z0-9_-]+/i', '-', $value ) );
+}
+
+function get_main_site_id( int $network_id = 1 ): int {
+	unset( $network_id );
+	return 1;
+}
+
+function wp_cache_delete( string $key, string $group = '' ): bool {
+	$GLOBALS['__agents_api_cache_deletes'][] = $group . ':' . $key;
+	return true;
+}
+
+function wp_cache_set( string $key, mixed $value, string $group = '', int $expire = 0 ): bool {
+	unset( $value, $expire );
+	$GLOBALS['__agents_api_cache_sets'][] = $group . ':' . $key;
+	return true;
+}
+
+function wp_debug_backtrace_summary( string $ignore_class = '', int $skip_frames = 0, bool $pretty = true ): string {
+	unset( $ignore_class, $skip_frames, $pretty );
+	return '';
+}
+
+function integration_db(): wpdb {
+	$db = new wpdb(
+		(string) getenv( 'AGENTS_API_DB_USER' ),
+		(string) getenv( 'AGENTS_API_DB_PASSWORD' ),
+		(string) getenv( 'AGENTS_API_DB_NAME' ),
+		(string) getenv( 'AGENTS_API_DB_HOST' )
+	);
+	$db->set_prefix( 'aatest_' );
+	$db->set_blog_id( 1 );
+	$db->siteid = 1;
+	if ( ! $db->dbh ) {
+		throw new RuntimeException( 'Could not connect to the integration database.' );
+	}
+	return $db;
+}
+
+function integration_schema( wpdb $db ): void {
+	$db->query( 'DROP TABLE IF EXISTS aatest_sitemeta' );
+	$db->query( 'DROP TABLE IF EXISTS aatest_options' );
+	$db->query( "CREATE TABLE aatest_options (option_id bigint unsigned NOT NULL AUTO_INCREMENT, option_name varchar(191) NOT NULL DEFAULT '', option_value longtext NOT NULL, autoload varchar(20) NOT NULL DEFAULT 'yes', PRIMARY KEY (option_id), UNIQUE KEY option_name (option_name)) ENGINE=InnoDB" );
+	$db->query( "CREATE TABLE aatest_sitemeta (meta_id bigint unsigned NOT NULL AUTO_INCREMENT, site_id bigint unsigned NOT NULL DEFAULT 0, meta_key varchar(255) DEFAULT NULL, meta_value longtext DEFAULT NULL, PRIMARY KEY (meta_id), KEY meta_key (meta_key(191)), KEY site_id (site_id)) ENGINE=InnoDB" );
+}
+
+function integration_store(): WP_Agent_Option_Run_Control_Store {
+	$db = integration_db();
+	$store = new WP_Agent_Option_Run_Control_Store( $db );
+	WP_Agent_Run_Control::set_store( $store );
+	return $store;
+}
+
+function integration_conversation_store( WP_Agent_Workspace_Scope $workspace ): WP_Agent_Conversation_Store {
+	return new class( $workspace ) implements WP_Agent_Conversation_Store {
+		public function __construct( private WP_Agent_Workspace_Scope $workspace ) {}
+		public function create_session( WP_Agent_Workspace_Scope $workspace, int $user_id, string $agent_slug = '', array $metadata = array(), string $context = 'chat' ): string {
+			unset( $workspace, $user_id, $agent_slug, $metadata, $context );
+			return '';
+		}
+		public function list_sessions( WP_Agent_Workspace_Scope $workspace, int $user_id, array $args = array() ): array {
+			unset( $workspace, $user_id, $args );
+			return array();
+		}
+		public function get_session( string $session_id ): ?array {
+			$owners = array( 'race-a' => '101', 'race-b' => '202', 'queue-session' => '101' );
+			if ( ! isset( $owners[ $session_id ] ) ) {
+				return null;
+			}
+			return array(
+				'session_id'     => $session_id,
+				'workspace_type' => $this->workspace->workspace_type,
+				'workspace_id'   => $this->workspace->workspace_id,
+				'owner_type'     => 'user',
+				'owner_key'      => $owners[ $session_id ],
+			);
+		}
+		public function update_session( string $session_id, array $messages, array $metadata = array(), string $provider = '', string $model = '', ?string $provider_response_id = null ): bool {
+			unset( $session_id, $messages, $metadata, $provider, $model, $provider_response_id );
+			return true;
+		}
+		public function delete_session( string $session_id ): bool {
+			unset( $session_id );
+			return true;
+		}
+		public function get_recent_pending_session( WP_Agent_Workspace_Scope $workspace, int $user_id, int $seconds = 600, string $context = 'chat', ?int $token_id = null ): ?array {
+			unset( $workspace, $user_id, $seconds, $context, $token_id );
+			return null;
+		}
+		public function update_title( string $session_id, string $title ): bool {
+			unset( $session_id, $title );
+			return true;
+		}
+	};
+}
+
+/** @return array<int,array<string,mixed>> */
+function integration_pair( callable $worker ): array {
+	$dir = sys_get_temp_dir() . '/agents-api-race-' . bin2hex( random_bytes( 6 ) );
+	mkdir( $dir, 0700 );
+	$pids = array();
+	for ( $index = 0; $index < 2; ++$index ) {
+		$pid = pcntl_fork();
+		if ( 0 === $pid ) {
+			file_put_contents( $dir . '/ready-' . $index, '1' );
+			while ( ! is_file( $dir . '/go' ) ) {
+				usleep( 1000 );
+			}
+			try {
+				$result = $worker( $index );
+			} catch ( Throwable $error ) {
+				$result = array( 'exception' => $error->getMessage() );
+			}
+			file_put_contents( $dir . '/result-' . $index, json_encode( $result ) );
+			exit( 0 );
+		}
+		$pids[] = $pid;
+	}
+	$deadline = microtime( true ) + 10;
+	while ( ( ! is_file( $dir . '/ready-0' ) || ! is_file( $dir . '/ready-1' ) ) && microtime( true ) < $deadline ) {
+		usleep( 1000 );
+	}
+	touch( $dir . '/go' );
+	foreach ( $pids as $pid ) {
+		pcntl_waitpid( $pid, $status );
+	}
+	$results = array();
+	for ( $index = 0; $index < 2; ++$index ) {
+		$decoded = json_decode( (string) file_get_contents( $dir . '/result-' . $index ), true );
+		$results[] = is_array( $decoded ) ? $decoded : array();
+	}
+	foreach ( glob( $dir . '/*' ) ?: array() as $file ) {
+		unlink( $file );
+	}
+	rmdir( $dir );
+	return $results;
+}
+
+function integration_assert( bool $condition, string $message ): void {
+	if ( ! $condition ) {
+		throw new RuntimeException( $message );
+	}
+	echo "  PASS {$message}\n";
+}
+
+function integration_snapshot( WP_Agent_Option_Run_Control_Store $store, WP_Agent_Workspace_Scope $workspace ): array {
+	$result = $store->mutate_workspace_state(
+		'agents_api_chat_run_control',
+		$workspace,
+		static fn( array $state ): array => array( 'state' => $state, 'result' => $state )
+	);
+	return is_array( $result ) ? $result : array();
+}
+
+echo "run-control-option-store-integration\n";
+$GLOBALS['__agents_api_integration_multisite'] = true;
+$GLOBALS['__agents_api_cache_deletes'] = array();
+$GLOBALS['__agents_api_cache_sets'] = array();
+$setup = integration_db();
+integration_schema( $setup );
+$setup->close();
+
+$workspace = WP_Agent_Workspace_Scope::from_parts( 'network', 'integration-' . bin2hex( random_bytes( 6 ) ) );
+
+integration_pair(
+	static function ( int $index ): array {
+		unset( $index );
+		$store = integration_store();
+		$count = $store->mutate_state(
+			'integration_site_counter',
+			static function ( array $state ): array {
+				$current = (int) ( $state['runs']['counter']['value'] ?? 0 );
+				usleep( 100000 );
+				$state['runs']['counter'] = array( 'value' => $current + 1 );
+				return array( 'state' => $state, 'result' => $current + 1 );
+			}
+		);
+		return array( 'count' => $count );
+	}
+);
+$site_store = integration_store();
+$site_state = $site_store->mutate_state( 'integration_site_counter', static fn( array $state ): array => array( 'state' => $state, 'result' => $state ) );
+integration_assert( 2 === ( $site_state['runs']['counter']['value'] ?? 0 ), 'site option mutex serializes two independent connection mutations' );
+
+$lease_race = integration_pair(
+	static function ( int $index ): array {
+		$store = integration_store();
+		if ( 1 === $index ) {
+			usleep( 15200000 );
+		}
+		try {
+			$value = $store->mutate_state(
+				'integration_lease_race',
+				static function ( array $state ) use ( $index ): array {
+					if ( 0 === $index ) {
+						usleep( 16500000 );
+					}
+					$state['runs']['winner'] = array( 'value' => $index );
+					return array( 'state' => $state, 'result' => $index );
+				}
+			);
+			return array( 'value' => $value, 'error' => '' );
+		} catch ( RuntimeException $error ) {
+			return array( 'value' => null, 'error' => $error->getMessage() );
+		}
+	}
+);
+$lease_state = $site_store->mutate_state( 'integration_lease_race', static fn( array $state ): array => array( 'state' => $state, 'result' => $state ) );
+integration_assert( 1 === ( $lease_state['runs']['winner']['value'] ?? null ), 'expired lease holder cannot overwrite a conditional takeover winner' );
+integration_assert( str_contains( (string) ( $lease_race[0]['error'] ?? '' ), 'ownership was lost' ), 'expired lease holder fails closed before stale state write' );
+
+$race = integration_pair(
+	static function ( int $index ) use ( $workspace ): array {
+		integration_store();
+		$conversation_store = integration_conversation_store( $workspace );
+		$owner   = 0 === $index ? array( 'type' => 'user', 'key' => '101' ) : array( 'type' => 'user', 'key' => '202' );
+		$session = 0 === $index ? 'race-a' : 'race-b';
+		$result  = WP_Agent_Chat_Run_Control::start_run( 'shared-run', $session, array(), $workspace, $owner, $conversation_store );
+		return array(
+			'error'      => $result instanceof WP_Error ? $result->get_error_code() : '',
+			'executions' => $result instanceof WP_Error ? 0 : 1,
+		);
+	}
+);
+if ( 1 !== array_sum( array_column( $race, 'executions' ) ) ) {
+	echo '  race diagnostics: ' . json_encode( $race ) . "\n";
+}
+integration_assert( 1 === array_sum( array_column( $race, 'executions' ) ), 'same run_id race admits exactly one runner execution' );
+integration_assert( 1 === count( array_filter( array_column( $race, 'error' ), static fn( string $error ): bool => 'agents_chat_run_owner_forbidden' === $error ) ), 'same run_id race rejects the losing owner' );
+
+$same_owner_workspace = WP_Agent_Workspace_Scope::from_parts( 'network', 'same-owner-' . bin2hex( random_bytes( 6 ) ) );
+$same_owner_race = integration_pair(
+	static function ( int $index ) use ( $same_owner_workspace ): array {
+		unset( $index );
+		integration_store();
+		$result = WP_Agent_Chat_Run_Control::start_run( 'same-owner-run', 'race-a', array(), $same_owner_workspace, array( 'type' => 'user', 'key' => '101' ), integration_conversation_store( $same_owner_workspace ) );
+		return array(
+			'error'      => $result instanceof WP_Error ? $result->get_error_code() : '',
+			'executions' => $result instanceof WP_Error ? 0 : 1,
+		);
+	}
+);
+integration_assert( 1 === array_sum( array_column( $same_owner_race, 'executions' ) ), 'same-owner duplicate run_id race executes only one runner' );
+integration_assert( 1 === count( array_filter( array_column( $same_owner_race, 'error' ), static fn( string $error ): bool => 'agents_chat_run_already_started' === $error ) ), 'same-owner duplicate run_id race rejects the losing request' );
+
+$pending_workspace = WP_Agent_Workspace_Scope::from_parts( 'network', 'pending-' . bin2hex( random_bytes( 6 ) ) );
+$pending_race = integration_pair(
+	static function ( int $index ) use ( $pending_workspace ): array {
+		integration_store();
+		$token = 'pending-claim-' . $index;
+		$result = WP_Agent_Chat_Run_Control::claim_pending_run( 'pending-run', $token, $pending_workspace, array( 'type' => 'user', 'key' => '101' ) );
+		return array(
+			'token'      => $token,
+			'error'      => $result instanceof WP_Error ? $result->get_error_code() : '',
+			'executions' => $result instanceof WP_Error ? 0 : 1,
+		);
+	}
+);
+integration_assert( 1 === array_sum( array_column( $pending_race, 'executions' ) ), 'pre-session run reservation admits exactly one arbitrary handler execution' );
+$pending_winner = current( array_filter( $pending_race, static fn( array $item ): bool => 1 === $item['executions'] ) );
+$pending_token = is_array( $pending_winner ) ? (string) ( $pending_winner['token'] ?? '' ) : '';
+integration_store();
+$pending_bound = WP_Agent_Chat_Run_Control::start_run( 'pending-run', 'race-a', array( '_claim_token' => $pending_token ), $pending_workspace, array( 'type' => 'user', 'key' => '101' ), integration_conversation_store( $pending_workspace ) );
+integration_assert( is_array( $pending_bound ) && 'race-a' === ( $pending_bound['session_id'] ?? '' ), 'winning pre-session reservation binds its canonical session' );
+
+$store = integration_store();
+$conversation_store = integration_conversation_store( $workspace );
+$owner = array( 'type' => 'user', 'key' => '101' );
+WP_Agent_Chat_Run_Control::start_run( 'queue-run', 'queue-session', array(), $workspace, $owner, $conversation_store );
+foreach ( array( 'first', 'second' ) as $message ) {
+	WP_Agent_Chat_Run_Control::queue_message( array( 'session_id' => 'queue-session', 'run_id' => 'queue-run', 'message' => $message ), $workspace, $owner, $conversation_store );
+}
+
+$claims = integration_pair(
+	static function ( int $index ) use ( $workspace, $owner ): array {
+		unset( $index );
+		integration_store();
+		$claimed = WP_Agent_Chat_Run_Control::claim_queued_messages( 'queue-session', $workspace, $owner, integration_conversation_store( $workspace ) );
+		return array( 'messages' => array_column( $claimed, 'message' ) );
+	}
+);
+$claimed_messages = array_merge( $claims[0]['messages'] ?? array(), $claims[1]['messages'] ?? array() );
+sort( $claimed_messages );
+integration_assert( array( 'first', 'second' ) === $claimed_messages, 'double claim returns each queued message exactly once' );
+integration_assert( ! isset( integration_snapshot( integration_store(), $workspace )['queues']['queue-session'] ), 'double claim leaves no resurrected queue' );
+
+WP_Agent_Chat_Run_Control::queue_message( array( 'session_id' => 'queue-session', 'run_id' => 'queue-run', 'message' => 'before' ), $workspace, $owner, $conversation_store );
+$enqueue_claim = integration_pair(
+	static function ( int $index ) use ( $workspace, $owner ): array {
+		integration_store();
+		$conversation_store = integration_conversation_store( $workspace );
+		if ( 0 === $index ) {
+			$result = WP_Agent_Chat_Run_Control::queue_message( array( 'session_id' => 'queue-session', 'run_id' => 'queue-run', 'message' => 'during' ), $workspace, $owner, $conversation_store );
+			return array( 'queued' => ! $result instanceof WP_Error );
+		}
+		$claimed = WP_Agent_Chat_Run_Control::claim_queued_messages( 'queue-session', $workspace, $owner, $conversation_store );
+		return array( 'messages' => array_column( $claimed, 'message' ) );
+	}
+);
+$remaining = WP_Agent_Chat_Run_Control::claim_queued_messages( 'queue-session', $workspace, $owner, $conversation_store );
+$all_messages = array_merge( $enqueue_claim[1]['messages'] ?? array(), array_column( $remaining, 'message' ) );
+sort( $all_messages );
+integration_assert( ! empty( $enqueue_claim[0]['queued'] ), 'enqueue concurrent with claim succeeds' );
+integration_assert( array( 'before', 'during' ) === $all_messages, 'enqueue concurrent with claim loses or resurrects no messages' );
+
+$db = integration_db();
+$option_key = 'agents_api_chat_run_control_workspace_' . hash( 'sha256', $workspace->key() );
+$lock_key = '_agents_api_run_lock_' . hash( 'sha256', 'workspace:' . $db->sitemeta . ':1:' . $option_key );
+$expired = json_encode( array( 'token' => 'expired', 'expires_at' => microtime( true ) - 60 ) );
+$db->query( $db->prepare( "INSERT INTO %i (option_name, option_value, autoload) VALUES (%s, %s, 'no')", $db->options, $lock_key, $expired ) );
+$stale_store = new WP_Agent_Option_Run_Control_Store( $db );
+$stale_result = $stale_store->mutate_workspace_state( 'agents_api_chat_run_control', $workspace, static fn( array $state ): array => array( 'state' => $state, 'result' => 'recovered' ) );
+integration_assert( 'recovered' === $stale_result, 'expired mutex is taken over conditionally' );
+integration_assert( null === $db->get_var( $db->prepare( 'SELECT option_value FROM %i WHERE option_name = %s', $db->options, $lock_key ) ), 'token-checked release removes the recovered mutex' );
+
+$active = json_encode( array( 'token' => 'active', 'expires_at' => microtime( true ) + 60 ) );
+$db->query( $db->prepare( "INSERT INTO %i (option_name, option_value, autoload) VALUES (%s, %s, 'no')", $db->options, $lock_key, $active ) );
+$mutation_ran = false;
+try {
+	$stale_store->mutate_workspace_state(
+		'agents_api_chat_run_control',
+		$workspace,
+		static function ( array $state ) use ( &$mutation_ran ): array {
+			$mutation_ran = true;
+			return array( 'state' => $state, 'result' => null );
+		}
+	);
+	$timed_out = false;
+} catch ( RuntimeException $error ) {
+	$timed_out = str_contains( $error->getMessage(), 'timed out' );
+}
+integration_assert( $timed_out && ! $mutation_ran, 'active mutex contention fails closed before mutation' );
+$db->query( $db->prepare( 'DELETE FROM %i WHERE option_name = %s', $db->options, $lock_key ) );
+
+try {
+	$stale_store->mutate_workspace_state(
+		'agents_api_chat_run_control',
+		$workspace,
+		static function ( array $state ): array {
+			unset( $state );
+			throw new RuntimeException( 'mutation failed' );
+		}
+	);
+} catch ( RuntimeException $error ) {
+	$callback_failed = 'mutation failed' === $error->getMessage();
+}
+integration_assert( ! empty( $callback_failed ) && null === $db->get_var( $db->prepare( 'SELECT option_value FROM %i WHERE option_name = %s', $db->options, $lock_key ) ), 'exceptional mutation releases only its own mutex token' );
+
+$corrupt_key = 'integration_corrupt_state';
+$db->query( $db->prepare( "INSERT INTO %i (option_name, option_value, autoload) VALUES (%s, %s, 'no')", $db->options, $corrupt_key, 'not-serialized-state' ) );
+try {
+	$stale_store->mutate_state( $corrupt_key, static fn( array $state ): array => array( 'state' => $state, 'result' => null ) );
+	$corrupt_failed = false;
+} catch ( RuntimeException $error ) {
+	$corrupt_failed = str_contains( $error->getMessage(), 'corrupt' );
+}
+integration_assert( $corrupt_failed && 'not-serialized-state' === $db->get_var( $db->prepare( 'SELECT option_value FROM %i WHERE option_name = %s', $db->options, $corrupt_key ) ), 'corrupt stored state fails closed without overwrite' );
+$malformed_key = 'integration_malformed_state';
+$malformed_value = serialize( array( 'runs' => 'invalid', 'queues' => array(), 'events' => array() ) );
+$db->query( $db->prepare( "INSERT INTO %i (option_name, option_value, autoload) VALUES (%s, %s, 'no')", $db->options, $malformed_key, $malformed_value ) );
+try {
+	$stale_store->mutate_state( $malformed_key, static fn( array $state ): array => array( 'state' => $state, 'result' => null ) );
+	$malformed_failed = false;
+} catch ( RuntimeException $error ) {
+	$malformed_failed = str_contains( $error->getMessage(), 'corrupt' );
+}
+integration_assert( $malformed_failed && $malformed_value === $db->get_var( $db->prepare( 'SELECT option_value FROM %i WHERE option_name = %s', $db->options, $malformed_key ) ), 'malformed state members fail closed without partial normalization' );
+
+$GLOBALS['__agents_api_integration_multisite'] = false;
+$single_workspace = WP_Agent_Workspace_Scope::from_parts( 'site', 'single-site-workspace' );
+$single_key = 'single_site_state_workspace_' . hash( 'sha256', $single_workspace->key() );
+$single_result = $stale_store->mutate_workspace_state(
+	'single_site_state',
+	$single_workspace,
+	static function ( array $state ): array {
+		$state['runs']['single'] = array( 'value' => 'stored' );
+		return array( 'state' => $state, 'result' => 'stored' );
+	}
+);
+$single_value = $db->get_var( $db->prepare( 'SELECT option_value FROM %i WHERE option_name = %s', $db->options, $single_key ) );
+$single_network_value = $db->get_var( $db->prepare( 'SELECT meta_value FROM %i WHERE site_id = 1 AND meta_key = %s', $db->sitemeta, $single_key ) );
+integration_assert( 'stored' === $single_result && is_string( $single_value ) && null === $single_network_value, 'single-site workspace mutation uses the existing site options table' );
+integration_assert( in_array( 'options:alloptions', $GLOBALS['__agents_api_cache_deletes'], true ) && in_array( 'options:notoptions', $GLOBALS['__agents_api_cache_deletes'], true ) && in_array( 'options:' . $single_key, $GLOBALS['__agents_api_cache_sets'], true ), 'direct option writes invalidate aggregate caches and publish fresh state' );
+$GLOBALS['__agents_api_integration_multisite'] = true;
+
+$db->query( 'DROP TABLE IF EXISTS aatest_sitemeta' );
+$db->query( 'DROP TABLE IF EXISTS aatest_options' );
+$db->close();
+echo "All option-store integration assertions passed.\n";

--- a/tests/run-control-option-store-integration.php
+++ b/tests/run-control-option-store-integration.php
@@ -56,6 +56,10 @@ function is_multisite(): bool {
 	return (bool) ( $GLOBALS['__agents_api_integration_multisite'] ?? true );
 }
 
+function absint( mixed $value ): int {
+	return abs( (int) $value );
+}
+
 function sanitize_title( string $value ): string {
 	return strtolower( (string) preg_replace( '/[^a-z0-9_-]+/i', '-', $value ) );
 }


### PR DESCRIPTION
## Summary
- add a generic optional atomic mutation seam for run-control stores and use it for chat ownership, lifecycle, enqueue, and claim mutations
- implement the default mutex with bounded non-autoloaded rows in existing WordPress options storage, including token expiry, conditional takeover, transactional fencing, and token-checked release
- reserve run IDs before handlers execute, including pre-session dispatch, so foreign-owner and same-owner duplicate requests cannot both run
- preserve canonical conversation-session ownership, workspace scoping, single-site compatibility, and generic layer purity
- add no custom production tables or migrations

## Concurrency Coverage
- independent MariaDB connections serialize site and workspace state mutations
- expired holders cannot overwrite takeover winners
- different-owner, same-owner, and pre-session duplicate run races admit one execution
- double claims return each queued message exactly once
- enqueue concurrent with claim loses or resurrects no messages
- active contention, stale takeover, exception release, corrupt state, cache coherence, and single-site fallback

## Tests
- `composer test`
- `composer phpstan`
- `composer validate --strict`
- `php tests/agents-chat-ability-smoke.php`
- `php tests/default-agents-chat-handler-smoke.php`
- `php tests/provider-turn-adapter-smoke.php`
- `php tests/chat-run-control-smoke.php`
- `php tests/chat-run-control-multisite-smoke.php`
- `php tests/bootstrap-version-skew-smoke.php`
- real WordPress `wpdb` / MariaDB integration: `php tests/run-control-option-store-integration.php` with isolated option and sitemeta fixtures
- PHP syntax checks and `git diff --check`

Follow-up to #452 and #451.