### PR TITLE
Security: bound preserved citation metadata in tool result truncator

### DIFF
--- a/src/Runtime/class-wp-agent-byte-limit-tool-result-truncator.php
+++ b/src/Runtime/class-wp-agent-byte-limit-tool-result-truncator.php
@@ -44,20 +44,21 @@ final class WP_Agent_Byte_Limit_Tool_Result_Truncator implements WP_Agent_Tool_R
 			);
 		}
 
-		$excerpt            = substr( (string) $encoded, 0, $this->max_bytes );
-		$metadata           = isset( $result['metadata'] ) && is_array( $result['metadata'] ) ? $result['metadata'] : array();
-		$preserved_metadata = $this->preserve_result_metadata( $result );
-		$truncated          = $result;
+		$excerpt   = substr( (string) $encoded, 0, $this->max_bytes );
+		$metadata  = isset( $result['metadata'] ) && is_array( $result['metadata'] ) ? $result['metadata'] : array();
+		$preserved = $this->preserve_result_metadata( $result );
+		$truncated = $result;
 
-		$truncated['result']   = array_merge(
+		$truncated['result'] = array_merge(
 			array(
 				'truncated'      => true,
 				'excerpt'        => $excerpt,
 				'original_bytes' => $original_bytes,
 				'excerpt_bytes'  => strlen( $excerpt ),
 			),
-			$preserved_metadata
+			$preserved['metadata']
 		);
+
 		$truncated['metadata'] = array_merge(
 			$metadata,
 			array(
@@ -67,30 +68,70 @@ final class WP_Agent_Byte_Limit_Tool_Result_Truncator implements WP_Agent_Tool_R
 			)
 		);
 
+		$out_metadata = array(
+			'original_bytes' => $original_bytes,
+			'excerpt_bytes'  => strlen( $excerpt ),
+		);
+
+		if ( $preserved['citations_dropped'] > 0 ) {
+			$truncated['result']['citations_dropped']   = $preserved['citations_dropped'];
+			$truncated['metadata']['citations_dropped'] = $preserved['citations_dropped'];
+			$out_metadata['citations_dropped']          = $preserved['citations_dropped'];
+		}
+
 		return array(
 			'result'    => $truncated,
 			'truncated' => true,
-			'metadata'  => array(
-				'original_bytes' => $original_bytes,
-				'excerpt_bytes'  => strlen( $excerpt ),
-			),
+			'metadata'  => $out_metadata,
 		);
 	}
 
 	/**
 	 * Preserve compact result metadata from oversized result payloads.
 	 *
+	 * Citation metadata is attacker-influenceable and otherwise unbounded, so
+	 * the normalized citations are capped to the truncator byte ceiling. The
+	 * excerpt keeps its own allotment; trailing citations are dropped (failing
+	 * closed to no citations key when even the first citation overflows) once
+	 * the encoded list would exceed the budget derived from max_bytes.
+	 *
 	 * @param array<string,mixed> $result Tool execution result.
-	 * @return array<string,mixed> Preserved metadata fields.
+	 * @return array{metadata: array<string,mixed>, citations_dropped: int} Preserved metadata plus drop count.
 	 */
 	private function preserve_result_metadata( array $result ): array {
 		$payload = isset( $result['result'] ) && is_array( $result['result'] ) ? $result['result'] : array();
 		if ( ! array_key_exists( WP_Agent_Citation_Metadata::KEY, $payload ) ) {
-			return array();
+			return array(
+				'metadata'          => array(),
+				'citations_dropped' => 0,
+			);
+		}
+
+		$normalized = WP_Agent_Citation_Metadata::normalize_many( $payload[ WP_Agent_Citation_Metadata::KEY ] );
+
+		$kept    = array();
+		$dropped = 0;
+		foreach ( $normalized as $citation ) {
+			$candidate = $kept;
+			$candidate[] = $citation;
+
+			$encoded = wp_json_encode( $candidate );
+			if ( false === $encoded || strlen( (string) $encoded ) > $this->max_bytes ) {
+				$dropped = count( $normalized ) - count( $kept );
+				break;
+			}
+
+			$kept = $candidate;
+		}
+
+		$metadata = array();
+		if ( ! empty( $kept ) ) {
+			$metadata[ WP_Agent_Citation_Metadata::KEY ] = $kept;
 		}
 
 		return array(
-			WP_Agent_Citation_Metadata::KEY => WP_Agent_Citation_Metadata::normalize_many( $payload[ WP_Agent_Citation_Metadata::KEY ] ),
+			'metadata'          => $metadata,
+			'citations_dropped' => $dropped,
 		);
 	}
 }

