### PR TITLE
Security: bind branch reconcile to stored suspension state and fail closed on lock loss

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -135,6 +135,7 @@
       "php tests/workflow-async-loopback-target-smoke.php",
       "php tests/workflow-async-runner-dispatch-result-smoke.php",
       "php tests/workflow-reconcile-race-smoke.php",
+      "php tests/workflow-reconcile-branch-authorization-smoke.php",
       "php tests/workflow-lifecycle-smoke.php",
       "php tests/agents-workflow-ability-smoke.php",
       "php tests/routine-smoke.php",

--- a/src/Workflows/class-wp-agent-workflow-action-scheduler-branch-executor.php
+++ b/src/Workflows/class-wp-agent-workflow-action-scheduler-branch-executor.php
@@ -772,14 +772,40 @@ final class WP_Agent_Workflow_Action_Scheduler_Branch_Executor implements WP_Age
 				),
 				'item'   => null,
 			);
-			agents_reconcile_workflow_branch( $run_id, $handle_id, $branch_result );
+			self::reconcile_branch_result( $payload, $branch_result );
 			return;
 		}
 
 		$key           = self::string_value( $descriptor['key'] ?? '' );
 		$branch_result = self::execute_branch( $descriptor, $key );
 
-		agents_reconcile_workflow_branch( $run_id, $handle_id, $branch_result );
+		self::reconcile_branch_result( $payload, $branch_result );
+	}
+
+	/**
+	 * Reconcile a completed branch, re-enqueuing it when lock contention prevents
+	 * the result from being recorded. Other errors are authoritative and are not
+	 * retried.
+	 *
+	 * @since 0.5.0
+	 *
+	 * @param array<mixed>        $payload       Original branch action payload.
+	 * @param array<string,mixed> $branch_result Terminal branch result.
+	 * @return void
+	 */
+	private static function reconcile_branch_result( array $payload, array $branch_result ): void {
+		$run_id    = self::string_value( $payload['run_id'] ?? '' );
+		$handle_id = self::string_value( $payload['handle_id'] ?? '' );
+		$result    = agents_reconcile_workflow_branch( $run_id, $handle_id, $branch_result );
+
+		if ( ! is_wp_error( $result ) || 'agents_reconcile_lock_unavailable' !== $result->get_error_code() ) {
+			return;
+		}
+
+		$action_id = self::enqueue_async_action( self::BRANCH_HOOK, array( $payload ), self::group_for_run( $run_id ) );
+		if ( $action_id <= 0 ) {
+			throw new \RuntimeException( sprintf( 'Could not re-enqueue branch `%s` for run `%s` after reconcile lock contention.', $handle_id, $run_id ) );
+		}
 	}
 
 	/**

--- a/src/Workflows/class-wp-agent-workflow-reconcile-lock.php
+++ b/src/Workflows/class-wp-agent-workflow-reconcile-lock.php
@@ -75,16 +75,21 @@ final class WP_Agent_Workflow_Reconcile_Lock {
 	private const TTL_SECONDS = 60;
 
 	/**
-	 * Max acquisition attempts before giving up. With the sleep below this is a
-	 * bounded wait; a reconcile section is short, so contenders win quickly.
+	 * Max acquisition attempts before giving up. Sized (with the backoff below) so
+	 * the total bounded wait covers {@see self::TTL_SECONDS}: a healthy holder's
+	 * short section releases far sooner, and a crashed holder's lock row expires
+	 * within the TTL and is then reclaimed. So acquisition effectively always
+	 * succeeds in normal operation and the fail-closed path in {@see self::with_lock()}
+	 * is only a genuine last resort. 3000 × 20ms ≈ 60s = TTL_SECONDS.
 	 *
 	 * @since 0.5.0
 	 */
-	private const MAX_ATTEMPTS = 50;
+	private const MAX_ATTEMPTS = 3000;
 
 	/**
-	 * Per-attempt backoff (microseconds). 20ms × 50 attempts ≈ 1s worst-case
-	 * wait — well under the TTL, so a waiter either wins or reclaims a stale lock.
+	 * Per-attempt backoff (microseconds). 20ms × 3000 attempts ≈ 60s worst-case
+	 * wait — matching the TTL, so a waiter either wins, reclaims a stale lock once
+	 * it expires, or (only under pathological sustained contention) fails closed.
 	 *
 	 * @since 0.5.0
 	 */
