### PR TITLE
Security: authorize task run actions against stored owner, not client-asserted session_owner

### DIFF
--- a/src/Tasks/class-wp-agent-task-run-control.php
+++ b/src/Tasks/class-wp-agent-task-run-control.php
@@ -153,23 +153,25 @@ class WP_Agent_Task_Run_Control {
 	}
 
 	/**
-	 * Start or update an addressable task run in the default store.
+	 * Start an addressable task run in the default store.
 	 *
 	 * @param string              $run_id      Run ID.
 	 * @param string              $session_id  Session ID.
 	 * @param string              $executor_id Executor ID.
 	 * @param array<string,mixed> $metadata    Run metadata.
 	 * @param array<string,mixed> $owner       Owning principal tuple ({type,key}).
-	 * @return array<string,mixed> Normalized run.
+	 * @return array<string,mixed>|\WP_Error Normalized run, or an error when already claimed.
 	 */
-	public static function start_run( string $run_id, string $session_id, string $executor_id, array $metadata = array(), array $owner = array() ): array {
+	public static function start_run( string $run_id, string $session_id, string $executor_id, array $metadata = array(), array $owner = array() ) {
 		$now   = self::now();
 		$state = self::state();
 		$owner = self::owner_value( $owner );
 
-		// Never let a re-issued start_run silently drop the bound owner.
-		if ( array() === $owner && isset( $state['runs'][ $run_id ]['owner'] ) ) {
-			$owner = self::owner_value( $state['runs'][ $run_id ]['owner'] );
+		if ( isset( $state['runs'][ $run_id ] ) ) {
+			return new \WP_Error( 'agents_task_run_already_started', 'The run_id has already been claimed for execution.' );
+		}
+		if ( function_exists( 'add_option' ) && ! add_option( self::claim_option_key( $run_id ), $now, '', false ) ) {
+			return new \WP_Error( 'agents_task_run_already_started', 'The run_id has already been claimed for execution.' );
 		}
 
 		$run = array(
@@ -202,8 +204,8 @@ class WP_Agent_Task_Run_Control {
 
 		$state = self::state();
 
-		// Executor result payloads carry no owner; keep the principal bound at start_run.
-		if ( array() === $normalized['owner'] && isset( $state['runs'][ $run_id ]['owner'] ) ) {
+		// Ownership is server-bound at start_run and cannot be replaced by an executor.
+		if ( isset( $state['runs'][ $run_id ]['owner'] ) ) {
 			$normalized['owner'] = self::owner_value( $state['runs'][ $run_id ]['owner'] );
 		}
 
@@ -262,6 +264,10 @@ class WP_Agent_Task_Run_Control {
 
 	private static function string_value( mixed $value ): string {
 		return is_int( $value ) || is_float( $value ) || is_string( $value ) || is_bool( $value ) ? (string) $value : '';
+	}
+
+	private static function claim_option_key( string $run_id ): string {
+		return self::OPTION_KEY . '_claim_' . md5( $run_id );
 	}
 
 	/** @return array<string,mixed> */

--- a/src/Tasks/class-wp-agent-task-run-control.php
+++ b/src/Tasks/class-wp-agent-task-run-control.php
@@ -82,6 +82,7 @@ class WP_Agent_Task_Run_Control {
 			'session_id'        => $session_id,
 			'status'            => $status,
 			'executor_id'       => $executor_id,
+			'owner'             => self::owner_value( $run['owner'] ?? array() ),
 			'execution_metrics' => self::execution_metrics_value( $run['execution_metrics'] ?? array(), $executor_id ),
 			'artifact_refs'     => self::list_value( $run['artifact_refs'] ?? array() ),
 			'diagnostics'       => self::map_value( $run['diagnostics'] ?? array() ),
@@ -158,21 +159,30 @@ class WP_Agent_Task_Run_Control {
 	 * @param string              $session_id  Session ID.
 	 * @param string              $executor_id Executor ID.
 	 * @param array<string,mixed> $metadata    Run metadata.
+	 * @param array<string,mixed> $owner       Owning principal tuple ({type,key}).
 	 * @return array<string,mixed> Normalized run.
 	 */
-	public static function start_run( string $run_id, string $session_id, string $executor_id, array $metadata = array() ): array {
-		$now = self::now();
+	public static function start_run( string $run_id, string $session_id, string $executor_id, array $metadata = array(), array $owner = array() ): array {
+		$now   = self::now();
+		$state = self::state();
+		$owner = self::owner_value( $owner );
+
+		// Never let a re-issued start_run silently drop the bound owner.
+		if ( array() === $owner && isset( $state['runs'][ $run_id ]['owner'] ) ) {
+			$owner = self::owner_value( $state['runs'][ $run_id ]['owner'] );
+		}
+
 		$run = array(
 			'run_id'      => $run_id,
 			'session_id'  => $session_id,
 			'executor_id' => $executor_id,
 			'status'      => self::STATUS_RUNNING,
+			'owner'       => $owner,
 			'started_at'  => $metadata['started_at'] ?? $now,
 			'updated_at'  => $now,
 			'metadata'    => $metadata,
 		);
 
-		$state                    = self::state();
 		$state['runs'][ $run_id ] = $run;
 		self::save_state( $state );
 
@@ -190,7 +200,13 @@ class WP_Agent_Task_Run_Control {
 		$normalized['updated_at'] = '' !== $normalized['updated_at'] ? $normalized['updated_at'] : self::now();
 		$run_id                   = self::string_value( $normalized['run_id'] );
 
-		$state                    = self::state();
+		$state = self::state();
+
+		// Executor result payloads carry no owner; keep the principal bound at start_run.
+		if ( array() === $normalized['owner'] && isset( $state['runs'][ $run_id ]['owner'] ) ) {
+			$normalized['owner'] = self::owner_value( $state['runs'][ $run_id ]['owner'] );
+		}
+
 		$state['runs'][ $run_id ] = $normalized;
 		self::save_state( $state );
 
@@ -262,6 +278,25 @@ class WP_Agent_Task_Run_Control {
 		}
 
 		return $map;
+	}
+
+	/**
+	 * Normalize a stored owning-principal tuple, dropping partial/invalid claims.
+	 *
+	 * @return array<string,mixed>
+	 */
+	private static function owner_value( mixed $value ): array {
+		$owner = self::map_value( $value );
+		$type  = self::non_empty_string_value( $owner['type'] ?? null );
+		$key   = self::non_empty_string_value( $owner['key'] ?? null );
+		if ( null === $type || null === $key ) {
+			return array();
+		}
+
+		return array(
+			'type' => $type,
+			'key'  => $key,
+		);
 	}
 
 	/** @return array<string,mixed> */

--- a/src/Tasks/register-agents-task-abilities.php
+++ b/src/Tasks/register-agents-task-abilities.php
@@ -143,7 +143,10 @@ function agents_run_task( array $input ) {
 		'target_kind'    => $target['kind'],
 		'resource_class' => $placement['resource_class'] ?? '',
 	);
-	WP_Agent_Task_Run_Control::start_run( $run_id, $session_id, $executor_id, $metadata, agents_task_current_owner() );
+	$started = WP_Agent_Task_Run_Control::start_run( $run_id, $session_id, $executor_id, $metadata, agents_task_current_owner() );
+	if ( is_wp_error( $started ) ) {
+		return $started;
+	}
 
 	$result = call_user_func( $handler, $input, $target );
 	if ( is_wp_error( $result ) ) {
@@ -178,14 +181,15 @@ function agents_run_task( array $input ) {
 
 	$result = agents_task_string_keyed_array( $result );
 	$result = array_merge(
+		$result,
 		array(
 			'schema'      => 'agents-api/task-result/v1',
 			'run_id'      => $run_id,
 			'session_id'  => $session_id,
 			'executor_id' => $executor_id,
-		),
-		$result
+		)
 	);
+	unset( $result['owner'] );
 
 	try {
 		return WP_Agent_Task_Run_Control::save_run( $result );
@@ -238,28 +242,16 @@ function agents_list_execution_targets( array $input ) {
  * @return array<string,mixed>|\WP_Error
  */
 function agents_get_task_run( array $input ) {
-	$handler = apply_filters( 'wp_agent_task_run_status_handler', null, $input );
-	if ( is_callable( $handler ) ) {
-		$result = agents_task_normalize_run_control_result( call_user_func( $handler, $input ), 'agents_task_run_invalid_status' );
-		return is_wp_error( $result ) ? $result : agents_task_run_observer_payload( $result, $input );
+	$run = agents_task_resolve_run( $input );
+	if ( is_wp_error( $run ) ) {
+		return $run;
 	}
 
-	$run                  = WP_Agent_Task_Run_Control::get_run( agents_task_string( $input['run_id'] ?? '' ) );
-	$requested_session_id = agents_task_string( $input['session_id'] ?? '' );
-	if ( null !== $run && agents_task_string( $run['session_id'] ?? '' ) !== $requested_session_id ) {
+	if ( ! agents_task_manage_permission() && ! agents_task_current_user_owns_run( $run ) ) {
 		return new \WP_Error( 'agents_task_run_not_found', 'No task run was found for the requested session_id and run_id.' );
 	}
-	if ( null !== $run ) {
-		// Authorize reads against the stored owner, not a client-asserted principal.
-		// Managers bypass; everyone else must own the run. Fail closed with the same
-		// generic error so the boundary is not an existence oracle.
-		if ( ! agents_task_unredacted_read_permission( $input ) && ! agents_task_current_user_owns_run( $run ) ) {
-			return new \WP_Error( 'agents_task_run_not_found', 'No task run was found for the requested session_id and run_id.' );
-		}
-		return agents_task_run_observer_payload( $run, $input );
-	}
 
-	return new \WP_Error( 'agents_task_run_not_found', 'No task run was found for the requested run_id.' );
+	return agents_task_run_observer_payload( $run, $input );
 }
 
 /**
@@ -489,10 +481,37 @@ function agents_run_task_permission( array $input ): bool {
  * @param array<string,mixed> $input Ability input.
  */
 function agents_cancel_task_run_permission( array $input ): bool {
-	$run     = WP_Agent_Task_Run_Control::get_run( agents_task_string( $input['run_id'] ?? '' ) );
-	$allowed = agents_task_manage_permission() || agents_task_current_user_owns_run( $run );
+	$run     = agents_task_resolve_run( $input );
+	$allowed = agents_task_manage_permission() || ( is_array( $run ) && agents_task_current_user_owns_run( $run ) );
 	$allowed = (bool) apply_filters( 'agents_cancel_task_run_permission', $allowed, $input );
 	return (bool) apply_filters( 'agents_task_permission', $allowed, $input );
+}
+
+/**
+ * Resolve a run from the configured status backend and verify its address.
+ *
+ * @param array<string,mixed> $input Ability input.
+ * @return array<string,mixed>|\WP_Error
+ */
+function agents_task_resolve_run( array $input ) {
+	$handler = apply_filters( 'wp_agent_task_run_status_handler', null, $input );
+	if ( is_callable( $handler ) ) {
+		$run = agents_task_normalize_run_control_result( call_user_func( $handler, $input ), 'agents_task_run_invalid_status' );
+	} else {
+		$run = WP_Agent_Task_Run_Control::get_run( agents_task_string( $input['run_id'] ?? '' ) );
+	}
+
+	if ( is_wp_error( $run ) ) {
+		return $run;
+	}
+
+	$requested_run_id     = agents_task_string( $input['run_id'] ?? '' );
+	$requested_session_id = agents_task_string( $input['session_id'] ?? '' );
+	if ( ! is_array( $run ) || agents_task_string( $run['run_id'] ?? '' ) !== $requested_run_id || agents_task_string( $run['session_id'] ?? '' ) !== $requested_session_id ) {
+		return new \WP_Error( 'agents_task_run_not_found', 'No task run was found for the requested session_id and run_id.' );
+	}
+
+	return $run;
 }
 
 /** True when the current request can manage the site (manager bypass). */

--- a/src/Tasks/register-agents-task-abilities.php
+++ b/src/Tasks/register-agents-task-abilities.php
@@ -143,7 +143,7 @@ function agents_run_task( array $input ) {
 		'target_kind'    => $target['kind'],
 		'resource_class' => $placement['resource_class'] ?? '',
 	);
-	WP_Agent_Task_Run_Control::start_run( $run_id, $session_id, $executor_id, $metadata );
+	WP_Agent_Task_Run_Control::start_run( $run_id, $session_id, $executor_id, $metadata, agents_task_current_owner() );
 
 	$result = call_user_func( $handler, $input, $target );
 	if ( is_wp_error( $result ) ) {
@@ -250,6 +250,12 @@ function agents_get_task_run( array $input ) {
 		return new \WP_Error( 'agents_task_run_not_found', 'No task run was found for the requested session_id and run_id.' );
 	}
 	if ( null !== $run ) {
+		// Authorize reads against the stored owner, not a client-asserted principal.
+		// Managers bypass; everyone else must own the run. Fail closed with the same
+		// generic error so the boundary is not an existence oracle.
+		if ( ! agents_task_unredacted_read_permission( $input ) && ! agents_task_current_user_owns_run( $run ) ) {
+			return new \WP_Error( 'agents_task_run_not_found', 'No task run was found for the requested session_id and run_id.' );
+		}
 		return agents_task_run_observer_payload( $run, $input );
 	}
 
@@ -476,17 +482,33 @@ function agents_run_task_permission( array $input ): bool {
 	return (bool) apply_filters( 'agents_task_permission', $allowed, $input );
 }
 
-/** @param array<string,mixed> $input Ability input. */
+/**
+ * Cancellation acts on an EXISTING run, so authorize against the run's stored
+ * owner rather than the trivially self-satisfiable client session_owner claim.
+ *
+ * @param array<string,mixed> $input Ability input.
+ */
 function agents_cancel_task_run_permission( array $input ): bool {
-	$allowed = agents_task_write_permission( $input );
+	$run     = WP_Agent_Task_Run_Control::get_run( agents_task_string( $input['run_id'] ?? '' ) );
+	$allowed = agents_task_manage_permission() || agents_task_current_user_owns_run( $run );
 	$allowed = (bool) apply_filters( 'agents_cancel_task_run_permission', $allowed, $input );
 	return (bool) apply_filters( 'agents_task_permission', $allowed, $input );
 }
 
-/** @param array<string,mixed> $input Ability input. */
+/** True when the current request can manage the site (manager bypass). */
+function agents_task_manage_permission(): bool {
+	return function_exists( 'current_user_can' ) ? current_user_can( 'manage_options' ) : false;
+}
+
+/**
+ * Ownership gate for CREATING a run: the client stamps itself as the owner of a
+ * brand-new run/session it is dispatching. Safe as a creation stamp because the
+ * run does not yet exist and cannot belong to another principal.
+ *
+ * @param array<string,mixed> $input Ability input.
+ */
 function agents_task_write_permission( array $input ): bool {
-	$allowed = function_exists( 'current_user_can' ) ? current_user_can( 'manage_options' ) : false;
-	return $allowed || agents_task_current_user_owns_session( $input );
+	return agents_task_manage_permission() || agents_task_current_user_owns_session( $input );
 }
 
 /** @param array<string,mixed> $input Ability input. */
@@ -498,6 +520,38 @@ function agents_task_current_user_owns_session( array $input ): bool {
 
 	$user_id = function_exists( 'get_current_user_id' ) ? (int) get_current_user_id() : 0;
 	return 0 < $user_id && agents_task_string( $owner['key'] ?? '' ) === (string) $user_id;
+}
+
+/**
+ * Ownership gate for acting on an EXISTING run: compare the run's server-stored
+ * owner against the current user. Fails closed when the run is absent or has no
+ * stored owner, so a caller who lacks manage_options cannot self-assert access.
+ *
+ * @param array<string,mixed>|null $run Stored run resolved via get_run(), or null.
+ */
+function agents_task_current_user_owns_run( ?array $run ): bool {
+	if ( null === $run ) {
+		return false;
+	}
+
+	$owner = is_array( $run['owner'] ?? null ) ? agents_task_string_keyed_array( $run['owner'] ) : array();
+	if ( 'user' !== agents_task_string( $owner['type'] ?? '' ) ) {
+		return false;
+	}
+
+	$user_id = function_exists( 'get_current_user_id' ) ? (int) get_current_user_id() : 0;
+	return 0 < $user_id && agents_task_string( $owner['key'] ?? '' ) === (string) $user_id;
+}
+
+/**
+ * Resolve the authenticated principal that owns a newly created run. Bound to
+ * the server-verified current user, never to a client-asserted session_owner.
+ *
+ * @return array<string,mixed>
+ */
+function agents_task_current_owner(): array {
+	$user_id = function_exists( 'get_current_user_id' ) ? (int) get_current_user_id() : 0;
+	return 0 < $user_id ? array( 'type' => 'user', 'key' => (string) $user_id ) : array();
 }
 
 function agents_task_optional_string( mixed $value ): ?string {

--- a/tests/task-execution-smoke.php
+++ b/tests/task-execution-smoke.php
@@ -89,6 +89,17 @@ if ( ! function_exists( 'update_option' ) ) {
 	}
 }
 
+if ( ! function_exists( 'add_option' ) ) {
+	function add_option( string $option, $value = '', $deprecated = '', $autoload = 'yes' ): bool {
+		unset( $deprecated, $autoload );
+		if ( isset( $GLOBALS['__agents_api_smoke_options'][ $option ] ) ) {
+			return false;
+		}
+		$GLOBALS['__agents_api_smoke_options'][ $option ] = $value;
+		return true;
+	}
+}
+
 /**
  * Resolve a registered ability's output schema in either backend.
  *
@@ -173,9 +184,10 @@ add_filter(
 		$captured_target = $target;
 		return static function ( array $runtime_input, array $runtime_target ): array {
 			return array(
-				'run_id'            => $runtime_input['run_id'],
-				'session_id'        => $runtime_input['session_id'],
-				'executor_id'       => $runtime_target['id'],
+				'run_id'            => 'executor-controlled-run',
+				'session_id'        => 'executor-controlled-session',
+				'executor_id'       => 'executor-controlled-id',
+				'owner'             => array( 'type' => 'user', 'key' => '456' ),
 				'status'            => 'succeeded',
 				'execution_metrics' => array(
 					'environment'         => 'test',
@@ -244,6 +256,8 @@ agents_api_smoke_assert_equals( 'fake-executor', $captured_target['id'] ?? null,
 agents_api_smoke_assert_equals( 'agents-api/task-result/v1', $result['schema'] ?? null, 'run-task returns result envelope schema', $failures, $passes );
 agents_api_smoke_assert_equals( 'succeeded', $result['status'] ?? null, 'run-task normalizes task result status', $failures, $passes );
 agents_api_smoke_assert_equals( 'fake-executor', $result['executor_id'] ?? null, 'run-task preserves executor id', $failures, $passes );
+agents_api_smoke_assert_equals( $captured_input['run_id'] ?? null, $result['run_id'] ?? null, 'executor cannot replace canonical run id', $failures, $passes );
+agents_api_smoke_assert_equals( $captured_input['session_id'] ?? null, $result['session_id'] ?? null, 'executor cannot replace canonical session id', $failures, $passes );
 agents_api_smoke_assert_equals( 'object', task_execution_smoke_output_schema( AgentsAPI\AI\Tasks\AGENTS_RUN_TASK_ABILITY )['properties']['execution_metrics']['type'] ?? null, 'run-task result schema allows execution metrics', $failures, $passes );
 agents_api_smoke_assert_equals( 'agents-api/execution-metrics/v1', $result['execution_metrics']['schema'] ?? null, 'run-task normalizes execution metrics schema', $failures, $passes );
 agents_api_smoke_assert_equals( 'test', $result['execution_metrics']['environment'] ?? null, 'run-task preserves metrics environment', $failures, $passes );
@@ -305,6 +319,25 @@ agents_api_smoke_assert_equals( 'task-run-owned', $owner_read['run_id'] ?? null,
 $GLOBALS['__agents_api_smoke_user_id'] = 456;
 agents_api_smoke_assert_equals( false, call_user_func( $task_cancel_permission, array( 'session_id' => 'task-session-owned', 'run_id' => 'task-run-owned', 'session_owner' => array( 'type' => 'user', 'key' => '456' ) ) ), 'non-owner read user cannot cancel another principal run', $failures, $passes );
 
+$duplicate = AgentsAPI\AI\Tasks\agents_run_task(
+	array(
+		'task'          => array( 'id' => 'task-duplicate-run' ),
+		'session_id'    => 'task-session-owned',
+		'run_id'        => 'task-run-owned',
+		'session_owner' => array( 'type' => 'user', 'key' => '456' ),
+		'placement'     => array( 'preferred_target' => 'fake-executor' ),
+	)
+);
+agents_api_smoke_assert_equals( 'agents_task_run_already_started', $duplicate instanceof WP_Error ? $duplicate->get_error_code() : null, 'duplicate run id is rejected before executor dispatch', $failures, $passes );
+$still_owned = AgentsAPI\AI\Tasks\WP_Agent_Task_Run_Control::get_run( 'task-run-owned' );
+agents_api_smoke_assert_equals( '123', $still_owned['owner']['key'] ?? null, 'duplicate run id cannot replace stored owner', $failures, $passes );
+
+$concurrent_run_id = 'task-run-concurrent-claim';
+$GLOBALS['__agents_api_smoke_options']['agents_api_task_run_control_claim_' . md5( $concurrent_run_id )] = 'claimed-by-another-request';
+$concurrent_loser = AgentsAPI\AI\Tasks\WP_Agent_Task_Run_Control::start_run( $concurrent_run_id, 'task-session-concurrent', 'fake-executor', array(), array( 'type' => 'user', 'key' => '456' ) );
+agents_api_smoke_assert_equals( 'agents_task_run_already_started', $concurrent_loser instanceof WP_Error ? $concurrent_loser->get_error_code() : null, 'atomic run claim admits only the winning request', $failures, $passes );
+agents_api_smoke_assert_equals( null, AgentsAPI\AI\Tasks\WP_Agent_Task_Run_Control::get_run( $concurrent_run_id ), 'losing atomic claim does not overwrite task state', $failures, $passes );
+
 $cross_read = AgentsAPI\AI\Tasks\agents_get_task_run( array( 'session_id' => 'task-session-owned', 'run_id' => 'task-run-owned' ) );
 agents_api_smoke_assert_equals( true, $cross_read instanceof WP_Error, 'non-owner read user cannot read another principal run', $failures, $passes );
 agents_api_smoke_assert_equals( 'agents_task_run_not_found', $cross_read->get_error_code(), 'cross-principal read fails closed with generic not_found', $failures, $passes );
@@ -315,6 +348,30 @@ agents_api_smoke_assert_equals( true, call_user_func( $task_cancel_permission, a
 $manager_read = AgentsAPI\AI\Tasks\agents_get_task_run( array( 'session_id' => 'task-session-owned', 'run_id' => 'task-run-owned' ) );
 agents_api_smoke_assert_equals( 'task-run-owned', $manager_read['run_id'] ?? null, 'manager can read any stored run', $failures, $passes );
 $GLOBALS['__agents_api_smoke_user_id'] = 123;
+
+$external_status_handler = static function ( $handler, array $input ): callable {
+	unset( $handler );
+	return static function () use ( $input ): array {
+		return array(
+			'run_id'      => $input['run_id'],
+			'session_id'  => $input['session_id'],
+			'executor_id' => 'external-executor',
+			'status'      => 'running',
+			'owner'       => array( 'type' => 'user', 'key' => '123' ),
+		);
+	};
+};
+add_filter( 'wp_agent_task_run_status_handler', $external_status_handler, 10, 2 );
+$GLOBALS['__agents_api_smoke_caps']['manage_options'] = false;
+$external_owner_read = AgentsAPI\AI\Tasks\agents_get_task_run( array( 'session_id' => 'external-session', 'run_id' => 'external-run' ) );
+agents_api_smoke_assert_equals( 'external-run', $external_owner_read['run_id'] ?? null, 'external status backend owner can read their run', $failures, $passes );
+agents_api_smoke_assert_equals( true, call_user_func( $task_cancel_permission, array( 'session_id' => 'external-session', 'run_id' => 'external-run' ) ), 'external status backend owner can cancel their run', $failures, $passes );
+$GLOBALS['__agents_api_smoke_user_id'] = 456;
+$external_cross_read = AgentsAPI\AI\Tasks\agents_get_task_run( array( 'session_id' => 'external-session', 'run_id' => 'external-run' ) );
+agents_api_smoke_assert_equals( 'agents_task_run_not_found', $external_cross_read instanceof WP_Error ? $external_cross_read->get_error_code() : null, 'external status backend rejects cross-principal reads', $failures, $passes );
+agents_api_smoke_assert_equals( false, call_user_func( $task_cancel_permission, array( 'session_id' => 'external-session', 'run_id' => 'external-run' ) ), 'external status backend rejects cross-principal cancellation', $failures, $passes );
+$GLOBALS['__agents_api_smoke_user_id']                = 123;
+$GLOBALS['__agents_api_smoke_caps']['manage_options'] = true;
 
 add_filter(
 	'wp_agent_task_handler',

--- a/tests/task-execution-smoke.php
+++ b/tests/task-execution-smoke.php
@@ -125,7 +125,7 @@ agents_api_smoke_assert_equals( true, call_user_func( $task_read_permission, arr
 agents_api_smoke_assert_equals( false, call_user_func( $task_run_permission, array( 'task' => array( 'id' => 'task-1' ), 'session_id' => 'task-session-1', 'run_id' => 'task-run-1' ) ), 'read-only user cannot queue task run by id alone', $failures, $passes );
 agents_api_smoke_assert_equals( false, call_user_func( $task_cancel_permission, array( 'session_id' => 'task-session-1', 'run_id' => 'task-run-1' ) ), 'read-only user cannot cancel task run by id alone', $failures, $passes );
 agents_api_smoke_assert_equals( true, call_user_func( $task_run_permission, array( 'task' => array( 'id' => 'task-1' ), 'session_id' => 'task-session-1', 'run_id' => 'task-run-1', 'session_owner' => array( 'type' => 'user', 'key' => '123' ) ) ), 'session owner can queue task run', $failures, $passes );
-agents_api_smoke_assert_equals( true, call_user_func( $task_cancel_permission, array( 'session_id' => 'task-session-1', 'run_id' => 'task-run-1', 'session_owner' => array( 'type' => 'user', 'key' => '123' ) ) ), 'session owner can cancel task run', $failures, $passes );
+agents_api_smoke_assert_equals( false, call_user_func( $task_cancel_permission, array( 'session_id' => 'task-session-1', 'run_id' => 'task-run-1', 'session_owner' => array( 'type' => 'user', 'key' => '123' ) ) ), 'self-asserted owner cannot cancel a run with no stored owner', $failures, $passes );
 $GLOBALS['__agents_api_smoke_caps']['manage_options'] = true;
 agents_api_smoke_assert_equals( true, call_user_func( $task_run_permission, array( 'task' => array( 'id' => 'task-1' ), 'session_id' => 'task-session-1', 'run_id' => 'task-run-1' ) ), 'manager can queue task run without owner claim', $failures, $passes );
 agents_api_smoke_assert_equals( true, call_user_func( $task_cancel_permission, array( 'session_id' => 'task-session-1', 'run_id' => 'task-run-1' ) ), 'manager can cancel task run without owner claim', $failures, $passes );
@@ -252,6 +252,10 @@ agents_api_smoke_assert_equals( 42, $result['execution_metrics']['wall_time_ms']
 agents_api_smoke_assert_equals( 11, $result['execution_metrics']['per_tool_timings_ms']['inspect'] ?? null, 'run-task normalizes per-tool timing metrics', $failures, $passes );
 agents_api_smoke_assert_equals( 'artifact-1', $result['artifact_refs'][0]['id'] ?? null, 'run-task preserves artifact refs', $failures, $passes );
 
+$dispatched_run = AgentsAPI\AI\Tasks\WP_Agent_Task_Run_Control::get_run( $result['run_id'] );
+agents_api_smoke_assert_equals( 'user', $dispatched_run['owner']['type'] ?? null, 'run-task binds run to authenticated principal type', $failures, $passes );
+agents_api_smoke_assert_equals( '123', $dispatched_run['owner']['key'] ?? null, 'run-task binds run to authenticated principal id', $failures, $passes );
+
 $stored = AgentsAPI\AI\Tasks\agents_get_task_run(
 	array(
 		'session_id' => $result['session_id'],
@@ -286,6 +290,31 @@ $cancelled = AgentsAPI\AI\Tasks\agents_cancel_task_run(
 );
 agents_api_smoke_assert_equals( 'cancelling', $cancelled['status'] ?? null, 'cancel-task-run marks running runs as cancelling', $failures, $passes );
 agents_api_smoke_assert_equals( true, $cancelled['cancelled'] ?? null, 'cancel-task-run reports cancellation accepted', $failures, $passes );
+
+// Ownership is authorized against the run's stored owner, not client-asserted input.
+$GLOBALS['__agents_api_smoke_caps']['manage_options'] = false;
+$GLOBALS['__agents_api_smoke_user_id']                = 123;
+AgentsAPI\AI\Tasks\WP_Agent_Task_Run_Control::start_run( 'task-run-owned', 'task-session-owned', 'fake-executor', array(), array( 'type' => 'user', 'key' => '123' ) );
+
+agents_api_smoke_assert_equals( true, call_user_func( $task_cancel_permission, array( 'session_id' => 'task-session-owned', 'run_id' => 'task-run-owned' ) ), 'stored owner can cancel their own run', $failures, $passes );
+
+$owner_read = AgentsAPI\AI\Tasks\agents_get_task_run( array( 'session_id' => 'task-session-owned', 'run_id' => 'task-run-owned' ) );
+agents_api_smoke_assert_equals( 'task-run-owned', $owner_read['run_id'] ?? null, 'stored owner can read their own run', $failures, $passes );
+
+// A different read user cannot cancel or read another principal's run, even with a self-asserted owner claim.
+$GLOBALS['__agents_api_smoke_user_id'] = 456;
+agents_api_smoke_assert_equals( false, call_user_func( $task_cancel_permission, array( 'session_id' => 'task-session-owned', 'run_id' => 'task-run-owned', 'session_owner' => array( 'type' => 'user', 'key' => '456' ) ) ), 'non-owner read user cannot cancel another principal run', $failures, $passes );
+
+$cross_read = AgentsAPI\AI\Tasks\agents_get_task_run( array( 'session_id' => 'task-session-owned', 'run_id' => 'task-run-owned' ) );
+agents_api_smoke_assert_equals( true, $cross_read instanceof WP_Error, 'non-owner read user cannot read another principal run', $failures, $passes );
+agents_api_smoke_assert_equals( 'agents_task_run_not_found', $cross_read->get_error_code(), 'cross-principal read fails closed with generic not_found', $failures, $passes );
+
+// Managers still bypass ownership for both read and cancel.
+$GLOBALS['__agents_api_smoke_caps']['manage_options'] = true;
+agents_api_smoke_assert_equals( true, call_user_func( $task_cancel_permission, array( 'session_id' => 'task-session-owned', 'run_id' => 'task-run-owned' ) ), 'manager can cancel any stored run', $failures, $passes );
+$manager_read = AgentsAPI\AI\Tasks\agents_get_task_run( array( 'session_id' => 'task-session-owned', 'run_id' => 'task-run-owned' ) );
+agents_api_smoke_assert_equals( 'task-run-owned', $manager_read['run_id'] ?? null, 'manager can read any stored run', $failures, $passes );
+$GLOBALS['__agents_api_smoke_user_id'] = 123;
 
 add_filter(
 	'wp_agent_task_handler',


### PR DESCRIPTION
## Summary

The canonical task-execution abilities (`agents/run-task`, `agents/cancel-task-run`, `agents/get-task-run`) authorized destructive and read actions against a **client-supplied** `session_owner` tuple. A run's ownership was never persisted, so the claim was a throwaway gate-pass: any authenticated read-level user could submit `session_owner={type:user,key:<their own user ID>}` and pass the ownership gate for a run they do not own. This is a **self-asserted-owner authorization bypass** (CWE-639, Authorization Bypass Through User-Controlled Key).

- **[high] `agents/cancel-task-run`** — `src/Tasks/register-agents-task-abilities.php:480` (`agents_cancel_task_run_permission` → `agents_task_write_permission` → `agents_task_current_user_owns_session`). A read-without-`manage_options` user who knows another user's `session_id`+`run_id` could cancel that run by self-asserting ownership. CWE-639 — cross-principal cancellation of an existing run.
- **[low] `agents/get-task-run`** — `src/Tasks/register-agents-task-abilities.php:240` (`agents_get_task_run`). Authorization was by `session_id` match alone against a globally keyed store with no principal binding, so a read user who knows a valid `(run_id, session_id)` pair could read another principal's run (redacted observer payload still leaks status, executor, metrics, artifact refs, timestamps). CWE-639 / CWE-285 — cross-principal read.
- **[medium] `agents/run-task`** — `src/Tasks/register-agents-task-abilities.php:473` (`agents_run_task_permission` → `agents_task_write_permission`). The self-satisfiable `{type:user,key:own_id}` claim was treated as authorization for the destructive dispatch, and the created run was never bound to any principal. CWE-639 — read-level dispatch of host executors with no durable ownership.

## Fix

Authorize against **server-verified stored state**, and make the boundaries fail **closed**:

- `WP_Agent_Task_Run_Control::start_run`/`save_run`/`normalize_run` now persist a normalized `owner` tuple (`{type:'user',key:(string)$id}`) alongside `session_id`. `save_run` and re-issued `start_run` preserve the bound owner so executor result payloads (which carry no owner) never drop it.
- `agents/run-task` binds the new run to the **authenticated** principal (`agents_task_current_owner()` from `get_current_user_id()`), never to the client-asserted `session_owner`. The owner claim remains only a creation-time stamp for a brand-new run that cannot belong to anyone else.
- `agents/cancel-task-run` resolves the run via `get_run()` and compares its **stored** owner to the current user (`agents_task_current_user_owns_run()`); managers bypass via `manage_options`. It fails closed when the run is absent or has no stored owner.
- `agents/get-task-run` applies the same stored-owner check for non-managers and returns the identical generic `agents_task_run_not_found` error on mismatch, so the boundary is not an existence oracle.

Legitimate callers are unaffected: a real owner still cancels/reads their own run, and managers still bypass ownership.

## Testing

- `php tests/task-execution-smoke.php` (part of `composer smoke`) — extended with assertions that FAIL before the fix and PASS after:
  - `self-asserted owner cannot cancel a run with no stored owner`
  - `run-task binds run to authenticated principal type` / `... id`
  - `stored owner can cancel their own run` / `stored owner can read their own run`
  - `non-owner read user cannot cancel another principal run` / `... cannot read another principal run`
  - `cross-principal read fails closed with generic not_found`
  - `manager can cancel any stored run` / `manager can read any stored run`
- Full `composer smoke` suite: green.
- `vendor/bin/phpstan analyse --no-progress --memory-limit=2G` (level max): **No errors**.

---

This issue was found by an automated security scan; the fix is offered as a draft for maintainer review.

## AI assistance
OpenAI `openai/gpt-5.6-sol` via OpenCode reviewed this PR and drafted the security follow-up commit and tests. Chris Huber directed the work and remains responsible for the resulting changes.