### PR TITLE
Security: redact workflow run metadata for non-manager readers

### DIFF
--- a/src/Workflows/register-agents-workflow-abilities.php
+++ b/src/Workflows/register-agents-workflow-abilities.php
@@ -314,7 +314,8 @@ function agents_describe_workflow( array $input ): array {
 function agents_get_workflow_run( array $input ) {
 	$handler = apply_filters( 'wp_agent_workflow_run_status_handler', null, $input );
 	if ( is_callable( $handler ) ) {
-		return \AgentsAPI\AI\WP_Agent_Run_Control::normalize_run_result( call_user_func( $handler, $input ), 'agents_workflow_run_invalid_status' );
+		$result = \AgentsAPI\AI\WP_Agent_Run_Control::normalize_run_result( call_user_func( $handler, $input ), 'agents_workflow_run_invalid_status' );
+		return is_wp_error( $result ) ? $result : agents_workflow_run_observer_payload( $result, $input );
 	}
 
 	$run = \AgentsAPI\AI\WP_Agent_Run_Control::get_run( WP_Agent_Workflow_Runner::RUN_CONTROL_STORE, agents_workflow_string( $input['run_id'] ?? '' ) );
@@ -322,7 +323,7 @@ function agents_get_workflow_run( array $input ) {
 		return new \WP_Error( 'agents_workflow_run_not_found', 'No workflow run was found for the requested run_id.' );
 	}
 
-	return $run;
+	return agents_workflow_run_observer_payload( $run, $input );
 }
 
 /**
@@ -351,7 +352,8 @@ function agents_cancel_workflow_run( array $input ) {
 function agents_list_workflow_run_events( array $input ) {
 	$handler = apply_filters( 'wp_agent_workflow_run_events_handler', null, $input );
 	if ( is_callable( $handler ) ) {
-		return \AgentsAPI\AI\WP_Agent_Run_Control::normalize_events_result( call_user_func( $handler, $input ), 'agents_workflow_run_invalid_events_result' );
+		$result = \AgentsAPI\AI\WP_Agent_Run_Control::normalize_events_result( call_user_func( $handler, $input ), 'agents_workflow_run_invalid_events_result' );
+		return is_wp_error( $result ) ? $result : agents_workflow_run_observer_payload( $result, $input );
 	}
 
 	$result = \AgentsAPI\AI\WP_Agent_Run_Control::list_events(
@@ -365,7 +367,7 @@ function agents_list_workflow_run_events( array $input ) {
 		return new \WP_Error( 'agents_workflow_run_not_found', 'No workflow run was found for the requested run_id.' );
 	}
 
-	return $result;
+	return agents_workflow_run_observer_payload( $result, $input );
 }
 
 /**
@@ -427,6 +429,32 @@ function agents_validate_workflow_permission( array $input ): bool {
 function agents_workflow_run_read_permission( array $input ): bool {
 	$allowed = function_exists( 'current_user_can' ) ? current_user_can( 'read' ) : false;
 	return (bool) apply_filters( 'agents_workflow_run_read_permission', $allowed, $input );
+}
+
+/**
+ * Gate for whether a reader may see unredacted workflow run metadata. The
+ * read gate above stays permissive (any `read`-capable user can poll a run
+ * they know the id of), but sensitive run metadata is only exposed to
+ * managers by default — mirroring the chat/task/runtime-package abilities.
+ *
+ * @param array<string,mixed> $input Ability input.
+ */
+function agents_workflow_run_unredacted_read_permission( array $input ): bool {
+	$allowed = function_exists( 'current_user_can' ) ? current_user_can( 'manage_options' ) : false;
+	return (bool) apply_filters( 'agents_workflow_run_unredacted_read_permission', $allowed, $input );
+}
+
+/**
+ * Project a run/event-page payload for the current reader: full fidelity for
+ * privileged callers, redacted metadata for everyone else. Fails closed —
+ * non-managers never receive raw run metadata.
+ *
+ * @param array<string,mixed> $payload Run or event-page payload.
+ * @param array<string,mixed> $input Ability input.
+ * @return array<string,mixed>
+ */
+function agents_workflow_run_observer_payload( array $payload, array $input ): array {
+	return agents_workflow_run_unredacted_read_permission( $input ) ? $payload : \AgentsAPI\AI\WP_Agent_Run_Control::redacted_observer_payload( $payload );
 }
 
 /** @param array<string,mixed> $input Ability input. */

--- a/tests/agents-workflow-ability-smoke.php
+++ b/tests/agents-workflow-ability-smoke.php
@@ -27,7 +27,9 @@ if ( ! class_exists( 'WP_Error' ) ) {
 }
 
 if ( ! function_exists( 'current_user_can' ) ) {
-	function current_user_can( string $cap ): bool { unset( $cap ); return $GLOBALS['__can'] ?? false; }
+	function current_user_can( string $cap ): bool {
+		return 'read' === $cap ? ( $GLOBALS['__can_read'] ?? $GLOBALS['__can'] ?? false ) : ( $GLOBALS['__can'] ?? false );
+	}
 } else {
 	add_filter(
 		'user_has_cap',
@@ -78,6 +80,7 @@ use function AgentsAPI\AI\Workflows\agents_validate_workflow;
 use function AgentsAPI\AI\Workflows\register_workflow_handler;
 use function AgentsAPI\AI\Workflows\agents_get_workflow_run;
 use function AgentsAPI\AI\Workflows\agents_list_workflow_run_events;
+use function AgentsAPI\AI\Workflows\agents_workflow_run_read_permission;
 
 // ─── Permission gate ─────────────────────────────────────────────────
 
@@ -236,6 +239,8 @@ smoke_assert( 'test', $manager_run['metadata']['provider'] ?? null, 'manager get
 smoke_assert( 'secret-token', $manager_run['metadata']['token'] ?? null, 'manager get-workflow-run preserves operator metadata', $failures, $passes );
 
 $GLOBALS['__can'] = false;
+$GLOBALS['__can_read'] = true;
+smoke_assert( true, agents_workflow_run_read_permission( array() ), 'observer has workflow run read permission', $failures, $passes );
 $observer_run     = agents_get_workflow_run( array( 'run_id' => 'run-redact-1' ) );
 smoke_assert( 'test', $observer_run['metadata']['provider'] ?? null, 'observer get-workflow-run preserves safe metadata', $failures, $passes );
 smoke_assert( '[redacted]', $observer_run['metadata']['token'] ?? null, 'observer get-workflow-run redacts metadata secrets', $failures, $passes );

--- a/tests/agents-workflow-ability-smoke.php
+++ b/tests/agents-workflow-ability-smoke.php
@@ -76,6 +76,8 @@ use function AgentsAPI\AI\Workflows\agents_run_workflow_dispatch;
 use function AgentsAPI\AI\Workflows\agents_run_workflow_permission;
 use function AgentsAPI\AI\Workflows\agents_validate_workflow;
 use function AgentsAPI\AI\Workflows\register_workflow_handler;
+use function AgentsAPI\AI\Workflows\agents_get_workflow_run;
+use function AgentsAPI\AI\Workflows\agents_list_workflow_run_events;
 
 // ─── Permission gate ─────────────────────────────────────────────────
 
@@ -197,6 +199,88 @@ add_filter(
 );
 agents_run_workflow_dispatch( array( 'workflow_id' => 'whatever' ) );
 smoke_assert( true, in_array( 'no_handler', $failed_reasons, true ), 'dispatch_failed fires with no_handler', $failures, $passes );
+
+// ─── read-observer redaction: get-workflow-run ───────────────────────
+//
+// A read-capable but non-manager reader who learns an opaque run_id must
+// receive redacted run metadata; managers keep full fidelity. Without the
+// observer projection both callers would see the raw consumer-supplied
+// metadata (secret token below), which is the information-disclosure gap
+// this test guards against.
+
+if ( function_exists( 'remove_all_filters' ) ) {
+	remove_all_filters( 'wp_agent_workflow_run_status_handler' );
+	remove_all_filters( 'wp_agent_workflow_run_events_handler' );
+}
+
+add_filter(
+	'wp_agent_workflow_run_status_handler',
+	static fn() => static fn( array $input ): array => array(
+		'run_id'      => (string) ( $input['run_id'] ?? '' ),
+		'status'      => 'running',
+		'started_at'  => '2026-01-01T00:00:00Z',
+		'updated_at'  => '2026-01-01T00:00:01Z',
+		'workflow_id' => 'demo/redaction',
+		'metadata'    => array(
+			'provider' => 'test',
+			'token'    => 'secret-token',
+		),
+	),
+	10,
+	2
+);
+
+$GLOBALS['__can'] = true;
+$manager_run      = agents_get_workflow_run( array( 'run_id' => 'run-redact-1' ) );
+smoke_assert( 'test', $manager_run['metadata']['provider'] ?? null, 'manager get-workflow-run preserves safe metadata', $failures, $passes );
+smoke_assert( 'secret-token', $manager_run['metadata']['token'] ?? null, 'manager get-workflow-run preserves operator metadata', $failures, $passes );
+
+$GLOBALS['__can'] = false;
+$observer_run     = agents_get_workflow_run( array( 'run_id' => 'run-redact-1' ) );
+smoke_assert( 'test', $observer_run['metadata']['provider'] ?? null, 'observer get-workflow-run preserves safe metadata', $failures, $passes );
+smoke_assert( '[redacted]', $observer_run['metadata']['token'] ?? null, 'observer get-workflow-run redacts metadata secrets', $failures, $passes );
+
+// ─── read-observer redaction: list-workflow-run-events ───────────────
+
+add_filter(
+	'wp_agent_workflow_run_events_handler',
+	static fn() => static fn( array $input ): array => array(
+		'run_id'      => (string) ( $input['run_id'] ?? '' ),
+		'status'      => 'running',
+		'started_at'  => '2026-01-01T00:00:00Z',
+		'updated_at'  => '2026-01-01T00:00:01Z',
+		'workflow_id' => 'demo/redaction',
+		'metadata'    => array(
+			'provider' => 'test',
+			'token'    => 'secret-token',
+		),
+		'events'      => array(
+			array(
+				'id'       => 'evt_1',
+				'type'     => 'run_started',
+				'metadata' => array(
+					'provider' => 'test',
+					'token'    => 'event-secret-token',
+				),
+			),
+		),
+		'cursor'      => 'evt_1',
+		'has_more'    => false,
+	),
+	10,
+	2
+);
+
+$GLOBALS['__can'] = true;
+$manager_events   = agents_list_workflow_run_events( array( 'run_id' => 'run-redact-1' ) );
+smoke_assert( 'secret-token', $manager_events['metadata']['token'] ?? null, 'manager list-events preserves operator run metadata', $failures, $passes );
+smoke_assert( 'event-secret-token', $manager_events['events'][0]['metadata']['token'] ?? null, 'manager list-events preserves operator event metadata', $failures, $passes );
+
+$GLOBALS['__can'] = false;
+$observer_events  = agents_list_workflow_run_events( array( 'run_id' => 'run-redact-1' ) );
+smoke_assert( 'test', $observer_events['metadata']['provider'] ?? null, 'observer list-events preserves safe run metadata', $failures, $passes );
+smoke_assert( '[redacted]', $observer_events['metadata']['token'] ?? null, 'observer list-events redacts run metadata secrets', $failures, $passes );
+smoke_assert( '[redacted]', $observer_events['events'][0]['metadata']['token'] ?? null, 'observer list-events redacts event metadata secrets', $failures, $passes );
 
 echo "Passed: {$passes}, Failed: " . count( $failures ) . "\n";
 exit( count( $failures ) > 0 ? 1 : 0 );


### PR DESCRIPTION
## Summary

Information-disclosure (CWE-200) in the canonical workflow run-control abilities. `agents/get-workflow-run` and `agents/list-workflow-run-events` are registered `show_in_rest` behind a permissive read gate (`current_user_can( 'read' )`, i.e. any subscriber), yet they returned the stored run record **verbatim** — including consumer-supplied `options.metadata` that can carry secrets, tokens, and workflow internals. Any read-capable user who learns an opaque `run_id` could read that raw metadata.

The three analogous ability families already apply an observer projection for non-managers under the identical read gate — chat (`agents_chat_run_observer_payload`), task (`agents_task_run_observer_payload`), and runtime-package-run. The two workflow read abilities were the sole outliers.

## Findings

- `src/Workflows/register-agents-workflow-abilities.php:314` — `agents/get-workflow-run` (CWE-200): returned the normalized run unredacted from both the filtered-handler branch and the default `WP_Agent_Run_Control::get_run()` store branch. Read-capable non-managers received raw run metadata.
- `src/Workflows/register-agents-workflow-abilities.php:351` — `agents/list-workflow-run-events` (CWE-200): merged the full run record (with metadata) into every event page and returned it unredacted from both the filtered-handler and default `list_events()` branches.

## Fix

Mirror the existing sibling convention exactly, reusing the `redacted_observer_payload()` primitive — no store changes:

- Add `agents_workflow_run_unredacted_read_permission()` — default `current_user_can( 'manage_options' )`, filterable via `agents_workflow_run_unredacted_read_permission`.
- Add `agents_workflow_run_observer_payload( $payload, $input )` — returns the raw payload for privileged callers, otherwise `WP_Agent_Run_Control::redacted_observer_payload( $payload )`.
- Route every non-`WP_Error` return of `agents_get_workflow_run()` and `agents_list_workflow_run_events()` (both the filtered-handler branch and the default store branch) through the projection.

The permissive `read` gate is unchanged — legitimate readers can still poll runs they know — but sensitive metadata now fails closed: only managers (or callers the filter widens) see it unredacted.

## Testing

- `php tests/agents-workflow-ability-smoke.php` — extended with observer-vs-manager redaction assertions for both abilities. A manager sees `secret-token`; a non-manager reader sees `[redacted]` for both top-level run metadata and per-event metadata. These assertions fail on trunk and pass with this change (verified by stashing the source fix: 3 failures → 0).
- `composer smoke` — full suite green (exit 0).
- `vendor/bin/phpstan analyse --no-progress --memory-limit=2G` — level max, "No errors".

---

_Found by an automated security scan; this fix is offered as a draft for maintainer review._

## AI assistance
OpenAI `openai/gpt-5.6-sol` via OpenCode reviewed this PR and drafted the security follow-up commit and tests. Chris Huber directed the work and remains responsible for the resulting changes.