### PR TITLE
fix: make bootstrap glob discovery portable

### DIFF
--- a/agents-api.php
+++ b/agents-api.php
@@ -79,7 +79,8 @@ if ( defined( 'AGENTS_API_LOADED' ) ) {
 	};
 
 	$agents_api_symbol_files = array_merge(
-		glob( __DIR__ . '/src/*/{class,interface}-*.php', GLOB_BRACE ) ?: array(),
+		glob( __DIR__ . '/src/*/class-*.php' ) ?: array(),
+		glob( __DIR__ . '/src/*/interface-*.php' ) ?: array(),
 		array( __DIR__ . '/src/Channels/register-default-agents-chat-handler.php' )
 	);
 	foreach ( $agents_api_symbol_files as $agents_api_symbol_file ) {

--- a/tests/bootstrap-version-skew-smoke.php
+++ b/tests/bootstrap-version-skew-smoke.php
@@ -32,6 +32,11 @@ function agents_api_copy_directory( string $source, string $destination ): void 
 
 agents_api_copy_directory( $root . '/src', $old_copy . '/src' );
 $old_bootstrap = (string) file_get_contents( $root . '/agents-api.php' );
+if ( str_contains( $old_bootstrap, 'GLOB_BRACE' ) ) {
+	fwrite( STDERR, "FAIL: bootstrap discovery depends on the optional GLOB_BRACE flag.\n" );
+	exit( 1 );
+}
+
 $old_bootstrap = str_replace(
 	"require_once AGENTS_API_PATH . 'src/Channels/class-wp-agent-channel.php';\n",
 	'',
@@ -59,4 +64,4 @@ if ( $hook_count !== count( $GLOBALS['__agents_api_smoke_actions'] ) ) {
 	exit( 1 );
 }
 
-echo "PASS: newer copy tops up missing classes without repeating hooks.\n";
+echo "PASS: portable discovery tops up missing classes without repeating hooks.\n";


### PR DESCRIPTION
## Summary

- replace brace-expansion bootstrap discovery with separate portable class and interface glob patterns
- keep version-skew symbol top-up behavior unchanged without depending on optional PHP glob flags
- guard the existing version-skew regression against reintroducing `GLOB_BRACE`

## Root cause

The already-loaded/version-skew bootstrap path passed `GLOB_BRACE` unconditionally. That flag is optional and is not defined by PHP-WASM, so evaluating the argument fatally failed before plugin activation could complete.

Plain `glob()` wildcard matching is the core PHP primitive needed here. Running one pattern for `class-*.php` and one for `interface-*.php` discovers the same files without libc brace-expansion support, downstream shims, or runtime coupling.

## Validation

- `php tests/bootstrap-version-skew-smoke.php`
- `composer smoke`
- `composer phpstan`
- `composer validate --strict`
- PHP syntax checks for both changed files
- compared portable discovery against brace discovery on normal PHP: identical 202-file set
- WP Codebox 0.12.29 / Playground PHP-WASM / WordPress nightly activation probe: succeeded (`run_ca3fad443dcd4f9b8b0eab3a3f32d0e9`)
- preserved activation artifact bundle: `sha256:0bcb94af5bbd829575820c3e890305fc3a3a4fe2a5fcc463a93f4426918040d5`

Fixes #459