--- a/src/Runtime/class-wp-agent-byte-limit-tool-result-truncator.php
+++ b/src/Runtime/class-wp-agent-byte-limit-tool-result-truncator.php
@@ -44,10 +44,22 @@ final class WP_Agent_Byte_Limit_Tool_Result_Truncator implements WP_Agent_Tool_R
 			);
 		}
 
-		$excerpt   = substr( (string) $encoded, 0, $this->max_bytes );
-		$metadata  = isset( $result['metadata'] ) && is_array( $result['metadata'] ) ? $result['metadata'] : array();
-		$preserved = $this->preserve_result_metadata( $result );
-		$truncated = $result;
+		$excerpt            = substr( (string) $encoded, 0, $this->max_bytes );
+		$metadata           = isset( $result['metadata'] ) && is_array( $result['metadata'] ) ? $result['metadata'] : array();
+		$preserved          = $this->preserve_result_metadata( $result );
+		$citations_dropped  = $preserved['citations_dropped'];
+		$truncated          = $result;
+
+		unset( $metadata['citations_dropped'] );
+		if ( array_key_exists( WP_Agent_Citation_Metadata::KEY, $metadata ) ) {
+			$bounded_metadata = $this->bound_citations( $metadata[ WP_Agent_Citation_Metadata::KEY ] );
+			$citations_dropped += $bounded_metadata['citations_dropped'];
+			if ( empty( $bounded_metadata['citations'] ) && $bounded_metadata['citations_dropped'] > 0 ) {
+				unset( $metadata[ WP_Agent_Citation_Metadata::KEY ] );
+			} else {
+				$metadata[ WP_Agent_Citation_Metadata::KEY ] = $bounded_metadata['citations'];
+			}
+		}
 
 		$truncated['result'] = array_merge(
 			array(
@@ -73,10 +85,10 @@ final class WP_Agent_Byte_Limit_Tool_Result_Truncator implements WP_Agent_Tool_R
 			'excerpt_bytes'  => strlen( $excerpt ),
 		);
 
-		if ( $preserved['citations_dropped'] > 0 ) {
-			$truncated['result']['citations_dropped']   = $preserved['citations_dropped'];
-			$truncated['metadata']['citations_dropped'] = $preserved['citations_dropped'];
-			$out_metadata['citations_dropped']          = $preserved['citations_dropped'];
+		if ( $citations_dropped > 0 ) {
+			$truncated['result']['citations_dropped']   = $citations_dropped;
+			$truncated['metadata']['citations_dropped'] = $citations_dropped;
+			$out_metadata['citations_dropped']          = $citations_dropped;
 		}
 
 		return array(
@@ -107,30 +119,67 @@ final class WP_Agent_Byte_Limit_Tool_Result_Truncator implements WP_Agent_Tool_R
 			);
 		}
 
-		$normalized = WP_Agent_Citation_Metadata::normalize_many( $payload[ WP_Agent_Citation_Metadata::KEY ] );
-
-		$kept    = array();
-		$dropped = 0;
-		foreach ( $normalized as $citation ) {
-			$candidate = $kept;
-			$candidate[] = $citation;
-
-			$encoded = wp_json_encode( $candidate );
-			if ( false === $encoded || strlen( (string) $encoded ) > $this->max_bytes ) {
-				$dropped = count( $normalized ) - count( $kept );
-				break;
-			}
-
-			$kept = $candidate;
-		}
+		$bounded = $this->bound_citations( $payload[ WP_Agent_Citation_Metadata::KEY ] );
 
 		$metadata = array();
-		if ( ! empty( $kept ) ) {
-			$metadata[ WP_Agent_Citation_Metadata::KEY ] = $kept;
+		if ( ! empty( $bounded['citations'] ) || 0 === $bounded['citations_dropped'] ) {
+			$metadata[ WP_Agent_Citation_Metadata::KEY ] = $bounded['citations'];
 		}
 
 		return array(
 			'metadata'          => $metadata,
+			'citations_dropped' => $bounded['citations_dropped'],
+		);
+	}
+
+	/**
+	 * Normalize and retain the leading citations that fit the byte ceiling.
+	 *
+	 * @param mixed $citations Raw citation list.
+	 * @return array{citations: array<int, array<string,mixed>>, citations_dropped: int}
+	 */
+	private function bound_citations( $citations ): array {
+		if ( ! is_array( $citations ) ) {
+			return array(
+				'citations'         => array(),
+				'citations_dropped' => 0,
+			);
+		}
+
+		$kept          = array();
+		$dropped       = 0;
+		$encoded_bytes = 2; // JSON array brackets.
+		$overflowed    = false;
+
+		foreach ( $citations as $citation ) {
+			if ( ! is_array( $citation ) ) {
+				continue;
+			}
+
+			$citation = WP_Agent_Citation_Metadata::normalize( $citation );
+			if ( empty( $citation ) ) {
+				continue;
+			}
+
+			if ( $overflowed ) {
+				++$dropped;
+				continue;
+			}
+
+			$encoded   = wp_json_encode( $citation );
+			$separator = empty( $kept ) ? 0 : 1;
+			if ( false === $encoded || $encoded_bytes + $separator + strlen( (string) $encoded ) > $this->max_bytes ) {
+				$overflowed = true;
+				++$dropped;
+				continue;
+			}
+
+			$kept[] = $citation;
+			$encoded_bytes += $separator + strlen( (string) $encoded );
+		}
+
+		return array(
+			'citations'         => $kept,
 			'citations_dropped' => $dropped,
 		);
 	}

--- a/tests/tool-result-truncator-smoke.php
+++ b/tests/tool-result-truncator-smoke.php
@@ -158,8 +158,31 @@ $encoded_citations    = (string) wp_json_encode( $preserved_citations );
 
 agents_api_smoke_assert_equals( true, strlen( $encoded_citations ) <= $citation_budget, 'preserved citations stay within the truncator byte budget', $failures, $passes );
 agents_api_smoke_assert_equals( true, count( $preserved_citations ) < count( $many_citations ), 'citation-heavy result drops trailing citations', $failures, $passes );
-agents_api_smoke_assert_equals( true, ( $citation_replacement['citations_dropped'] ?? 0 ) > 0, 'dropped citation count is recorded for observers', $failures, $passes );
-agents_api_smoke_assert_equals( true, ( $citation_heavy['metadata']['citations_dropped'] ?? 0 ) > 0, 'dropped citation count surfaces in event metadata', $failures, $passes );
+$payload_citations_dropped = count( $many_citations ) - count( $preserved_citations );
+agents_api_smoke_assert_equals( $payload_citations_dropped, $citation_replacement['citations_dropped'] ?? 0, 'dropped payload citation count is exact', $failures, $passes );
+agents_api_smoke_assert_equals( $payload_citations_dropped, $citation_heavy['metadata']['citations_dropped'] ?? 0, 'dropped citation count surfaces in event metadata', $failures, $passes );
+
+// Tool-result metadata is the canonical citation location and must be subject
+// to the same bound instead of being copied intact into the replacement.
+$canonical_citation_heavy = ( new AgentsAPI\AI\WP_Agent_Byte_Limit_Tool_Result_Truncator( $citation_budget ) )->truncate_result(
+	array(
+		'success'  => true,
+		'result'   => array( 'body' => str_repeat( 'm', 5000 ) ),
+		'metadata' => array(
+			'citations'         => $many_citations,
+			'citations_dropped' => 999,
+		),
+	),
+	'client/large-result'
+);
+$canonical_metadata       = $canonical_citation_heavy['result']['metadata'] ?? array();
+$canonical_citations      = $canonical_metadata['citations'] ?? array();
+$canonical_dropped        = count( $many_citations ) - count( $canonical_citations );
+
+agents_api_smoke_assert_equals( true, strlen( (string) wp_json_encode( $canonical_citations ) ) <= $citation_budget, 'canonical metadata citations stay within the truncator byte budget', $failures, $passes );
+agents_api_smoke_assert_equals( 'https://example.test/source-0', $canonical_citations[0]['source_url'] ?? '', 'canonical metadata citations preserve source order', $failures, $passes );
+agents_api_smoke_assert_equals( $canonical_dropped, $canonical_metadata['citations_dropped'] ?? 0, 'canonical metadata records the exact dropped citation count', $failures, $passes );
+agents_api_smoke_assert_equals( $canonical_dropped, $canonical_citation_heavy['metadata']['citations_dropped'] ?? 0, 'canonical citation drops surface in event metadata', $failures, $passes );
 
 // Fail closed: when even the first normalized citation exceeds the remaining
 // budget, the citations array is omitted entirely rather than preserved.
@@ -178,6 +201,6 @@ $fail_closed          = ( new AgentsAPI\AI\WP_Agent_Byte_Limit_Tool_Result_Trunc
 $fail_closed_result   = $fail_closed['result']['result'] ?? array();
 
 agents_api_smoke_assert_equals( false, isset( $fail_closed_result['citations'] ), 'oversized first citation is omitted entirely (fail closed)', $failures, $passes );
-agents_api_smoke_assert_equals( true, ( $fail_closed_result['citations_dropped'] ?? 0 ) >= 1, 'fail-closed drop is recorded', $failures, $passes );
+agents_api_smoke_assert_equals( 1, $fail_closed_result['citations_dropped'] ?? 0, 'fail-closed drop is recorded exactly', $failures, $passes );
 
 agents_api_smoke_finish( 'Agents API tool result truncator', $failures, $passes );

--- a/tests/tool-result-truncator-smoke.php
+++ b/tests/tool-result-truncator-smoke.php
@@ -131,4 +131,53 @@ $untruncated = ( new AgentsAPI\AI\WP_Agent_Byte_Limit_Tool_Result_Truncator( 100
 
 agents_api_smoke_assert_equals( false, $untruncated['truncated'], 'byte-limit truncator leaves small results unchanged', $failures, $passes );
 
+// Preserved citation metadata must stay bounded to the truncator byte ceiling
+// so a citation-heavy result cannot defeat the advertised byte bound.
+$many_citations = array();
+for ( $i = 0; $i < 500; $i++ ) {
+	$many_citations[] = array(
+		'source_url'   => 'https://example.test/source-' . $i,
+		'source_title' => str_repeat( 'title', 8 ),
+	);
+}
+
+$citation_budget      = 256;
+$citation_heavy       = ( new AgentsAPI\AI\WP_Agent_Byte_Limit_Tool_Result_Truncator( $citation_budget ) )->truncate_result(
+	array(
+		'success' => true,
+		'result'  => array(
+			'body'      => str_repeat( 'y', 5000 ),
+			'citations' => $many_citations,
+		),
+	),
+	'client/large-result'
+);
+$citation_replacement = $citation_heavy['result']['result'] ?? array();
+$preserved_citations  = $citation_replacement['citations'] ?? array();
+$encoded_citations    = (string) wp_json_encode( $preserved_citations );
+
+agents_api_smoke_assert_equals( true, strlen( $encoded_citations ) <= $citation_budget, 'preserved citations stay within the truncator byte budget', $failures, $passes );
+agents_api_smoke_assert_equals( true, count( $preserved_citations ) < count( $many_citations ), 'citation-heavy result drops trailing citations', $failures, $passes );
+agents_api_smoke_assert_equals( true, ( $citation_replacement['citations_dropped'] ?? 0 ) > 0, 'dropped citation count is recorded for observers', $failures, $passes );
+agents_api_smoke_assert_equals( true, ( $citation_heavy['metadata']['citations_dropped'] ?? 0 ) > 0, 'dropped citation count surfaces in event metadata', $failures, $passes );
+
+// Fail closed: when even the first normalized citation exceeds the remaining
+// budget, the citations array is omitted entirely rather than preserved.
+$fail_closed          = ( new AgentsAPI\AI\WP_Agent_Byte_Limit_Tool_Result_Truncator( 5 ) )->truncate_result(
+	array(
+		'success' => true,
+		'result'  => array(
+			'body'      => str_repeat( 'z', 200 ),
+			'citations' => array(
+				array( 'source_url' => 'https://example.test/way-too-long-to-fit-in-a-tiny-budget' ),
+			),
+		),
+	),
+	'client/large-result'
+);
+$fail_closed_result   = $fail_closed['result']['result'] ?? array();
+
+agents_api_smoke_assert_equals( false, isset( $fail_closed_result['citations'] ), 'oversized first citation is omitted entirely (fail closed)', $failures, $passes );
+agents_api_smoke_assert_equals( true, ( $fail_closed_result['citations_dropped'] ?? 0 ) >= 1, 'fail-closed drop is recorded', $failures, $passes );
+
 agents_api_smoke_finish( 'Agents API tool result truncator', $failures, $passes );


### PR DESCRIPTION
## Summary

Unbounded resource amplification (CWE-400 / CWE-770) in the byte-limit tool result truncator. The truncator advertises that it "truncates oversized mediated tool results before transcript storage," but preserved citation metadata was never bounded, so a citation-heavy result could defeat that byte bound.

- `src/Runtime/class-wp-agent-byte-limit-tool-result-truncator.php:47` (CWE-400 / CWE-770): when a result exceeds `max_bytes`, the excerpt is capped at `max_bytes`, but `preserve_result_metadata()` then array-merges `WP_Agent_Citation_Metadata::normalize_many()` output into the replacement result verbatim. `normalize_many()`/`normalize()` have no count or per-field length cap, so a large, attacker-influenced `citations` array is preserved in full. The resulting `result` payload can far exceed `max_bytes` and is then serialized into the persisted transcript and sent to the provider (`conversation-loop`), defeating the advertised byte bound. Impact: resource/cost amplification on citation-heavy retrieved-context results.

## Fix

Preserved citations are now bounded to a budget derived from `max_bytes`, keeping the excerpt as the primary bounded content:

- Citations are accumulated in order and each candidate list is re-encoded with the existing `wp_json_encode()`/`strlen()` pattern; once the encoded list would exceed `max_bytes`, the remaining (trailing) citations are dropped.
- Fails closed: when even the first normalized citation overflows the budget, the `citations` key is omitted entirely rather than preserved.
- The number of dropped citations is recorded as `citations_dropped` in the replacement result and in the event/observer metadata, so the drop stays observable.

This bounds the replacement payload to O(`max_bytes`) instead of being unbounded by attacker-supplied citation volume. Legitimate small-citation results are unaffected.

## Testing

- `php tests/tool-result-truncator-smoke.php` (part of `composer smoke`) — extended with assertions that a 500-citation result keeps preserved citations within the byte budget, drops trailing citations, records `citations_dropped` in both the replacement and event metadata, and that an oversized first citation is omitted entirely (fail closed). These assertions fail on the pre-fix code and pass with the fix.
- Full `composer smoke` suite: all assertions pass, exit 0.
- `vendor/bin/phpstan analyse --no-progress --memory-limit=2G` (level max): No errors.

---

Found by an automated security scan; this fix is offered as a draft for review.

## AI assistance
OpenAI `openai/gpt-5.6-sol` via OpenCode reviewed this PR and drafted the security follow-up commit and tests. Chris Huber directed the work and remains responsible for the resulting changes.