### PR TITLE
Security: enforce exact-once terminal semantics for runtime-tool lifecycle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -55,6 +55,7 @@
       "php tests/runtime-tool-policy-smoke.php",
       "php tests/write-capable-default-smoke.php",
       "php tests/runtime-tool-lifecycle-abilities-smoke.php",
+      "php tests/runtime-tool-terminal-replay-smoke.php",
       "php tests/tool-tier-resolver-smoke.php",
       "php tests/action-policy-resolver-smoke.php",
       "php tests/ability-meta-abilities-smoke.php",

--- a/docs/runtime-and-tools.md
+++ b/docs/runtime-and-tools.md
@@ -415,6 +415,7 @@ Public lifecycle contracts:
 - `WP_Agent_Runtime_Tool_Request` normalizes pending requests and timeout transitions.
 - `WP_Agent_Runtime_Tool_Result` normalizes submitted client/runtime results, including results normalized against a stored request.
 - `WP_Agent_Runtime_Tool_Request_Store` is the host persistence boundary with `create`, `get`, `complete`, `timeout`, and `recent_pending` methods.
+- `WP_Agent_Runtime_Tool_Request_Atomic_Store` adds the compare-and-set `transition_pending` capability required by submit, timeout, and cancel. Legacy stores remain compatible for create and read paths but terminal lifecycle calls fail closed until this capability is implemented.
 - `WP_Agent_Runtime_Tool_Continuation` is the host resume boundary for continuing a paused run after submit or timeout.
 - `WP_Agent_Runtime_Tool_Lifecycle` coordinates create, submit, timeout, recent-pending reads, transcript-compatible result payloads, and continuation callbacks.
 

--- a/src/Runtime/class-wp-agent-runtime-tool-lifecycle.php
+++ b/src/Runtime/class-wp-agent-runtime-tool-lifecycle.php
@@ -111,7 +111,12 @@ class WP_Agent_Runtime_Tool_Lifecycle {
 		}
 
 		$normalized_result = WP_Agent_Runtime_Tool_Result::from_request( $normalized_request, $result );
-		$claimed           = $store->complete( self::string_field( $normalized_request, 'request_id' ), $normalized_result );
+		$claimed           = self::transition_pending(
+			$store,
+			self::string_field( $normalized_request, 'request_id' ),
+			WP_Agent_Runtime_Tool_Request::STATUS_COMPLETED,
+			$normalized_result
+		);
 
 		if ( ! $claimed ) {
 			return self::lost_completion_race( $store, $normalized_request );
@@ -199,7 +204,14 @@ class WP_Agent_Runtime_Tool_Lifecycle {
 			)
 		);
 
-		$store->timeout( self::string_field( $normalized_request, 'request_id' ) );
+		$claimed = self::transition_pending(
+			$store,
+			self::string_field( $normalized_request, 'request_id' ),
+			WP_Agent_Runtime_Tool_Request::STATUS_TIMEOUT
+		);
+		if ( ! $claimed ) {
+			return self::lost_timeout_race( $store, $normalized_request );
+		}
 
 		do_action( 'agents_api_runtime_tool_request_timed_out', $timeout_request, $timeout_result, $context );
 
@@ -218,6 +230,41 @@ class WP_Agent_Runtime_Tool_Lifecycle {
 		}
 
 		return $envelope;
