### PR TITLE
Fix principal-owned default chat sessions

### DIFF
--- a/src/Channels/register-default-agents-chat-handler.php
+++ b/src/Channels/register-default-agents-chat-handler.php
@@ -38,12 +38,14 @@
 namespace AgentsAPI\AI\Channels;
 
 use AgentsAPI\AI\WP_Agent_Conversation_Loop;
+use AgentsAPI\AI\WP_Agent_Execution_Principal;
 use AgentsAPI\AI\WP_Agent_Message;
 use AgentsAPI\AI\Tools\WP_Agent_Ability_Tool_Executor;
 use AgentsAPI\AI\Tools\WP_Agent_Tool_Declaration;
 use AgentsAPI\AI\Tools\WP_Agent_Tool_Executor_Registry;
 use AgentsAPI\Core\Database\Chat\WP_Agent_Conversation_Sessions;
 use AgentsAPI\Core\Database\Chat\WP_Agent_Conversation_Store;
+use AgentsAPI\Core\Database\Chat\WP_Agent_Principal_Conversation_Store;
 use AgentsAPI\Core\Workspace\WP_Agent_Workspace_Scope;
 
 defined( 'ABSPATH' ) || exit;
@@ -469,13 +471,11 @@ class WP_Agent_Default_Chat_Handler {
 	}
 
 	/**
-	 * Best-effort creation of a transcript session row for a user-owned chat.
+	 * Best-effort creation of a transcript session row for the authenticated owner.
 	 *
-	 * The default driver stays generic: it only creates a row when a store is
-	 * registered and a WordPress user owns the turn (the contracts-only default
-	 * CPT store keys sessions by user id). Anonymous or principal-owned chats run
-	 * statelessly with a synthesized session id rather than coupling this default
-	 * to a specific principal-store implementation.
+	 * User-owned sessions retain the legacy store path. Non-user principals use
+	 * the optional principal-aware store contract when available; otherwise they
+	 * remain stateless with a synthesized session id.
 	 *
 	 * @param WP_Agent_Conversation_Store $store      Resolved conversation store.
 	 * @param string                      $agent_slug Registered agent slug.
@@ -483,11 +483,6 @@ class WP_Agent_Default_Chat_Handler {
 	 * @return string Created session id, or empty string when none was created.
 	 */
 	private static function create_session( WP_Agent_Conversation_Store $store, string $agent_slug, array $input ): string {
-		$user_id = self::resolve_user_id( $input );
-		if ( $user_id <= 0 ) {
-			return '';
-		}
-
 		try {
 			$workspace = self::workspace_from_input( $input ) ?? WP_Agent_Workspace_Scope::from_parts( 'site', self::default_workspace_id() );
 		} catch ( \Throwable $error ) {
@@ -496,19 +491,37 @@ class WP_Agent_Default_Chat_Handler {
 		}
 
 		try {
-			$session_id = $store->create_session(
-				$workspace,
-				$user_id,
-				$agent_slug,
-				array( 'source' => 'agents-api-default-chat-handler' ),
-				'chat'
-			);
+			$user_id = self::resolve_user_id( $input );
+			if ( $user_id > 0 ) {
+				return $store->create_session(
+					$workspace,
+					$user_id,
+					$agent_slug,
+					array( 'source' => 'agents-api-default-chat-handler' ),
+					'chat'
+				);
+			}
+
+			$principal = $input['principal'] ?? null;
+			if ( is_array( $principal ) ) {
+				$principal = WP_Agent_Execution_Principal::from_array( agents_chat_string_keyed_array( $principal ) );
+			}
+			$owner = $principal instanceof WP_Agent_Execution_Principal ? $principal->conversation_owner() : null;
+			if ( $store instanceof WP_Agent_Principal_Conversation_Store && is_array( $owner ) ) {
+				return $store->create_session_for_owner(
+					$workspace,
+					$owner,
+					$agent_slug,
+					array( 'source' => 'agents-api-default-chat-handler' ),
+					'chat'
+				);
+			}
 		} catch ( \Throwable $error ) {
 			unset( $error );
 			return '';
 		}
 
-		return $session_id;
+		return '';
 	}
 
 	/** @param array<string,mixed> $input Canonical chat input. */

--- a/tests/default-agents-chat-handler-smoke.php
+++ b/tests/default-agents-chat-handler-smoke.php
@@ -164,7 +164,7 @@ namespace {
 
 	if ( ! function_exists( 'get_current_user_id' ) ) {
 		function get_current_user_id(): int {
-			return 0;
+			return (int) ( $GLOBALS['__chat_handler_user_id'] ?? 0 );
 		}
 	}
 
@@ -377,6 +377,83 @@ namespace {
 		}
 	}
 
+	class Agents_Chat_Principal_Conversation_Store implements \AgentsAPI\Core\Database\Chat\WP_Agent_Principal_Conversation_Store {
+		/** @var array<string,array<string,mixed>> */
+		public array $sessions = array();
+		/** @var array<int,array<string,mixed>> */
+		public array $principal_creations = array();
+		/** @var int[] */
+		public array $user_creations = array();
+
+		public function create_session( \AgentsAPI\Core\Workspace\WP_Agent_Workspace_Scope $workspace, int $user_id, string $agent_slug = '', array $metadata = array(), string $context = 'chat' ): string {
+			$this->user_creations[] = $user_id;
+			return $this->create_session_for_owner( $workspace, array( 'type' => 'user', 'key' => (string) $user_id ), $agent_slug, $metadata, $context );
+		}
+
+		public function create_session_for_owner( \AgentsAPI\Core\Workspace\WP_Agent_Workspace_Scope $workspace, array $owner, string $agent_slug = '', array $metadata = array(), string $context = 'chat' ): string {
+			$session_id = 'principal-session-' . ( count( $this->sessions ) + 1 );
+			$row        = array(
+				'session_id'     => $session_id,
+				'workspace_type' => $workspace->workspace_type,
+				'workspace_id'   => $workspace->workspace_id,
+				'owner_type'     => $owner['type'],
+				'owner_key'      => $owner['key'],
+				'agent_slug'     => $agent_slug,
+				'messages'       => array(),
+				'metadata'       => $metadata,
+				'context'        => $context,
+			);
+			$this->sessions[ $session_id ] = $row;
+			$this->principal_creations[]   = $row;
+			return $session_id;
+		}
+
+		public function list_sessions( \AgentsAPI\Core\Workspace\WP_Agent_Workspace_Scope $workspace, int $user_id, array $args = array() ): array {
+			unset( $workspace, $user_id, $args );
+			return array_values( $this->sessions );
+		}
+
+		public function list_sessions_for_owner( \AgentsAPI\Core\Workspace\WP_Agent_Workspace_Scope $workspace, array $owner, array $args = array() ): array {
+			unset( $workspace, $owner, $args );
+			return array_values( $this->sessions );
+		}
+
+		public function get_session( string $session_id ): ?array {
+			return $this->sessions[ $session_id ] ?? null;
+		}
+
+		public function update_session( string $session_id, array $messages, array $metadata = array(), string $provider = '', string $model = '', ?string $provider_response_id = null ): bool {
+			if ( ! isset( $this->sessions[ $session_id ] ) ) {
+				return false;
+			}
+			$this->sessions[ $session_id ] = array_merge( $this->sessions[ $session_id ], compact( 'messages', 'metadata', 'provider', 'model', 'provider_response_id' ) );
+			return true;
+		}
+
+		public function delete_session( string $session_id ): bool {
+			unset( $this->sessions[ $session_id ] );
+			return true;
+		}
+
+		public function get_recent_pending_session( \AgentsAPI\Core\Workspace\WP_Agent_Workspace_Scope $workspace, int $user_id, int $seconds = 600, string $context = 'chat', ?int $token_id = null ): ?array {
+			unset( $workspace, $user_id, $seconds, $context, $token_id );
+			return null;
+		}
+
+		public function get_recent_pending_session_for_owner( \AgentsAPI\Core\Workspace\WP_Agent_Workspace_Scope $workspace, array $owner, int $seconds = 600, string $context = 'chat', ?int $token_id = null ): ?array {
+			unset( $workspace, $owner, $seconds, $context, $token_id );
+			return null;
+		}
+
+		public function update_title( string $session_id, string $title ): bool {
+			if ( ! isset( $this->sessions[ $session_id ] ) ) {
+				return false;
+			}
+			$this->sessions[ $session_id ]['title'] = $title;
+			return true;
+		}
+	}
+
 	use function AgentsAPI\AI\Channels\agents_chat_dispatch;
 	use function AgentsAPI\AI\Channels\register_chat_handler;
 
@@ -567,6 +644,39 @@ namespace {
 	agents_api_smoke_assert_equals( true, $request_model instanceof \WordPress\AiClient\Providers\Models\Contracts\ModelInterface, 'request-supplied provider/model resolve to a ModelInterface for dispatch', $failures, $passes );
 	agents_api_smoke_assert_equals( 'request-provider', $request_model->provider_id ?? '', 'request provider overrides/supplies the dispatch provider', $failures, $passes );
 	agents_api_smoke_assert_equals( 'request-model', $request_model->model_id ?? '', 'request model overrides/supplies the dispatch model', $failures, $passes );
+
+	echo "\n[2b] Principal-owned turns create an authoritative session before run control finalizes:\n";
+	$principal_store = new Agents_Chat_Principal_Conversation_Store();
+	$store_filter    = static fn() => $principal_store;
+	add_filter( 'wp_agent_conversation_store', $store_filter );
+	$runtime_principal = \AgentsAPI\AI\WP_Agent_Execution_Principal::runtime(
+		'contained-runtime',
+		'kitchen-brain',
+		array( 'source' => 'test-runtime' ),
+		'wp-codebox',
+		'wp-codebox-cli',
+		array( 'runtime_type' => 'wordpress-playground' )
+	);
+	$reset_provider();
+	$principal_output = agents_chat_dispatch(
+		array(
+			'agent'     => 'kitchen-brain',
+			'message'   => 'Run as the contained runtime.',
+			'principal' => $runtime_principal->to_array(),
+		)
+	);
+
+	agents_api_smoke_assert_equals( false, $principal_output instanceof WP_Error, 'principal-owned dispatch completes without an ownership error', $failures, $passes );
+	agents_api_smoke_assert_equals( 'principal-session-1', $principal_output['session_id'] ?? '', 'principal-owned dispatch returns the authoritative session id', $failures, $passes );
+	agents_api_smoke_assert_equals( 'runtime', $principal_store->principal_creations[0]['owner_type'] ?? '', 'session owner type comes from the resolved runtime principal', $failures, $passes );
+	agents_api_smoke_assert_equals( 'contained-runtime', $principal_store->principal_creations[0]['owner_key'] ?? '', 'session owner key comes from the resolved runtime principal', $failures, $passes );
+	agents_api_smoke_assert_equals( true, is_string( $principal_output['run_id'] ?? null ) && '' !== $principal_output['run_id'], 'run control finalizes and returns the principal-owned run id', $failures, $passes );
+	$GLOBALS['__chat_handler_user_id'] = 17;
+	$reset_provider();
+	$user_output = AgentsAPI\AI\Channels\WP_Agent_Default_Chat_Handler::execute( array( 'agent' => 'kitchen-brain', 'message' => 'Run as a WordPress user.' ) );
+	$GLOBALS['__chat_handler_user_id'] = 0;
+	agents_api_smoke_assert_equals( false, $user_output instanceof WP_Error, 'user-owned dispatch remains compatible', $failures, $passes );
+	agents_api_smoke_assert_equals( 17, $principal_store->user_creations[0] ?? 0, 'user-owned dispatch retains the legacy integer-user store method', $failures, $passes );
 
 	echo "\n[3] Error contracts: empty message, unknown agent, missing provider:\n";
 	$empty = AgentsAPI\AI\Channels\WP_Agent_Default_Chat_Handler::execute( array( 'agent' => 'kitchen-brain', 'message' => '   ' ) );


### PR DESCRIPTION
## Summary

- create authoritative sessions for non-user execution principals when the configured store implements `WP_Agent_Principal_Conversation_Store`
- preserve the existing integer-user session path and stateless fallback for stores without principal support
- prove runtime-owner propagation and exact-once dispatch finalization through the default `agents/chat` handler

Fixes #482.

## Verification

- `php tests/default-agents-chat-handler-smoke.php` (59 assertions)
- `composer phpstan`
- `composer smoke`
- `git diff --check`

## AI assistance

OpenAI `gpt-5.6-sol` through OpenCode diagnosed the Codebox reproduction, drafted the implementation and regression coverage, and ran the verification commands. Chris Huber reviewed and remains responsible for the change.