### PR TITLE
Security: reject duplicate artifact identities in agent packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,7 @@
       "php tests/registered-agent-materialization-adapter-smoke.php",
       "php tests/runtime-agent-bundle-importer-smoke.php",
       "php tests/package-lifecycle-smoke.php",
+      "php tests/package-duplicate-artifact-identity-smoke.php",
       "php tests/package-capability-contract-smoke.php",
       "php tests/package-adoption-orchestration-smoke.php",
       "php tests/execution-principal-smoke.php",

--- a/docs/registry-and-packages.md
+++ b/docs/registry-and-packages.md
@@ -129,7 +129,7 @@ Normalized package fields:
 | `version` | Non-empty version string, default `1.0.0`. |
 | `agent` | `WP_Agent` definition. |
 | `capabilities` | Sorted, unique capability/component strings. |
-| `artifacts` | Sorted `WP_Agent_Package_Artifact` declarations. |
+| `artifacts` | Sorted `WP_Agent_Package_Artifact` declarations, unique by normalized `(type, slug)` identity. |
 | `meta` | Package-owned JSON-friendly metadata. |
 
 Construct from a manifest with `WP_Agent_Package::from_array( $manifest )`.

--- a/src/Packages/class-wp-agent-package.php
+++ b/src/Packages/class-wp-agent-package.php
@@ -271,6 +271,18 @@ if ( ! class_exists( 'WP_Agent_Package' ) ) {
 				}
 			);
 
+			$seen = array();
+			foreach ( $prepared as $artifact ) {
+				$key = $artifact->get_type() . ':' . $artifact->get_slug();
+				if ( isset( $seen[ $key ] ) ) {
+					throw new InvalidArgumentException(
+						sprintf( 'Agent package declares duplicate artifact identity: %s.', esc_html( $key ) )
+					);
+				}
+
+				$seen[ $key ] = true;
+			}
+
 			return $prepared;
 		}
 

