### PR TITLE
Security: bind conversation session owner to authenticated principal and enforce workspace boundary

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,6 +45,7 @@
       "php tests/autonomous-capability-ceiling-smoke.php",
       "php tests/agents-access-ability-smoke.php",
       "php tests/agents-conversation-session-abilities-smoke.php",
+      "php tests/conversation-session-authz-smoke.php",
       "php tests/conversation-session-store-contract-smoke.php",
       "php tests/action-policy-values-smoke.php",
       "php tests/consent-policy-smoke.php",

--- a/src/Transcripts/register-agents-conversation-session-abilities.php
+++ b/src/Transcripts/register-agents-conversation-session-abilities.php
@@ -344,18 +344,28 @@ function agents_conversation_session_owner_from_input( array $input, WP_Agent_Ex
 		return new \WP_Error( 'agents_conversation_session_non_isolating_owner', 'Public audience is not an isolating conversation session owner.' );
 	}
 
-	$principal_owner = $principal->conversation_owner();
+	// Normalize user keys that clients may prefix with "user:" so the binding
+	// check below compares against the canonical numeric key.
 	if ( WP_Agent_Execution_Principal::OWNER_TYPE_USER === $type ) {
-		if ( ! is_array( $principal_owner ) || WP_Agent_Execution_Principal::OWNER_TYPE_USER !== $principal_owner['type'] || preg_replace( '/^user:/', '', $key ) !== (string) $principal_owner['key'] ) {
-			return new \WP_Error( 'agents_conversation_session_user_owner_forbidden', 'User conversation session owners must match the authenticated user principal.' );
-		}
+		$key = (string) preg_replace( '/^user:/', '', $key );
+	}
 
-		$key = (string) $principal_owner['key'];
+	// Bind every asserted owner to the authenticated principal's own owner.
+	// Identity is established by the resolved principal, never declared in the
+	// request body, so a caller can only ever address the owner it actually
+	// holds. This fails closed for user and non-user (token/audience/system/
+	// runtime/custom) owner types alike.
+	$principal_owner = $principal->conversation_owner();
+	if ( ! is_array( $principal_owner ) || $principal_owner['type'] !== $type || (string) $principal_owner['key'] !== $key ) {
+		$code = WP_Agent_Execution_Principal::OWNER_TYPE_USER === $type
+			? 'agents_conversation_session_user_owner_forbidden'
+			: 'agents_conversation_session_owner_forbidden';
+		return new \WP_Error( $code, 'Conversation session owner must match the authenticated principal.' );
 	}
 
 	return array(
 		'type' => $type,
-		'key'  => $key,
+		'key'  => (string) $principal_owner['key'],
 	);
 }
 
@@ -491,7 +501,14 @@ function agents_conversation_sessions_owned_session( string $session_id, array $
 	}
 
 	$session = agents_conversation_sessions_array_value( $session );
