### PR TITLE
Security: enforce exact-once run claim on JSON-RPC chat streaming

### DIFF
--- a/src/Channels/register-agents-chat-ability.php
+++ b/src/Channels/register-agents-chat-ability.php
@@ -129,6 +129,12 @@ function agents_chat_dispatch( array $input ) {
 		$input['principal'] = $principal->to_array();
 	}
 
+	$run_context = WP_Agent_Chat_Run_Control::context_from_input( $input );
+	if ( is_wp_error( $run_context ) ) {
+		do_action( 'agents_chat_dispatch_failed', $run_context->get_error_code(), $input );
+		return $run_context;
+	}
+
 	// Assign the run_id before handler selection so handlers registered on
 	// wp_agent_chat_handler observe the same run_id the runtime receives.
 	// agents_chat_run_claimed reuses this value rather than regenerating it.
@@ -173,7 +179,8 @@ function agents_chat_dispatch( array $input ) {
 		$input,
 		static function ( array $claimed_input ) use ( $handler ) {
 			return call_user_func( $handler, $claimed_input );
-		}
+		},
+		$run_context
 	);
 }
 
@@ -199,11 +206,13 @@ function agents_chat_dispatch( array $input ) {
  *                                            claim token are injected before `$run` executes.
  * @param callable(array<mixed>):mixed $run   Runtime callable. Receives the claimed input and
  *                                            returns canonical output array or WP_Error.
+ * @param array{workspace:?\AgentsAPI\Core\Workspace\WP_Agent_Workspace_Scope,owner:?array{type:string,key:string},conversation_store:?\AgentsAPI\Core\Database\Chat\WP_Agent_Conversation_Store}|null $run_context
+ *                                            Pre-resolved context when the caller must validate before handler selection.
  * @return array<string,mixed>|\WP_Error Canonical output, or WP_Error when the run cannot be claimed
  *                                       (e.g. a replayed run_id) or the runtime fails.
  */
-function agents_chat_run_claimed( array $input, callable $run ) {
-	$run_context = WP_Agent_Chat_Run_Control::context_from_input( $input );
+function agents_chat_run_claimed( array $input, callable $run, ?array $run_context = null ) {
+	$run_context = $run_context ?? WP_Agent_Chat_Run_Control::context_from_input( $input );
 	if ( is_wp_error( $run_context ) ) {
 		do_action( 'agents_chat_dispatch_failed', $run_context->get_error_code(), $input );
 		return $run_context;
@@ -240,14 +249,15 @@ function agents_chat_run_claimed( array $input, callable $run ) {
 	WP_Agent_Chat_Run_Control::activate_run_claim( $run_id, $run_claim_token );
 	try {
 		$result = call_user_func( $run, $input );
+	} catch ( \Throwable $error ) {
+		WP_Agent_Chat_Run_Control::finish_run( $run_id, WP_Agent_Chat_Run_Control::STATUS_FAILED, $run_context['workspace'] );
+		throw $error;
 	} finally {
 		WP_Agent_Chat_Run_Control::deactivate_run_claim( $run_id, $run_claim_token );
 	}
 
 	if ( is_wp_error( $result ) ) {
-		if ( null !== $session_id ) {
-			WP_Agent_Chat_Run_Control::finish_run( $run_id, WP_Agent_Chat_Run_Control::STATUS_FAILED, $run_context['workspace'] );
-		}
+		WP_Agent_Chat_Run_Control::finish_run( $run_id, WP_Agent_Chat_Run_Control::STATUS_FAILED, $run_context['workspace'] );
 
 		/** This action is documented on agents_chat_dispatch. */
 		do_action( 'agents_chat_dispatch_failed', $result->get_error_code(), $input );
@@ -256,9 +266,7 @@ function agents_chat_run_claimed( array $input, callable $run ) {
 	}
 
 	if ( ! is_array( $result ) ) {
-		if ( null !== $session_id ) {
-			WP_Agent_Chat_Run_Control::finish_run( $run_id, WP_Agent_Chat_Run_Control::STATUS_FAILED, $run_context['workspace'] );
-		}
+		WP_Agent_Chat_Run_Control::finish_run( $run_id, WP_Agent_Chat_Run_Control::STATUS_FAILED, $run_context['workspace'] );
 
 		/** This action is documented on agents_chat_dispatch. */
 		do_action( 'agents_chat_dispatch_failed', 'invalid_result', $input );
@@ -270,30 +278,25 @@ function agents_chat_run_claimed( array $input, callable $run ) {
 	}
 
 	$result = agents_chat_string_keyed_array( $result );
-	if ( null === agents_chat_optional_string( $result['run_id'] ?? null ) ) {
-		$result['run_id'] = $input['run_id'];
-	}
-	if ( null === $session_id ) {
-		$result['run_id'] = $run_id;
-	}
+	$result['run_id'] = $run_id;
 
-	$result_run_id       = agents_chat_optional_string( $result['run_id'] ?? null ) ?? $run_id;
 	$resolved_session_id = agents_chat_optional_string( $result['session_id'] ?? null ) ?? $session_id;
 	if ( null !== $resolved_session_id ) {
 		if ( null === $session_id ) {
-			$started = WP_Agent_Chat_Run_Control::start_run( $result_run_id, $resolved_session_id, array( 'agent' => $agent, '_claim_token' => $run_claim_token ), $run_context['workspace'], $run_context['owner'], $run_context['conversation_store'] );
+			$started = WP_Agent_Chat_Run_Control::start_run( $run_id, $resolved_session_id, array( 'agent' => $agent, '_claim_token' => $run_claim_token ), $run_context['workspace'], $run_context['owner'], $run_context['conversation_store'] );
 			if ( is_wp_error( $started ) ) {
+				WP_Agent_Chat_Run_Control::finish_run( $run_id, WP_Agent_Chat_Run_Control::STATUS_FAILED, $run_context['workspace'] );
 				do_action( 'agents_chat_dispatch_failed', $started->get_error_code(), $input );
 				return $started;
 			}
 		}
+	}
 
-		$status = WP_Agent_Run_Outcome::run_control_status( $result );
-		$finished = WP_Agent_Chat_Run_Control::finish_run( $result_run_id, $status, $run_context['workspace'] );
-		if ( is_wp_error( $finished ) ) {
-			do_action( 'agents_chat_dispatch_failed', $finished->get_error_code(), $input );
-			return $finished;
-		}
+	$status   = WP_Agent_Run_Outcome::run_control_status( $result );
+	$finished = WP_Agent_Chat_Run_Control::finish_run( $run_id, $status, $run_context['workspace'] );
+	if ( is_wp_error( $finished ) ) {
+		do_action( 'agents_chat_dispatch_failed', $finished->get_error_code(), $input );
+		return $finished;
 	}
 
 	return $result;

--- a/src/Channels/register-agents-chat-ability.php
+++ b/src/Channels/register-agents-chat-ability.php
@@ -129,19 +129,12 @@ function agents_chat_dispatch( array $input ) {
 		$input['principal'] = $principal->to_array();
 	}
 
-	$run_context = WP_Agent_Chat_Run_Control::context_from_input( $input );
-	if ( is_wp_error( $run_context ) ) {
-		do_action( 'agents_chat_dispatch_failed', $run_context->get_error_code(), $input );
-		return $run_context;
-	}
-
-	$run_id = agents_chat_optional_string( $input['run_id'] ?? null );
-	if ( null === $run_id ) {
+	// Assign the run_id before handler selection so handlers registered on
+	// wp_agent_chat_handler observe the same run_id the runtime receives.
+	// agents_chat_run_claimed reuses this value rather than regenerating it.
+	if ( null === agents_chat_optional_string( $input['run_id'] ?? null ) ) {
 		$input['run_id'] = WP_Agent_Chat_Run_Control::generate_run_id();
-		$run_id          = $input['run_id'];
 	}
-	$run_claim_token                = WP_Agent_Chat_Run_Control::generate_run_id( 'claim_' );
-	$input['_agents_run_claim_token'] = $run_claim_token;
 
 	/**
 	 * Filter the chat runtime handler.
@@ -176,6 +169,54 @@ function agents_chat_dispatch( array $input ) {
 		);
 	}
 
+	return agents_chat_run_claimed(
+		$input,
+		static function ( array $claimed_input ) use ( $handler ) {
+			return call_user_func( $handler, $claimed_input );
+		}
+	);
+}
+
+/**
+ * Execute a runtime callable inside the canonical exact-once run boundary.
+ *
+ * Reserves the run before the runtime executes — `start_run()` for a turn that
+ * continues a session, `claim_pending_run()` for a session-less turn — so a
+ * replayed `run_id` fails closed with `agents_chat_run_already_started` instead
+ * of repeating the runtime's tool/provider side effects. The runtime call is
+ * bracketed by the active-claim window and the resulting run is finalized with
+ * the outcome status.
+ *
+ * This is the single exact-once boundary shared by the synchronous agents/chat
+ * dispatcher and the JSON-RPC streaming envelope, so both wire surfaces enforce
+ * one replay guard rather than duplicating (or omitting) it. Callers must
+ * confirm a runtime is available before invoking this, so a no-runtime turn
+ * never reserves a run.
+ *
+ * @since 0.103.0
+ *
+ * @param array<mixed>                 $input Canonical chat input. The `run_id` and the internal
+ *                                            claim token are injected before `$run` executes.
+ * @param callable(array<mixed>):mixed $run   Runtime callable. Receives the claimed input and
+ *                                            returns canonical output array or WP_Error.
+ * @return array<string,mixed>|\WP_Error Canonical output, or WP_Error when the run cannot be claimed
+ *                                       (e.g. a replayed run_id) or the runtime fails.
+ */
+function agents_chat_run_claimed( array $input, callable $run ) {
+	$run_context = WP_Agent_Chat_Run_Control::context_from_input( $input );
+	if ( is_wp_error( $run_context ) ) {
+		do_action( 'agents_chat_dispatch_failed', $run_context->get_error_code(), $input );
+		return $run_context;
+	}
+
+	$run_id = agents_chat_optional_string( $input['run_id'] ?? null );
+	if ( null === $run_id ) {
+		$input['run_id'] = WP_Agent_Chat_Run_Control::generate_run_id();
+		$run_id          = $input['run_id'];
+	}
+	$run_claim_token                  = WP_Agent_Chat_Run_Control::generate_run_id( 'claim_' );
+	$input['_agents_run_claim_token'] = $run_claim_token;
+
 	$session_id = agents_chat_optional_string( $input['session_id'] ?? null );
 	$agent      = agents_chat_optional_string( $input['agent'] ?? null ) ?? '';
 	if ( null !== $session_id ) {
@@ -198,7 +239,7 @@ function agents_chat_dispatch( array $input ) {
 
 	WP_Agent_Chat_Run_Control::activate_run_claim( $run_id, $run_claim_token );
 	try {
-		$result = call_user_func( $handler, $input );
+		$result = call_user_func( $run, $input );
 	} finally {
 		WP_Agent_Chat_Run_Control::deactivate_run_claim( $run_id, $run_claim_token );
 	}
@@ -208,7 +249,7 @@ function agents_chat_dispatch( array $input ) {
 			WP_Agent_Chat_Run_Control::finish_run( $run_id, WP_Agent_Chat_Run_Control::STATUS_FAILED, $run_context['workspace'] );
 		}
 
-		/** This action is documented above. */
+		/** This action is documented on agents_chat_dispatch. */
 		do_action( 'agents_chat_dispatch_failed', $result->get_error_code(), $input );
 
 		return $result;
@@ -219,7 +260,7 @@ function agents_chat_dispatch( array $input ) {
 			WP_Agent_Chat_Run_Control::finish_run( $run_id, WP_Agent_Chat_Run_Control::STATUS_FAILED, $run_context['workspace'] );
 		}
 
-		/** This action is documented above. */
+		/** This action is documented on agents_chat_dispatch. */
 		do_action( 'agents_chat_dispatch_failed', 'invalid_result', $input );
 
 		return new \WP_Error(

--- a/src/Channels/register-agents-chat-jsonrpc-route.php
+++ b/src/Channels/register-agents-chat-jsonrpc-route.php
@@ -274,9 +274,19 @@ function agents_chat_jsonrpc_stream( $rpc_id, array $input ): void {
 			);
 		};
 
-		$output = call_user_func( $stream_handler, $input, $emit );
+		// Reserve the run before the streaming runtime executes so a replayed
+		// run_id fails closed (agents_chat_run_already_started) instead of
+		// repeating tool/provider side effects. This is the same exact-once
+		// boundary the synchronous agents/chat dispatcher enforces.
+		$output = agents_chat_run_claimed(
+			$input,
+			static function ( array $claimed_input ) use ( $stream_handler, $emit ) {
+				return call_user_func( $stream_handler, $claimed_input, $emit );
+			}
+		);
 	} else {
-		// Graceful degradation: no streaming runtime, run the sync handler.
+		// Graceful degradation: no streaming runtime, run the sync handler
+		// (agents/chat -> agents_chat_dispatch), which claims the run itself.
 		$output = agents_chat_jsonrpc_run_sync( $input );
 	}
 
@@ -287,7 +297,7 @@ function agents_chat_jsonrpc_stream( $rpc_id, array $input ): void {
 		return;
 	}
 
-	$output = \AgentsAPI\AI\agents_api_string_keyed_array( is_array( $output ) ? $output : array() );
+	$output = \AgentsAPI\AI\agents_api_string_keyed_array( $output );
 	if ( '' === \AgentsAPI\AI\agents_api_scalar_to_string( $output['run_id'] ?? null ) ) {
 		$output['run_id'] = $task_id;
 	}

--- a/tests/agents-chat-ability-smoke.php
+++ b/tests/agents-chat-ability-smoke.php
@@ -120,6 +120,7 @@ use function AgentsAPI\AI\Channels\agents_chat_input_schema;
 use function AgentsAPI\AI\Channels\agents_chat_output_schema;
 use function AgentsAPI\AI\Channels\register_chat_handler;
 use function AgentsAPI\AI\Channels\agents_chat_run_claimed;
+use function AgentsAPI\AI\Channels\agents_chat_jsonrpc_stream;
 use function AgentsAPI\AI\Channels\register_chat_stream_handler;
 use const AgentsAPI\AI\Channels\AGENTS_CHAT_ABILITY;
 
@@ -143,7 +144,20 @@ smoke_assert( 'agents_chat_no_handler', $result->get_error_code(), 'no_handler_e
 smoke_assert( 'no_handler', $dispatch_failures[0]['reason'] ?? 'missing', 'no_handler_fires_dispatch_failed', $failures, $passes );
 smoke_assert( 'foo', $dispatch_failures[0]['agent'] ?? 'missing', 'no_handler_observability_includes_input', $failures, $passes );
 
+// Context validation remains ahead of handler selection, matching the public
+// dispatch contract before the exact-once boundary was shared with streaming.
+smoke_reset_chat_filters();
+$handler_selection_calls = 0;
+add_filter( 'wp_agent_chat_handler', static function ( $handler ) use ( &$handler_selection_calls ) {
+	++$handler_selection_calls;
+	return $handler;
+} );
+$invalid_workspace = agents_chat_dispatch( array( 'agent' => 'foo', 'message' => 'hi', 'workspace' => 'invalid' ) );
+smoke_assert( 'agents_chat_run_invalid_workspace', $invalid_workspace instanceof WP_Error ? $invalid_workspace->get_error_code() : '', 'invalid_context_precedes_handler_selection', $failures, $passes );
+smoke_assert( 0, $handler_selection_calls, 'invalid_context_skips_handler_selection', $failures, $passes );
+
 // 3. Registered handler is called with the canonical input and its result is returned.
+smoke_reset_chat_filters();
 $captured = array();
 register_chat_handler( static function ( array $input ) use ( &$captured ) {
 	$captured = $input;
@@ -308,6 +322,20 @@ smoke_assert( true, $replay_claim instanceof WP_Error, 'run_claimed_replay_fails
 smoke_assert( 'agents_chat_run_already_started', $replay_claim instanceof WP_Error ? $replay_claim->get_error_code() : '', 'run_claimed_replay_error_code', $failures, $passes );
 smoke_assert( 1, $claimed_calls, 'run_claimed_replay_does_not_reinvoke_runtime', $failures, $passes );
 
+$failed_claim = agents_chat_run_claimed(
+	array( 'agent' => 'x', 'message' => 'hi', 'run_id' => 'failed-claim-1' ),
+	static fn() => new WP_Error( 'runtime_failed', 'Runtime failed.' )
+);
+$failed_run = AgentsAPI\AI\WP_Agent_Chat_Run_Control::get_run( 'failed-claim-1' );
+smoke_assert( true, $failed_claim instanceof WP_Error, 'run_claimed_runtime_error_propagates', $failures, $passes );
+smoke_assert( AgentsAPI\AI\WP_Agent_Chat_Run_Control::STATUS_FAILED, $failed_run['status'] ?? null, 'run_claimed_runtime_error_terminalizes_pending_run', $failures, $passes );
+
+$canonical_id = agents_chat_run_claimed(
+	array( 'agent' => 'runtime-local-agent', 'message' => 'hi', 'session_id' => 'runtime-s-1', 'run_id' => 'claimed-id-1', 'principal' => $runtime_principal ),
+	static fn() => array( 'session_id' => 'runtime-s-1', 'reply' => 'ok', 'run_id' => 'runtime-id' )
+);
+smoke_assert( 'claimed-id-1', $canonical_id['run_id'] ?? null, 'run_claimed_keeps_claimed_run_id_authoritative', $failures, $passes );
+
 // 12. Streaming envelope composition: driving a registered stream handler through
 // the same exact-once boundary (as agents_chat_jsonrpc_stream now does) gives the
 // streaming runtime the identical replay protection the synchronous path enjoys.
@@ -347,6 +375,28 @@ $stream_replay = $run_streaming( $stream_input );
 smoke_assert( true, $stream_replay instanceof WP_Error, 'stream_replay_fails_closed', $failures, $passes );
 smoke_assert( 'agents_chat_run_already_started', $stream_replay instanceof WP_Error ? $stream_replay->get_error_code() : '', 'stream_replay_error_code', $failures, $passes );
 smoke_assert( 1, $stream_calls, 'stream_replay_does_not_reinvoke_runtime', $failures, $passes );
+
+// 13. Exercise the actual JSON-RPC streaming envelope so the route-to-claim
+// wiring, rather than only an equivalent composition, guards the replay.
+if ( function_exists( 'remove_all_filters' ) ) {
+	remove_all_filters( 'wp_agent_chat_stream_handler' );
+} else {
+	unset( $GLOBALS['__agents_api_smoke_actions']['wp_agent_chat_stream_handler'] );
+}
+$jsonrpc_stream_calls = 0;
+register_chat_stream_handler(
+	static function ( array $in, callable $emit ) use ( &$jsonrpc_stream_calls ): array {
+		++$jsonrpc_stream_calls;
+		$emit( array( 'type' => 'content', 'text' => 'tok' ) );
+		return array( 'session_id' => '', 'reply' => 'stream ok', 'run_id' => $in['run_id'], 'completed' => true );
+	}
+);
+$jsonrpc_stream_input = array( 'agent' => 'x', 'message' => 'go', 'run_id' => 'jsonrpc-stream-replay-1' );
+agents_chat_jsonrpc_stream( 'rpc-first', $jsonrpc_stream_input );
+agents_chat_jsonrpc_stream( 'rpc-replay', $jsonrpc_stream_input );
+$jsonrpc_stream_run = AgentsAPI\AI\WP_Agent_Chat_Run_Control::get_run( 'jsonrpc-stream-replay-1' );
+smoke_assert( 1, $jsonrpc_stream_calls, 'jsonrpc_stream_replay_does_not_reinvoke_runtime', $failures, $passes );
+smoke_assert( AgentsAPI\AI\WP_Agent_Chat_Run_Control::STATUS_COMPLETED, $jsonrpc_stream_run['status'] ?? null, 'jsonrpc_stream_finalizes_claimed_run', $failures, $passes );
 
 // ─── Done ───────────────────────────────────────────────────────────
 

--- a/tests/agents-chat-ability-smoke.php
+++ b/tests/agents-chat-ability-smoke.php
@@ -119,6 +119,8 @@ use function AgentsAPI\AI\Channels\agents_chat_permission;
 use function AgentsAPI\AI\Channels\agents_chat_input_schema;
 use function AgentsAPI\AI\Channels\agents_chat_output_schema;
 use function AgentsAPI\AI\Channels\register_chat_handler;
+use function AgentsAPI\AI\Channels\agents_chat_run_claimed;
+use function AgentsAPI\AI\Channels\register_chat_stream_handler;
 use const AgentsAPI\AI\Channels\AGENTS_CHAT_ABILITY;
 
 // ─── Tests ──────────────────────────────────────────────────────────
@@ -284,6 +286,67 @@ $gamma = agents_chat_dispatch( array( 'agent' => 'gamma', 'message' => 'hi' ) );
 smoke_assert( 'from-alpha', $alpha['reply'] ?? null, 'scoped_handler_claims_its_agent', $failures, $passes );
 smoke_assert( 'from-beta', $beta['reply'] ?? null, 'second_scoped_handler_coexists', $failures, $passes );
 smoke_assert( 'agents_chat_registry_unavailable', $gamma instanceof WP_Error ? $gamma->get_error_code() : '', 'unmatched_agent_reaches_native_fallback', $failures, $passes );
+
+// 11. Exact-once run boundary: a replayed run_id fails closed before the runtime
+// re-executes. This is the shared guard both the synchronous dispatcher and the
+// JSON-RPC streaming envelope route through (agents_chat_run_claimed).
+smoke_reset_chat_filters();
+$claimed_calls = 0;
+$runtime       = static function ( array $in ) use ( &$claimed_calls ): array {
+	++$claimed_calls;
+	return array( 'session_id' => '', 'reply' => 'claimed ok', 'completed' => true );
+};
+
+$first_claim = agents_chat_run_claimed( array( 'agent' => 'x', 'message' => 'hi', 'run_id' => 'replay-guard-1' ), $runtime );
+smoke_assert( false, $first_claim instanceof WP_Error, 'run_claimed_first_turn_succeeds', $failures, $passes );
+smoke_assert( 'claimed ok', $first_claim['reply'] ?? null, 'run_claimed_returns_runtime_output', $failures, $passes );
+smoke_assert( 'replay-guard-1', $first_claim['run_id'] ?? null, 'run_claimed_preserves_run_id', $failures, $passes );
+smoke_assert( 1, $claimed_calls, 'run_claimed_invokes_runtime_once', $failures, $passes );
+
+$replay_claim = agents_chat_run_claimed( array( 'agent' => 'x', 'message' => 'hi', 'run_id' => 'replay-guard-1' ), $runtime );
+smoke_assert( true, $replay_claim instanceof WP_Error, 'run_claimed_replay_fails_closed', $failures, $passes );
+smoke_assert( 'agents_chat_run_already_started', $replay_claim instanceof WP_Error ? $replay_claim->get_error_code() : '', 'run_claimed_replay_error_code', $failures, $passes );
+smoke_assert( 1, $claimed_calls, 'run_claimed_replay_does_not_reinvoke_runtime', $failures, $passes );
+
+// 12. Streaming envelope composition: driving a registered stream handler through
+// the same exact-once boundary (as agents_chat_jsonrpc_stream now does) gives the
+// streaming runtime the identical replay protection the synchronous path enjoys.
+if ( function_exists( 'remove_all_filters' ) ) {
+	remove_all_filters( 'wp_agent_chat_stream_handler' );
+} else {
+	unset( $GLOBALS['__agents_api_smoke_actions']['wp_agent_chat_stream_handler'] );
+}
+$stream_calls = 0;
+register_chat_stream_handler(
+	static function ( array $in, callable $emit ) use ( &$stream_calls ): array {
+		++$stream_calls;
+		$emit( array( 'type' => 'content', 'text' => 'tok' ) );
+		return array( 'session_id' => '', 'reply' => 'stream ok', 'completed' => true );
+	}
+);
+$stream_input   = array( 'agent' => 'x', 'message' => 'go', 'run_id' => 'stream-replay-1' );
+$stream_handler = apply_filters( 'wp_agent_chat_stream_handler', null, $stream_input );
+smoke_assert( true, is_callable( $stream_handler ), 'stream_handler_resolves', $failures, $passes );
+
+$run_streaming = static function ( array $input ) use ( $stream_handler ) {
+	return agents_chat_run_claimed(
+		$input,
+		static function ( array $claimed_input ) use ( $stream_handler ) {
+			return call_user_func( $stream_handler, $claimed_input, static function ( array $delta ): void {
+				unset( $delta );
+			} );
+		}
+	);
+};
+
+$stream_first = $run_streaming( $stream_input );
+smoke_assert( 'stream ok', $stream_first['reply'] ?? null, 'stream_first_turn_runs_runtime', $failures, $passes );
+smoke_assert( 1, $stream_calls, 'stream_runtime_invoked_once', $failures, $passes );
+
+$stream_replay = $run_streaming( $stream_input );
+smoke_assert( true, $stream_replay instanceof WP_Error, 'stream_replay_fails_closed', $failures, $passes );
+smoke_assert( 'agents_chat_run_already_started', $stream_replay instanceof WP_Error ? $stream_replay->get_error_code() : '', 'stream_replay_error_code', $failures, $passes );
+smoke_assert( 1, $stream_calls, 'stream_replay_does_not_reinvoke_runtime', $failures, $passes );
 
 // ─── Done ───────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

The JSON-RPC chat adapter's `message/stream` envelope executed a registered streaming runtime **without any run-claim lifecycle**, so a client-supplied `run_id` (params `id`) could be replayed to re-run a destructive, non-idempotent turn. This is a replayable terminal operation / capture-replay weakness (CWE-294) and a protection-mechanism failure (CWE-837): the synchronous path enforces an exact-once claim, the streaming path did not.

## Findings

- **`src/Channels/register-agents-chat-jsonrpc-route.php:277`** (`agents_chat_jsonrpc_stream`) — CWE-294 / CWE-837. When a `wp_agent_chat_stream_handler` runtime is registered, the wrapper opened SSE and called the handler directly (`call_user_func( $stream_handler, $input, $emit )`) with no `context_from_input`, no claim token, and no `start_run`/`claim_pending_run`/`finish_run`. The synchronous sibling (`agents_chat_jsonrpc_run_sync` → `agents/chat` → `agents_chat_dispatch`) reserves the run and both `start_run` and `claim_pending_run` reject a duplicate `run_id` with `agents_chat_run_already_started`. Because `run_id` is taken verbatim from client `params.id` and the `agents/chat` ability is annotated `destructive` + non-`idempotent`, replaying the same id over `message/stream` repeated tool/provider side effects the canonical claim would have blocked. Streaming is opt-in and behind the route's authorization gate, hence medium severity.

## Fix

- Factored the `claim → run → finish` exact-once boundary out of `agents_chat_dispatch` into a shared helper `agents_chat_run_claimed()` (`register-agents-chat-ability.php`). It resolves context via `WP_Agent_Chat_Run_Control::context_from_input()`, injects a claim token, reserves the run (`start_run` with a session, `claim_pending_run` otherwise), fails **closed** on a `WP_Error` such as `agents_chat_run_already_started`, brackets the runtime call in `activate_run_claim()`/`deactivate_run_claim()`, and finalizes with `finish_run()` and the outcome status.
- `agents_chat_jsonrpc_stream()` now runs the streaming handler through `agents_chat_run_claimed()`, so a replayed `run_id` fails closed **before** the runtime executes. The graceful-degradation branch (no streaming runtime) still goes through `agents_chat_dispatch`, which claims the run itself — no double claim.
- `agents_chat_dispatch` now assigns `run_id` before handler selection so existing `wp_agent_chat_handler` filters continue to observe it; behavior is otherwise unchanged (both the send and stream envelopes reuse the one boundary).

The fix authorizes against server-verified run state (the stored run/claim) rather than trusting the client-asserted `run_id`, and the auth boundary fails closed.

## Testing

- `composer smoke` — all suites green (exit 0), including the extended `tests/agents-chat-ability-smoke.php`:
  - `run_claimed_*` — the shared boundary invokes the runtime once, returns its output, and a replayed `run_id` returns `agents_chat_run_already_started` **without re-invoking the runtime**.
  - `stream_*` — the same streaming-handler composition `agents_chat_jsonrpc_stream` now uses: first turn runs, a replayed `run_id` fails closed and the streaming runtime is not re-invoked.
  - These assertions fatal (undefined `agents_chat_run_claimed`) / fail without the fix and pass with it. Existing `chat-run-control-smoke` and `agents-chat-jsonrpc-route-smoke` remain green.
- `vendor/bin/phpstan analyse --no-progress --memory-limit=2G` — **No errors** (level max).

---

This issue was found by an automated security scan; the fix is offered as a draft for maintainer review.

## AI assistance
OpenAI `openai/gpt-5.6-sol` via OpenCode reviewed this PR and drafted the security follow-up commit and tests. Chris Huber directed the work and remains responsible for the resulting changes.