--- a/tests/package-duplicate-artifact-identity-smoke.php
+++ b/tests/package-duplicate-artifact-identity-smoke.php
@@ -1,0 +1,122 @@
+<?php
+/**
+ * Pure-PHP smoke test asserting packages reject duplicate artifact identities.
+ *
+ * A package must not carry two artifacts that normalize to the same
+ * (type, slug) identity. That pair is the canonical key used downstream by
+ * the update planner and adoption orchestrator, whose last-wins index maps
+ * disagree with artifact_from_entry()'s first-match lookup. Left unchecked,
+ * the diff a reviewer approves can describe a different declaration than the
+ * one import() resolves. Fail closed at construction to remove the ambiguity.
+ *
+ * Run with: php tests/package-duplicate-artifact-identity-smoke.php
+ *
+ * @package AgentsAPI\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+$failures = array();
+$passes   = 0;
+
+echo "agents-api-package-duplicate-artifact-identity-smoke\n";
+
+require_once __DIR__ . '/agents-api-smoke-helpers.php';
+agents_api_smoke_require_module();
+
+echo "\n[1] Distinct artifact identities are accepted:\n";
+$distinct_ok = false;
+try {
+	$package = WP_Agent_Package::from_array(
+		array(
+			'slug'      => 'demo-package',
+			'version'   => '1.0.0',
+			'agent'     => array(
+				'slug'  => 'demo-agent',
+				'label' => 'Demo Agent',
+			),
+			'artifacts' => array(
+				array(
+					'type'   => 'example/prompt',
+					'slug'   => 'welcome',
+					'source' => 'prompts/welcome.md',
+				),
+				array(
+					'type'   => 'example/prompt',
+					'slug'   => 'farewell',
+					'source' => 'prompts/farewell.md',
+				),
+			),
+		)
+	);
+	$distinct_ok = 2 === count( $package->get_artifacts() );
+} catch ( InvalidArgumentException $e ) {
+	$distinct_ok = false;
+}
+agents_api_smoke_assert_equals( true, $distinct_ok, 'distinct (type, slug) artifacts are preserved', $failures, $passes );
+
+echo "\n[2] Duplicate normalized identity is rejected at construction:\n";
+$duplicate_rejected = false;
+try {
+	WP_Agent_Package::from_array(
+		array(
+			'slug'      => 'demo-package',
+			'version'   => '1.0.0',
+			'agent'     => array(
+				'slug'  => 'demo-agent',
+				'label' => 'Demo Agent',
+			),
+			'artifacts' => array(
+				array(
+					'type'    => 'example/prompt',
+					'slug'    => 'welcome',
+					'source'  => 'prompts/welcome-a.md',
+					'label'   => 'Declaration A',
+				),
+				array(
+					'type'    => 'example/prompt',
+					'slug'    => 'welcome',
+					'source'  => 'prompts/welcome-b.md',
+					'label'   => 'Declaration B',
+				),
+			),
+		)
+	);
+} catch ( InvalidArgumentException $e ) {
+	$duplicate_rejected = true;
+}
+agents_api_smoke_assert_equals( true, $duplicate_rejected, 'two artifacts with the same (type, slug) throw', $failures, $passes );
+
+echo "\n[3] Collision after slug normalization is also rejected:\n";
+$normalized_collision_rejected = false;
+try {
+	WP_Agent_Package::from_array(
+		array(
+			'slug'      => 'demo-package',
+			'version'   => '1.0.0',
+			'agent'     => array(
+				'slug'  => 'demo-agent',
+				'label' => 'Demo Agent',
+			),
+			'artifacts' => array(
+				array(
+					'type'   => 'example/prompt',
+					'slug'   => 'Welcome Note',
+					'source' => 'prompts/welcome-a.md',
+				),
+				array(
+					'type'   => 'example/prompt',
+					'slug'   => 'welcome-note',
+					'source' => 'prompts/welcome-b.md',
+				),
+			),
+		)
+	);
+} catch ( InvalidArgumentException $e ) {
+	$normalized_collision_rejected = true;
+}
+agents_api_smoke_assert_equals( true, $normalized_collision_rejected, 'slugs that normalize to the same value collide', $failures, $passes );
+
+agents_api_smoke_finish( 'Agents API package duplicate artifact identity', $failures, $passes );

--- a/tests/package-duplicate-artifact-identity-smoke.php
+++ b/tests/package-duplicate-artifact-identity-smoke.php
@@ -48,10 +48,15 @@ try {
 					'slug'   => 'farewell',
 					'source' => 'prompts/farewell.md',
 				),
+				array(
+					'type'   => 'example/template',
+					'slug'   => 'welcome',
+					'source' => 'templates/welcome.html',
+				),
 			),
 		)
 	);
-	$distinct_ok = 2 === count( $package->get_artifacts() );
+	$distinct_ok = 3 === count( $package->get_artifacts() );
 } catch ( InvalidArgumentException $e ) {
 	$distinct_ok = false;
 }
@@ -85,7 +90,7 @@ try {
 		)
 	);
 } catch ( InvalidArgumentException $e ) {
-	$duplicate_rejected = true;
+	$duplicate_rejected = 'Agent package declares duplicate artifact identity: example/prompt:welcome.' === $e->getMessage();
 }
 agents_api_smoke_assert_equals( true, $duplicate_rejected, 'two artifacts with the same (type, slug) throw', $failures, $passes );
 
@@ -115,7 +120,7 @@ try {
 		)
 	);
 } catch ( InvalidArgumentException $e ) {
-	$normalized_collision_rejected = true;
+	$normalized_collision_rejected = 'Agent package declares duplicate artifact identity: example/prompt:welcome-note.' === $e->getMessage();
 }
 agents_api_smoke_assert_equals( true, $normalized_collision_rejected, 'slugs that normalize to the same value collide', $failures, $passes );
 


### PR DESCRIPTION
## Summary

Interpretation-conflict / review-gate bypass (CWE-694: Use of Multiple Resources with Duplicate Identifier). An agent package could declare two artifacts that normalize to the same canonical `(type, slug)` identity. Nothing rejected the collision, and downstream consumers disagree about which of the colliding declarations wins — so the diff a reviewer approves can describe a *different* declaration than the one adoption/import actually resolves.

### Finding

- **[medium] duplicate-artifact-identity** — `src/Packages/class-wp-agent-package.php:267` (`WP_Agent_Package::prepare_artifacts()`). The method `usort`s artifacts by `(type, slug)` but never enforces uniqueness of that pair. `WP_Agent_Package_Update_Planner::index_artifacts()` and `WP_Agent_Package_Adoption_Orchestrator::index_artifacts()` build **last-wins** maps keyed by `type:slug`, so the plan entry and target row come from the *last* duplicate (B). But `artifact_from_entry()` iterates `get_artifacts()` and returns the **first** match (A), which is then passed to `import()` alongside the last row's payload. The approval diff (source + payload from B) and the resolved import (source from A) can therefore describe different content. CWE-694. Impact: a crafted package can make the artifact a reviewer approves differ from the artifact that is imported.

## Fix

After normalizing and sorting in `prepare_artifacts()`, track seen identities as `get_type() . ':' . get_slug()` and throw `InvalidArgumentException` (escaped via `esc_html()`, matching the existing `prepare_artifacts` / `prepare_string_list` error pattern) on the first collision. This fails **closed** at construction — the ambiguity is removed at the source, before any planner/orchestrator index is built, so the approval/diff boundary and import can no longer diverge. Because slugs are normalized (`sanitize_title`) before comparison, declarations that collide only after normalization are rejected too. Distinct identities are unaffected — legitimate packages still construct normally.

## Testing

- New smoke: `tests/package-duplicate-artifact-identity-smoke.php` (wired into the `composer smoke` array) — asserts distinct `(type, slug)` artifacts are preserved, exact duplicate identities throw, and slugs that normalize to the same value collide. Verified failing on the pre-fix tree (2 assertions fail) and passing with the fix.
- `composer smoke` — full suite green, exit 0.
- `vendor/bin/phpstan analyse --no-progress --memory-limit=2G` — No errors (level max).

---

This issue was found by an automated security scan; the fix is offered as a draft for maintainer review.

## AI assistance
OpenAI `openai/gpt-5.6-sol` via OpenCode reviewed this PR and drafted the security follow-up commit and tests. Chris Huber directed the work and remains responsible for the resulting changes.