-	if ( ! agents_conversation_sessions_session_matches_owner( $session, $context['owner'] ) && ! agents_conversation_sessions_can_manage_any() ) {
+
+	// A store that resolves rows by session id alone cannot prove workspace
+	// isolation, so verify both the requested workspace and the owner before
+	// treating the row as owned. This mirrors the canonical
+	// WP_Agent_Conversation_Sessions::get_owned_session() fallback.
+	$matches = agents_conversation_sessions_session_matches_workspace( $session, $workspace )
+		&& agents_conversation_sessions_session_matches_owner( $session, $context['owner'] );
+	if ( ! $matches && ! agents_conversation_sessions_can_manage_any() ) {
 		return new \WP_Error( 'agents_conversation_session_forbidden', 'The current principal cannot access this conversation session.', array( 'status' => 403 ) );
 	}
 
@@ -511,6 +528,15 @@ function agents_conversation_sessions_session_matches_owner( array $session, arr
 	}
 
 	return WP_Agent_Execution_Principal::OWNER_TYPE_USER === $owner['type'] && agents_conversation_sessions_int_value( $session['user_id'] ?? 0 ) === (int) $owner['key'];
+}
+
+/**
+ * @param array<string,mixed>       $session   Session row.
+ * @param WP_Agent_Workspace_Scope $workspace Requested workspace scope.
+ */
+function agents_conversation_sessions_session_matches_workspace( array $session, WP_Agent_Workspace_Scope $workspace ): bool {
+	return agents_conversation_sessions_string_value( $session['workspace_type'] ?? null ) === $workspace->workspace_type
+		&& agents_conversation_sessions_string_value( $session['workspace_id'] ?? null ) === $workspace->workspace_id;
 }
 
 function agents_conversation_sessions_can_manage_any(): bool {

--- a/tests/agents-conversation-session-abilities-smoke.php
+++ b/tests/agents-conversation-session-abilities-smoke.php
@@ -337,19 +337,36 @@ $audience_created = agents_create_conversation_session( array( 'principal' => $a
 smoke_assert( 'p-1', $audience_created['session']['session_id'] ?? null, 'principal store creates audience-owned session', $failures, $passes );
 smoke_assert( 'browser:one', $principal_store->sessions['p-1']['owner_key'] ?? null, 'principal store receives opaque owner key', $failures, $passes );
 
+// An explicit session_owner is honored only when it re-asserts the owner the
+// resolved principal already holds; the resolver — not the request body —
+// establishes identity.
+$audience_explicit      = WP_Agent_Execution_Principal::audience( 'audience:public', 'demo-agent', WP_Agent_Execution_Principal::REQUEST_CONTEXT_REST, array(), null, null, array(), 'browser:explicit' );
 $explicit_owner_created = agents_create_conversation_session(
 	array(
-		'principal'     => $audience_without_owner,
+		'principal'     => $audience_explicit,
 		'session_owner' => array(
-			'type' => 'browser',
+			'type' => 'audience',
 			'key'  => 'browser:explicit',
 		),
 		'workspace'     => array( 'workspace_type' => 'site', 'workspace_id' => '42' ),
 	)
 );
-smoke_assert( 'p-2', $explicit_owner_created['session']['session_id'] ?? null, 'explicit session_owner creates audience transcript session', $failures, $passes );
-smoke_assert( 'browser', $principal_store->sessions['p-2']['owner_type'] ?? null, 'principal store receives explicit owner type', $failures, $passes );
+smoke_assert( 'p-2', $explicit_owner_created['session']['session_id'] ?? null, 'matching explicit session_owner creates audience transcript session', $failures, $passes );
+smoke_assert( 'audience', $principal_store->sessions['p-2']['owner_type'] ?? null, 'principal store receives explicit owner type', $failures, $passes );
 smoke_assert( 'browser:explicit', $principal_store->sessions['p-2']['owner_key'] ?? null, 'principal store receives explicit owner key', $failures, $passes );
+
+// A forged session_owner that the principal does not hold fails closed.
+$forged_owner_rejected = agents_create_conversation_session(
+	array(
+		'principal'     => $audience_with_owner,
+		'session_owner' => array(
+			'type' => 'audience',
+			'key'  => 'browser:someone-else',
+		),
+		'workspace'     => array( 'workspace_type' => 'site', 'workspace_id' => '42' ),
+	)
+);
+smoke_assert( 'agents_conversation_session_owner_forbidden', $forged_owner_rejected instanceof WP_Error ? $forged_owner_rejected->get_error_code() : '', 'forged session_owner not held by principal is rejected', $failures, $passes );
 
 $public_owner_rejected = agents_list_conversation_sessions(
 	array(

--- a/tests/conversation-session-authz-smoke.php
+++ b/tests/conversation-session-authz-smoke.php
@@ -1,0 +1,246 @@
+<?php
+/**
+ * Pure-PHP smoke test for conversation session authorization boundaries.
+ *
+ * Covers two families of confirmed authorization defects in
+ * register-agents-conversation-session-abilities.php:
+ *
+ *   1. self-asserted-owner (CWE-863 / CWE-639): a low-privilege authenticated
+ *      caller must not be able to address a foreign, non-user owner
+ *      (token/audience/system/custom) by declaring it in the request body.
+ *   2. missing-workspace-boundary (CWE-639): the non-reader fallback must not
+ *      return a same-owner row that lives in a different workspace.
+ *
+ * Each assertion FAILS without the fix and PASSES with it.
+ *
+ * Run with: php tests/conversation-session-authz-smoke.php
+ *
+ * @package AgentsAPI\Tests
+ */
+
+defined( 'ABSPATH' ) || define( 'ABSPATH', __DIR__ . '/' );
+
+$failures = array();
+$passes   = 0;
+
+echo "conversation-session-authz-smoke\n";
+
+require_once __DIR__ . '/agents-api-smoke-helpers.php';
+
+if ( ! class_exists( 'WP_Error' ) ) {
+	class WP_Error {
+		public function __construct( private string $code = '', private string $message = '', private mixed $data = null ) {}
+		public function get_error_code(): string { return $this->code; }
+		public function get_error_message(): string { return $this->message; }
+		public function get_error_data(): mixed { return $this->data; }
+	}
+}
+
+if ( ! function_exists( 'current_user_can' ) ) {
+	function current_user_can( string $cap ): bool {
+		return in_array( $cap, $GLOBALS['__smoke_caps'] ?? array(), true );
+	}
+}
+
+if ( ! function_exists( 'get_current_user_id' ) ) {
+	function get_current_user_id(): int {
+		return (int) ( $GLOBALS['__smoke_current_user_id'] ?? 0 );
+	}
+}
+
+if ( ! function_exists( 'get_current_blog_id' ) ) {
+	function get_current_blog_id(): int {
+		return 42;
+	}
+}
+
+if ( ! function_exists( 'sanitize_key' ) ) {
+	function sanitize_key( string $key ): string {
+		return strtolower( preg_replace( '/[^a-z0-9_\-]/', '', $key ) ?? '' );
+	}
+}
+
+$GLOBALS['__smoke_caps']            = array( 'read' );
+$GLOBALS['__smoke_current_user_id'] = 0;
+
+function smoke_assert( $expected, $actual, string $name, array &$failures, int &$passes ): void {
+	if ( $expected === $actual ) {
+		++$passes;
+		echo "  PASS {$name}\n";
+		return;
+	}
+
+	$failures[] = $name;
+	echo "  FAIL {$name}\n";
+	echo '    expected: ' . var_export( $expected, true ) . "\n";
+	echo '    actual:   ' . var_export( $actual, true ) . "\n";
+}
+
+function smoke_error_code( $value ): string {
+	return $value instanceof WP_Error ? $value->get_error_code() : '(not-a-wp-error)';
+}
+
+agents_api_smoke_require_module();
+
+use AgentsAPI\AI\WP_Agent_Execution_Principal;
+use AgentsAPI\Core\Database\Chat\WP_Agent_Principal_Conversation_Store;
+use AgentsAPI\Core\Workspace\WP_Agent_Workspace_Scope;
+use function AgentsAPI\Core\Database\Chat\agents_create_conversation_session;
+use function AgentsAPI\Core\Database\Chat\agents_delete_conversation_session;
+use function AgentsAPI\Core\Database\Chat\agents_get_conversation_session;
+use function AgentsAPI\Core\Database\Chat\agents_list_conversation_sessions;
+use function AgentsAPI\Core\Database\Chat\agents_update_conversation_session_title;
+
+/*
+ * A principal-aware store that, like the shipped CPT store, implements
+ * WP_Agent_Principal_Conversation_Store but NOT the Session_Reader interface,
+ * so get/update/delete take the non-reader fallback. get_session() resolves a
+ * row by id alone, ignoring workspace — the property the fallback must guard.
+ */
+$store = new class() implements WP_Agent_Principal_Conversation_Store {
+	/** @var array<string,array<string,mixed>> */
+	public array $sessions = array();
+
+	public function seed( string $id, string $owner_type, string $owner_key, string $workspace_id, int $user_id = 0 ): void {
+		$this->sessions[ $id ] = array(
+			'session_id'     => $id,
+			'workspace_type' => 'site',
+			'workspace_id'   => $workspace_id,
+			'owner_type'     => $owner_type,
+			'owner_key'      => $owner_key,
+			'user_id'        => $user_id,
+			'title'          => 'seed',
+			'messages'       => array(),
+			'metadata'       => array(),
+			'context'        => 'chat',
+		);
+	}
+
+	public function create_session_for_owner( WP_Agent_Workspace_Scope $workspace, array $owner, string $agent_slug = '', array $metadata = array(), string $context = 'chat' ): string {
+		$id                  = 'c-' . ( count( $this->sessions ) + 1 );
+		$this->sessions[ $id ] = array(
+			'session_id'     => $id,
+			'workspace_type' => $workspace->workspace_type,
+			'workspace_id'   => $workspace->workspace_id,
+			'owner_type'     => $owner['type'],
+			'owner_key'      => $owner['key'],
+			'user_id'        => 0,
+			'agent_slug'     => $agent_slug,
+			'title'          => '',
+			'messages'       => array(),
+			'metadata'       => $metadata,
+			'context'        => $context,
+		);
+		return $id;
+	}
+
+	public function list_sessions_for_owner( WP_Agent_Workspace_Scope $workspace, array $owner, array $args = array() ): array {
+		unset( $args );
+		return array_values(
+			array_filter(
+				$this->sessions,
+				static fn( array $s ): bool => $s['workspace_type'] === $workspace->workspace_type && $s['workspace_id'] === $workspace->workspace_id && $s['owner_type'] === $owner['type'] && $s['owner_key'] === $owner['key']
+			)
+		);
+	}
+
+	public function get_recent_pending_session_for_owner( WP_Agent_Workspace_Scope $workspace, array $owner, int $seconds = 600, string $context = 'chat', ?int $token_id = null ): ?array {
+		unset( $workspace, $owner, $seconds, $context, $token_id );
+		return null;
+	}
+
+	public function create_session( WP_Agent_Workspace_Scope $workspace, int $user_id, string $agent_slug = '', array $metadata = array(), string $context = 'chat' ): string {
+		return $this->create_session_for_owner( $workspace, array( 'type' => WP_Agent_Execution_Principal::OWNER_TYPE_USER, 'key' => (string) $user_id ), $agent_slug, $metadata, $context );
+	}
+
+	public function list_sessions( WP_Agent_Workspace_Scope $workspace, int $user_id, array $args = array() ): array {
+		return $this->list_sessions_for_owner( $workspace, array( 'type' => WP_Agent_Execution_Principal::OWNER_TYPE_USER, 'key' => (string) $user_id ), $args );
+	}
+
+	// get_session resolves by id only — no workspace scoping (the vulnerable seam).
+	public function get_session( string $session_id ): ?array {
+		return $this->sessions[ $session_id ] ?? null;
+	}
+
+	public function update_session( string $session_id, array $messages, array $metadata = array(), string $provider = '', string $model = '', ?string $provider_response_id = null ): bool {
+		unset( $session_id, $messages, $metadata, $provider, $model, $provider_response_id );
+		return true;
+	}
+
+	public function delete_session( string $session_id ): bool {
+		unset( $this->sessions[ $session_id ] );
+		return true;
+	}
+
+	public function get_recent_pending_session( WP_Agent_Workspace_Scope $workspace, int $user_id, int $seconds = 600, string $context = 'chat', ?int $token_id = null ): ?array {
+		unset( $workspace, $user_id, $seconds, $context, $token_id );
+		return null;
+	}
+
+	public function update_title( string $session_id, string $title ): bool {
+		if ( ! isset( $this->sessions[ $session_id ] ) ) {
+			return false;
+		}
+		$this->sessions[ $session_id ]['title'] = $title;
+		return true;
+	}
+};
+
+// Foreign, non-user owner the attacker will try to forge (workspace 42).
+$store->seed( 'victim-token', WP_Agent_Execution_Principal::OWNER_TYPE_TOKEN, '999', '42' );
+// Same-owner (attacker == user 7) rows in two different workspaces.
+$store->seed( 'user7-wsA', WP_Agent_Execution_Principal::OWNER_TYPE_USER, '7', '42', 7 );
+$store->seed( 'user7-wsB', WP_Agent_Execution_Principal::OWNER_TYPE_USER, '7', '99', 7 );
+
+add_filter( 'wp_agent_conversation_store', static fn() => $store );
+
+$ws42     = array( 'workspace_type' => 'site', 'workspace_id' => '42' );
+$attacker = WP_Agent_Execution_Principal::user_session( 7, 'demo-agent', WP_Agent_Execution_Principal::REQUEST_CONTEXT_REST );
+
+// ---------------------------------------------------------------------------
+// Family 1: self-asserted non-user owner forgery. A read-level user principal
+// must not address the token:999 owner by declaring it in session_owner.
+// ---------------------------------------------------------------------------
+$forged_owner = array( 'type' => 'token', 'key' => '999' );
+
+$forged_list = agents_list_conversation_sessions( array( 'principal' => $attacker, 'workspace' => $ws42, 'session_owner' => $forged_owner ) );
+smoke_assert( 'agents_conversation_session_owner_forbidden', smoke_error_code( $forged_list ), 'list: forged non-user owner is rejected', $failures, $passes );
+
+$forged_get = agents_get_conversation_session( array( 'principal' => $attacker, 'workspace' => $ws42, 'session_id' => 'victim-token', 'session_owner' => $forged_owner ) );
+smoke_assert( 'agents_conversation_session_owner_forbidden', smoke_error_code( $forged_get ), 'get: forged non-user owner is rejected', $failures, $passes );
+
+$forged_create = agents_create_conversation_session( array( 'principal' => $attacker, 'workspace' => $ws42, 'session_owner' => $forged_owner ) );
+smoke_assert( 'agents_conversation_session_owner_forbidden', smoke_error_code( $forged_create ), 'create: forged non-user owner is rejected', $failures, $passes );
+
+$forged_title = agents_update_conversation_session_title( array( 'principal' => $attacker, 'workspace' => $ws42, 'session_id' => 'victim-token', 'title' => 'pwned', 'session_owner' => $forged_owner ) );
+smoke_assert( 'agents_conversation_session_owner_forbidden', smoke_error_code( $forged_title ), 'update-title: forged non-user owner is rejected', $failures, $passes );
+
+$forged_delete = agents_delete_conversation_session( array( 'principal' => $attacker, 'workspace' => $ws42, 'session_id' => 'victim-token', 'session_owner' => $forged_owner ) );
+smoke_assert( 'agents_conversation_session_owner_forbidden', smoke_error_code( $forged_delete ), 'delete: forged non-user owner is rejected', $failures, $passes );
+smoke_assert( true, isset( $store->sessions['victim-token'] ), 'delete: forged owner leaves victim session intact', $failures, $passes );
+
+// ---------------------------------------------------------------------------
+// Family 2: missing workspace boundary in the non-reader fallback. The
+// attacker owns user7-wsB, but it lives in workspace 99, not the requested 42.
+// ---------------------------------------------------------------------------
+$cross_get = agents_get_conversation_session( array( 'principal' => $attacker, 'workspace' => $ws42, 'session_id' => 'user7-wsB' ) );
+smoke_assert( 'agents_conversation_session_forbidden', smoke_error_code( $cross_get ), 'get: same-owner cross-workspace row is blocked', $failures, $passes );
+smoke_assert( 403, $cross_get instanceof WP_Error ? ( $cross_get->get_error_data()['status'] ?? null ) : null, 'get: cross-workspace block carries 403', $failures, $passes );
+
+$cross_title = agents_update_conversation_session_title( array( 'principal' => $attacker, 'workspace' => $ws42, 'session_id' => 'user7-wsB', 'title' => 'renamed' ) );
+smoke_assert( 'agents_conversation_session_forbidden', smoke_error_code( $cross_title ), 'update-title: same-owner cross-workspace row is blocked', $failures, $passes );
+
+$cross_delete = agents_delete_conversation_session( array( 'principal' => $attacker, 'workspace' => $ws42, 'session_id' => 'user7-wsB' ) );
+smoke_assert( 'agents_conversation_session_forbidden', smoke_error_code( $cross_delete ), 'delete: same-owner cross-workspace row is blocked', $failures, $passes );
+smoke_assert( true, isset( $store->sessions['user7-wsB'] ), 'delete: cross-workspace row survives', $failures, $passes );
+
+// Positive control: the attacker can still reach its own row in workspace 42.
+$own_get = agents_get_conversation_session( array( 'principal' => $attacker, 'workspace' => $ws42, 'session_id' => 'user7-wsA' ) );
+smoke_assert( 'user7-wsA', is_array( $own_get ) ? ( $own_get['session']['session_id'] ?? null ) : null, 'get: legitimate same-workspace owner still resolves', $failures, $passes );
+
+if ( $failures ) {
+	echo "\nFAILED: " . count( $failures ) . " conversation session authorization assertions failed.\n";
+	exit( 1 );
+}
+
+echo "\nAll {$passes} conversation session authorization assertions passed.\n";


### PR DESCRIPTION
## Summary

Two authorization-boundary defect families in the generic conversation session abilities (`src/Transcripts/register-agents-conversation-session-abilities.php`). Both let an authenticated, read-level caller reach conversation sessions that belong to a different principal or a different workspace, because authorization was decided from **client-asserted input** instead of **server-verified state** (the resolved execution principal and the requested workspace tuple).

- **Self-asserted owner forgery (CWE-863 / CWE-639).** `agents_conversation_session_owner_from_input()` bound only `OWNER_TYPE_USER` to the authenticated principal and returned every other owner tuple (`token`/`audience`/`system`/`runtime`/`custom`) from the request body verbatim. Because this helper is the single owner-resolution seam shared by list/get/create/update-title/delete, a `current_user_can('read')` caller could declare a foreign non-user owner and operate on that owner's sessions.
- **Missing workspace boundary (CWE-639).** In the non-reader fallback of `agents_conversation_sessions_owned_session()`, ownership was proven by owner tuple alone; the requested workspace was resolved but never compared. A same-owner row living in another workspace could therefore be read, renamed, or deleted by supplying its session id.

## Findings

- `register-agents-conversation-session-abilities.php:326` (`agents_conversation_session_owner_from_input`) — **[medium]** create/get/list/update-title/delete non-user-owner forgery (CWE-863/CWE-639). A read-level user forges a `token`/`audience`/`system`/`custom` owner to enumerate, read, mutate, or permanently delete another principal's sessions on the opt-in principal-aware (CPT) store.
- `register-agents-conversation-session-abilities.php:488` (`agents_conversation_sessions_owned_session` fallback) — **[high]** get / **[medium]** delete / **[low]** update-title fallback workspace omission (CWE-639). A same-owner caller reaches another workspace's session by id because the fallback never checks `workspace_type`/`workspace_id`.

## Fix

- Generalize the principal binding in `agents_conversation_session_owner_from_input()`: after normalizing the asserted `{type,key}` (including the existing `user:` prefix stripping and public-audience rejection), require it to equal `$principal->conversation_owner()` and fail closed with a `WP_Error` otherwise. This applies uniformly to user and non-user owner types, so identity is always established by the resolved principal, never declared in the body. The legitimate anonymous/external path is preserved: a resolved token/audience principal that re-asserts its own owner tuple still matches.
- Add `agents_conversation_sessions_session_matches_workspace()` and require both a workspace match and an owner match in the non-reader fallback of `agents_conversation_sessions_owned_session()`, mirroring the canonical `WP_Agent_Conversation_Sessions::get_owned_session()`. The existing `current_user_can('manage_options')` override and the 403/404 error shaping are preserved.

## Testing

- New regression test `tests/conversation-session-authz-smoke.php` (added to the `smoke` script in `composer.json`) asserts that forged non-user owners are rejected across list/get/create/update-title/delete, that same-owner cross-workspace rows are blocked with a 403, that the victim/cross-workspace rows survive the blocked delete, and — as a positive control — that a caller still reaches its own same-workspace session. Verified it fails without the fix (11 failing assertions) and passes with it.
- Updated `tests/agents-conversation-session-abilities-smoke.php` so the explicit-`session_owner` case now re-asserts the owner the principal actually holds, plus a new negative assertion for a forged tuple.
- `composer smoke` is green (exit 0) and `vendor/bin/phpstan analyse --no-progress --memory-limit=2G` reports no errors (level max).

---

Found by an automated security scan; this fix is offered as a draft for maintainer review.

## AI assistance
OpenAI `openai/gpt-5.6-sol` via OpenCode reviewed this PR and its tests; no follow-up code changes were required. Chris Huber directed the review and remains responsible for the merge decision.