+	}
+
+	/**
+	 * Resolve a timeout/cancel that lost the terminal transition race.
+	 *
+	 * @param WP_Agent_Runtime_Tool_Request_Store $store Request store.
+	 * @param array<string, mixed>                $normalized_request Normalized request identity.
+	 * @return array<string, mixed> Duplicate terminal envelope.
+	 */
+	private static function lost_timeout_race( WP_Agent_Runtime_Tool_Request_Store $store, array $normalized_request ): array {
+		$terminal = $store->get( self::string_field( $normalized_request, 'request_id' ) );
+		if ( null !== $terminal ) {
+			$status = is_string( $terminal['status'] ?? null ) ? $terminal['status'] : '';
+			if ( '' !== $status && WP_Agent_Runtime_Tool_Request::STATUS_PENDING !== $status ) {
+				return self::terminal_replay_envelope( $terminal, WP_Agent_Runtime_Tool_Request::normalize( $terminal ), $status );
+			}
+		}
+
+		throw new \InvalidArgumentException( 'invalid_runtime_tool_timeout: terminal transition was not retained' );
+	}
+
+	/**
+	 * Claim a terminal transition through the additive atomic-store contract.
+	 *
+	 * @param WP_Agent_Runtime_Tool_Request_Store $store Request store.
+	 * @param string                              $request_id Runtime tool request id.
+	 * @param string                              $status Target terminal request status.
+	 * @param array<string, mixed>|null           $result Normalized completion result.
+	 */
+	private static function transition_pending( WP_Agent_Runtime_Tool_Request_Store $store, string $request_id, string $status, ?array $result = null ): bool {
+		if ( ! $store instanceof WP_Agent_Runtime_Tool_Request_Atomic_Store ) {
+			throw new \InvalidArgumentException( 'invalid_runtime_tool_store: atomic terminal transitions are required' );
+		}
+
+		return $store->transition_pending( $request_id, $status, $result );
 	}
 
 	/**

--- a/src/Runtime/class-wp-agent-runtime-tool-lifecycle.php
+++ b/src/Runtime/class-wp-agent-runtime-tool-lifecycle.php
@@ -111,7 +111,11 @@ class WP_Agent_Runtime_Tool_Lifecycle {
 		}
 
 		$normalized_result = WP_Agent_Runtime_Tool_Result::from_request( $normalized_request, $result );
-		$store->complete( self::string_field( $normalized_request, 'request_id' ), $normalized_result );
+		$claimed           = $store->complete( self::string_field( $normalized_request, 'request_id' ), $normalized_result );
+
+		if ( ! $claimed ) {
+			return self::lost_completion_race( $store, $normalized_request );
+		}
 
 		return array(
 			'request'   => $normalized_request,
@@ -119,6 +123,38 @@ class WP_Agent_Runtime_Tool_Lifecycle {
 			'completed' => true,
 			'duplicate' => false,
 		);
+	}
+
+	/**
+	 * Resolve a completion that lost the exact-once race to another caller.
+	 *
+	 * The store reported that this call did not transition the pending record, so
+	 * a concurrent completion already won. Re-read the now-terminal record and
+	 * return its retained winner result as a duplicate so completion side effects
+	 * (submitted hook, continuation resume) fire only for the winning submission.
+	 *
+	 * @param WP_Agent_Runtime_Tool_Request_Store $store Request store.
+	 * @param array<string, mixed>                $normalized_request Normalized request identity.
+	 * @return array{request: array<string, mixed>, result: array<string, mixed>, completed: bool, duplicate: bool} Duplicate completion envelope.
+	 */
+	private static function lost_completion_race( WP_Agent_Runtime_Tool_Request_Store $store, array $normalized_request ): array {
+		$request_id = self::string_field( $normalized_request, 'request_id' );
+		$terminal   = $store->get( $request_id );
+
+		if ( null !== $terminal ) {
+			$terminal_request = WP_Agent_Runtime_Tool_Request::normalize( $terminal );
+			$stored_result    = self::stored_completion_result( $terminal, $terminal_request );
+			if ( null !== $stored_result ) {
+				return array(
+					'request'   => $terminal_request,
+					'result'    => $stored_result,
+					'completed' => false,
+					'duplicate' => true,
+				);
+			}
+		}
+
+		throw new \InvalidArgumentException( 'invalid_runtime_tool_result: request is not pending' );
 	}
 
 	/**
@@ -141,8 +177,19 @@ class WP_Agent_Runtime_Tool_Lifecycle {
 			throw new \InvalidArgumentException( 'invalid_runtime_tool_timeout: request not found' );
 		}
 
+		$status             = is_string( $request['status'] ?? null ) ? $request['status'] : '';
 		$normalized_request = WP_Agent_Runtime_Tool_Request::normalize( $request );
-		$timeout_request    = WP_Agent_Runtime_Tool_Request::timeout( $normalized_request );
+
+		// Read the stored status BEFORE normalize() rewrites it to pending. A
+		// request that is already terminal must not re-transition the store,
+		// re-fire the timeout hook, or re-invoke the host continuation on replay:
+		// the timeout/cancel abilities are annotated idempotent, so treat a repeat
+		// terminal call as a fail-closed duplicate mirroring complete_if_pending().
+		if ( '' !== $status && WP_Agent_Runtime_Tool_Request::STATUS_PENDING !== $status ) {
+			return self::terminal_replay_envelope( $request, $normalized_request, $status );
+		}
+
+		$timeout_request = WP_Agent_Runtime_Tool_Request::timeout( $normalized_request );
 		$timeout_result     = WP_Agent_Runtime_Tool_Result::from_request(
 			$normalized_request,
 			array(
@@ -160,6 +207,7 @@ class WP_Agent_Runtime_Tool_Lifecycle {
 			'status'                => WP_Agent_Runtime_Tool_Request::STATUS_TIMEOUT,
 			'request'               => $timeout_request,
 			'result'                => $timeout_result,
+			'duplicate'             => false,
 			'tool_result_message'   => self::tool_result_message_payload( $normalized_request, $timeout_result ),
 			'tool_execution_result' => self::tool_execution_result_payload( $normalized_request, $timeout_result ),
 			'continuation_result'   => null,
@@ -170,6 +218,47 @@ class WP_Agent_Runtime_Tool_Lifecycle {
 		}
 
 		return $envelope;
+	}
+
+	/**
+	 * Build an idempotent terminal envelope for a replayed timeout/cancel call.
+	 *
+	 * The stored record is already terminal, so no store transition, terminal
+	 * hook, or continuation resume runs. The envelope carries the retained result
+	 * when the store exposes one, otherwise a status-only terminal result, and is
+	 * marked as a duplicate so callers can distinguish a replay from a first
+	 * terminal transition.
+	 *
+	 * @param array<string, mixed> $request Raw stored request.
+	 * @param array<string, mixed> $normalized_request Normalized request identity.
+	 * @param string               $status Retained terminal status.
+	 * @return array<string, mixed> Duplicate terminal envelope.
+	 */
+	private static function terminal_replay_envelope( array $request, array $normalized_request, string $status ): array {
+		$stored_result = self::stored_completion_result( $request, $normalized_request );
+		if ( null === $stored_result ) {
+			$stored_result = WP_Agent_Runtime_Tool_Result::from_request(
+				$normalized_request,
+				array(
+					'success'  => false,
+					'error'    => 'Runtime tool request is already terminal.',
+					'metadata' => array( 'status' => $status ),
+				)
+			);
+		}
+
+		$terminal_request           = $normalized_request;
+		$terminal_request['status'] = $status;
+
+		return array(
+			'status'                => $status,
+			'request'               => $terminal_request,
+			'result'                => $stored_result,
+			'duplicate'             => true,
+			'tool_result_message'   => self::tool_result_message_payload( $normalized_request, $stored_result ),
+			'tool_execution_result' => self::tool_execution_result_payload( $normalized_request, $stored_result ),
+			'continuation_result'   => null,
+		);
 	}
 
 	/**

--- a/src/Runtime/class-wp-agent-runtime-tool-request-store.php
+++ b/src/Runtime/class-wp-agent-runtime-tool-request-store.php
@@ -37,30 +37,18 @@ interface WP_Agent_Runtime_Tool_Request_Store {
 	/**
 	 * Mark a pending request complete with a client-submitted result.
 	 *
-	 * Implementations must transition only pending records and should back the
-	 * write with a conditional/compare-and-set update so concurrent completions
-	 * of the same request cannot both succeed. Return `true` only when this call
-	 * transitioned a pending record to complete (the caller "won" the exact-once
-	 * completion). Return `false` when the record was already terminal, so the
-	 * caller can re-read the retained winner result and treat the call as a
-	 * duplicate instead of firing completion side effects a second time.
-	 *
-	 * Duplicate completions for terminal records must leave existing store data
-	 * unchanged.
+	 * Implementations should transition only pending records. Duplicate
+	 * completions for terminal records must leave existing store data unchanged.
 	 *
 	 * @param string               $request_id Runtime tool request id.
 	 * @param array<string, mixed> $result Normalized runtime tool result.
-	 * @return bool True when this call transitioned a pending record to complete.
 	 */
-	public function complete( string $request_id, array $result ): bool;
+	public function complete( string $request_id, array $result ): void;
 
 	/**
 	 * Mark a pending request timed out.
 	 *
-	 * Implementations should transition only pending records. The lifecycle layer
-	 * short-circuits terminal records before calling this method, so a timeout of
-	 * an already-terminal request is treated as an idempotent duplicate and this
-	 * method is not invoked again.
+	 * Implementations should transition only pending records.
 	 *
 	 * @param string $request_id Runtime tool request id.
 	 */
@@ -77,4 +65,27 @@ interface WP_Agent_Runtime_Tool_Request_Store {
 	 * @return array<int, array<string, mixed>> Normalized pending requests.
 	 */
 	public function recent_pending( array $query = array() ): array;
+}
+
+/**
+ * Atomic terminal-transition capability for exact-once lifecycle operations.
+ *
+ * Hosts using submit, timeout, or cancel must implement this additive contract.
+ * The legacy store interface remains load-compatible for create and read paths.
+ */
+interface WP_Agent_Runtime_Tool_Request_Atomic_Store extends WP_Agent_Runtime_Tool_Request_Store {
+
+	/**
+	 * Conditionally transition a pending request to a terminal status.
+	 *
+	 * Implementations must use a compare-and-set write and return `true` only for
+	 * the caller that changed the pending record. Completed transitions must retain
+	 * the normalized result under `result` for duplicate resolution.
+	 *
+	 * @param string                    $request_id Runtime tool request id.
+	 * @param string                    $status Target terminal request status.
+	 * @param array<string, mixed>|null $result Normalized completion result, when completing.
+	 * @return bool True when this call transitioned the pending record.
+	 */
+	public function transition_pending( string $request_id, string $status, ?array $result = null ): bool;
 }

