### PR TITLE
Surface failed partial package adoption as incomplete

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,7 @@
       "php tests/package-duplicate-artifact-identity-smoke.php",
       "php tests/package-capability-contract-smoke.php",
       "php tests/package-adoption-orchestration-smoke.php",
+      "php tests/package-adoption-result-canonical-status-smoke.php",
       "php tests/execution-principal-smoke.php",
       "php tests/effective-agent-resolver-smoke.php",
       "php tests/runtime-profile-smoke.php",

--- a/src/Packages/class-wp-agent-package-adoption-result.php
+++ b/src/Packages/class-wp-agent-package-adoption-result.php
@@ -208,7 +208,7 @@ if ( ! class_exists( 'WP_Agent_Package_Adoption_Result' ) ) {
 			if ( 'failed' === $this->status ) {
 				return \AgentsAPI\AI\WP_Agent_Run_Result_Envelope::STATUS_FAILED;
 			}
-			if ( 'partial' === $this->status ) {
+			if ( 'partial' === $this->status && ! empty( $this->failed_artifacts ) ) {
 				return \AgentsAPI\AI\WP_Agent_Run_Result_Envelope::STATUS_INCOMPLETE;
 			}
 			if ( in_array( $this->status, array( 'skipped', 'needs-approval' ), true ) ) {

--- a/src/Packages/class-wp-agent-package-adoption-result.php
+++ b/src/Packages/class-wp-agent-package-adoption-result.php
@@ -208,6 +208,9 @@ if ( ! class_exists( 'WP_Agent_Package_Adoption_Result' ) ) {
 			if ( 'failed' === $this->status ) {
 				return \AgentsAPI\AI\WP_Agent_Run_Result_Envelope::STATUS_FAILED;
 			}
+			if ( 'partial' === $this->status ) {
+				return \AgentsAPI\AI\WP_Agent_Run_Result_Envelope::STATUS_INCOMPLETE;
+			}
 			if ( in_array( $this->status, array( 'skipped', 'needs-approval' ), true ) ) {
 				return 'needs-approval' === $this->status ? \AgentsAPI\AI\WP_Agent_Run_Result_Envelope::STATUS_APPROVAL_REQUIRED : \AgentsAPI\AI\WP_Agent_Run_Result_Envelope::STATUS_SKIPPED;
 			}

--- a/tests/package-adoption-result-canonical-status-smoke.php
+++ b/tests/package-adoption-result-canonical-status-smoke.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * Pure-PHP smoke test for package adoption canonical status mapping.
+ *
+ * Guards against partial adoptions (some artifacts applied, others failed)
+ * being surfaced as a top-level `succeeded` canonical status, which would
+ * hide the failures from any consumer keying on the envelope status.
+ *
+ * Run with: php tests/package-adoption-result-canonical-status-smoke.php
+ *
+ * @package AgentsAPI\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+$failures = array();
+$passes   = 0;
+
+echo "agents-api-package-adoption-result-canonical-status-smoke\n";
+
+require_once __DIR__ . '/agents-api-smoke-helpers.php';
+agents_api_smoke_require_module();
+
+use AgentsAPI\AI\WP_Agent_Run_Result_Envelope;
+
+$applied_artifact = array( 'artifact_type' => 'example/prompt', 'artifact_id' => 'applied-one', 'apply_status' => 'applied' );
+$failed_artifact  = array( 'artifact_type' => 'example/prompt', 'artifact_id' => 'failed-one', 'apply_status' => 'failed', 'apply_reason' => 'import rejected' );
+
+echo "\n[1] Partial adoption surfaces a non-success canonical status with failures intact:\n";
+
+$partial_result   = new WP_Agent_Package_Adoption_Result(
+	'partial',
+	'demo-agent',
+	array(),
+	null,
+	array( $applied_artifact ),
+	array(),
+	array( $failed_artifact )
+);
+$partial_envelope = $partial_result->to_run_result_envelope();
+$partial_status   = $partial_envelope->get_status();
+$partial_outputs  = $partial_envelope->get_outputs();
+
+agents_api_smoke_assert_equals( false, WP_Agent_Run_Result_Envelope::STATUS_SUCCEEDED === $partial_status, 'partial adoption does not report succeeded', $failures, $passes );
+agents_api_smoke_assert_equals( WP_Agent_Run_Result_Envelope::STATUS_INCOMPLETE, $partial_status, 'partial adoption maps to the incomplete canonical status', $failures, $passes );
+agents_api_smoke_assert_equals( 1, count( $partial_outputs['failed'] ?? array() ), 'failed artifacts remain visible in the envelope outputs', $failures, $passes );
+agents_api_smoke_assert_equals( 'failed-one', $partial_outputs['failed'][0]['artifact_id'] ?? null, 'failed artifact identity is preserved', $failures, $passes );
+
+echo "\n[2] Fully successful adoption still maps to succeeded (no regression):\n";
+
+$success_result  = new WP_Agent_Package_Adoption_Result(
+	'applied',
+	'demo-agent',
+	array(),
+	null,
+	array( $applied_artifact )
+);
+$success_status  = $success_result->to_run_result_envelope()->get_status();
+agents_api_smoke_assert_equals( WP_Agent_Run_Result_Envelope::STATUS_SUCCEEDED, $success_status, 'clean adoption maps to succeeded', $failures, $passes );
+
+echo "\n[3] Fully failed adoption still maps to failed (no regression):\n";
+
+$failed_result = new WP_Agent_Package_Adoption_Result(
+	'failed',
+	'demo-agent',
+	array(),
+	null,
+	array(),
+	array(),
+	array( $failed_artifact )
+);
+$failed_status = $failed_result->to_run_result_envelope()->get_status();
+agents_api_smoke_assert_equals( WP_Agent_Run_Result_Envelope::STATUS_FAILED, $failed_status, 'fully failed adoption maps to failed', $failures, $passes );
+
+agents_api_smoke_finish( 'Agents API package adoption result canonical status', $failures, $passes );

--- a/tests/package-adoption-result-canonical-status-smoke.php
+++ b/tests/package-adoption-result-canonical-status-smoke.php
@@ -2,9 +2,8 @@
 /**
  * Pure-PHP smoke test for package adoption canonical status mapping.
  *
- * Guards against partial adoptions (some artifacts applied, others failed)
- * being surfaced as a top-level `succeeded` canonical status, which would
- * hide the failures from any consumer keying on the envelope status.
+ * Guards the canonical distinction between partial adoptions with failures
+ * and partial adoptions containing only intentionally skipped artifacts.
  *
  * Run with: php tests/package-adoption-result-canonical-status-smoke.php
  *
@@ -26,9 +25,10 @@ agents_api_smoke_require_module();
 use AgentsAPI\AI\WP_Agent_Run_Result_Envelope;
 
 $applied_artifact = array( 'artifact_type' => 'example/prompt', 'artifact_id' => 'applied-one', 'apply_status' => 'applied' );
+$skipped_artifact = array( 'artifact_type' => 'example/prompt', 'artifact_id' => 'skipped-one', 'apply_status' => 'skipped', 'apply_reason' => 'not approved' );
 $failed_artifact  = array( 'artifact_type' => 'example/prompt', 'artifact_id' => 'failed-one', 'apply_status' => 'failed', 'apply_reason' => 'import rejected' );
 
-echo "\n[1] Partial adoption surfaces a non-success canonical status with failures intact:\n";
+echo "\n[1] Partial adoption with a failure maps to incomplete:\n";
 
 $partial_result   = new WP_Agent_Package_Adoption_Result(
 	'partial',
@@ -39,16 +39,36 @@ $partial_result   = new WP_Agent_Package_Adoption_Result(
 	array(),
 	array( $failed_artifact )
 );
-$partial_envelope = $partial_result->to_run_result_envelope();
+$partial_envelope = $partial_result->to_canonical_envelope();
 $partial_status   = $partial_envelope->get_status();
 $partial_outputs  = $partial_envelope->get_outputs();
 
-agents_api_smoke_assert_equals( false, WP_Agent_Run_Result_Envelope::STATUS_SUCCEEDED === $partial_status, 'partial adoption does not report succeeded', $failures, $passes );
 agents_api_smoke_assert_equals( WP_Agent_Run_Result_Envelope::STATUS_INCOMPLETE, $partial_status, 'partial adoption maps to the incomplete canonical status', $failures, $passes );
 agents_api_smoke_assert_equals( 1, count( $partial_outputs['failed'] ?? array() ), 'failed artifacts remain visible in the envelope outputs', $failures, $passes );
 agents_api_smoke_assert_equals( 'failed-one', $partial_outputs['failed'][0]['artifact_id'] ?? null, 'failed artifact identity is preserved', $failures, $passes );
+agents_api_smoke_assert_equals( 'partial', $partial_result->get_status(), 'raw partial status remains unchanged', $failures, $passes );
+agents_api_smoke_assert_equals( 'partial', $partial_result->to_array()['status'], 'serialized partial status remains unchanged', $failures, $passes );
 
-echo "\n[2] Fully successful adoption still maps to succeeded (no regression):\n";
+echo "\n[2] Partial adoption with only an intentional skip maps to succeeded:\n";
+
+$skipped_result   = new WP_Agent_Package_Adoption_Result(
+	'partial',
+	'demo-agent',
+	array(),
+	null,
+	array( $applied_artifact ),
+	array( $skipped_artifact )
+);
+$skipped_envelope = $skipped_result->to_canonical_envelope();
+$skipped_outputs  = $skipped_envelope->get_outputs();
+
+agents_api_smoke_assert_equals( WP_Agent_Run_Result_Envelope::STATUS_SUCCEEDED, $skipped_envelope->get_status(), 'benign partial adoption maps to succeeded', $failures, $passes );
+agents_api_smoke_assert_equals( 0, count( $skipped_outputs['failed'] ?? array() ), 'benign partial adoption has no failed artifacts', $failures, $passes );
+agents_api_smoke_assert_equals( 'skipped-one', $skipped_outputs['skipped'][0]['artifact_id'] ?? null, 'skipped artifact remains visible in the envelope outputs', $failures, $passes );
+agents_api_smoke_assert_equals( 'partial', $skipped_result->get_status(), 'raw benign partial status remains unchanged', $failures, $passes );
+agents_api_smoke_assert_equals( 'partial', $skipped_result->to_array()['status'], 'serialized benign partial status remains unchanged', $failures, $passes );
+
+echo "\n[3] Fully successful adoption maps to succeeded:\n";
 
 $success_result  = new WP_Agent_Package_Adoption_Result(
 	'applied',
@@ -57,10 +77,10 @@ $success_result  = new WP_Agent_Package_Adoption_Result(
 	null,
 	array( $applied_artifact )
 );
-$success_status  = $success_result->to_run_result_envelope()->get_status();
+$success_status  = $success_result->to_canonical_envelope()->get_status();
 agents_api_smoke_assert_equals( WP_Agent_Run_Result_Envelope::STATUS_SUCCEEDED, $success_status, 'clean adoption maps to succeeded', $failures, $passes );
 
-echo "\n[3] Fully failed adoption still maps to failed (no regression):\n";
+echo "\n[4] Fully failed adoption maps to failed:\n";
 
 $failed_result = new WP_Agent_Package_Adoption_Result(
 	'failed',
@@ -71,7 +91,7 @@ $failed_result = new WP_Agent_Package_Adoption_Result(
 	array(),
 	array( $failed_artifact )
 );
-$failed_status = $failed_result->to_run_result_envelope()->get_status();
+$failed_status = $failed_result->to_canonical_envelope()->get_status();
 agents_api_smoke_assert_equals( WP_Agent_Run_Result_Envelope::STATUS_FAILED, $failed_status, 'fully failed adoption maps to failed', $failures, $passes );
 
 agents_api_smoke_finish( 'Agents API package adoption result canonical status', $failures, $passes );


### PR DESCRIPTION
## Summary

Package adoption uses the raw `partial` status for two distinct outcomes:

- Some artifacts applied while others failed.
- Some artifacts applied while others were intentionally skipped, such as artifacts awaiting approval.

The canonical run-result envelope previously could not distinguish those cases consistently for status-oriented consumers.

## Fix

Canonical status now derives the partial outcome from the artifact results:

- `partial` with a non-empty `failed_artifacts` list maps to `incomplete`.
- `partial` with applied and intentionally skipped artifacts but no failures remains `succeeded`.
- Full failure remains `failed`.
- Clean success remains `succeeded`.

The raw package adoption contract is unchanged: `get_status()` and `to_array()` continue to expose `partial` for both partial variants.

## Testing

Expanded `tests/package-adoption-result-canonical-status-smoke.php` with canonical envelope coverage for:

- Applied plus failed artifacts.
- Applied plus intentionally skipped artifacts.
- Full success.
- Full failure.
- Raw `get_status()` and `to_array()` compatibility for both partial variants.

Validation completed after merging current `origin/main`:

- All focused `tests/package-*.php` smoke tests pass.
- `composer test` passes.
- `composer phpstan` passes with no errors.
- `git diff --check origin/main...HEAD` passes.