### PR TITLE
Remove legacy workflow drain compatibility

### DIFF
--- a/src/Workflows/class-wp-agent-workflow-action-scheduler-branch-executor.php
+++ b/src/Workflows/class-wp-agent-workflow-action-scheduler-branch-executor.php
@@ -22,9 +22,8 @@
  * ({@see WP_Agent_Workflow_Action_Scheduler_Bridge}), which schedules ONE
  * recurring action per workflow trigger under `wp_agent_workflow_run_scheduled`.
 	 * This executor enqueues ONE async action PER BRANCH under a distinct hook,
-	 * plus one RESUME action per suspended run. New runs use one durable group per
-	 * run so foreground awaiters cannot claim another run's work; legacy in-flight
-	 * runs without a mapping retain GROUP `agents-api` across upgrades.
+	 * plus one RESUME action per suspended run. Every run uses one deterministic
+	 * group so foreground awaiters cannot claim another run's work.
  *
  * The runner owns the suspend/resume state machine and the reconcile entry
  * point ({@see agents_reconcile_workflow_branch()}); this executor owns only the
@@ -39,9 +38,6 @@ namespace AgentsAPI\AI\Workflows;
 defined( 'ABSPATH' ) || exit;
 
 final class WP_Agent_Workflow_Action_Scheduler_Branch_Executor implements WP_Agent_Workflow_Branch_Executor {
-
-	/** Option prefix mapping newly dispatched runs to their isolated AS group. */
-	private const RUN_GROUP_PREFIX = 'agents_wf_as_group_';
 
 	/**
 	 * Stable executor id stamped on every frame + handle so reconcile and the
@@ -107,20 +103,12 @@ final class WP_Agent_Workflow_Action_Scheduler_Branch_Executor implements WP_Age
 	}
 
 	/**
-	 * Resolve the durable queue group for a run.
-	 *
-	 * Runs dispatched before run-group isolation have no mapping and deliberately
-	 * retain the legacy shared group so an upgrade cannot strand in-flight actions.
+	 * Resolve the deterministic queue group for a run.
 	 *
 	 * @since 0.5.2
 	 */
 	public static function group_for_run( string $run_id ): string {
-		if ( '' === $run_id || ! function_exists( 'get_option' ) ) {
-			return self::GROUP;
-		}
-
-		$group = get_option( self::RUN_GROUP_PREFIX . md5( $run_id ), '' );
-		return is_string( $group ) && '' !== $group ? $group : self::GROUP;
+		return '' !== $run_id ? 'agents-api-run-' . md5( $run_id ) : '';
 	}
 
 	/**
@@ -219,7 +207,7 @@ final class WP_Agent_Workflow_Action_Scheduler_Branch_Executor implements WP_Age
 				'context_ref' => $context_ref,
 			);
 
-			$group     = self::ensure_run_group( $run_id );
+			$group     = self::group_for_run( $run_id );
 			$action_id = self::enqueue_async_action( self::BRANCH_HOOK, array( $payload ), $group );
 
 			// FAIL LOUD: a non-positive action id means the enqueue did not durably
@@ -231,7 +219,6 @@ final class WP_Agent_Workflow_Action_Scheduler_Branch_Executor implements WP_Age
 			if ( $action_id <= 0 ) {
 				if ( '' !== $run_id ) {
 					WP_Agent_Workflow_Branch_Store::forget_run( $run_id );
-					self::forget_run_group( $run_id );
 				}
 				return new \WP_Error(
 					'workflow_branch_dispatch_enqueue_failed',
@@ -765,18 +752,14 @@ final class WP_Agent_Workflow_Action_Scheduler_Branch_Executor implements WP_Age
 		// Rehydrate the full self-contained descriptor from the branch store using
 		// the lightweight ref the AS args carried. The store re-seats the run-scoped
 		// shared context into branch_vars.context, so the branch runs against the
-		// same descriptor shape the runner built at dispatch. A backward-compatible
-		// inline descriptor (a payload enqueued before the offload) is still honored.
+		// same descriptor shape the runner built at dispatch.
 		$descriptor = '' !== $store_ref
 			? WP_Agent_Workflow_Branch_Store::get_branch( $store_ref, $context_ref )
 			: null;
-		if ( null === $descriptor && is_array( $payload['branch'] ?? null ) ) {
-			$descriptor = self::string_keyed_array( $payload['branch'] );
-		}
 
 		if ( ! is_array( $descriptor ) ) {
-			// The stored descriptor is gone (expired / evicted) and no inline
-			// fallback exists. Reconcile a clean failure so the run does not hang
+			// The stored descriptor is gone (expired / evicted). Reconcile a clean
+			// failure so the run does not hang
 			// SUSPENDED against a branch that can no longer run.
 			$branch_result = array(
 				'key'    => '',
@@ -977,19 +960,15 @@ final class WP_Agent_Workflow_Action_Scheduler_Branch_Executor implements WP_Age
 			// claim + this SUSPENDED re-check.
 			if ( null !== $result ) {
 				WP_Agent_Workflow_Branch_Store::forget_run( $run_id );
-				self::forget_run_group( $run_id );
 			}
 			return;
 		}
 
 		$expected_suspension = self::string_value( $payload['suspension_id'] ?? '' );
-		if ( '' === $expected_suspension && self::GROUP !== self::group_for_run( $run_id ) ) {
-			// Tokenless actions predate suspension generations. They remain valid only
-			// for genuinely legacy runs that also lack a run-group mapping; once such a
-			// run advances into a new fan-out, its new mapping blocks delayed old actions.
+		if ( '' === $expected_suspension ) {
 			return;
 		}
-		if ( '' !== $expected_suspension && ! hash_equals( $expected_suspension, self::suspension_id( $result->get_suspension() ) ) ) {
+		if ( ! hash_equals( $expected_suspension, self::suspension_id( $result->get_suspension() ) ) ) {
 			// A delayed duplicate from an earlier fan-out must not resume through the
 			// current, newer suspension generation.
 			return;
@@ -998,13 +977,11 @@ final class WP_Agent_Workflow_Action_Scheduler_Branch_Executor implements WP_Age
 		$runner = agents_workflow_resolve_runner( $recorder );
 		$runner->resume( $run_id );
 
-		// resume() can reach another parallel step and suspend again. Keep the shared
-		// group mapping and branch-store index until the run is truly terminal so the
-		// next foreground await claims the new fan-out in the same isolated scope.
+		// resume() can reach another parallel step and suspend again. Keep the branch
+		// store index until the run is truly terminal.
 		$current = $recorder->find( $run_id );
 		if ( null !== $current && ! $current->is_suspended() ) {
 			WP_Agent_Workflow_Branch_Store::forget_run( $run_id );
-			self::forget_run_group( $run_id );
 		}
 	}
 
@@ -1045,26 +1022,6 @@ final class WP_Agent_Workflow_Action_Scheduler_Branch_Executor implements WP_Age
 			// letting the throw be swallowed by AS's queue runner into a hang.
 			unset( $error );
 			return 0;
-		}
-	}
-
-	/** Persist and return the isolated group for a newly dispatched run. */
-	private static function ensure_run_group( string $run_id ): string {
-		$existing = self::group_for_run( $run_id );
-		if ( self::GROUP !== $existing || '' === $run_id || ! function_exists( 'update_option' ) || ! function_exists( 'get_option' ) ) {
-			return $existing;
-		}
-
-		$group = 'agents-api-run-' . md5( $run_id );
-		update_option( self::RUN_GROUP_PREFIX . md5( $run_id ), $group, false );
-
-		return self::group_for_run( $run_id );
-	}
-
-	/** Remove a terminal run's queue-group mapping. */
-	private static function forget_run_group( string $run_id ): void {
-		if ( '' !== $run_id && function_exists( 'delete_option' ) ) {
-			delete_option( self::RUN_GROUP_PREFIX . md5( $run_id ) );
 		}
 	}
 

--- a/tests/workflow-as-branch-smoke.php
+++ b/tests/workflow-as-branch-smoke.php
@@ -416,6 +416,8 @@ $tables_before = $recorder->tables();
 $run = ( new WP_Agent_Workflow_Runner( $recorder ) )->run( as_smoke_roles_spec(), array(), array( 'run_id' => 'as-A' ) );
 
 smoke_assert( WP_Agent_Workflow_Run_Result::STATUS_SUSPENDED, $run->get_status(), 'AS path: run SUSPENDED after dispatch', $failures, $passes );
+WP_Agent_Workflow_Action_Scheduler_Branch_Executor::run_resume_action( array( 'run_id' => 'as-A' ) );
+smoke_assert( WP_Agent_Workflow_Run_Result::STATUS_SUSPENDED, $recorder->find( 'as-A' )->get_status(), 'resume: tokenless action cannot advance a suspended run', $failures, $passes );
 AS_Shim::$reject_hook = WP_Agent_Workflow_Action_Scheduler_Branch_Executor::RESUME_HOOK;
 smoke_assert( false, WP_Agent_Workflow_Action_Scheduler_Branch_Executor::maybe_defer_resume( false, 'as-A', WP_Agent_Workflow_Action_Scheduler_Branch_Executor::ID, $run ), 'resume enqueue failure falls back to inline reconcile instead of stranding the run', $failures, $passes );
 AS_Shim::$reject_hook = '';
@@ -495,7 +497,7 @@ $out_steps = $final->get_output()['steps'] ?? array();
 smoke_assert( 'FUSED[HEAD|BODY]', $out_steps['scatter']['final']['final_bundle'] ?? '', 'AS path: aggregate fused REAL branch outputs (run_branch_steps ran demo/role-worker)', $failures, $passes );
 smoke_assert( 'GOT:FUSED[HEAD|BODY]', $out_steps['after']['consumed'] ?? '', 'AS path: sequential step consumed the aggregate on resume', $failures, $passes );
 smoke_assert( array(), $final->get_suspension(), 'table-free: frame DELETED on resume', $failures, $passes );
-smoke_assert( WP_Agent_Workflow_Action_Scheduler_Branch_Executor::GROUP, WP_Agent_Workflow_Action_Scheduler_Branch_Executor::group_for_run( 'as-A' ), 'terminal resume deletes the run-group mapping', $failures, $passes );
+smoke_assert( $run_group, WP_Agent_Workflow_Action_Scheduler_Branch_Executor::group_for_run( 'as-A' ), 'terminal run keeps its deterministic group identity without persisted compatibility state', $failures, $passes );
 smoke_assert( $tables_before, $recorder->tables(), 'table-free: NO new table after full run', $failures, $passes );
 
 // ═════════════════════════════════════════════════════════════════════════════
@@ -700,7 +702,7 @@ $mid5      = $recorder5->find( 'as-two' );
 $branches5 = AS_Shim::actions_for( WP_Agent_Workflow_Action_Scheduler_Branch_Executor::BRANCH_HOOK );
 smoke_assert( WP_Agent_Workflow_Run_Result::STATUS_SUSPENDED, $mid5->get_status(), 'multi-fanout: intermediate resume suspends on the second fan-out', $failures, $passes );
 smoke_assert( 1, (int) ( $mid5->get_suspension()['step_index'] ?? 0 ), 'multi-fanout: delayed duplicate resume cannot skip the newer suspension generation', $failures, $passes );
-smoke_assert( $group5, WP_Agent_Workflow_Action_Scheduler_Branch_Executor::group_for_run( 'as-two' ), 'multi-fanout: intermediate resume preserves the run-group mapping', $failures, $passes );
+smoke_assert( $group5, WP_Agent_Workflow_Action_Scheduler_Branch_Executor::group_for_run( 'as-two' ), 'multi-fanout: intermediate resume preserves deterministic group identity', $failures, $passes );
 smoke_assert( $group5, $branches5[1]['group'] ?? '', 'multi-fanout: second fan-out stays in the original isolated group', $failures, $passes );
 
 AS_Shim::fire( $branches5[1]['id'] );
@@ -708,7 +710,7 @@ $resumes5 = AS_Shim::actions_for( WP_Agent_Workflow_Action_Scheduler_Branch_Exec
 AS_Shim::fire( $resumes5[2]['id'] );
 $final5 = $recorder5->find( 'as-two' );
 smoke_assert( WP_Agent_Workflow_Run_Result::STATUS_SUCCEEDED, $final5->get_status(), 'multi-fanout: second resume reaches terminal success', $failures, $passes );
-smoke_assert( WP_Agent_Workflow_Action_Scheduler_Branch_Executor::GROUP, WP_Agent_Workflow_Action_Scheduler_Branch_Executor::group_for_run( 'as-two' ), 'multi-fanout: terminal resume finally removes the group mapping', $failures, $passes );
+smoke_assert( $group5, WP_Agent_Workflow_Action_Scheduler_Branch_Executor::group_for_run( 'as-two' ), 'multi-fanout: terminal run retains the same deterministic group identity', $failures, $passes );
 
 echo "Passed: {$passes}, Failed: " . count( $failures ) . "\n";
 exit( count( $failures ) > 0 ? 1 : 0 );

--- a/tests/workflow-run-awaiter-smoke.php
+++ b/tests/workflow-run-awaiter-smoke.php
@@ -135,7 +135,7 @@ await_assert( false, $limited['terminal'], 'limit-exhausted suspended run is non
 await_assert( true, $limited['reconnectable'], 'limit-exhausted suspended run is reconnectable' );
 await_assert( 'limit', $limited['drain']['stop_reason'], 'limit stop is preserved' );
 await_assert( null, $limited['result'], 'nonterminal state has no terminal result' );
-await_assert( 'agents-api', $awaiter->last_options['group'] ?? '', 'legacy run without a persisted mapping drains through the backward-compatible shared group' );
+await_assert( 'agents-api-run-' . md5( 'limited' ), $awaiter->last_options['group'] ?? '', 'run await derives its isolated group directly from run identity' );
 await_assert( false, $awaiter->last_options['allow_group_fallback'] ?? null, 'run await never widens a failed group claim to other runs sharing the hooks' );
 
 $awaiter->await( 'limited', $recorder, array( 'limit' => 1, 'group' => 'caller-supplied' ) );


### PR DESCRIPTION
## Summary
- derive isolated Action Scheduler groups directly from `run_id` without persisted mapping options
- reject tokenless resume actions
- remove pre-offload inline branch descriptor fallback
- eliminate shared-group fallback for run-scoped await

This intentionally removes compatibility with in-flight actions created before run isolation, suspension tokens, and branch-store payload offload. Modern runs have one deterministic claim group and mandatory current payload fields.

## Verification
- `composer test`
- `composer phpstan`
- workflow Action Scheduler, awaiter, and reconcile race suites

Continues #455.