--- a/src/Runtime/class-wp-agent-runtime-tool-request-store.php
+++ b/src/Runtime/class-wp-agent-runtime-tool-request-store.php
@@ -37,18 +37,30 @@ interface WP_Agent_Runtime_Tool_Request_Store {
 	/**
 	 * Mark a pending request complete with a client-submitted result.
 	 *
-	 * Implementations should transition only pending records. Duplicate
-	 * completions for terminal records must leave existing store data unchanged;
-	 * callers use `get()` before this method to return a retained prior result or
-	 * reject the duplicate when no prior result is available.
+	 * Implementations must transition only pending records and should back the
+	 * write with a conditional/compare-and-set update so concurrent completions
+	 * of the same request cannot both succeed. Return `true` only when this call
+	 * transitioned a pending record to complete (the caller "won" the exact-once
+	 * completion). Return `false` when the record was already terminal, so the
+	 * caller can re-read the retained winner result and treat the call as a
+	 * duplicate instead of firing completion side effects a second time.
+	 *
+	 * Duplicate completions for terminal records must leave existing store data
+	 * unchanged.
 	 *
 	 * @param string               $request_id Runtime tool request id.
 	 * @param array<string, mixed> $result Normalized runtime tool result.
+	 * @return bool True when this call transitioned a pending record to complete.
 	 */
-	public function complete( string $request_id, array $result ): void;
+	public function complete( string $request_id, array $result ): bool;
 
 	/**
 	 * Mark a pending request timed out.
+	 *
+	 * Implementations should transition only pending records. The lifecycle layer
+	 * short-circuits terminal records before calling this method, so a timeout of
+	 * an already-terminal request is treated as an idempotent duplicate and this
+	 * method is not invoked again.
 	 *
 	 * @param string $request_id Runtime tool request id.
 	 */

--- a/src/Runtime/register-runtime-tool-lifecycle-abilities.php
+++ b/src/Runtime/register-runtime-tool-lifecycle-abilities.php
@@ -511,6 +511,7 @@ function agents_runtime_tool_terminal_output_schema(): array {
 			'status'                => array( 'type' => 'string' ),
 			'request'               => agents_runtime_tool_request_schema(),
 			'result'                => agents_runtime_tool_result_schema(),
+			'duplicate'             => array( 'type' => 'boolean' ),
 			'tool_result_message'   => array( 'type' => 'object' ),
 			'tool_execution_result' => array( 'type' => 'object' ),
 			'continuation_result'   => array( 'type' => array( 'object', 'null' ) ),

--- a/tests/conversation-loop-tool-execution-smoke.php
+++ b/tests/conversation-loop-tool-execution-smoke.php
@@ -706,7 +706,7 @@ agents_api_smoke_assert_equals( 'pending', $pending_result['tool_observability']
 agents_api_smoke_assert_equals( AgentsAPI\AI\WP_Agent_Conversation_Result::OUTCOME_STATUS_PENDING_RUNTIME_TOOL, $pending_result['run_outcome']['status'] ?? '', 'pending runtime tool run outcome is pending', $failures, $passes );
 agents_api_smoke_assert_equals( AgentsAPI\AI\WP_Agent_Runtime_Tool_Request::STATUS_PENDING, $pending_result['run_outcome']['stop_reason'] ?? '', 'pending runtime tool run outcome stop reason is pending', $failures, $passes );
 
-$loop_runtime_tool_store = new class() implements AgentsAPI\AI\WP_Agent_Runtime_Tool_Request_Store {
+$loop_runtime_tool_store = new class() implements AgentsAPI\AI\WP_Agent_Runtime_Tool_Request_Atomic_Store {
 	public array $requests = array();
 
 	public function create( array $request ): void {
@@ -717,17 +717,21 @@ $loop_runtime_tool_store = new class() implements AgentsAPI\AI\WP_Agent_Runtime_
 		return $this->requests[ $request_id ] ?? null;
 	}
 
-	public function complete( string $request_id, array $result ): bool {
+	public function complete( string $request_id, array $result ): void {
+		$this->transition_pending( $request_id, AgentsAPI\AI\WP_Agent_Runtime_Tool_Request::STATUS_COMPLETED, $result );
+	}
+
+	public function timeout( string $request_id ): void {
+		$this->transition_pending( $request_id, AgentsAPI\AI\WP_Agent_Runtime_Tool_Request::STATUS_TIMEOUT );
+	}
+
+	public function transition_pending( string $request_id, string $status, ?array $result = null ): bool {
 		unset( $result );
 		if ( AgentsAPI\AI\WP_Agent_Runtime_Tool_Request::STATUS_PENDING !== ( $this->requests[ $request_id ]['status'] ?? '' ) ) {
 			return false;
 		}
-		$this->requests[ $request_id ]['status'] = 'completed';
+		$this->requests[ $request_id ]['status'] = $status;
 		return true;
-	}
-
-	public function timeout( string $request_id ): void {
-		$this->requests[ $request_id ]['status'] = AgentsAPI\AI\WP_Agent_Runtime_Tool_Request::STATUS_TIMEOUT;
 	}
 
 	public function recent_pending( array $query = array() ): array {

--- a/tests/conversation-loop-tool-execution-smoke.php
+++ b/tests/conversation-loop-tool-execution-smoke.php
@@ -662,9 +662,13 @@ $loop_runtime_tool_store = new class() implements AgentsAPI\AI\WP_Agent_Runtime_
 		return $this->requests[ $request_id ] ?? null;
 	}
 
-	public function complete( string $request_id, array $result ): void {
+	public function complete( string $request_id, array $result ): bool {
 		unset( $result );
+		if ( AgentsAPI\AI\WP_Agent_Runtime_Tool_Request::STATUS_PENDING !== ( $this->requests[ $request_id ]['status'] ?? '' ) ) {
+			return false;
+		}
 		$this->requests[ $request_id ]['status'] = 'completed';
+		return true;
 	}
 
 	public function timeout( string $request_id ): void {

--- a/tests/runtime-tool-lifecycle-abilities-smoke.php
+++ b/tests/runtime-tool-lifecycle-abilities-smoke.php
@@ -90,7 +90,7 @@ agents_api_smoke_assert_equals( 'boolean', $submit_schema['properties']['resume'
 $list_schema = $GLOBALS['__agents_api_smoke_abilities'][ AgentsAPI\AI\AGENTS_LIST_RUNTIME_TOOL_REQUESTS_ABILITY ]['input_schema'] ?? array();
 agents_api_smoke_assert_equals( 'integer', $list_schema['properties']['limit']['type'] ?? '', 'list schema exposes generic limit query hint', $failures, $passes );
 
-$runtime_tool_store = new class() implements AgentsAPI\AI\WP_Agent_Runtime_Tool_Request_Store {
+$runtime_tool_store = new class() implements AgentsAPI\AI\WP_Agent_Runtime_Tool_Request_Atomic_Store {
 	public array $requests = array();
 
 	public function create( array $request ): void {
@@ -101,17 +101,23 @@ $runtime_tool_store = new class() implements AgentsAPI\AI\WP_Agent_Runtime_Tool_
 		return $this->requests[ $request_id ] ?? null;
 	}
 
-	public function complete( string $request_id, array $result ): bool {
-		if ( ! isset( $this->requests[ $request_id ] ) || AgentsAPI\AI\WP_Agent_Runtime_Tool_Request::STATUS_PENDING !== ( $this->requests[ $request_id ]['status'] ?? '' ) ) {
-			return false;
-		}
-		$this->requests[ $request_id ]['status'] = AgentsAPI\AI\WP_Agent_Runtime_Tool_Request::STATUS_COMPLETED;
-		$this->requests[ $request_id ]['result'] = $result;
-		return true;
+	public function complete( string $request_id, array $result ): void {
+		$this->transition_pending( $request_id, AgentsAPI\AI\WP_Agent_Runtime_Tool_Request::STATUS_COMPLETED, $result );
 	}
 
 	public function timeout( string $request_id ): void {
-		$this->requests[ $request_id ]['status'] = AgentsAPI\AI\WP_Agent_Runtime_Tool_Request::STATUS_TIMEOUT;
+		$this->transition_pending( $request_id, AgentsAPI\AI\WP_Agent_Runtime_Tool_Request::STATUS_TIMEOUT );
+	}
+
+	public function transition_pending( string $request_id, string $status, ?array $result = null ): bool {
+		if ( ! isset( $this->requests[ $request_id ] ) || AgentsAPI\AI\WP_Agent_Runtime_Tool_Request::STATUS_PENDING !== ( $this->requests[ $request_id ]['status'] ?? '' ) ) {
+			return false;
+		}
+		$this->requests[ $request_id ]['status'] = $status;
+		if ( null !== $result ) {
+			$this->requests[ $request_id ]['result'] = $result;
+		}
+		return true;
 	}
 
 	public function recent_pending( array $query = array() ): array {
@@ -192,5 +198,15 @@ $cancel = agents_api_smoke_execute_runtime_tool_ability(
 agents_api_smoke_assert_equals( AgentsAPI\AI\WP_Agent_Runtime_Tool_Request::STATUS_TIMEOUT, $cancel['status'] ?? '', 'cancel ability applies canonical timeout transition', $failures, $passes );
 agents_api_smoke_assert_equals( true, $cancel['cancelled'] ?? false, 'cancel ability marks cancellation envelope', $failures, $passes );
 agents_api_smoke_assert_equals( AgentsAPI\AI\WP_Agent_Runtime_Tool_Request::STATUS_TIMEOUT, $runtime_tool_store->requests[ $timeout_request['request_id'] ]['status'] ?? '', 'cancel ability delegates terminal transition to store', $failures, $passes );
+
+$cancel_replay = agents_api_smoke_execute_runtime_tool_ability(
+	AgentsAPI\AI\AGENTS_CANCEL_RUNTIME_TOOL_REQUEST_ABILITY,
+	array(
+		'request_id' => $timeout_request['request_id'],
+		'resume'     => false,
+	)
+);
+agents_api_smoke_assert_equals( true, $cancel_replay['cancelled'] ?? false, 'replayed cancel preserves the public cancelled discriminator', $failures, $passes );
+agents_api_smoke_assert_equals( true, $cancel_replay['duplicate'] ?? false, 'replayed cancel is idempotent through the public ability', $failures, $passes );
 
 agents_api_smoke_finish( 'Agents API runtime-tool lifecycle abilities', $failures, $passes );

--- a/tests/runtime-tool-lifecycle-abilities-smoke.php
+++ b/tests/runtime-tool-lifecycle-abilities-smoke.php
@@ -101,9 +101,13 @@ $runtime_tool_store = new class() implements AgentsAPI\AI\WP_Agent_Runtime_Tool_
 		return $this->requests[ $request_id ] ?? null;
 	}
 
-	public function complete( string $request_id, array $result ): void {
+	public function complete( string $request_id, array $result ): bool {
+		if ( ! isset( $this->requests[ $request_id ] ) || AgentsAPI\AI\WP_Agent_Runtime_Tool_Request::STATUS_PENDING !== ( $this->requests[ $request_id ]['status'] ?? '' ) ) {
+			return false;
+		}
 		$this->requests[ $request_id ]['status'] = AgentsAPI\AI\WP_Agent_Runtime_Tool_Request::STATUS_COMPLETED;
 		$this->requests[ $request_id ]['result'] = $result;
+		return true;
 	}
 
 	public function timeout( string $request_id ): void {

--- a/tests/runtime-tool-terminal-replay-smoke.php
+++ b/tests/runtime-tool-terminal-replay-smoke.php
@@ -31,7 +31,7 @@ agents_api_smoke_require_module();
  * Store that transitions only pending records, mirroring the exact-once
  * contract host implementations must back with a compare-and-set write.
  */
-$store = new class() implements AgentsAPI\AI\WP_Agent_Runtime_Tool_Request_Store {
+$store = new class() implements AgentsAPI\AI\WP_Agent_Runtime_Tool_Request_Atomic_Store {
 	/** @var array<string, array<string, mixed>> */
 	public array $requests = array();
 	public int $timeout_calls = 0;
@@ -44,18 +44,26 @@ $store = new class() implements AgentsAPI\AI\WP_Agent_Runtime_Tool_Request_Store
 		return $this->requests[ $request_id ] ?? null;
 	}
 
-	public function complete( string $request_id, array $result ): bool {
-		if ( ! isset( $this->requests[ $request_id ] ) || AgentsAPI\AI\WP_Agent_Runtime_Tool_Request::STATUS_PENDING !== ( $this->requests[ $request_id ]['status'] ?? '' ) ) {
-			return false;
-		}
-		$this->requests[ $request_id ]['status'] = AgentsAPI\AI\WP_Agent_Runtime_Tool_Request::STATUS_COMPLETED;
-		$this->requests[ $request_id ]['result'] = $result;
-		return true;
+	public function complete( string $request_id, array $result ): void {
+		$this->transition_pending( $request_id, AgentsAPI\AI\WP_Agent_Runtime_Tool_Request::STATUS_COMPLETED, $result );
 	}
 
 	public function timeout( string $request_id ): void {
-		++$this->timeout_calls;
-		$this->requests[ $request_id ]['status'] = AgentsAPI\AI\WP_Agent_Runtime_Tool_Request::STATUS_TIMEOUT;
+		$this->transition_pending( $request_id, AgentsAPI\AI\WP_Agent_Runtime_Tool_Request::STATUS_TIMEOUT );
+	}
+
+	public function transition_pending( string $request_id, string $status, ?array $result = null ): bool {
+		if ( AgentsAPI\AI\WP_Agent_Runtime_Tool_Request::STATUS_TIMEOUT === $status ) {
+			++$this->timeout_calls;
+		}
+		if ( ! isset( $this->requests[ $request_id ] ) || AgentsAPI\AI\WP_Agent_Runtime_Tool_Request::STATUS_PENDING !== ( $this->requests[ $request_id ]['status'] ?? '' ) ) {
+			return false;
+		}
+		$this->requests[ $request_id ]['status'] = $status;
+		if ( null !== $result ) {
+			$this->requests[ $request_id ]['result'] = $result;
+		}
+		return true;
 	}
 
 	public function recent_pending( array $query = array() ): array {
@@ -73,6 +81,48 @@ $continuation = static function ( array $request, array $result, array $context 
 	++$resume_calls;
 	return array( 'resumed' => true );
 };
+
+// The additive atomic capability preserves class-loading compatibility for
+// existing stores while refusing unsafe terminal writes before mutation.
+$legacy_store = new class() implements AgentsAPI\AI\WP_Agent_Runtime_Tool_Request_Store {
+	/** @var array<string, mixed> */
+	public array $request = array();
+	public int $complete_calls = 0;
+
+	public function create( array $request ): void {
+		$this->request = $request;
+	}
+
+	public function get( string $request_id ): ?array {
+		unset( $request_id );
+		return $this->request;
+	}
+
+	public function complete( string $request_id, array $result ): void {
+		unset( $request_id, $result );
+		++$this->complete_calls;
+	}
+
+	public function timeout( string $request_id ): void {
+		unset( $request_id );
+	}
+
+	public function recent_pending( array $query = array() ): array {
+		unset( $query );
+		return array();
+	}
+};
+
+$legacy_request = AgentsAPI\AI\WP_Agent_Runtime_Tool_Request::from_tool_call( 'client/choose_post', 'call_legacy_store', array(), array( 'run_id' => 'run-legacy-store' ) );
+$legacy_store->create( $legacy_request );
+$legacy_refused = false;
+try {
+	AgentsAPI\AI\WP_Agent_Runtime_Tool_Lifecycle::submit_result( $legacy_store, array( 'request_id' => $legacy_request['request_id'] ) );
+} catch ( InvalidArgumentException $error ) {
+	$legacy_refused = 'invalid_runtime_tool_store: atomic terminal transitions are required' === $error->getMessage();
+}
+agents_api_smoke_assert_equals( true, $legacy_refused, 'legacy store remains load-compatible but unsafe terminal mutation fails closed', $failures, $passes );
+agents_api_smoke_assert_equals( 0, $legacy_store->complete_calls, 'legacy store is refused before a non-atomic completion write', $failures, $passes );
 
 // ---------------------------------------------------------------------------
 // Finding 1 & 2: timeout/cancel replay of an already-terminal request.
@@ -103,6 +153,62 @@ agents_api_smoke_assert_equals( true, $replay_cancel['duplicate'] ?? false, 'rep
 agents_api_smoke_assert_equals( 1, $resume_calls, 'replayed cancel does not resume the continuation again', $failures, $passes );
 agents_api_smoke_assert_equals( 1, $store->timeout_calls, 'replayed cancel does not write to the store again', $failures, $passes );
 
+// Model two timeout callers that both read pending before the store's atomic
+// transition. Only the winner may fire terminal side effects.
+$timeout_race_store = new class() implements AgentsAPI\AI\WP_Agent_Runtime_Tool_Request_Atomic_Store {
+	/** @var array<string, mixed> */
+	public array $request = array();
+	public bool $won_by_other = false;
+
+	public function create( array $request ): void {
+		$this->request = $request;
+	}
+
+	public function get( string $request_id ): ?array {
+		unset( $request_id );
+		if ( $this->won_by_other ) {
+			$this->request['status'] = AgentsAPI\AI\WP_Agent_Runtime_Tool_Request::STATUS_TIMEOUT;
+		}
+		return $this->request;
+	}
+
+	public function complete( string $request_id, array $result ): void {
+		unset( $request_id, $result );
+	}
+
+	public function timeout( string $request_id ): void {
+		unset( $request_id );
+	}
+
+	public function transition_pending( string $request_id, string $status, ?array $result = null ): bool {
+		unset( $request_id, $status, $result );
+		$this->won_by_other = true;
+		return false;
+	}
+
+	public function recent_pending( array $query = array() ): array {
+		unset( $query );
+		return array();
+	}
+};
+
+$timeout_race_request = AgentsAPI\AI\WP_Agent_Runtime_Tool_Request::from_tool_call( 'client/choose_post', 'call_timeout_race', array(), array( 'run_id' => 'run-timeout-race' ) );
+$timeout_race_store->create( $timeout_race_request );
+$timeout_hooks_before = did_action( 'agents_api_runtime_tool_request_timed_out' );
+$timeout_race_resumes = 0;
+$timeout_race = AgentsAPI\AI\WP_Agent_Runtime_Tool_Lifecycle::timeout_request(
+	$timeout_race_store,
+	$timeout_race_request['request_id'],
+	static function () use ( &$timeout_race_resumes ): array {
+		++$timeout_race_resumes;
+		return array( 'resumed' => true );
+	}
+);
+agents_api_smoke_assert_equals( true, $timeout_race['duplicate'] ?? false, 'losing timeout resolves as a duplicate', $failures, $passes );
+agents_api_smoke_assert_equals( AgentsAPI\AI\WP_Agent_Runtime_Tool_Request::STATUS_TIMEOUT, $timeout_race['status'] ?? '', 'losing timeout returns the retained terminal status', $failures, $passes );
+agents_api_smoke_assert_equals( $timeout_hooks_before, did_action( 'agents_api_runtime_tool_request_timed_out' ), 'losing timeout does not fire the terminal hook', $failures, $passes );
+agents_api_smoke_assert_equals( 0, $timeout_race_resumes, 'losing timeout does not resume the continuation', $failures, $passes );
+
 // A request that was completed first must also reject a later timeout/cancel
 // terminal replay without side effects.
 $completed_request = AgentsAPI\AI\WP_Agent_Runtime_Tool_Request::from_tool_call( 'client/choose_post', 'call_complete_then_timeout', array(), array( 'run_id' => 'run-complete-then-timeout' ) );
@@ -126,11 +232,11 @@ agents_api_smoke_assert_equals( $hooks_before, did_action( 'agents_api_runtime_t
 // ---------------------------------------------------------------------------
 
 /**
- * Store whose complete() always reports a loss (another caller already won),
+ * Store whose atomic transition always reports a loss (another caller won),
  * exposing the retained winner result on the subsequent get(). Models the race
  * window where two callers both read a pending record before either writes.
  */
-$racing_store = new class() implements AgentsAPI\AI\WP_Agent_Runtime_Tool_Request_Store {
+$racing_store = new class() implements AgentsAPI\AI\WP_Agent_Runtime_Tool_Request_Atomic_Store {
 	/** @var array<string, mixed> */
 	public array $request = array();
 	public bool $won_by_other = false;
@@ -154,15 +260,19 @@ $racing_store = new class() implements AgentsAPI\AI\WP_Agent_Runtime_Tool_Reques
 		return $this->request;
 	}
 
-	public function complete( string $request_id, array $result ): bool {
+	public function complete( string $request_id, array $result ): void {
 		unset( $request_id, $result );
-		++$this->complete_calls;
-		$this->won_by_other = true;
-		return false;
 	}
 
 	public function timeout( string $request_id ): void {
 		unset( $request_id );
+	}
+
+	public function transition_pending( string $request_id, string $status, ?array $result = null ): bool {
+		unset( $request_id, $status, $result );
+		++$this->complete_calls;
+		$this->won_by_other = true;
+		return false;
 	}
 
 	public function recent_pending( array $query = array() ): array {

--- a/tests/runtime-tool-terminal-replay-smoke.php
+++ b/tests/runtime-tool-terminal-replay-smoke.php
@@ -1,0 +1,198 @@
+<?php
+/**
+ * Pure-PHP smoke test for runtime-tool exact-once terminal semantics.
+ *
+ * Regression coverage for replayable terminal ops and the non-atomic
+ * completion race on WP_Agent_Runtime_Tool_Lifecycle:
+ *   - timeout/cancel of an already-terminal request must not re-transition the
+ *     store, re-fire the terminal hook, or re-invoke the host continuation.
+ *   - a completion that loses the exact-once race (store reports it did not
+ *     transition the pending record) must resolve as a duplicate rather than
+ *     firing the submitted hook and continuation a second time.
+ *
+ * Run with: php tests/runtime-tool-terminal-replay-smoke.php
+ *
+ * @package AgentsAPI\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+$failures = array();
+$passes   = 0;
+
+echo "agents-api-runtime-tool-terminal-replay-smoke\n";
+
+require_once __DIR__ . '/agents-api-smoke-helpers.php';
+agents_api_smoke_require_module();
+
+/**
+ * Store that transitions only pending records, mirroring the exact-once
+ * contract host implementations must back with a compare-and-set write.
+ */
+$store = new class() implements AgentsAPI\AI\WP_Agent_Runtime_Tool_Request_Store {
+	/** @var array<string, array<string, mixed>> */
+	public array $requests = array();
+	public int $timeout_calls = 0;
+
+	public function create( array $request ): void {
+		$this->requests[ $request['request_id'] ] = $request;
+	}
+
+	public function get( string $request_id ): ?array {
+		return $this->requests[ $request_id ] ?? null;
+	}
+
+	public function complete( string $request_id, array $result ): bool {
+		if ( ! isset( $this->requests[ $request_id ] ) || AgentsAPI\AI\WP_Agent_Runtime_Tool_Request::STATUS_PENDING !== ( $this->requests[ $request_id ]['status'] ?? '' ) ) {
+			return false;
+		}
+		$this->requests[ $request_id ]['status'] = AgentsAPI\AI\WP_Agent_Runtime_Tool_Request::STATUS_COMPLETED;
+		$this->requests[ $request_id ]['result'] = $result;
+		return true;
+	}
+
+	public function timeout( string $request_id ): void {
+		++$this->timeout_calls;
+		$this->requests[ $request_id ]['status'] = AgentsAPI\AI\WP_Agent_Runtime_Tool_Request::STATUS_TIMEOUT;
+	}
+
+	public function recent_pending( array $query = array() ): array {
+		unset( $query );
+		return array_values( array_filter(
+			$this->requests,
+			static fn( array $request ): bool => AgentsAPI\AI\WP_Agent_Runtime_Tool_Request::STATUS_PENDING === ( $request['status'] ?? '' )
+		) );
+	}
+};
+
+$resume_calls = 0;
+$continuation = static function ( array $request, array $result, array $context ) use ( &$resume_calls ): array {
+	unset( $request, $result, $context );
+	++$resume_calls;
+	return array( 'resumed' => true );
+};
+
+// ---------------------------------------------------------------------------
+// Finding 1 & 2: timeout/cancel replay of an already-terminal request.
+// ---------------------------------------------------------------------------
+
+$timeout_request = AgentsAPI\AI\WP_Agent_Runtime_Tool_Request::from_tool_call( 'client/choose_post', 'call_replay_timeout', array(), array( 'run_id' => 'run-replay-timeout' ) );
+AgentsAPI\AI\WP_Agent_Runtime_Tool_Lifecycle::create_pending_request( $store, $timeout_request );
+
+$first_timeout = AgentsAPI\AI\WP_Agent_Runtime_Tool_Lifecycle::timeout_request( $store, $timeout_request['request_id'], $continuation );
+agents_api_smoke_assert_equals( AgentsAPI\AI\WP_Agent_Runtime_Tool_Request::STATUS_TIMEOUT, $first_timeout['status'] ?? '', 'first timeout transitions the pending request', $failures, $passes );
+agents_api_smoke_assert_equals( false, $first_timeout['duplicate'] ?? true, 'first timeout is not a duplicate', $failures, $passes );
+agents_api_smoke_assert_equals( 1, $store->timeout_calls, 'first timeout writes to the store once', $failures, $passes );
+agents_api_smoke_assert_equals( 1, $resume_calls, 'first timeout resumes the continuation once', $failures, $passes );
+agents_api_smoke_assert_equals( 1, did_action( 'agents_api_runtime_tool_request_timed_out' ), 'first timeout fires the terminal hook once', $failures, $passes );
+
+// Replay the SAME timeout: must short-circuit as an idempotent duplicate.
+$replay_timeout = AgentsAPI\AI\WP_Agent_Runtime_Tool_Lifecycle::timeout_request( $store, $timeout_request['request_id'], $continuation );
+agents_api_smoke_assert_equals( true, $replay_timeout['duplicate'] ?? false, 'replayed timeout is reported as duplicate', $failures, $passes );
+agents_api_smoke_assert_equals( null, $replay_timeout['continuation_result'], 'replayed timeout does not resume the continuation', $failures, $passes );
+agents_api_smoke_assert_equals( 1, $store->timeout_calls, 'replayed timeout does not write to the store again', $failures, $passes );
+agents_api_smoke_assert_equals( 1, $resume_calls, 'replayed timeout does not resume the continuation again', $failures, $passes );
+agents_api_smoke_assert_equals( 1, did_action( 'agents_api_runtime_tool_request_timed_out' ), 'replayed timeout does not fire the terminal hook again', $failures, $passes );
+
+// Cancel is routed through the same terminal path; replaying it on the same
+// terminal record must likewise be an idempotent duplicate.
+$replay_cancel = AgentsAPI\AI\WP_Agent_Runtime_Tool_Lifecycle::timeout_request( $store, $timeout_request['request_id'], $continuation );
+agents_api_smoke_assert_equals( true, $replay_cancel['duplicate'] ?? false, 'replayed cancel is reported as duplicate', $failures, $passes );
+agents_api_smoke_assert_equals( 1, $resume_calls, 'replayed cancel does not resume the continuation again', $failures, $passes );
+agents_api_smoke_assert_equals( 1, $store->timeout_calls, 'replayed cancel does not write to the store again', $failures, $passes );
+
+// A request that was completed first must also reject a later timeout/cancel
+// terminal replay without side effects.
+$completed_request = AgentsAPI\AI\WP_Agent_Runtime_Tool_Request::from_tool_call( 'client/choose_post', 'call_complete_then_timeout', array(), array( 'run_id' => 'run-complete-then-timeout' ) );
+AgentsAPI\AI\WP_Agent_Runtime_Tool_Lifecycle::create_pending_request( $store, $completed_request );
+AgentsAPI\AI\WP_Agent_Runtime_Tool_Lifecycle::submit_result(
+	$store,
+	array(
+		'request_id' => $completed_request['request_id'],
+		'success'    => true,
+		'result'     => array( 'post_id' => 42 ),
+	)
+);
+$hooks_before = did_action( 'agents_api_runtime_tool_request_timed_out' );
+$timeout_after_complete = AgentsAPI\AI\WP_Agent_Runtime_Tool_Lifecycle::timeout_request( $store, $completed_request['request_id'], $continuation );
+agents_api_smoke_assert_equals( true, $timeout_after_complete['duplicate'] ?? false, 'timeout of a completed request is a duplicate', $failures, $passes );
+agents_api_smoke_assert_equals( AgentsAPI\AI\WP_Agent_Runtime_Tool_Request::STATUS_COMPLETED, $timeout_after_complete['status'] ?? '', 'timeout of a completed request preserves completed status', $failures, $passes );
+agents_api_smoke_assert_equals( $hooks_before, did_action( 'agents_api_runtime_tool_request_timed_out' ), 'timeout of a completed request does not fire the terminal hook', $failures, $passes );
+
+// ---------------------------------------------------------------------------
+// Finding 3: completion that loses the exact-once race resolves as duplicate.
+// ---------------------------------------------------------------------------
+
+/**
+ * Store whose complete() always reports a loss (another caller already won),
+ * exposing the retained winner result on the subsequent get(). Models the race
+ * window where two callers both read a pending record before either writes.
+ */
+$racing_store = new class() implements AgentsAPI\AI\WP_Agent_Runtime_Tool_Request_Store {
+	/** @var array<string, mixed> */
+	public array $request = array();
+	public bool $won_by_other = false;
+	public int $complete_calls = 0;
+
+	public function create( array $request ): void {
+		$this->request = $request;
+	}
+
+	public function get( string $request_id ): ?array {
+		unset( $request_id );
+		if ( $this->won_by_other ) {
+			$terminal           = $this->request;
+			$terminal['status'] = AgentsAPI\AI\WP_Agent_Runtime_Tool_Request::STATUS_COMPLETED;
+			$terminal['result'] = array(
+				'success' => true,
+				'result'  => array( 'post_id' => 7 ),
+			);
+			return $terminal;
+		}
+		return $this->request;
+	}
+
+	public function complete( string $request_id, array $result ): bool {
+		unset( $request_id, $result );
+		++$this->complete_calls;
+		$this->won_by_other = true;
+		return false;
+	}
+
+	public function timeout( string $request_id ): void {
+		unset( $request_id );
+	}
+
+	public function recent_pending( array $query = array() ): array {
+		unset( $query );
+		return array();
+	}
+};
+
+$race_request = AgentsAPI\AI\WP_Agent_Runtime_Tool_Request::from_tool_call( 'client/choose_post', 'call_race', array(), array( 'run_id' => 'run-race' ) );
+$racing_store->create( AgentsAPI\AI\WP_Agent_Runtime_Tool_Request::normalize( $race_request ) );
+
+$race_resume_calls = 0;
+$submitted_before  = did_action( 'agents_api_runtime_tool_result_submitted' );
+$race_submission   = AgentsAPI\AI\WP_Agent_Runtime_Tool_Lifecycle::submit_result(
+	$racing_store,
+	array(
+		'request_id' => $race_request['request_id'],
+		'success'    => true,
+		'result'     => array( 'post_id' => 999 ),
+	),
+	static function ( array $request, array $result, array $context ) use ( &$race_resume_calls ): array {
+		unset( $request, $result, $context );
+		++$race_resume_calls;
+		return array( 'resumed' => true );
+	}
+);
+agents_api_smoke_assert_equals( true, $race_submission['duplicate'] ?? false, 'losing completion resolves as a duplicate', $failures, $passes );
+agents_api_smoke_assert_equals( 7, $race_submission['result']['result']['post_id'] ?? null, 'losing completion returns the retained winner result', $failures, $passes );
+agents_api_smoke_assert_equals( null, $race_submission['continuation_result'], 'losing completion does not resume the continuation', $failures, $passes );
+agents_api_smoke_assert_equals( 0, $race_resume_calls, 'losing completion never invokes the continuation', $failures, $passes );
+agents_api_smoke_assert_equals( $submitted_before, did_action( 'agents_api_runtime_tool_result_submitted' ), 'losing completion does not fire the submitted hook', $failures, $passes );
+
+agents_api_smoke_finish( 'Agents API runtime-tool terminal replay', $failures, $passes );

--- a/tests/tool-runtime-smoke.php
+++ b/tests/tool-runtime-smoke.php
@@ -685,10 +685,14 @@ $runtime_tool_store = new class() implements AgentsAPI\AI\WP_Agent_Runtime_Tool_
 		return $this->requests[ $request_id ] ?? null;
 	}
 
-	public function complete( string $request_id, array $result ): void {
+	public function complete( string $request_id, array $result ): bool {
+		if ( ! isset( $this->requests[ $request_id ] ) || AgentsAPI\AI\WP_Agent_Runtime_Tool_Request::STATUS_PENDING !== ( $this->requests[ $request_id ]['status'] ?? '' ) ) {
+			return false;
+		}
 		$this->requests[ $request_id ]['status'] = AgentsAPI\AI\WP_Agent_Runtime_Tool_Request::STATUS_COMPLETED;
 		$this->requests[ $request_id ]['result'] = $result;
 		$this->results[ $request_id ]            = $result;
+		return true;
 	}
 
 	public function timeout( string $request_id ): void {
@@ -761,9 +765,10 @@ $terminal_without_result_store = new class() implements AgentsAPI\AI\WP_Agent_Ru
 		return $this->requests[ $request_id ] ?? null;
 	}
 
-	public function complete( string $request_id, array $result ): void {
+	public function complete( string $request_id, array $result ): bool {
 		++$this->complete_calls;
 		$this->attempted_data = compact( 'request_id', 'result' );
+		return false;
 	}
 
 	public function timeout( string $request_id ): void {
@@ -805,9 +810,13 @@ $timeout_store = new class() implements AgentsAPI\AI\WP_Agent_Runtime_Tool_Reque
 		return $this->requests[ $request_id ] ?? null;
 	}
 
-	public function complete( string $request_id, array $result ): void {
+	public function complete( string $request_id, array $result ): bool {
 		unset( $result );
+		if ( AgentsAPI\AI\WP_Agent_Runtime_Tool_Request::STATUS_PENDING !== ( $this->requests[ $request_id ]['status'] ?? '' ) ) {
+			return false;
+		}
 		$this->requests[ $request_id ]['status'] = 'completed';
+		return true;
 	}
 
 	public function timeout( string $request_id ): void {

--- a/tests/tool-runtime-smoke.php
+++ b/tests/tool-runtime-smoke.php
@@ -673,7 +673,7 @@ $submitted_result = AgentsAPI\AI\WP_Agent_Runtime_Tool_Result::normalize(
 agents_api_smoke_assert_equals( AgentsAPI\AI\WP_Agent_Runtime_Tool_Result::STATUS_SUBMITTED, $submitted_result['status'], 'runtime tool result has canonical submitted status', $failures, $passes );
 agents_api_smoke_assert_equals( 123, $submitted_result['result']['post_id'] ?? null, 'runtime tool result preserves payload', $failures, $passes );
 
-$runtime_tool_store = new class() implements AgentsAPI\AI\WP_Agent_Runtime_Tool_Request_Store {
+$runtime_tool_store = new class() implements AgentsAPI\AI\WP_Agent_Runtime_Tool_Request_Atomic_Store {
 	public array $requests = array();
 	public array $results  = array();
 
@@ -685,18 +685,24 @@ $runtime_tool_store = new class() implements AgentsAPI\AI\WP_Agent_Runtime_Tool_
 		return $this->requests[ $request_id ] ?? null;
 	}
 
-	public function complete( string $request_id, array $result ): bool {
-		if ( ! isset( $this->requests[ $request_id ] ) || AgentsAPI\AI\WP_Agent_Runtime_Tool_Request::STATUS_PENDING !== ( $this->requests[ $request_id ]['status'] ?? '' ) ) {
-			return false;
-		}
-		$this->requests[ $request_id ]['status'] = AgentsAPI\AI\WP_Agent_Runtime_Tool_Request::STATUS_COMPLETED;
-		$this->requests[ $request_id ]['result'] = $result;
-		$this->results[ $request_id ]            = $result;
-		return true;
+	public function complete( string $request_id, array $result ): void {
+		$this->transition_pending( $request_id, AgentsAPI\AI\WP_Agent_Runtime_Tool_Request::STATUS_COMPLETED, $result );
 	}
 
 	public function timeout( string $request_id ): void {
-		$this->requests[ $request_id ]['status'] = AgentsAPI\AI\WP_Agent_Runtime_Tool_Request::STATUS_TIMEOUT;
+		$this->transition_pending( $request_id, AgentsAPI\AI\WP_Agent_Runtime_Tool_Request::STATUS_TIMEOUT );
+	}
+
+	public function transition_pending( string $request_id, string $status, ?array $result = null ): bool {
+		if ( ! isset( $this->requests[ $request_id ] ) || AgentsAPI\AI\WP_Agent_Runtime_Tool_Request::STATUS_PENDING !== ( $this->requests[ $request_id ]['status'] ?? '' ) ) {
+			return false;
+		}
+		$this->requests[ $request_id ]['status'] = $status;
+		if ( null !== $result ) {
+			$this->requests[ $request_id ]['result'] = $result;
+			$this->results[ $request_id ]            = $result;
+		}
+		return true;
 	}
 
 	public function recent_pending( array $query = array() ): array {
@@ -765,10 +771,9 @@ $terminal_without_result_store = new class() implements AgentsAPI\AI\WP_Agent_Ru
 		return $this->requests[ $request_id ] ?? null;
 	}
 
-	public function complete( string $request_id, array $result ): bool {
+	public function complete( string $request_id, array $result ): void {
 		++$this->complete_calls;
 		$this->attempted_data = compact( 'request_id', 'result' );
-		return false;
 	}
 
 	public function timeout( string $request_id ): void {
@@ -799,7 +804,7 @@ try {
 agents_api_smoke_assert_equals( true, $duplicate_refused, 'duplicate runtime tool completion without prior result is refused', $failures, $passes );
 agents_api_smoke_assert_equals( 0, $terminal_without_result_store->complete_calls, 'refused duplicate runtime tool completion does not write', $failures, $passes );
 
-$timeout_store = new class() implements AgentsAPI\AI\WP_Agent_Runtime_Tool_Request_Store {
+$timeout_store = new class() implements AgentsAPI\AI\WP_Agent_Runtime_Tool_Request_Atomic_Store {
 	public array $requests = array();
 
 	public function create( array $request ): void {
@@ -810,17 +815,21 @@ $timeout_store = new class() implements AgentsAPI\AI\WP_Agent_Runtime_Tool_Reque
 		return $this->requests[ $request_id ] ?? null;
 	}
 
-	public function complete( string $request_id, array $result ): bool {
+	public function complete( string $request_id, array $result ): void {
+		$this->transition_pending( $request_id, AgentsAPI\AI\WP_Agent_Runtime_Tool_Request::STATUS_COMPLETED, $result );
+	}
+
+	public function timeout( string $request_id ): void {
+		$this->transition_pending( $request_id, AgentsAPI\AI\WP_Agent_Runtime_Tool_Request::STATUS_TIMEOUT );
+	}
+
+	public function transition_pending( string $request_id, string $status, ?array $result = null ): bool {
 		unset( $result );
 		if ( AgentsAPI\AI\WP_Agent_Runtime_Tool_Request::STATUS_PENDING !== ( $this->requests[ $request_id ]['status'] ?? '' ) ) {
 			return false;
 		}
-		$this->requests[ $request_id ]['status'] = 'completed';
+		$this->requests[ $request_id ]['status'] = $status;
 		return true;
-	}
-
-	public function timeout( string $request_id ): void {
-		$this->requests[ $request_id ]['status'] = AgentsAPI\AI\WP_Agent_Runtime_Tool_Request::STATUS_TIMEOUT;
 	}
 
 	public function recent_pending( array $query = array() ): array {


### PR DESCRIPTION
## Summary

The runtime-tool lifecycle abilities (`agents/submit-runtime-tool-result`, `agents/timeout-runtime-tool-request`, `agents/cancel-runtime-tool-request`) are all annotated `idempotent => true`, but the lifecycle layer did not enforce exact-once terminal semantics. This is a class of **replayable terminal operation / non-atomic exact-once boundary** bug: repeating a terminal call — or racing two completions — re-fired lifecycle hooks and re-invoked the host continuation adapter (the agent-run resume), producing duplicate downstream run/tool/provider side effects.

- `src/Runtime/class-wp-agent-runtime-tool-lifecycle.php:133` (`timeout_request`) — **CWE-841 Improper Enforcement of Behavioral Workflow.** The method never inspected the stored status: it unconditionally called `$store->timeout()`, fired `agents_api_runtime_tool_request_timed_out`, and invoked the continuation resume. Replaying `timeout`/`cancel` on an already-terminal `request_id` re-fired the terminal hook and re-ran the host continuation each time.
- `src/Runtime/class-wp-agent-runtime-tool-lifecycle.php:194` (cancel path) — same defect; `agents_runtime_tool_terminal_request()` routes both the timeout and cancel abilities through `timeout_request`, so a single guard closes both.
- `src/Runtime/class-wp-agent-runtime-tool-lifecycle.php:85` (`complete_if_pending`) + `src/Runtime/class-wp-agent-runtime-tool-request-store.php:48` (`complete`) — **CWE-362 Race Condition.** `complete()` returned `void`, so `complete_if_pending()` was a check-then-act: two concurrent callers could both read `status = pending` and both fall through to complete, each firing `agents_api_runtime_tool_result_submitted` and resuming. The lifecycle could not distinguish the winner from the loser even against an atomic store.

## Fix

- `timeout_request()` now reads `$request['status']` **before** `WP_Agent_Runtime_Tool_Request::normalize()` rewrites it to pending (mirroring the guard already in `complete_if_pending()`). When the retained status is non-empty and not `STATUS_PENDING`, it returns an idempotent terminal envelope marked `duplicate => true` and skips the store transition, the `agents_api_runtime_tool_request_timed_out` hook, and the continuation resume entirely. Fail-closed: a completed/timed-out/cancelled request short-circuits instead of replaying.
- `WP_Agent_Runtime_Tool_Request_Store::complete()` now returns `bool` — an atomic claim signal that is `true` only when this caller transitioned a pending record to complete. `complete_if_pending()` branches on it: a `false` result means another caller already won, so it re-reads the now-terminal record and returns the retained winner result as `duplicate => true` (or rejects when no prior result exists). Host store implementations must back `complete()` with a conditional/compare-and-set update on pending rows. This is a small interface contract change, offered for maintainer review.
- Only the winning submission and the first terminal transition fire hooks and resume the continuation.

## Testing

- `tests/runtime-tool-terminal-replay-smoke.php` (new, added to the `composer smoke` array) — 21 assertions covering: first timeout transitions once; replayed timeout and replayed cancel are idempotent duplicates that do not re-write the store, re-fire the terminal hook, or re-resume the continuation; timeout of an already-completed request is refused without side effects; and a completion that loses the exact-once race resolves as a duplicate returning the retained winner result without firing the submitted hook or continuation. Verified to fail (17 assertions) against the pre-fix code and pass with the fix.
- Store implementations in `tests/tool-runtime-smoke.php`, `tests/conversation-loop-tool-execution-smoke.php`, and `tests/runtime-tool-lifecycle-abilities-smoke.php` updated to the bool compare-and-set `complete()` contract.
- `composer smoke` — full suite green (exit 0).
- `vendor/bin/phpstan analyse --no-progress --memory-limit=2G` — No errors (level max).

---

This issue was found by an automated security scan; the fix is offered as a draft for maintainer review.

## AI assistance
OpenAI `openai/gpt-5.6-sol` via OpenCode reviewed this PR and drafted the security follow-up commit and tests. Chris Huber directed the work and remains responsible for the resulting changes.