@@ -93,34 +98,67 @@ final class WP_Agent_Workflow_Reconcile_Lock {
 	/**
 	 * Run one callback under an exclusive per-run lock. The callback runs at most
 	 * once and only while the lock is held; the lock is always released, even if
-	 * the callback throws. When the lock genuinely cannot be acquired (a wedged
-	 * holder that never expires) the callback still runs — stranding the branch
-	 * would be strictly worse than a best-effort merge, and the TTL makes a real
-	 * crash reclaimable so this fallback is rare.
+	 * the callback throws.
+	 *
+	 * FAIL CLOSED. The reconcile critical section is a read-modify-write on the
+	 * suspension frame's `completed[]` map; running it WITHOUT the lock risks a
+	 * lost update that permanently strands the run SUSPENDED. So when acquisition
+	 * ultimately fails, the callback is NOT run — instead a retryable WP_Error is
+	 * returned so the executor re-enqueues the branch and reconcile is retried once
+	 * the contention clears. Because the acquire loop's bounded wait covers the
+	 * TTL (a live holder releases quickly, a crashed holder's row expires and is
+	 * reclaimed), this last-resort error is unreachable in normal operation.
+	 *
+	 * When there is no option layer at all (a non-WordPress harness) there is
+	 * nothing to serialize against and callers are already single-process, so the
+	 * callback runs directly.
 	 *
 	 * @since 0.5.0
 	 *
 	 * @template T
 	 * @param string           $run_id   Run whose reconcile section is serialized.
 	 * @param callable():T     $critical The critical section (find → merge → decide).
-	 * @return T The callback's return value.
+	 * @return T|\WP_Error The callback's return value, or a retryable WP_Error when the lock could not be acquired.
 	 */
 	public static function with_lock( string $run_id, callable $critical ) {
+		if ( ! self::has_option_layer() ) {
+			// No option layer (e.g. a non-WordPress harness) — nothing to lock
+			// against; callers are already single-process there.
+			return $critical();
+		}
+
 		$token = self::acquire( $run_id );
+		if ( null === $token ) {
+			// Acquisition ultimately failed under sustained contention. Fail closed:
+			// do NOT run the unguarded read-modify-write. Return a retryable error so
+			// the branch is re-enqueued rather than risking a lost update.
+			return new \WP_Error(
+				'agents_reconcile_lock_unavailable',
+				sprintf( 'Could not acquire the reconcile lock for run `%s` after %d attempts; retry the branch reconcile.', $run_id, self::MAX_ATTEMPTS )
+			);
+		}
+
 		try {
 			return $critical();
 		} finally {
-			if ( null !== $token ) {
-				self::release( $run_id, $token );
-			}
+			self::release( $run_id, $token );
 		}
 	}
 
 	/**
+	 * Whether the WordPress option layer used by the lock is available.
+	 *
+	 * @since 0.5.0
+	 */
+	private static function has_option_layer(): bool {
+		return function_exists( 'add_option' ) && function_exists( 'get_option' ) && function_exists( 'delete_option' );
+	}
+
+	/**
 	 * Acquire the per-run lock, blocking with bounded retries. Returns the lock
-	 * token on success, or null when acquisition ultimately failed (the caller
-	 * proceeds without the lock rather than dropping the branch — see
-	 * {@see self::with_lock()}).
+	 * token on success, or null when acquisition ultimately failed — in which case
+	 * {@see self::with_lock()} fails closed and returns a retryable error rather
+	 * than running the critical section unguarded.
 	 *
 	 * @since 0.5.0
 	 *

--- a/src/Workflows/register-reconcile-workflow-branch.php
+++ b/src/Workflows/register-reconcile-workflow-branch.php
@@ -202,8 +202,8 @@ function agents_reconcile_workflow_branch_locked( WP_Agent_Workflow_Run_Recorder
 
 	// Bind the completion to the handle's stored key too: the caller may not
 	// remap its output onto a different branch's aggregate key. An empty stored
-	// or asserted key skips this check to stay backward compatible with frames
-	// that did not stamp a key.
+	// key preserves compatibility with frames that did not stamp one; otherwise
+	// the stored key remains authoritative when the caller omits it.
 	$stored_key   = agents_workflow_string( $stored_handle['key'] ?? '' );
 	$asserted_key = agents_workflow_string( $branch_result['key'] ?? '' );
 	if ( '' !== $stored_key && '' !== $asserted_key && $stored_key !== $asserted_key ) {
@@ -214,10 +214,15 @@ function agents_reconcile_workflow_branch_locked( WP_Agent_Workflow_Run_Recorder
 	}
 
 	$status = agents_workflow_string( $branch_result['status'] ?? '' );
-	$status = ( WP_Agent_Workflow_Run_Result::STATUS_FAILED === $status ) ? WP_Agent_Workflow_Run_Result::STATUS_FAILED : WP_Agent_Workflow_Run_Result::STATUS_SUCCEEDED;
+	if ( WP_Agent_Workflow_Run_Result::STATUS_SUCCEEDED !== $status && WP_Agent_Workflow_Run_Result::STATUS_FAILED !== $status ) {
+		return new \WP_Error(
+			'agents_reconcile_workflow_branch_invalid_status',
+			sprintf( 'Branch result status `%s` is not terminal for handle `%s`.', $status, $handle_id )
+		);
+	}
 
 	$completed[ $handle_id ] = array(
-		'key'    => agents_workflow_string( $branch_result['key'] ?? '' ),
+		'key'    => '' !== $stored_key ? $stored_key : $asserted_key,
 		'status' => $status,
 		'output' => $branch_result['output'] ?? null,
 		'steps'  => is_array( $branch_result['steps'] ?? null ) ? $branch_result['steps'] : array(),

--- a/src/Workflows/register-reconcile-workflow-branch.php
+++ b/src/Workflows/register-reconcile-workflow-branch.php
@@ -181,6 +181,38 @@ function agents_reconcile_workflow_branch_locked( WP_Agent_Workflow_Run_Recorder
 		return $result;
 	}
 
+	// Bind the completion to server-stored suspension state: only a handle id
+	// that was actually recorded when the run suspended may complete. A
+	// caller-asserted handle id that is not among the stored handles is rejected
+	// (fail closed) so a forged/unknown id cannot inflate the completed[]
+	// accounting and prematurely trip the all-terminal gate below.
+	$stored_handle = null;
+	foreach ( $handles as $handle ) {
+		if ( is_array( $handle ) && agents_workflow_string( $handle['id'] ?? '' ) === $handle_id ) {
+			$stored_handle = $handle;
+			break;
+		}
+	}
+	if ( null === $stored_handle ) {
+		return new \WP_Error(
+			'agents_reconcile_workflow_branch_unknown_handle',
+			sprintf( 'Handle id `%s` is not a known suspended branch of run `%s`.', $handle_id, $run_id )
+		);
+	}
+
+	// Bind the completion to the handle's stored key too: the caller may not
+	// remap its output onto a different branch's aggregate key. An empty stored
+	// or asserted key skips this check to stay backward compatible with frames
+	// that did not stamp a key.
+	$stored_key   = agents_workflow_string( $stored_handle['key'] ?? '' );
+	$asserted_key = agents_workflow_string( $branch_result['key'] ?? '' );
+	if ( '' !== $stored_key && '' !== $asserted_key && $stored_key !== $asserted_key ) {
+		return new \WP_Error(
+			'agents_reconcile_workflow_branch_key_mismatch',
+			sprintf( 'branch_result key `%s` does not match the stored key `%s` for handle `%s`.', $asserted_key, $stored_key, $handle_id )
+		);
+	}
+
 	$status = agents_workflow_string( $branch_result['status'] ?? '' );
 	$status = ( WP_Agent_Workflow_Run_Result::STATUS_FAILED === $status ) ? WP_Agent_Workflow_Run_Result::STATUS_FAILED : WP_Agent_Workflow_Run_Result::STATUS_SUCCEEDED;
 
@@ -316,7 +348,7 @@ function agents_workflow_defer_resume( string $run_id, WP_Agent_Workflow_Run_Res
  * @template T
  * @param string       $run_id   Suspended run id whose reconcile is serialized.
  * @param callable():T $critical The load → merge → decide → resume-dispatch section.
- * @return T
+ * @return T|\WP_Error The section's result, or a retryable WP_Error when the lock could not be acquired.
  */
 function agents_workflow_reconcile_with_lock( string $run_id, callable $critical ) {
 	/**

--- a/tests/reconcile-lock-fail-closed-usleep-shim.php
+++ b/tests/reconcile-lock-fail-closed-usleep-shim.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Test-only shim: neutralize the reconcile lock's per-attempt backoff so the
+ * fail-closed acquisition path can be exercised without real wall-clock sleeps.
+ *
+ * The lock class calls an unqualified `usleep()` from inside the
+ * `AgentsAPI\AI\Workflows` namespace. PHP resolves that to this namespaced
+ * function (which takes precedence over the global builtin) when it is defined,
+ * turning the bounded acquire loop into an instant spin for the test.
+ *
+ * @package AgentsAPI\Tests
+ */
+
+namespace AgentsAPI\AI\Workflows;
+
+if ( ! function_exists( __NAMESPACE__ . '\\usleep' ) ) {
+	/**
+	 * No-op stand-in for the global usleep() during the fail-closed lock test.
+	 *
+	 * @param int $microseconds Ignored.
+	 * @return void
+	 */
+	function usleep( int $microseconds ): void {
+		unset( $microseconds );
+	}
+}

--- a/tests/workflow-as-branch-smoke.php
+++ b/tests/workflow-as-branch-smoke.php
@@ -465,6 +465,31 @@ $handles = $frame['handles'] ?? array();
 smoke_assert( 2, count( $handles ), 'frame carries 2 sibling handles', $failures, $passes );
 smoke_assert_true( is_int( $handles[0]['ref'] ?? null ) && $handles[0]['ref'] > 0, 'handle ref is the AS action id', $failures, $passes );
 
+// A contended reconcile must enqueue another branch action instead of silently
+// completing the current action without recording its result.
+$lock_attempts = 0;
+add_filter(
+	'wp_agent_workflow_reconcile_lock',
+	static function ( $override, string $run_id, callable $critical ) use ( &$lock_attempts ) {
+		unset( $override );
+		if ( 'as-A' === $run_id && 0 === $lock_attempts++ ) {
+			return new WP_Error( 'agents_reconcile_lock_unavailable', 'contended' );
+		}
+		return $critical();
+	},
+	10,
+	3
+);
+$branch_count_before_retry = count( AS_Shim::actions_for( WP_Agent_Workflow_Action_Scheduler_Branch_Executor::BRANCH_HOOK ) );
+AS_Shim::fire( $branch_actions[0]['id'] );
+$branch_actions_with_retry = AS_Shim::actions_for( WP_Agent_Workflow_Action_Scheduler_Branch_Executor::BRANCH_HOOK );
+smoke_assert( $branch_count_before_retry + 1, count( $branch_actions_with_retry ), 'lock contention: branch action re-enqueued', $failures, $passes );
+smoke_assert( 0, count( $recorder->find( 'as-A' )->get_suspension()['completed'] ?? array() ), 'lock contention: result not recorded without lock', $failures, $passes );
+$retry_action = $branch_actions_with_retry[ count( $branch_actions_with_retry ) - 1 ];
+AS_Shim::fire( $retry_action['id'] );
+smoke_assert( 1, count( $recorder->find( 'as-A' )->get_suspension()['completed'] ?? array() ), 'lock contention: queued retry records completion', $failures, $passes );
+remove_all_filters( 'wp_agent_workflow_reconcile_lock' );
+
 // TABLE-FREE: the frame lives in metadata._suspension, not a new table.
 smoke_assert_true( is_array( $recorder->find( 'as-A' )->get_suspension()['handles'] ?? null ), 'table-free: frame in metadata._suspension while suspended', $failures, $passes );
 smoke_assert( $tables_before, $recorder->tables(), 'table-free: NO new table created on suspend', $failures, $passes );
@@ -473,7 +498,6 @@ smoke_assert( $tables_before, $recorder->tables(), 'table-free: NO new table cre
 // Firing the SECOND (last) branch action makes reconcile observe all-terminal
 // and enqueue a claimed RESUME action (deferred, not inline).
 $resume_before = count( AS_Shim::actions_for( WP_Agent_Workflow_Action_Scheduler_Branch_Executor::RESUME_HOOK ) );
-AS_Shim::fire( $branch_actions[0]['id'] );
 $mid = $recorder->find( 'as-A' );
 smoke_assert( WP_Agent_Workflow_Run_Result::STATUS_SUSPENDED, $mid->get_status(), 'AS path: still SUSPENDED after 1 of 2 branch actions', $failures, $passes );
 smoke_assert( $resume_before, count( AS_Shim::actions_for( WP_Agent_Workflow_Action_Scheduler_Branch_Executor::RESUME_HOOK ) ), 'AS path: no resume enqueued before all branches terminal', $failures, $passes );

--- a/tests/workflow-reconcile-branch-authorization-smoke.php
+++ b/tests/workflow-reconcile-branch-authorization-smoke.php
@@ -1,0 +1,464 @@
+<?php
+/**
+ * Pure-PHP regression test for two reconcile-branch hardening fixes.
+ *
+ * Run with: php tests/workflow-reconcile-branch-authorization-smoke.php
+ *
+ * FINDING 1 — self-asserted branch handle (register-reconcile-workflow-branch.php).
+ * agents_reconcile_workflow_branch_locked() used to insert a `completed[handle_id]`
+ * entry for ANY caller-supplied handle_id, with no check that the id (or its key)
+ * belonged to the run's stored suspension frame. A forged handle id could inflate
+ * the completed[] map until count(completed) reached count(handles), tripping the
+ * all-terminal gate and resuming the run early with an ATTACKER-chosen aggregate
+ * output — while a genuine branch had not yet finished. The fix binds the merge to
+ * server-stored state: an unknown handle id (or a key that does not match the
+ * stored handle) fails closed with a WP_Error and never touches completed[].
+ *
+ * FINDING 2 — fail-open reconcile lock (class-wp-agent-workflow-reconcile-lock.php).
+ * WP_Agent_Workflow_Reconcile_Lock::with_lock() used to run the reconcile critical
+ * section EVEN WHEN the per-run lock could not be acquired (acquire() returned
+ * null), re-opening the very lost-update window the lock exists to close. The fix
+ * makes it fail closed: when the lock is unavailable it returns a retryable
+ * WP_Error and does NOT run the critical section, so the executor re-enqueues the
+ * branch instead of performing an unguarded write.
+ *
+ * Both assertions FAIL against the pre-fix code and PASS after.
+ *
+ * @package AgentsAPI\Tests
+ */
+
+defined( 'ABSPATH' ) || define( 'ABSPATH', __DIR__ . '/' );
+
+// Neutralize the lock backoff BEFORE the lock class loads/runs so the fail-closed
+// acquire loop spins instantly instead of sleeping for the full TTL window.
+require_once __DIR__ . '/reconcile-lock-fail-closed-usleep-shim.php';
+
+$failures = array();
+$passes   = 0;
+
+echo "workflow-reconcile-branch-authorization-smoke\n";
+
+if ( ! class_exists( 'WP_Error' ) ) {
+	class WP_Error {
+		public function __construct( private string $code = '', private string $message = '', private $data = null ) {}
+		public function get_error_code(): string { return $this->code; }
+		public function get_error_message(): string { return $this->message; }
+		public function get_error_data() { return $this->data; }
+	}
+}
+if ( ! function_exists( 'is_wp_error' ) ) {
+	function is_wp_error( $value ): bool {
+		return $value instanceof WP_Error;
+	}
+}
+if ( ! class_exists( 'WP_Ability' ) ) {
+	class WP_Ability {
+		public function __construct( private string $name, private array $args ) {}
+		public function get_name(): string { return $this->name; }
+		public function execute( $input = null ) {
+			$callback = $this->args['execute_callback'] ?? null;
+			return is_callable( $callback ) ? call_user_func( $callback, is_array( $input ) ? $input : array() ) : null;
+		}
+	}
+}
+
+$GLOBALS['__filters']   = array();
+$GLOBALS['__abilities'] = array();
+$GLOBALS['__options']   = array();
+
+if ( ! function_exists( 'add_filter' ) ) {
+	function add_filter( string $hook, callable $cb, int $priority = 10, int $accepted_args = 1 ): void {
+		unset( $accepted_args );
+		$GLOBALS['__filters'][ $hook ][ $priority ][] = $cb;
+	}
+}
+if ( ! function_exists( 'remove_all_filters' ) ) {
+	function remove_all_filters( string $hook ): void {
+		unset( $GLOBALS['__filters'][ $hook ] );
+	}
+}
+if ( ! function_exists( 'apply_filters' ) ) {
+	function apply_filters( string $hook, $value, ...$args ) {
+		$cbs = $GLOBALS['__filters'][ $hook ] ?? array();
+		ksort( $cbs );
+		foreach ( $cbs as $bucket ) {
+			foreach ( $bucket as $cb ) {
+				$value = call_user_func_array( $cb, array_merge( array( $value ), $args ) );
+			}
+		}
+		return $value;
+	}
+}
+if ( ! function_exists( 'add_action' ) ) {
+	function add_action( string $hook, callable $cb, int $priority = 10, int $accepted_args = 1 ): void {
+		add_filter( $hook, $cb, $priority, $accepted_args );
+	}
+}
+if ( ! function_exists( 'do_action' ) ) {
+	function do_action( string $hook, ...$args ): void {
+		$cbs = $GLOBALS['__filters'][ $hook ] ?? array();
+		ksort( $cbs );
+		foreach ( $cbs as $bucket ) {
+			foreach ( $bucket as $cb ) {
+				call_user_func_array( $cb, $args );
+			}
+		}
+	}
+}
+if ( ! function_exists( 'wp_get_ability' ) ) {
+	function wp_get_ability( string $name ) { return $GLOBALS['__abilities'][ $name ] ?? null; }
+}
+if ( ! function_exists( 'wp_has_ability' ) ) {
+	function wp_has_ability( string $name ): bool { return isset( $GLOBALS['__abilities'][ $name ] ); }
+}
+if ( ! function_exists( 'wp_register_ability' ) ) {
+	function wp_register_ability( string $name, array $args ) {
+		$GLOBALS['__abilities'][ $name ] = new WP_Ability( $name, $args );
+		return $GLOBALS['__abilities'][ $name ];
+	}
+}
+if ( ! function_exists( 'current_user_can' ) ) {
+	function current_user_can( $cap ): bool { unset( $cap ); return true; }
+}
+
+// Option-backed store shim modelling add_option()'s atomic-INSERT CAS contract:
+// add_option() returns false when the option row already exists (unique key).
+if ( ! function_exists( 'get_option' ) ) {
+	function get_option( string $option, $default = false ) {
+		return array_key_exists( $option, $GLOBALS['__options'] ) ? $GLOBALS['__options'][ $option ] : $default;
+	}
+}
+if ( ! function_exists( 'update_option' ) ) {
+	function update_option( string $option, $value, $autoload = null ): bool {
+		unset( $autoload );
+		$GLOBALS['__options'][ $option ] = $value;
+		return true;
+	}
+}
+if ( ! function_exists( 'add_option' ) ) {
+	function add_option( string $option, $value = '', $deprecated = '', $autoload = null ): bool {
+		unset( $deprecated, $autoload );
+		if ( array_key_exists( $option, $GLOBALS['__options'] ) ) {
+			return false;
+		}
+		$GLOBALS['__options'][ $option ] = $value;
+		return true;
+	}
+}
+if ( ! function_exists( 'delete_option' ) ) {
+	function delete_option( string $option ): bool {
+		if ( ! array_key_exists( $option, $GLOBALS['__options'] ) ) {
+			return false;
+		}
+		unset( $GLOBALS['__options'][ $option ] );
+		return true;
+	}
+}
+
+function smoke_assert( $expected, $actual, string $name, array &$failures, int &$passes ): void {
+	if ( $expected === $actual ) {
+		++$passes;
+		echo "  PASS {$name}\n";
+		return;
+	}
+	$failures[] = $name;
+	echo "  FAIL {$name}\n";
+	echo '    expected: ' . var_export( $expected, true ) . "\n";
+	echo '    actual:   ' . var_export( $actual, true ) . "\n";
+}
+
+function smoke_assert_true( $actual, string $name, array &$failures, int &$passes ): void {
+	smoke_assert( true, (bool) $actual, $name, $failures, $passes );
+}
+
+require_once __DIR__ . '/../src/Workflows/class-wp-agent-workflow-bindings.php';
+require_once __DIR__ . '/../src/Workflows/class-wp-agent-workflow-spec-validator.php';
+require_once __DIR__ . '/../src/Workflows/class-wp-agent-workflow-spec.php';
+require_once __DIR__ . '/../src/Workflows/class-wp-agent-workflow-run-result.php';
+require_once __DIR__ . '/../src/Workflows/class-wp-agent-workflow-store.php';
+require_once __DIR__ . '/../src/Workflows/class-wp-agent-workflow-run-recorder.php';
+require_once __DIR__ . '/../src/Abilities/class-wp-agent-ability-dispatcher.php';
+require_once __DIR__ . '/../src/Runtime/interface-wp-agent-run-control-store.php';
+require_once __DIR__ . '/../src/Runtime/class-wp-agent-option-run-control-store.php';
+require_once __DIR__ . '/../src/Runtime/class-wp-agent-run-control.php';
+require_once __DIR__ . '/../src/Workflows/class-wp-agent-workflow-run-context.php';
+require_once __DIR__ . '/../src/Workflows/interface-wp-agent-workflow-branch-executor.php';
+require_once __DIR__ . '/../src/Workflows/class-wp-agent-workflow-step-executor.php';
+require_once __DIR__ . '/../src/Workflows/class-wp-agent-workflow-runner.php';
+require_once __DIR__ . '/../src/Workflows/register-agents-workflow-abilities.php';
+require_once __DIR__ . '/../src/Workflows/class-wp-agent-workflow-reconcile-lock.php';
+require_once __DIR__ . '/../src/Workflows/register-reconcile-workflow-branch.php';
+
+use AgentsAPI\AI\Workflows\WP_Agent_Workflow_Run_Result;
+use AgentsAPI\AI\Workflows\WP_Agent_Workflow_Run_Recorder;
+use AgentsAPI\AI\Workflows\WP_Agent_Workflow_Runner;
+use AgentsAPI\AI\Workflows\WP_Agent_Workflow_Spec;
+use AgentsAPI\AI\Workflows\WP_Agent_Workflow_Reconcile_Lock;
+
+use function AgentsAPI\AI\Workflows\agents_reconcile_workflow_branch;
+
+final class Auth_Recorder implements WP_Agent_Workflow_Run_Recorder {
+	/** @var array<string,array<string,mixed>> */
+	public array $rows = array();
+
+	public function start( WP_Agent_Workflow_Run_Result $result ) {
+		$this->rows[ $result->get_run_id() ] = $result->to_array();
+		return $result->get_run_id();
+	}
+	public function update( WP_Agent_Workflow_Run_Result $result ) {
+		$this->rows[ $result->get_run_id() ] = $result->to_array();
+		return true;
+	}
+	public function find( string $run_id ): ?WP_Agent_Workflow_Run_Result {
+		return isset( $this->rows[ $run_id ] )
+			? WP_Agent_Workflow_Run_Result::from_array( $this->rows[ $run_id ] )
+			: null;
+	}
+	public function recent( array $args = array() ): array {
+		unset( $args );
+		return array_map( array( WP_Agent_Workflow_Run_Result::class, 'from_array' ), array_values( $this->rows ) );
+	}
+}
+
+final class Auth_Executor implements \AgentsAPI\AI\Workflows\WP_Agent_Workflow_Branch_Executor {
+	/** @var array<int,array<string,mixed>> */
+	public static array $dispatched = array();
+
+	public function id(): string { return 'auth_exec'; }
+
+	public function dispatch( array $branches, array $context ): array {
+		self::$dispatched = array();
+		$run_id  = (string) ( $context['_workflow_run_id'] ?? '' );
+		$step_id = (string) ( $context['_workflow_step_id'] ?? '' );
+		$handles = array();
+		foreach ( $branches as $index => $branch ) {
+			$key        = (string) ( $branch['key'] ?? (string) $index );
+			$handle_id  = $run_id . ':' . $step_id . ':' . $key . ':' . $index;
+			$descriptor = array_merge( $branch, array( 'run_id' => $run_id, 'step_id' => $step_id, 'handle_id' => $handle_id, 'key' => $key ) );
+			self::$dispatched[] = $descriptor;
+			$handles[] = array(
+				'id'       => $handle_id,
+				'key'      => $key,
+				'executor' => $this->id(),
+				'status'   => 'dispatched',
+				'required' => ! empty( $branch['required'] ),
+				'ref'      => $index + 1,
+			);
+		}
+		return $handles;
+	}
+
+	public function are_all_complete( array $handles ): bool {
+		foreach ( $handles as $handle ) {
+			$status = (string) ( $handle['status'] ?? '' );
+			if ( WP_Agent_Workflow_Run_Result::STATUS_SUCCEEDED !== $status && WP_Agent_Workflow_Run_Result::STATUS_FAILED !== $status ) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	public function collect( array $handles ): array {
+		$out = array();
+		foreach ( $handles as $handle ) {
+			$key         = (string) ( $handle['key'] ?? '' );
+			$out[ $key ] = array( 'key' => $key, 'status' => (string) ( $handle['status'] ?? 'dispatched' ), 'output' => null );
+		}
+		return $out;
+	}
+}
+
+function auth_register_ability( string $name, \Closure $handler ): void {
+	$GLOBALS['__abilities'][ $name ] = new WP_Ability( $name, array( 'execute_callback' => $handler ) );
+}
+
+auth_register_ability(
+	'demo/role-worker',
+	static function ( array $input ): array {
+		return array( 'fragment' => strtoupper( (string) ( $input['label'] ?? 'X' ) ) );
+	}
+);
+auth_register_ability(
+	'demo/aggregate',
+	static function ( array $input ): array {
+		return array( 'final_bundle' => 'FUSED[' . (string) ( $input['a'] ?? '' ) . '|' . (string) ( $input['b'] ?? '' ) . ']' );
+	}
+);
+
+// Two required sibling branches (a, b) + an aggregator. With exactly two handles,
+// a single forged completion is enough to reach count parity and (pre-fix) resume
+// the run before branch b has actually finished.
+function auth_roles_spec(): WP_Agent_Workflow_Spec {
+	return WP_Agent_Workflow_Spec::from_array(
+		array(
+			'id'    => 'demo/auth-roles',
+			'steps' => array(
+				array(
+					'id'       => 'scatter',
+					'type'     => 'parallel',
+					'context'  => array( 'marker' => 'M' ),
+					'branches' => array(
+						array( 'role' => 'a', 'required' => true, 'is_aggregator' => false, 'steps' => array( array( 'id' => 'sa', 'type' => 'ability', 'ability' => 'demo/role-worker', 'args' => array( 'label' => 'a' ) ) ) ),
+						array( 'role' => 'b', 'required' => true, 'is_aggregator' => false, 'steps' => array( array( 'id' => 'sb', 'type' => 'ability', 'ability' => 'demo/role-worker', 'args' => array( 'label' => 'b' ) ) ) ),
+						array(
+							'role'          => 'fuse',
+							'required'      => true,
+							'is_aggregator' => true,
+							'steps'         => array(
+								array(
+									'id'      => 'agg',
+									'type'    => 'ability',
+									'ability' => 'demo/aggregate',
+									'args'    => array(
+										'a' => '${vars.branch_outputs.a.fragment}',
+										'b' => '${vars.branch_outputs.b.fragment}',
+									),
+								),
+							),
+						),
+					),
+				),
+			),
+		)
+	);
+}
+
+function auth_execute_branch( array $descriptor ): array {
+	$key      = (string) ( $descriptor['key'] ?? '' );
+	$steps    = is_array( $descriptor['steps'] ?? null ) ? $descriptor['steps'] : array();
+	$handlers = array(
+		'ability'  => array( WP_Agent_Workflow_Runner::class, 'default_ability_handler' ),
+		'agent'    => array( WP_Agent_Workflow_Runner::class, 'default_agent_handler' ),
+		'foreach'  => array( WP_Agent_Workflow_Runner::class, 'default_foreach_handler' ),
+		'parallel' => array( WP_Agent_Workflow_Runner::class, 'default_parallel_handler' ),
+	);
+	$executor    = new \AgentsAPI\AI\Workflows\WP_Agent_Workflow_Step_Executor( $handlers );
+	$branch_vars = is_array( $descriptor['branch_vars'] ?? null ) ? $descriptor['branch_vars'] : array();
+	$branch_context = ( new \AgentsAPI\AI\Workflows\WP_Agent_Workflow_Run_Context(
+		array( 'inputs' => array(), 'steps' => array(), 'vars' => array() )
+	) )->with_vars( $branch_vars );
+
+	$run = WP_Agent_Workflow_Runner::run_branch_steps( $steps, $branch_context, $executor, $handlers, false, $key );
+	if ( is_wp_error( $run ) ) {
+		return array( 'key' => $key, 'status' => WP_Agent_Workflow_Run_Result::STATUS_FAILED, 'output' => null, 'steps' => array(), 'error' => array( 'code' => $run->get_error_code(), 'message' => $run->get_error_message() ) );
+	}
+	return array( 'key' => $key, 'status' => WP_Agent_Workflow_Run_Result::STATUS_SUCCEEDED, 'output' => $run['last'], 'steps' => $run['steps'], 'error' => null );
+}
+
+function auth_completed_count( Auth_Recorder $recorder, string $run_id ): int {
+	$result = $recorder->find( $run_id );
+	if ( null === $result ) {
+		return -1;
+	}
+	$suspension = $result->get_suspension();
+	$completed  = is_array( $suspension['completed'] ?? null ) ? $suspension['completed'] : array();
+	return count( $completed );
+}
+
+// ═════════════════════════════════════════════════════════════════════════════
+// FINDING 1: a forged / unknown handle id must NOT inflate completed[] nor resume
+// the run early with attacker-chosen output.
+// ═════════════════════════════════════════════════════════════════════════════
+
+$GLOBALS['__options'] = array();
+$recorder = new Auth_Recorder();
+remove_all_filters( 'wp_agent_workflow_run_recorder' );
+remove_all_filters( 'wp_agent_workflow_step_executor' );
+remove_all_filters( 'wp_agent_workflow_resume_dispatch' );
+add_filter( 'wp_agent_workflow_run_recorder', static function () use ( $recorder ) { return $recorder; } );
+add_filter( 'wp_agent_workflow_step_executor', static function () { return new Auth_Executor(); } );
+
+$run = ( new WP_Agent_Workflow_Runner( $recorder ) )->run( auth_roles_spec(), array(), array( 'run_id' => 'auth-1' ) );
+smoke_assert( WP_Agent_Workflow_Run_Result::STATUS_SUSPENDED, $run->get_status(), 'auth: run SUSPENDED after dispatch', $failures, $passes );
+
+$descriptors = Auth_Executor::$dispatched; // two siblings: a, b
+smoke_assert( 2, count( $descriptors ), 'auth: two sibling branches dispatched', $failures, $passes );
+
+// Branch a finishes legitimately. completed == {a}, still suspended.
+$result_a = auth_execute_branch( $descriptors[0] );
+agents_reconcile_workflow_branch( 'auth-1', (string) $descriptors[0]['handle_id'], $result_a );
+smoke_assert( WP_Agent_Workflow_Run_Result::STATUS_SUSPENDED, $recorder->find( 'auth-1' )->get_status(), 'auth: still suspended after branch a', $failures, $passes );
+smoke_assert( 1, auth_completed_count( $recorder, 'auth-1' ), 'auth: completed has exactly branch a', $failures, $passes );
+
+// ATTACK: forge a completion under a handle id that was never dispatched, claiming
+// branch b's key + an attacker output. Pre-fix this would push completed to 2/2,
+// trip the all-terminal gate and resume the run to SUCCEEDED with the forged
+// aggregate. Post-fix it fails closed and leaves the frame untouched.
+$forged = agents_reconcile_workflow_branch(
+	'auth-1',
+	'FORGED-handle-never-dispatched',
+	array( 'key' => 'b', 'status' => WP_Agent_Workflow_Run_Result::STATUS_SUCCEEDED, 'output' => array( 'fragment' => 'HACK' ) )
+);
+smoke_assert_true( is_wp_error( $forged ), 'auth: forged handle id rejected with WP_Error', $failures, $passes );
+smoke_assert( 'agents_reconcile_workflow_branch_unknown_handle', is_wp_error( $forged ) ? $forged->get_error_code() : '', 'auth: rejection uses unknown_handle code', $failures, $passes );
+smoke_assert( WP_Agent_Workflow_Run_Result::STATUS_SUSPENDED, $recorder->find( 'auth-1' )->get_status(), 'auth: run STILL suspended after forged reconcile (not resumed early)', $failures, $passes );
+smoke_assert( 1, auth_completed_count( $recorder, 'auth-1' ), 'auth: forged handle did NOT inflate completed[]', $failures, $passes );
+
+// ATTACK 2: use branch b's REAL handle id but remap its output onto a different
+// aggregate key. Post-fix this fails closed on the stored-key binding.
+$mismatch = agents_reconcile_workflow_branch(
+	'auth-1',
+	(string) $descriptors[1]['handle_id'],
+	array( 'key' => 'a', 'status' => WP_Agent_Workflow_Run_Result::STATUS_SUCCEEDED, 'output' => array( 'fragment' => 'HACK' ) )
+);
+smoke_assert_true( is_wp_error( $mismatch ), 'auth: key-remapped reconcile rejected with WP_Error', $failures, $passes );
+smoke_assert( 'agents_reconcile_workflow_branch_key_mismatch', is_wp_error( $mismatch ) ? $mismatch->get_error_code() : '', 'auth: rejection uses key_mismatch code', $failures, $passes );
+smoke_assert( WP_Agent_Workflow_Run_Result::STATUS_SUSPENDED, $recorder->find( 'auth-1' )->get_status(), 'auth: run STILL suspended after key-mismatch reconcile', $failures, $passes );
+
+// LEGITIMATE completion of branch b with its real handle + key resumes the run and
+// fuses the GENUINE outputs — proving the fix does not break real callers.
+$result_b = auth_execute_branch( $descriptors[1] );
+agents_reconcile_workflow_branch( 'auth-1', (string) $descriptors[1]['handle_id'], $result_b );
+$final = $recorder->find( 'auth-1' );
+smoke_assert( WP_Agent_Workflow_Run_Result::STATUS_SUCCEEDED, $final->get_status(), 'auth: legitimate branch b resumes run to SUCCEEDED', $failures, $passes );
+$bundle = $final->get_output()['steps']['scatter']['final']['final_bundle'] ?? '';
+smoke_assert( 'FUSED[A|B]', $bundle, 'auth: aggregate fused the GENUINE branch outputs (no HACK)', $failures, $passes );
+
+// ═════════════════════════════════════════════════════════════════════════════
+// FINDING 2: when the per-run reconcile lock cannot be acquired, with_lock() must
+// FAIL CLOSED (retryable WP_Error) and must NOT run the critical section.
+// ═════════════════════════════════════════════════════════════════════════════
+
+$GLOBALS['__options'] = array();
+$lock_run_id = 'lock-contended';
+
+// Pre-occupy the lock row with a live (non-expired) holder so acquire() can never
+// win nor reclaim it — modelling a genuinely contended lock.
+$lock_option = 'agents_wf_reconcile_lock_' . md5( $lock_run_id );
+$GLOBALS['__options'][ $lock_option ] = array(
+	'token'   => 'held-by-another-process',
+	'expires' => time() + 3600,
+);
+
+$critical_ran = false;
+$result = WP_Agent_Workflow_Reconcile_Lock::with_lock(
+	$lock_run_id,
+	static function () use ( &$critical_ran ) {
+		$critical_ran = true;
+		return 'CRITICAL-RAN';
+	}
+);
+
+smoke_assert( false, $critical_ran, 'lock: critical section NOT run when lock unavailable', $failures, $passes );
+smoke_assert_true( is_wp_error( $result ), 'lock: with_lock returns WP_Error when lock unavailable', $failures, $passes );
+smoke_assert( 'agents_reconcile_lock_unavailable', is_wp_error( $result ) ? $result->get_error_code() : '', 'lock: fail-closed error uses lock_unavailable code', $failures, $passes );
+
+// The pre-existing holder's lock must be untouched (not stolen/deleted by the loser).
+smoke_assert_true( array_key_exists( $lock_option, $GLOBALS['__options'] ) && 'held-by-another-process' === ( $GLOBALS['__options'][ $lock_option ]['token'] ?? '' ), 'lock: existing holder lock left intact', $failures, $passes );
+
+// Sanity: an UNCONTENDED with_lock still runs the critical section and releases.
+$GLOBALS['__options'] = array();
+$ran2 = false;
+$ok   = WP_Agent_Workflow_Reconcile_Lock::with_lock(
+	'lock-free',
+	static function () use ( &$ran2 ) {
+		$ran2 = true;
+		return 'OK';
+	}
+);
+smoke_assert( true, $ran2, 'lock: uncontended critical section runs', $failures, $passes );
+smoke_assert( 'OK', $ok, 'lock: uncontended with_lock returns the critical result', $failures, $passes );
+smoke_assert( false, array_key_exists( 'agents_wf_reconcile_lock_' . md5( 'lock-free' ), $GLOBALS['__options'] ), 'lock: lock released after uncontended run', $failures, $passes );
+
+echo "Passed: {$passes}, Failed: " . count( $failures ) . "\n";
+exit( count( $failures ) > 0 ? 1 : 0 );

--- a/tests/workflow-reconcile-branch-authorization-smoke.php
+++ b/tests/workflow-reconcile-branch-authorization-smoke.php
@@ -414,6 +414,28 @@ smoke_assert( WP_Agent_Workflow_Run_Result::STATUS_SUCCEEDED, $final->get_status
 $bundle = $final->get_output()['steps']['scatter']['final']['final_bundle'] ?? '';
 smoke_assert( 'FUSED[A|B]', $bundle, 'auth: aggregate fused the GENUINE branch outputs (no HACK)', $failures, $passes );
 
+// The stored key remains authoritative when a legitimate callback cannot recover
+// its descriptor and therefore omits the key.
+$key_run = ( new WP_Agent_Workflow_Runner( $recorder ) )->run( auth_roles_spec(), array(), array( 'run_id' => 'auth-key' ) );
+$key_descriptors = Auth_Executor::$dispatched;
+$invalid_status = agents_reconcile_workflow_branch(
+	'auth-key',
+	(string) $key_descriptors[0]['handle_id'],
+	array( 'key' => 'a', 'status' => 'pending', 'output' => array( 'fragment' => 'HACK' ) )
+);
+smoke_assert( 'agents_reconcile_workflow_branch_invalid_status', is_wp_error( $invalid_status ) ? $invalid_status->get_error_code() : '', 'auth: nonterminal status rejected', $failures, $passes );
+smoke_assert( 0, auth_completed_count( $recorder, 'auth-key' ), 'auth: invalid status did not complete the stored handle', $failures, $passes );
+$missing_key = agents_reconcile_workflow_branch(
+	'auth-key',
+	(string) $key_descriptors[0]['handle_id'],
+	array( 'status' => WP_Agent_Workflow_Run_Result::STATUS_FAILED, 'output' => null )
+);
+smoke_assert_true( ! is_wp_error( $missing_key ), 'auth: omitted asserted key uses the stored key', $failures, $passes );
+$missing_key_frame = $recorder->find( 'auth-key' )->get_suspension();
+$missing_key_entry = $missing_key_frame['completed'][ (string) $key_descriptors[0]['handle_id'] ] ?? array();
+smoke_assert( WP_Agent_Workflow_Run_Result::STATUS_SUSPENDED, $key_run->get_status(), 'auth: omitted-key fixture starts suspended', $failures, $passes );
+smoke_assert( 'a', $missing_key_entry['key'] ?? '', 'auth: completed entry keeps authoritative stored key', $failures, $passes );
+
 // ═════════════════════════════════════════════════════════════════════════════
 // FINDING 2: when the per-run reconcile lock cannot be acquired, with_lock() must
 // FAIL CLOSED (retryable WP_Error) and must NOT run the critical section.


### PR DESCRIPTION
## Summary

Two hardening fixes in the workflow branch-reconcile path. Both are **authorization/state-integrity** defects where the reconcile flow trusted caller-asserted input or failed **open** instead of authorizing against server-verified suspension state. They share files, so they land together.

- **`src/Workflows/register-reconcile-workflow-branch.php:180`** (`agents_reconcile_workflow_branch_locked`) — **CWE-639 Authorization Bypass Through User-Controlled Key.** The only guard on `handle_id` was a duplicate-completed check; any caller-supplied id was inserted into `completed[]`. A forged/unknown id inflated the completed map until `count(completed) == count(handles)`, tripping the all-terminal gate and resuming the run **early with an attacker-chosen aggregate output** while a genuine branch had not finished.
- **`src/Workflows/class-wp-agent-workflow-reconcile-lock.php:108`** (`WP_Agent_Workflow_Reconcile_Lock::with_lock`) — **CWE-667 Improper Locking / CWE-636 Not Failing Securely.** When the per-run lock could not be acquired, `with_lock()` ran the reconcile critical section **anyway (unlocked)**, re-opening the lost-update window the lock exists to close — a lost merge permanently strands the run `SUSPENDED`.

## Fix

- **Bind the completion to stored state.** Before merging, build the set of known handle ids from the run's stored `_suspension.handles` and reject a `handle_id` that is not a member — returning `WP_Error('agents_reconcile_workflow_branch_unknown_handle')` so the merge fails closed rather than inflating `completed[]`. Additionally reject a `branch_result['key']` that does not match the stored handle's key (`agents_reconcile_workflow_branch_key_mismatch`) so a caller cannot remap its output onto a different branch's aggregate slot. The idempotent duplicate-completed guard is unchanged, and legitimate owners (real handle id + key) still pass.
- **Fail closed on lock loss.** `with_lock()` no longer invokes `$critical` when `acquire()` returned `null`; it returns a retryable `WP_Error('agents_reconcile_lock_unavailable')` so the Action Scheduler executor re-enqueues the branch instead of performing a lost-update-prone write. The `add_option()`-CAS primitive is unchanged; the bounded acquire-retry budget is extended to cover the lock TTL (a live short section releases quickly; a crashed holder's row expires and is reclaimed within TTL), so `null` is effectively unreachable in normal operation and the fail-closed error is only a last resort. The no-option-layer (non-WordPress) path stays single-process and unaffected.

## Testing

- New smoke test `tests/workflow-reconcile-branch-authorization-smoke.php` (registered in the composer `smoke` array; helper `tests/reconcile-lock-fail-closed-usleep-shim.php`) drives the **real** reconcile / aggregate / resume state machine and asserts: a forged handle id is rejected and does **not** resume the run early or inflate `completed[]`; a key-remapped completion is rejected; a legitimate branch still resumes the run and fuses the genuine outputs; and `with_lock()` returns a retryable `WP_Error` **without** running the critical section when the lock is unavailable (while an uncontended call still runs and releases). The test **fails against the pre-fix code (11 failing assertions) and passes after**.
- `composer smoke` — full suite green (exit 0).
- `vendor/bin/phpstan analyse --no-progress --memory-limit=2G` — **No errors** (level max).

---

_Found by an automated security scan; the fix is offered as a draft for review._

## AI assistance
OpenAI `openai/gpt-5.6-sol` via OpenCode reviewed this PR and drafted the security follow-up commit and tests. Chris Huber directed the work and remains responsible for the resulting changes.