### PR TITLE
Security: make importer-derived agent provenance authoritative

### DIFF
--- a/src/Registry/register-agent-runtime-bundle-importer.php
+++ b/src/Registry/register-agent-runtime-bundle-importer.php
@@ -228,18 +228,13 @@ add_filter(
 
 		$config         = is_array( $agent['agent_config'] ?? null ) ? $agent['agent_config'] : array();
 		$meta           = is_array( $agent['meta'] ?? null ) ? $agent['meta'] : array();
-		$source_type    = $string_value( $bundle['source_type'] ?? null, $spec['source_type'] ?? null, 'runtime-agent-package' );
-		$source_package = $string_value( $bundle['source_package'] ?? null, $spec['source_package'] ?? null, $bundle['package_slug'] ?? null, $spec['package_slug'] ?? null, $bundle['bundle_slug'] ?? null );
-		$source_version = $string_value( $bundle['source_version'] ?? null, $spec['source_version'] ?? null, $bundle['package_version'] ?? null, $spec['package_version'] ?? null, $bundle['bundle_version'] ?? null );
-		// Provenance is derived by the importer from host-trusted spec/input, so it must
-		// win over any source_* keys smuggled inside the bundle's own agent.meta. Merge
-		// the bundle meta as the base, then let the importer-derived provenance override
-		// the reserved keys (mirrors class-wp-agent-installed-agent-projector.php).
-		$meta['source_type'] = $source_type;
-		if ( '' !== $source_package ) {
+		$source_type    = $string_value( $spec['source_type'] ?? null, $bundle['source_type'] ?? null, 'runtime-agent-package' );
+		$source_package = $string_value( $spec['source_package'] ?? null, $bundle['source_package'] ?? null, $spec['package_slug'] ?? null, $bundle['package_slug'] ?? null, $bundle['bundle_slug'] ?? null );
+		$source_version = $string_value( $spec['source_version'] ?? null, $bundle['source_version'] ?? null, $spec['package_version'] ?? null, $bundle['package_version'] ?? null, $bundle['bundle_version'] ?? null );
+		if ( '' !== $source_package || '' !== $source_version ) {
+			// Keep the reserved provenance tuple authoritative and internally consistent.
+			$meta['source_type']    = $source_type;
 			$meta['source_package'] = $source_package;
-		}
-		if ( '' !== $source_version ) {
 			$meta['source_version'] = $source_version;
 		}
 

--- a/src/Registry/register-agent-runtime-bundle-importer.php
+++ b/src/Registry/register-agent-runtime-bundle-importer.php
@@ -231,15 +231,16 @@ add_filter(
 		$source_type    = $string_value( $bundle['source_type'] ?? null, $spec['source_type'] ?? null, 'runtime-agent-package' );
 		$source_package = $string_value( $bundle['source_package'] ?? null, $spec['source_package'] ?? null, $bundle['package_slug'] ?? null, $spec['package_slug'] ?? null, $bundle['bundle_slug'] ?? null );
 		$source_version = $string_value( $bundle['source_version'] ?? null, $spec['source_version'] ?? null, $bundle['package_version'] ?? null, $spec['package_version'] ?? null, $bundle['bundle_version'] ?? null );
-		if ( '' !== $source_package || '' !== $source_version ) {
-			$meta = array_merge(
-				array(
-					'source_type'    => $source_type,
-					'source_package' => $source_package,
-					'source_version' => $source_version,
-				),
-				$meta
-			);
+		// Provenance is derived by the importer from host-trusted spec/input, so it must
+		// win over any source_* keys smuggled inside the bundle's own agent.meta. Merge
+		// the bundle meta as the base, then let the importer-derived provenance override
+		// the reserved keys (mirrors class-wp-agent-installed-agent-projector.php).
+		$meta['source_type'] = $source_type;
+		if ( '' !== $source_package ) {
+			$meta['source_package'] = $source_package;
+		}
+		if ( '' !== $source_version ) {
+			$meta['source_version'] = $source_version;
 		}
 
 		$registered = $registry->register(

--- a/tests/runtime-agent-bundle-importer-smoke.php
+++ b/tests/runtime-agent-bundle-importer-smoke.php
@@ -126,9 +126,9 @@ agents_api_smoke_assert_equals( 'wp_agent_runtime_bundle_unclaimed', $helper_res
 
 echo "\n[5] Forged provenance in agent.meta cannot override importer-derived provenance:\n";
 $forged_bundle = array(
-	'source_type'    => 'runtime-agent-package',
-	'source_package' => 'trusted-package',
-	'source_version' => '2.0.0',
+	'source_type'    => 'forged-bundle-type',
+	'source_package' => 'forged-bundle-package',
+	'source_version' => '9.9.8',
 	'agent'          => array(
 		'agent_slug'   => 'forged-provenance-agent',
 		'agent_name'   => 'Forged Provenance Agent',
@@ -142,12 +142,23 @@ $forged_bundle = array(
 		),
 	),
 );
-$forged_result = apply_filters( 'wp_agent_runtime_import_bundle', null, array( 'bundle' => $forged_bundle ), array( 'on_conflict' => 'upgrade' ), 5 );
+$forged_result = apply_filters(
+	'wp_agent_runtime_import_bundle',
+	null,
+	array(
+		'bundle'         => $forged_bundle,
+		'source_type'    => 'runtime-agent-package',
+		'source_package' => 'trusted-package',
+		'source_version' => '2.0.0',
+	),
+	array( 'on_conflict' => 'upgrade' ),
+	5
+);
 agents_api_smoke_assert_equals( true, is_array( $forged_result ) && true === ( $forged_result['success'] ?? false ), 'forged-provenance bundle import succeeds', $failures, $passes );
 $forged_meta = wp_get_agent( 'forged-provenance-agent' )->get_meta();
-agents_api_smoke_assert_equals( 'runtime-agent-package', $forged_meta['source_type'] ?? null, 'importer-derived source_type overrides forged agent.meta', $failures, $passes );
-agents_api_smoke_assert_equals( 'trusted-package', $forged_meta['source_package'] ?? null, 'importer-derived source_package overrides forged agent.meta', $failures, $passes );
-agents_api_smoke_assert_equals( '2.0.0', $forged_meta['source_version'] ?? null, 'importer-derived source_version overrides forged agent.meta', $failures, $passes );
+agents_api_smoke_assert_equals( 'runtime-agent-package', $forged_meta['source_type'] ?? null, 'host source_type overrides forged bundle provenance', $failures, $passes );
+agents_api_smoke_assert_equals( 'trusted-package', $forged_meta['source_package'] ?? null, 'host source_package overrides forged bundle provenance', $failures, $passes );
+agents_api_smoke_assert_equals( '2.0.0', $forged_meta['source_version'] ?? null, 'host source_version overrides forged bundle provenance', $failures, $passes );
 agents_api_smoke_assert_equals( 'preserved', $forged_meta['custom_field'] ?? null, 'non-reserved agent.meta keys are preserved', $failures, $passes );
 
 agents_api_smoke_finish( 'Agents API runtime agent bundle importer', $failures, $passes );

--- a/tests/runtime-agent-bundle-importer-smoke.php
+++ b/tests/runtime-agent-bundle-importer-smoke.php
@@ -124,4 +124,30 @@ agents_api_smoke_assert_equals( false, $helper_results[1]['success'] ?? true, 'h
 agents_api_smoke_assert_equals( 'wp_agent_runtime_bundle_unclaimed', $helper_results[1]['error']['code'] ?? '', 'helper import has stable unclaimed error', $failures, $passes );
 @unlink( $source_file );
 
+echo "\n[5] Forged provenance in agent.meta cannot override importer-derived provenance:\n";
+$forged_bundle = array(
+	'source_type'    => 'runtime-agent-package',
+	'source_package' => 'trusted-package',
+	'source_version' => '2.0.0',
+	'agent'          => array(
+		'agent_slug'   => 'forged-provenance-agent',
+		'agent_name'   => 'Forged Provenance Agent',
+		'agent_config' => array( 'runtime' => array( 'source' => 'forged' ) ),
+		// Attacker-controlled bundle content attempting to spoof reserved provenance keys.
+		'meta'         => array(
+			'source_type'    => 'core-verified',
+			'source_package' => 'attacker-package',
+			'source_version' => '9.9.9',
+			'custom_field'   => 'preserved',
+		),
+	),
+);
+$forged_result = apply_filters( 'wp_agent_runtime_import_bundle', null, array( 'bundle' => $forged_bundle ), array( 'on_conflict' => 'upgrade' ), 5 );
+agents_api_smoke_assert_equals( true, is_array( $forged_result ) && true === ( $forged_result['success'] ?? false ), 'forged-provenance bundle import succeeds', $failures, $passes );
+$forged_meta = wp_get_agent( 'forged-provenance-agent' )->get_meta();
+agents_api_smoke_assert_equals( 'runtime-agent-package', $forged_meta['source_type'] ?? null, 'importer-derived source_type overrides forged agent.meta', $failures, $passes );
+agents_api_smoke_assert_equals( 'trusted-package', $forged_meta['source_package'] ?? null, 'importer-derived source_package overrides forged agent.meta', $failures, $passes );
+agents_api_smoke_assert_equals( '2.0.0', $forged_meta['source_version'] ?? null, 'importer-derived source_version overrides forged agent.meta', $failures, $passes );
+agents_api_smoke_assert_equals( 'preserved', $forged_meta['custom_field'] ?? null, 'non-reserved agent.meta keys are preserved', $failures, $passes );
+
 agents_api_smoke_finish( 'Agents API runtime agent bundle importer', $failures, $passes );


### PR DESCRIPTION
## Summary

Provenance-overwrite / data-authenticity bug in the runtime agent bundle importer. The importer stamps reserved provenance-diagnostic keys (`source_type`, `source_package`, `source_version`) onto a registered agent's `meta`, deriving them from host-trusted spec/input. Because the stamping used `array_merge()` with the bundle's own `agent.meta` as the *later* argument, attacker-controlled `agent.meta` keys silently overwrote the importer-derived provenance — defeating the provenance the importer intended to apply from trusted `$spec`/`$input`.

## Findings

- `src/Registry/register-agent-runtime-bundle-importer.php:235` — CWE-345 (Insufficient Verification of Data Authenticity). A forged runtime bundle can smuggle `source_type`/`source_package`/`source_version` inside `agent.meta` and have them win over the importer's host-trusted provenance stamp. Impact is low (these fields are diagnostic-only and importing a bundle is a host seam), but the reserved provenance keys should fail closed against bundle forgery.

## Fix

Reversed the merge so the bundle's `agent.meta` is the base and the importer-derived provenance overrides the reserved keys — mirroring the canonical convention in `class-wp-agent-installed-agent-projector.php`, which merges source meta first and then direct-assigns `source_package`/`source_version` so provenance wins. The existing "only stamp package/version when present" behavior is preserved (each reserved key is assigned only when its derived value is non-empty); non-reserved `agent.meta` keys still pass through untouched.

## Testing

- Extended `tests/runtime-agent-bundle-importer-smoke.php` with case `[5]`: a bundle whose `agent.meta` forges `source_type`/`source_package`/`source_version` now asserts the importer-derived provenance wins while a non-reserved custom key is preserved. This case FAILS without the fix (3 failing assertions) and PASSES with it.
- `composer smoke` — full suite green (exit 0).
- `vendor/bin/phpstan analyse --no-progress --memory-limit=2G` — No errors (level max).

---

Found by an automated security scan; the fix is offered as a draft for review.

## AI assistance
OpenAI `openai/gpt-5.6-sol` via OpenCode reviewed this PR and drafted the security follow-up commit and tests. Chris Huber directed the work and remains responsible for the resulting changes.