### PR TITLE
Honor explicit chat session principals

### DIFF
--- a/src/Channels/register-default-agents-chat-handler.php
+++ b/src/Channels/register-default-agents-chat-handler.php
@@ -491,26 +491,38 @@ class WP_Agent_Default_Chat_Handler {
 		}
 
 		try {
-			$user_id = self::resolve_user_id( $input );
-			if ( $user_id > 0 ) {
-				return $store->create_session(
-					$workspace,
-					$user_id,
-					$agent_slug,
-					array( 'source' => 'agents-api-default-chat-handler' ),
-					'chat'
-				);
-			}
-
 			$principal = $input['principal'] ?? null;
 			if ( is_array( $principal ) ) {
 				$principal = WP_Agent_Execution_Principal::from_array( agents_chat_string_keyed_array( $principal ) );
 			}
 			$owner = $principal instanceof WP_Agent_Execution_Principal ? $principal->conversation_owner() : null;
-			if ( $store instanceof WP_Agent_Principal_Conversation_Store && is_array( $owner ) ) {
-				return $store->create_session_for_owner(
+			if ( is_array( $owner ) ) {
+				if ( WP_Agent_Execution_Principal::OWNER_TYPE_USER === $owner['type'] && is_numeric( $owner['key'] ) && (int) $owner['key'] > 0 ) {
+					return $store->create_session(
+						$workspace,
+						(int) $owner['key'],
+						$agent_slug,
+						array( 'source' => 'agents-api-default-chat-handler' ),
+						'chat'
+					);
+				}
+				if ( $store instanceof WP_Agent_Principal_Conversation_Store ) {
+					return $store->create_session_for_owner(
+						$workspace,
+						$owner,
+						$agent_slug,
+						array( 'source' => 'agents-api-default-chat-handler' ),
+						'chat'
+					);
+				}
+				return '';
+			}
+
+			$user_id = self::resolve_user_id( $input );
+			if ( $user_id > 0 ) {
+				return $store->create_session(
 					$workspace,
-					$owner,
+					$user_id,
 					$agent_slug,
 					array( 'source' => 'agents-api-default-chat-handler' ),
 					'chat'

--- a/tests/default-agents-chat-handler-smoke.php
+++ b/tests/default-agents-chat-handler-smoke.php
@@ -657,6 +657,7 @@ namespace {
 		'wp-codebox-cli',
 		array( 'runtime_type' => 'wordpress-playground' )
 	);
+	$GLOBALS['__chat_handler_user_id'] = 1;
 	$reset_provider();
 	$principal_output = agents_chat_dispatch(
 		array(
@@ -670,6 +671,7 @@ namespace {
 	agents_api_smoke_assert_equals( 'principal-session-1', $principal_output['session_id'] ?? '', 'principal-owned dispatch returns the authoritative session id', $failures, $passes );
 	agents_api_smoke_assert_equals( 'runtime', $principal_store->principal_creations[0]['owner_type'] ?? '', 'session owner type comes from the resolved runtime principal', $failures, $passes );
 	agents_api_smoke_assert_equals( 'contained-runtime', $principal_store->principal_creations[0]['owner_key'] ?? '', 'session owner key comes from the resolved runtime principal', $failures, $passes );
+	agents_api_smoke_assert_equals( array(), $principal_store->user_creations, 'ambient WordPress user does not replace the explicit runtime owner', $failures, $passes );
 	agents_api_smoke_assert_equals( true, is_string( $principal_output['run_id'] ?? null ) && '' !== $principal_output['run_id'], 'run control finalizes and returns the principal-owned run id', $failures, $passes );
 	$GLOBALS['__chat_handler_user_id'] = 17;
 	$reset_provider();


### PR DESCRIPTION
## Summary

- prioritize an explicit canonical conversation principal over the ambient WordPress user when creating default chat sessions
- preserve the legacy current-user path when no transcript-owning principal is supplied
- cover the WP Codebox shape where user `1` executes capabilities for a distinct runtime owner

Fixes #482.

Follow-up to #483 based on the real contained-runtime reproduction.

## Verification

- `php tests/default-agents-chat-handler-smoke.php` (60 assertions)
- `composer phpstan`
- `composer smoke`
- `git diff --check`

## AI assistance

OpenAI `gpt-5.6-sol` through OpenCode diagnosed the ambient-user/principal compatibility gap, drafted the implementation and regression coverage, and ran verification. Chris Huber reviewed and remains responsible for the change.