### PR TITLE
Remove accidental absolute vendor symlink

### DIFF
--- a/vendor
+++ b/vendor
@@ -1,1 +1,0 @@
-/Users/miguel/dev/a8c/agents-api/vendor


### PR DESCRIPTION
## Summary
- remove the tracked `vendor` symlink introduced by #471
- restore the existing `/vendor/` ignore contract
- prevent fresh checkouts from pointing at a contributor-specific absolute path

## Verification
- `composer phpstan`
- `composer smoke`

## AI assistance
OpenAI `openai/gpt-5.6-sol` via OpenCode identified the merged repository artifact and drafted this cleanup. Chris Huber directed the work and remains responsible for the change.