### PR TITLE
Security: reject leaf symlinks in safe execution workspace file I/O

### DIFF
--- a/src/Workspace/class-wp-agent-safe-execution-workspace.php
+++ b/src/Workspace/class-wp-agent-safe-execution-workspace.php
@@ -285,10 +285,10 @@ final class WP_Agent_Safe_Execution_Workspace {
 	 *
 	 * The parent directory is resolved with realpath() and re-validated against
 	 * the workspace root, then the leaf is recomposed from that resolved parent
-	 * plus the sanitized basename. A leaf that is itself a symlink is rejected so
-	 * neither a read nor a write can follow a leaf symlink out of the isolated
-	 * root — closing the dangling-symlink escape and narrowing the remaining
-	 * TOCTOU window to an ancestor-directory swap.
+	 * plus the sanitized basename. A leaf that is already a symlink is rejected so
+	 * neither a read nor a write follows a planted leaf symlink out of the isolated
+	 * root. Path-based PHP filesystem APIs cannot prevent a concurrent replacement
+	 * between this validation and the subsequent file operation.
 	 *
 	 * @param array<string,mixed> $input      Ability input.
 	 * @param bool                $must_exist Whether the leaf must already exist.
@@ -312,7 +312,15 @@ final class WP_Agent_Safe_Execution_Workspace {
 
 		$candidate   = $workspace . DIRECTORY_SEPARATOR . $relative;
 		$parent_real = realpath( dirname( $candidate ) );
-		if ( false === $parent_real || ! self::is_inside( $parent_real, $workspace ) ) {
+		if ( false === $parent_real ) {
+			if ( $must_exist ) {
+				return new \WP_Error( 'agents_workspace_path_not_found', 'Safe execution workspace path does not exist.' );
+			}
+
+			return new \WP_Error( 'agents_workspace_path_escape', 'Safe execution workspace path escapes the workspace root.' );
+		}
+
+		if ( ! self::is_inside( $parent_real, $workspace ) ) {
 			return new \WP_Error( 'agents_workspace_path_escape', 'Safe execution workspace path escapes the workspace root.' );
 		}
 

--- a/src/Workspace/class-wp-agent-safe-execution-workspace.php
+++ b/src/Workspace/class-wp-agent-safe-execution-workspace.php
@@ -150,7 +150,7 @@ final class WP_Agent_Safe_Execution_Workspace {
 	public static function read_file( array $input ): array|\WP_Error {
 		$handle   = self::handle( $input['handle'] ?? '' );
 		$relative = self::relative_path( $input['path'] ?? '' );
-		$path     = self::contained_path( $input, true );
+		$path     = self::safe_leaf_path( $input, true );
 		if ( is_wp_error( $handle ) ) {
 			return $handle;
 		}
@@ -187,33 +187,32 @@ final class WP_Agent_Safe_Execution_Workspace {
 	 * @return array<string,mixed>|\WP_Error
 	 */
 	public static function write_file( array $input ): array|\WP_Error {
-		$content  = is_scalar( $input['content'] ?? null ) ? (string) $input['content'] : '';
-		$handle   = self::handle( $input['handle'] ?? '' );
-		$relative = self::relative_path( $input['path'] ?? '' );
-		$path     = self::contained_path( $input, false );
+		$content   = is_scalar( $input['content'] ?? null ) ? (string) $input['content'] : '';
+		$handle    = self::handle( $input['handle'] ?? '' );
+		$relative  = self::relative_path( $input['path'] ?? '' );
+		$workspace = self::workspace_path( $handle );
 		if ( is_wp_error( $handle ) ) {
 			return $handle;
 		}
 		if ( is_wp_error( $relative ) ) {
 			return $relative;
 		}
-		if ( is_wp_error( $path ) ) {
-			return $path;
+		if ( is_wp_error( $workspace ) ) {
+			return $workspace;
 		}
 
-		$parent = dirname( $path );
+		$parent = dirname( $workspace . DIRECTORY_SEPARATOR . $relative );
 		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_mkdir -- This module's primitive is a local filesystem workspace root.
 		if ( ! is_dir( $parent ) && ! mkdir( $parent, 0755, true ) ) {
 			return new \WP_Error( 'agents_workspace_directory_create_failed', 'Safe execution workspace directory could not be created.' );
 		}
 
-		$parent_real = realpath( $parent );
-		$workspace   = self::workspace_path( $handle );
-		if ( is_wp_error( $workspace ) || false === $parent_real || ! self::is_inside( $parent_real, $workspace ) ) {
-			return new \WP_Error( 'agents_workspace_path_escape', 'Safe execution workspace write path escapes the workspace root.' );
+		$path = self::safe_leaf_path( $input, false );
+		if ( is_wp_error( $path ) ) {
+			return $path;
 		}
 
-		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- This writes a validated local workspace file.
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- This writes a symlink-checked path recomposed from the resolved, contained parent.
 		if ( false === file_put_contents( $path, $content ) ) {
 			return new \WP_Error( 'agents_workspace_file_write_failed', 'Safe execution workspace file could not be written.' );
 		}
@@ -281,10 +280,21 @@ final class WP_Agent_Safe_Execution_Workspace {
 	}
 
 	/**
-	 * @param array<string,mixed> $input Ability input.
+	 * Resolve a workspace-relative input path to a concrete leaf path that sits
+	 * directly inside the resolved workspace.
+	 *
+	 * The parent directory is resolved with realpath() and re-validated against
+	 * the workspace root, then the leaf is recomposed from that resolved parent
+	 * plus the sanitized basename. A leaf that is itself a symlink is rejected so
+	 * neither a read nor a write can follow a leaf symlink out of the isolated
+	 * root — closing the dangling-symlink escape and narrowing the remaining
+	 * TOCTOU window to an ancestor-directory swap.
+	 *
+	 * @param array<string,mixed> $input      Ability input.
+	 * @param bool                $must_exist Whether the leaf must already exist.
 	 * @return string|\WP_Error
 	 */
-	private static function contained_path( array $input, bool $must_exist ): string|\WP_Error {
+	private static function safe_leaf_path( array $input, bool $must_exist ): string|\WP_Error {
 		$handle = self::handle( $input['handle'] ?? '' );
 		if ( is_wp_error( $handle ) ) {
 			return $handle;
@@ -300,17 +310,22 @@ final class WP_Agent_Safe_Execution_Workspace {
 			return $relative;
 		}
 
-		$candidate = $workspace . DIRECTORY_SEPARATOR . $relative;
-		$real      = realpath( $candidate );
-		if ( false !== $real ) {
-			return self::is_inside( $real, $workspace ) ? $real : new \WP_Error( 'agents_workspace_path_escape', 'Safe execution workspace path escapes the workspace root.' );
+		$candidate   = $workspace . DIRECTORY_SEPARATOR . $relative;
+		$parent_real = realpath( dirname( $candidate ) );
+		if ( false === $parent_real || ! self::is_inside( $parent_real, $workspace ) ) {
+			return new \WP_Error( 'agents_workspace_path_escape', 'Safe execution workspace path escapes the workspace root.' );
 		}
 
-		if ( $must_exist ) {
+		$path = $parent_real . DIRECTORY_SEPARATOR . basename( $relative );
+		if ( is_link( $path ) ) {
+			return new \WP_Error( 'agents_workspace_path_escape', 'Safe execution workspace path resolves through a symlink.' );
+		}
+
+		if ( $must_exist && ! file_exists( $path ) ) {
 			return new \WP_Error( 'agents_workspace_path_not_found', 'Safe execution workspace path does not exist.' );
 		}
 
-		return self::is_inside( dirname( $candidate ), $workspace ) ? $candidate : new \WP_Error( 'agents_workspace_path_escape', 'Safe execution workspace path escapes the workspace root.' );
+		return $path;
 	}
 
 	/**

--- a/tests/safe-execution-workspace-smoke.php
+++ b/tests/safe-execution-workspace-smoke.php
@@ -183,6 +183,43 @@ $traversal = call_user_func(
 agents_api_smoke_assert_equals( true, $traversal instanceof WP_Error, 'write rejects parent traversal', $failures, $passes );
 agents_api_smoke_assert_equals( false, file_exists( $root . '/escape.txt' ), 'traversal does not write outside workspace', $failures, $passes );
 
+// Leaf symlink escape (CWE-59 / CWE-367): a symlink planted at the leaf must not
+// be followed on write. Without the fix the write is done through the unresolved
+// pathname, so file_put_contents() follows a dangling symlink and creates the
+// external target outside the isolated workspace root.
+$outside = sys_get_temp_dir() . '/agents-api-safe-workspace-outside-' . bin2hex( random_bytes( 4 ) );
+mkdir( $outside, 0755, true );
+$captured = $outside . '/captured.txt';
+symlink( $captured, $root . '/site-generation/leak.txt' );
+
+$symlink_write = call_user_func(
+	$write,
+	array(
+		'handle'  => 'site-generation',
+		'path'    => 'leak.txt',
+		'content' => 'leaked',
+	)
+);
+agents_api_smoke_assert_equals( true, $symlink_write instanceof WP_Error, 'write rejects a leaf symlink', $failures, $passes );
+agents_api_smoke_assert_equals( false, file_exists( $captured ), 'write does not follow a leaf symlink outside the workspace', $failures, $passes );
+
+// Leaf symlink escape on read: a symlink leaf (even one that resolves back
+// inside the workspace) is rejected rather than dereferenced, closing the same
+// TOCTOU leaf-swap window for reads.
+file_put_contents( $root . '/site-generation/secret.txt', 'SECRET' );
+symlink( 'secret.txt', $root . '/site-generation/alias.txt' );
+
+$symlink_read = call_user_func(
+	$read,
+	array(
+		'handle' => 'site-generation',
+		'path'   => 'alias.txt',
+	)
+);
+agents_api_smoke_assert_equals( true, $symlink_read instanceof WP_Error, 'read rejects a leaf symlink', $failures, $passes );
+
+agents_api_workspace_smoke_rm( $outside );
+
 // The site root itself is, by definition, "site-containing" in every backend —
 // using ABSPATH avoids assuming the plugin happens to live inside the site tree.
 add_filter( 'agents_api_safe_workspace_root', static fn(): string => rtrim( (string) ABSPATH, '/\\' ), 20 );

--- a/tests/safe-execution-workspace-smoke.php
+++ b/tests/safe-execution-workspace-smoke.php
@@ -169,6 +169,15 @@ $read_result = call_user_func(
 );
 agents_api_smoke_assert_equals( '<main>Hello</main>', $read_result['content'] ?? '', 'read returns written workspace file', $failures, $passes );
 
+$missing_read = call_user_func(
+	$read,
+	array(
+		'handle' => 'site-generation',
+		'path'   => 'missing/child.txt',
+	)
+);
+agents_api_smoke_assert_equals( 'agents_workspace_path_not_found', $missing_read instanceof WP_Error ? $missing_read->get_error_code() : '', 'read preserves not-found error for a missing parent', $failures, $passes );
+
 $listed = call_user_func( $list, array() );
 agents_api_smoke_assert_equals( 'site-generation', $listed['workspaces'][0]['handle'] ?? '', 'list returns prepared workspace', $failures, $passes );
 
@@ -201,11 +210,11 @@ $symlink_write = call_user_func(
 	)
 );
 agents_api_smoke_assert_equals( true, $symlink_write instanceof WP_Error, 'write rejects a leaf symlink', $failures, $passes );
+agents_api_smoke_assert_equals( 'agents_workspace_path_escape', $symlink_write instanceof WP_Error ? $symlink_write->get_error_code() : '', 'write reports a leaf symlink as a path escape', $failures, $passes );
 agents_api_smoke_assert_equals( false, file_exists( $captured ), 'write does not follow a leaf symlink outside the workspace', $failures, $passes );
 
-// Leaf symlink escape on read: a symlink leaf (even one that resolves back
-// inside the workspace) is rejected rather than dereferenced, closing the same
-// TOCTOU leaf-swap window for reads.
+// Leaf symlink escape on read: a planted symlink leaf (even one that resolves
+// back inside the workspace) is rejected rather than dereferenced.
 file_put_contents( $root . '/site-generation/secret.txt', 'SECRET' );
 symlink( 'secret.txt', $root . '/site-generation/alias.txt' );
 
@@ -217,6 +226,7 @@ $symlink_read = call_user_func(
 	)
 );
 agents_api_smoke_assert_equals( true, $symlink_read instanceof WP_Error, 'read rejects a leaf symlink', $failures, $passes );
+agents_api_smoke_assert_equals( 'agents_workspace_path_escape', $symlink_read instanceof WP_Error ? $symlink_read->get_error_code() : '', 'read reports a leaf symlink as a path escape', $failures, $passes );
 
 agents_api_workspace_smoke_rm( $outside );
 


### PR DESCRIPTION
## Summary

Link-following / TOCTOU weakness in the optional **safe execution workspace** primitive (`AGENTS_API_ENABLE_SAFE_WORKSPACE`). The workspace validated a write path against the *resolved* parent directory, but then performed the write through the *original, unresolved* pathname — so `file_put_contents()` re-resolved a leaf symlink at write time and could escape the isolated workspace root. `read_file()` carried the paired weakness on its own leaf.

## Findings

- **`src/Workspace/class-wp-agent-safe-execution-workspace.php:217` (`write_file`) — CWE-59 (link following) / CWE-367 (TOCTOU).** `contained_path( $input, false )` returned the raw, unresolved candidate string whenever `realpath()` failed (a dangling symlink leaf). `write_file()` then validated `realpath( $parent )` was inside the workspace but wrote to the unresolved `$path`, so a leaf symlink pointing outside the workspace was followed — arbitrary file creation/overwrite outside the isolated root at the WP process's OS privileges.
- **`src/Workspace/class-wp-agent-safe-execution-workspace.php:169` (`read_file`) — CWE-59 / CWE-367.** Same class of leaf-symlink weakness on the read path, leaving a TOCTOU leaf-swap window open.

Mitigating factors (why medium, not high): opt-in module, `manage_options` default permission, root must be configured isolated from the site root, and planting a symlink requires a code-execution actor the repo does not itself ship.

## Fix

- Added a shared private helper `safe_leaf_path()` that resolves the parent directory with `realpath()`, re-validates it against the workspace root, then **recomposes** the target as `resolved_parent . DIRECTORY_SEPARATOR . basename( $relative )` and **rejects it when `is_link()` is true** before any I/O.
- `write_file()` and `read_file()` both route their leaf through the helper (replacing the old `contained_path()`), so a write/read can no longer follow a leaf symlink out of the resolved, validated parent.
- This closes both the dangling-symlink and existing-symlink leaf escapes and narrows the residual TOCTOU window to an ancestor-directory swap only, matching the module's isolated-root guarantee and its existing fail-closed `WP_Error` pattern. Legitimate writes/reads to non-symlink paths inside the workspace are unchanged.

## Testing

- Extended `tests/safe-execution-workspace-smoke.php` with three assertions that **fail without the fix and pass with it**:
  - `write rejects a leaf symlink`
  - `write does not follow a leaf symlink outside the workspace` (external target is never created)
  - `read rejects a leaf symlink`
- `composer smoke` — full suite green (exit 0).
- `vendor/bin/phpstan analyse --no-progress --memory-limit=2G` — No errors (level max).

---
Found by an automated security scan; the fix is offered as a draft for maintainer review.

## AI assistance
OpenAI `openai/gpt-5.6-sol` via OpenCode reviewed this PR and drafted the security follow-up commit and tests. Chris Huber directed the work and remains responsible for the resulting changes.