### PR TITLE
Security: enforce autonomous deny-by-default in the default authorization policy

### DIFF
--- a/src/Auth/class-wp-agent-wordpress-authorization-policy.php
+++ b/src/Auth/class-wp-agent-wordpress-authorization-policy.php
@@ -48,7 +48,10 @@ if ( ! class_exists( 'WP_Agent_WordPress_Authorization_Policy' ) ) {
 			// untouched and only substitutes the safe-default deny-list for
 			// autonomous principals lacking explicit shaping — mirroring the
 			// class_exists guard in WP_Agent_Execution_Principal::is_autonomous_execution().
-			if ( ! array_key_exists( 'capability_ceiling', $context ) && class_exists( 'WP_Agent_Autonomous_Capability_Policy' ) ) {
+			if (
+				( ! array_key_exists( 'capability_ceiling', $context ) || null === $context['capability_ceiling'] )
+				&& class_exists( 'WP_Agent_Autonomous_Capability_Policy' )
+			) {
 				$ceiling = WP_Agent_Autonomous_Capability_Policy::resolve_ceiling( $principal );
 			}
 

--- a/src/Auth/class-wp-agent-wordpress-authorization-policy.php
+++ b/src/Auth/class-wp-agent-wordpress-authorization-policy.php
@@ -40,6 +40,18 @@ if ( ! class_exists( 'WP_Agent_WordPress_Authorization_Policy' ) ) {
 				$ceiling = WP_Agent_Capability_Ceiling::from_array( $this->string_keyed_array( $ceiling ) );
 			}
 
+			// When the ceiling is derived from the principal (no explicit host
+			// override in context), resolve it through the autonomous capability
+			// policy so the documented deny-by-default ceiling for autonomous
+			// principals is actually enforced at this shared boundary.
+			// resolve_ceiling fails closed: it returns any host-shaped ceiling
+			// untouched and only substitutes the safe-default deny-list for
+			// autonomous principals lacking explicit shaping — mirroring the
+			// class_exists guard in WP_Agent_Execution_Principal::is_autonomous_execution().
+			if ( ! array_key_exists( 'capability_ceiling', $context ) && class_exists( 'WP_Agent_Autonomous_Capability_Policy' ) ) {
+				$ceiling = WP_Agent_Autonomous_Capability_Policy::resolve_ceiling( $principal );
+			}
+
 			if ( $ceiling instanceof WP_Agent_Capability_Ceiling && ! $ceiling->allows_capability( $capability ) ) {
 				return false;
 			}

--- a/tests/authorization-smoke.php
+++ b/tests/authorization-smoke.php
@@ -316,5 +316,12 @@ agents_api_smoke_assert_equals(
 	$failures,
 	$passes
 );
+agents_api_smoke_assert_equals(
+	false,
+	$autonomous_policy->can( $autonomous_principal, 'publish_posts', array( 'capability_ceiling' => null ) ),
+	'null context ceiling cannot bypass the autonomous safe default',
+	$failures,
+	$passes
+);
 
 agents_api_smoke_finish( 'Agents API authorization', $failures, $passes );

--- a/tests/authorization-smoke.php
+++ b/tests/authorization-smoke.php
@@ -235,4 +235,86 @@ $audience_principal = AgentsAPI\AI\WP_Agent_Execution_Principal::audience( 'audi
 agents_api_smoke_assert_equals( true, $audience_policy->can_access_agent( $audience_principal, 'viewer-agent', WP_Agent_Access_Grant::ROLE_VIEWER ), 'policy accepts principal-aware audience grant', $failures, $passes );
 agents_api_smoke_assert_equals( false, $audience_policy->can_access_agent( $audience_principal, 'viewer-agent', WP_Agent_Access_Grant::ROLE_OPERATOR ), 'policy rejects audience grant below operator level', $failures, $passes );
 
+echo "\n[autonomous deny-by-default] Agent-token principal without an allow-list cannot exercise content-mutating capabilities:\n";
+
+// Owner 7 is a privileged WordPress user that CAN publish/edit/delete/manage.
+$privileged_user_can = static function ( int $user_id, string $capability ): bool {
+	unset( $capability );
+	return 7 === $user_id;
+};
+
+$autonomous_policy = new WP_Agent_WordPress_Authorization_Policy( null, $privileged_user_can );
+
+// Agent-token principal bound to the privileged owner, carrying the
+// token-derived ceiling with a null allow-list (no explicit host shaping) —
+// exactly what WP_Agent_Token_Authenticator attaches for a token created with
+// allowed_capabilities = null.
+$null_cap_token = new WP_Agent_Token(
+	77,
+	'automation-agent',
+	7,
+	WP_Agent_Token::hash_token( 'wp_agent_automation-agent_secret' ),
+	'wp_agent_au',
+	'Automation',
+	null,
+	'2099-01-01 00:00:00'
+);
+$autonomous_principal = AgentsAPI\AI\WP_Agent_Execution_Principal::agent_token(
+	7,
+	'automation-agent',
+	77,
+	AgentsAPI\AI\WP_Agent_Execution_Principal::REQUEST_CONTEXT_REST,
+	array(),
+	null,
+	null,
+	$null_cap_token->capability_ceiling()
+);
+
+agents_api_smoke_assert_equals( true, $autonomous_principal->is_autonomous_execution(), 'agent-token principal is autonomous', $failures, $passes );
+agents_api_smoke_assert_equals( false, $autonomous_policy->can( $autonomous_principal, 'publish_posts' ), 'autonomous agent-token cannot publish posts even when the owner can', $failures, $passes );
+agents_api_smoke_assert_equals( false, $autonomous_policy->can( $autonomous_principal, 'delete_posts' ), 'autonomous agent-token cannot delete posts even when the owner can', $failures, $passes );
+agents_api_smoke_assert_equals( false, $autonomous_policy->can( $autonomous_principal, 'manage_options' ), 'autonomous agent-token cannot manage options even when the owner can', $failures, $passes );
+agents_api_smoke_assert_equals( true, $autonomous_policy->can( $autonomous_principal, 'read' ), 'autonomous agent-token keeps non-mutating read access', $failures, $passes );
+
+// A non-autonomous interactive principal with the same privileged owner is
+// unaffected and can still publish.
+$interactive_owner = AgentsAPI\AI\WP_Agent_Execution_Principal::user_session(
+	7,
+	'editor-agent',
+	AgentsAPI\AI\WP_Agent_Execution_Principal::REQUEST_CONTEXT_REST
+);
+agents_api_smoke_assert_equals( false, $interactive_owner->is_autonomous_execution(), 'user-session principal is not autonomous', $failures, $passes );
+agents_api_smoke_assert_equals( true, $autonomous_policy->can( $interactive_owner, 'publish_posts' ), 'interactive principal can still publish posts', $failures, $passes );
+
+// An explicit host grant that includes publish_posts is respected even for an
+// autonomous agent-token principal — the safe default never narrows a
+// deliberate host decision.
+$explicit_grant   = new WP_Agent_Capability_Ceiling( 7, array( 'publish_posts', 'read' ) );
+$granted_principal = new AgentsAPI\AI\WP_Agent_Execution_Principal(
+	7,
+	'automation-agent',
+	AgentsAPI\AI\WP_Agent_Execution_Principal::AUTH_SOURCE_AGENT_TOKEN,
+	AgentsAPI\AI\WP_Agent_Execution_Principal::REQUEST_CONTEXT_REST,
+	77,
+	array(),
+	null,
+	null,
+	$explicit_grant
+);
+agents_api_smoke_assert_equals( true, $autonomous_policy->can( $granted_principal, 'publish_posts' ), 'explicit host grant lets an autonomous principal publish', $failures, $passes );
+
+// A host-supplied context override ceiling still takes precedence and is not
+// second-guessed by the autonomous policy.
+agents_api_smoke_assert_equals(
+	true,
+	$autonomous_policy->can(
+		$autonomous_principal,
+		'publish_posts',
+		array( 'capability_ceiling' => new WP_Agent_Capability_Ceiling( 7, array( 'publish_posts' ) ) )
+	),
+	'host context ceiling override still authorizes publish for an autonomous principal',
+	$failures,
+	$passes
+);
+
 agents_api_smoke_finish( 'Agents API authorization', $failures, $passes );

--- a/vendor
+++ b/vendor
@@ -1,0 +1,1 @@
+/Users/miguel/dev/a8c/agents-api/vendor


### PR DESCRIPTION
## Summary

Fail-open authorization: the substrate's **default** capability-authorization boundary never applied the documented autonomous deny-by-default ceiling, so an autonomous agent-token principal bound to a privileged owner could exercise content-mutating WordPress capabilities that the autonomous policy is supposed to deny.

`WP_Agent_Autonomous_Capability_Policy::resolve_ceiling()` — the piece that substitutes the safe-default deny-list for autonomous principals — was only ever exercised in the smoke test. No production path called it. `WP_Agent_WordPress_Authorization_Policy::can()` read the principal's raw ceiling directly, and for an agent token created with `allowed_capabilities = null` that ceiling has neither an allow-list nor a deny-list, so `allows_capability('publish_posts')` returned `true` and the only remaining gate was `user_can( owner, 'publish_posts' )`.

## Findings

- **[high] agent-token-null-capability-list** — `src/Auth/class-wp-agent-wordpress-authorization-policy.php:38-45` (`can()`). CWE-285 (Improper Authorization) / CWE-636 (Not Failing Securely). An agent-token principal (`AUTH_SOURCE_AGENT_TOKEN` is in `DEFAULT_AUTONOMOUS_AUTH_SOURCES`) with a null allow-list, bound to a privileged owner, could invoke a tool declaring `required_capability = publish_posts` (or any capability in `DEFAULT_DENIED_CAPABILITIES`) and be authorized — defeating the intended autonomous deny-by-default. The default `WP_Agent_Ability_Tool_Executor` instantiates exactly this policy when none is supplied in context, so the substrate's default execution path was fail-open.

## Fix

In `WP_Agent_WordPress_Authorization_Policy::can()`, when the ceiling is derived from the principal (i.e. there is no explicit `$context['capability_ceiling']` host override), resolve the effective ceiling through `WP_Agent_Autonomous_Capability_Policy::resolve_ceiling( $principal )` before evaluating `allows_capability()`. The call is guarded by `class_exists( 'WP_Agent_Autonomous_Capability_Policy' )`, mirroring `WP_Agent_Execution_Principal::is_autonomous_execution()`.

`resolve_ceiling()` already fails closed and composes conservatively:
- any host-shaped ceiling (allow-list or deny-list present) is returned untouched — deliberate host grants are never widened or narrowed;
- an autonomous principal lacking explicit shaping receives the safe-default deny-list;
- non-autonomous principals are returned unchanged.

Applying it at this single shared boundary makes the documented default enforced without widening host grants, and every consumer of the default policy (the ability-tool executor and any other) inherits the fix. Host-supplied `$context['capability_ceiling']` overrides continue to take precedence and are not second-guessed.

## Testing

- `tests/authorization-smoke.php` — extended with an autonomous deny-by-default section that **fails without the fix and passes with it**: an agent-token principal with a null allow-list bound to a privileged owner is denied `publish_posts` / `delete_posts` / `manage_options`, still keeps non-mutating `read`, while (regression) an interactive `user_session` principal, an explicit host allow-list grant, and a host context-ceiling override all remain authorized. Verified the three vulnerable-path assertions fail on the pre-fix code.
- `composer smoke` — full suite green (exit 0).
- `vendor/bin/phpstan analyse --no-progress --memory-limit=2G` — level max, **No errors**.

---

_This issue was found by an automated security scan; the fix is offered as a draft PR for maintainer review._

## AI assistance
OpenAI `openai/gpt-5.6-sol` via OpenCode reviewed this PR and drafted the security follow-up commit and tests. Chris Huber directed the work and remains responsible for the resulting changes.