### PR TITLE
fix: unify canonical chat authorization

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -91,6 +91,7 @@
       "php tests/provider-turn-adapter-smoke.php",
       "php tests/default-provider-turn-adapter-smoke.php",
       "php tests/agents-chat-ability-smoke.php",
+      "php tests/chat-permission-parity-smoke.php",
       "php tests/default-agents-chat-handler-smoke.php",
       "php tests/tool-observability-smoke.php",
       "php tests/ability-tool-executor-smoke.php",

--- a/src/Channels/register-agents-chat-ability.php
+++ b/src/Channels/register-agents-chat-ability.php
@@ -326,9 +326,11 @@ function agents_chat_string_keyed_array( array $data ): array {
 }
 
 /**
- * Permission gate for `agents/chat`. Defaults to `manage_options`; consumers
- * with their own auth model (HMAC-signed webhook, OAuth bearer, etc.) can
- * widen the gate per-request via the `agents_chat_permission` filter.
+ * Permission gate for `agents/chat`.
+ *
+ * Administrators and principals with an operator grant for the requested agent
+ * can chat. Consumers with their own auth model (HMAC-signed webhook, OAuth
+ * bearer, etc.) can widen the gate per-request via the filters below.
  *
  * @since 0.103.0
  *
@@ -357,10 +359,19 @@ function agents_chat_permission( array $input ): bool {
 		$allowed = (bool) apply_filters( 'agents_chat_runtime_principal_permission', $allowed, $principal, $input );
 	}
 
+	$agent = sanitize_title( agents_chat_optional_string( $input['agent'] ?? null ) ?? '' );
+	if ( ! $allowed && null === $principal && '' !== $agent && class_exists( '\WP_Agent_Access' ) && class_exists( '\WP_Agent_Access_Grant' ) ) {
+		$allowed = \WP_Agent_Access::can_current_principal_access_agent(
+			$agent,
+			\WP_Agent_Access_Grant::ROLE_OPERATOR,
+			agents_chat_access_scope( $input )
+		);
+	}
+
 	/**
 	 * Filter the permission decision for the canonical chat ability.
 	 *
-	 * @param bool  $allowed Default: current_user_can( 'manage_options' ).
+	 * @param bool  $allowed Administrator, operator-grant, or runtime-principal decision.
 	 * @param array<mixed> $input   The canonical input being authorized.
 	 */
 	return (bool) apply_filters(
@@ -368,6 +379,24 @@ function agents_chat_permission( array $input ): bool {
 		$allowed,
 		$input
 	);
+}
+
+/**
+ * Build the canonical access scope used by every agents/chat transport.
+ *
+ * @param array<mixed> $input Canonical chat input.
+ * @return array<string,mixed>
+ */
+function agents_chat_access_scope( array $input ): array {
+	$input = agents_chat_string_keyed_array( $input );
+	$scope = \AgentsAPI\AI\Auth\agents_access_request_scope( $input );
+	if ( is_array( $input['client_context'] ?? null ) ) {
+		$client_context            = agents_chat_strip_runtime_tool_declaration_fields( agents_chat_string_keyed_array( $input['client_context'] ) );
+		$scope['client_context']   = $client_context;
+		$scope['request_metadata'] = array( 'client_context' => $client_context );
+	}
+
+	return $scope;
 }
 
 /**
@@ -414,6 +443,14 @@ function agents_chat_input_schema(): array {
 		'required'   => array( 'agent', 'message' ),
 		'properties' => array(
 			'workspace'             => agents_chat_workspace_schema(),
+			'workspace_id'          => array(
+				'type'        => array( 'string', 'null' ),
+				'description' => 'Optional host access-scope identifier. This narrows agent grant resolution and does not replace the canonical conversation workspace.',
+			),
+			'client_id'             => array(
+				'type'        => array( 'string', 'null' ),
+				'description' => 'Optional host client identifier used when resolving scoped agent grants.',
+			),
 			'agent'                 => array(
 				'type'        => 'string',
 				'description' => 'Slug or ID of the registered agent that should handle this turn.',

--- a/src/Channels/register-agents-chat-jsonrpc-route.php
+++ b/src/Channels/register-agents-chat-jsonrpc-route.php
@@ -120,16 +120,15 @@ function agents_chat_jsonrpc_permission( \WP_REST_Request $request ): bool|\WP_E
 		);
 	}
 
-	$input   = array( 'agent' => $agent );
-	$allowed = agents_chat_permission( $input );
-
-	if ( ! $allowed ) {
-		$allowed = \WP_Agent_Access::can_current_principal_access_agent(
-			$agent,
-			\WP_Agent_Access_Grant::ROLE_OPERATOR,
-			agents_chat_jsonrpc_scope( $request )
+	$input = agents_chat_jsonrpc_request_input( $request );
+	if ( is_wp_error( $input ) ) {
+		$input = array(
+			'agent'        => $agent,
+			'workspace_id' => $request->get_param( 'workspace_id' ),
+			'client_id'    => $request->get_param( 'client_id' ),
 		);
 	}
+	$allowed = agents_chat_permission( $input );
 
 	/**
 	 * Filter the JSON-RPC chat permission decision.
@@ -138,7 +137,7 @@ function agents_chat_jsonrpc_permission( \WP_REST_Request $request ): bool|\WP_E
 	 * @param string           $agent   Agent slug from the URL.
 	 * @param \WP_REST_Request $request REST request.
 	 */
-	$allowed = (bool) apply_filters( 'agents_chat_jsonrpc_permission', $allowed, $agent, $request );
+	$allowed = $allowed && (bool) apply_filters( 'agents_chat_jsonrpc_permission', $allowed, $agent, $request );
 
 	if ( $allowed ) {
 		return true;
@@ -171,7 +170,7 @@ function agents_chat_jsonrpc_dispatch( \WP_REST_Request $request ): \WP_REST_Res
 		);
 	}
 
-	$input = agents_chat_jsonrpc_input_from_params( $params, $agent, $body );
+	$input = agents_chat_jsonrpc_request_input( $request );
 	if ( is_wp_error( $input ) ) {
 		return rest_ensure_response(
 			agents_chat_jsonrpc_error_frame( $rpc_id, AGENTS_CHAT_JSONRPC_ERR_INVALID_PARAMS, $input->get_error_message() )
@@ -200,6 +199,45 @@ function agents_chat_jsonrpc_dispatch( \WP_REST_Request $request ): \WP_REST_Res
 	return rest_ensure_response(
 		agents_chat_jsonrpc_result_frame( $rpc_id, agents_chat_jsonrpc_task_from_output( $output ) )
 	);
+}
+
+/**
+ * Build and cache the canonical JSON-RPC input for one REST request.
+ *
+ * Permission and dispatch must observe one filtered input so stateful host
+ * filters cannot authorize one context and execute another.
+ *
+ * @param \WP_REST_Request $request REST request.
+ * @return array<string,mixed>|\WP_Error
+ */
+function agents_chat_jsonrpc_request_input( \WP_REST_Request $request ) {
+	static $cache = null;
+
+	if ( ! $cache instanceof \SplObjectStorage ) {
+		$cache = new \SplObjectStorage();
+	}
+	if ( $cache->offsetExists( $request ) ) {
+		$cached = $cache[ $request ];
+		if ( is_array( $cached ) ) {
+			return \AgentsAPI\AI\agents_api_string_keyed_array( $cached );
+		}
+		if ( is_wp_error( $cached ) ) {
+			return $cached;
+		}
+		return new \WP_Error( 'agents_chat_jsonrpc_invalid_params', 'The cached JSON-RPC chat input is invalid.' );
+	}
+
+	$agent  = sanitize_title( \AgentsAPI\AI\agents_api_scalar_to_string( $request->get_param( 'agent_id' ) ) );
+	$body   = $request->get_json_params();
+	$params = isset( $body['params'] ) && is_array( $body['params'] ) ? $body['params'] : array();
+	$input  = agents_chat_jsonrpc_input_from_params( $params, $agent, $body );
+	if ( is_array( $input ) ) {
+		$input['workspace_id'] = $request->get_param( 'workspace_id' );
+		$input['client_id']    = $request->get_param( 'client_id' );
+	}
+
+	$cache[ $request ] = $input;
+	return $input;
 }
 
 /**

--- a/src/Channels/register-frontend-chat-rest-route.php
+++ b/src/Channels/register-frontend-chat-rest-route.php
@@ -72,10 +72,6 @@ function agents_frontend_chat_rest_permission( \WP_REST_Request $request ): bool
 	$agent   = \AgentsAPI\AI\agents_api_scalar_to_string( $input['agent'] ?? null );
 	$allowed = '' !== $agent && agents_chat_permission( $input );
 
-	if ( ! $allowed && '' !== $agent ) {
-		$allowed = \WP_Agent_Access::can_current_principal_access_agent( $agent, \WP_Agent_Access_Grant::ROLE_OPERATOR, agents_frontend_chat_rest_scope( $request ) );
-	}
-
 	/**
 	 * Filter the frontend chat REST permission decision.
 	 *
@@ -83,7 +79,7 @@ function agents_frontend_chat_rest_permission( \WP_REST_Request $request ): bool
 	 * @param array<mixed>            $input   Canonical agents/chat input.
 	 * @param \WP_REST_Request $request REST request.
 	 */
-	$allowed = (bool) apply_filters( 'agents_frontend_chat_rest_permission', $allowed, $input, $request );
+	$allowed = $allowed && (bool) apply_filters( 'agents_frontend_chat_rest_permission', $allowed, $input, $request );
 
 	if ( $allowed ) {
 		return true;
@@ -139,6 +135,8 @@ function agents_frontend_chat_rest_input( \WP_REST_Request $request ) {
 		'session_id'     => null !== $session_id ? \AgentsAPI\AI\agents_api_scalar_to_string( $session_id ) : null,
 		'attachments'    => is_array( $attachments ) ? $attachments : array(),
 		'client_context' => $client_context,
+		'workspace_id'   => $request->get_param( 'workspace_id' ),
+		'client_id'      => $request->get_param( 'client_id' ),
 	);
 
 	/**

--- a/tests/agents-chat-jsonrpc-route-smoke.php
+++ b/tests/agents-chat-jsonrpc-route-smoke.php
@@ -131,6 +131,7 @@ use function AgentsAPI\AI\Channels\agents_chat_jsonrpc_extract_text;
 use function AgentsAPI\AI\Channels\agents_chat_jsonrpc_client_context;
 use function AgentsAPI\AI\Channels\agents_chat_jsonrpc_method_sends;
 use function AgentsAPI\AI\Channels\agents_chat_jsonrpc_method_streams;
+use function AgentsAPI\AI\Channels\agents_chat_jsonrpc_request_input;
 use function AgentsAPI\AI\Channels\agents_chat_input_schema;
 use function AgentsAPI\AI\Channels\register_chat_stream_handler;
 
@@ -203,6 +204,32 @@ agents_api_smoke_assert_equals( array( 'first' => 'a', 'shared' => 'new', 'secon
 $top_level_token_streaming = agents_chat_jsonrpc_input_from_params( $params, 'support-agent', array( 'tokenStreaming' => false ) );
 agents_api_smoke_assert_equals( false, $top_level_token_streaming['token_streaming'] ?? null, 'input preserves false top-level tokenStreaming', $failures, $passes );
 
+$jsonrpc_filter_calls = 0;
+add_filter(
+	'agents_chat_jsonrpc_input',
+	static function ( array $filtered ) use ( &$jsonrpc_filter_calls ): array {
+		++$jsonrpc_filter_calls;
+		return $filtered;
+	}
+);
+$cached_request = new WP_REST_Request(
+	array( 'agent_id' => 'support-agent', 'workspace_id' => 'site:42' ),
+	array( 'jsonrpc' => '2.0', 'id' => 'cached', 'method' => 'message/send', 'params' => $params )
+);
+$cached_first  = agents_chat_jsonrpc_request_input( $cached_request );
+$cached_second = agents_chat_jsonrpc_request_input( $cached_request );
+agents_api_smoke_assert_equals( 1, $jsonrpc_filter_calls, 'request input filter runs once across permission and dispatch reads', $failures, $passes );
+agents_api_smoke_assert_equals( $cached_first, $cached_second, 'request input cache preserves one canonical filtered input', $failures, $passes );
+
+add_filter( 'agents_chat_permission', static fn() => true );
+$invalid_version_request = new WP_REST_Request(
+	array( 'agent_id' => 'support-agent' ),
+	array( 'jsonrpc' => '1.0', 'id' => 'invalid-version', 'method' => 'message/send', 'params' => array() )
+);
+agents_api_smoke_assert_equals( true, AgentsAPI\AI\Channels\agents_chat_jsonrpc_permission( $invalid_version_request ), 'authorized malformed request reaches JSON-RPC dispatcher', $failures, $passes );
+$invalid_version_response = agents_chat_jsonrpc_dispatch( $invalid_version_request );
+agents_api_smoke_assert_equals( -32600, $invalid_version_response->data['error']['code'] ?? null, 'malformed request retains JSON-RPC invalid-request frame', $failures, $passes );
+
 // --- Legacy Agent Protocol method aliases -----------------------------------
 agents_api_smoke_assert_equals( true, agents_chat_jsonrpc_method_sends( 'message/send' ), 'message/send maps to sync send', $failures, $passes );
 agents_api_smoke_assert_equals( true, agents_chat_jsonrpc_method_sends( 'tasks/send' ), 'tasks/send maps to sync send', $failures, $passes );
@@ -222,7 +249,7 @@ $GLOBALS['__agents_api_smoke_abilities']['agents/chat'] = new class() {
 };
 $alias_response = agents_chat_jsonrpc_dispatch(
 	new WP_REST_Request(
-		array( 'agent_id' => 'support-agent' ),
+		array( 'agent_id' => 'support-agent', 'workspace_id' => 'site:42', 'client_id' => 'rpc-client-1' ),
 		array(
 			'jsonrpc' => '2.0',
 			'id'      => 'rpc-alias',
@@ -234,6 +261,8 @@ $alias_response = agents_chat_jsonrpc_dispatch(
 agents_api_smoke_assert_equals( 'rpc-alias', $alias_response->data['id'] ?? null, 'tasks/send dispatch echoes rpc id', $failures, $passes );
 agents_api_smoke_assert_equals( 'alias ok', $alias_response->data['result']['status']['message']['parts'][0]['text'] ?? null, 'tasks/send dispatch runs sync handler', $failures, $passes );
 agents_api_smoke_assert_equals( 'trace-1', $GLOBALS['__agents_api_smoke_jsonrpc_last_input']['client_context']['traceId'] ?? null, 'tasks/send dispatch preserves clientContext', $failures, $passes );
+agents_api_smoke_assert_equals( 'site:42', $GLOBALS['__agents_api_smoke_jsonrpc_last_input']['workspace_id'] ?? null, 'tasks/send dispatch preserves canonical access workspace', $failures, $passes );
+agents_api_smoke_assert_equals( 'rpc-client-1', $GLOBALS['__agents_api_smoke_jsonrpc_last_input']['client_id'] ?? null, 'tasks/send dispatch preserves canonical access client', $failures, $passes );
 
 // extract_text directly
 agents_api_smoke_assert_equals( 'ab', agents_chat_jsonrpc_extract_text( array( 'parts' => array( array( 'type' => 'text', 'text' => 'a' ), array( 'type' => 'text', 'text' => 'b' ) ) ) ), 'extract_text concatenates', $failures, $passes );

--- a/tests/chat-permission-parity-smoke.php
+++ b/tests/chat-permission-parity-smoke.php
@@ -1,0 +1,156 @@
+<?php
+/**
+ * Permission parity across direct, REST, and JSON-RPC agents/chat transports.
+ *
+ * @package AgentsAPI\Tests
+ */
+
+defined( 'ABSPATH' ) || define( 'ABSPATH', __DIR__ . '/' );
+
+$failures = array();
+$passes   = 0;
+
+echo "chat-permission-parity-smoke\n";
+
+require_once __DIR__ . '/agents-api-smoke-helpers.php';
+
+$GLOBALS['__agents_api_smoke_current_user_id'] = 7;
+$GLOBALS['__agents_api_smoke_can_manage']      = false;
+$GLOBALS['__agents_api_smoke_chat_role']       = null;
+
+if ( ! class_exists( 'WP_Error' ) ) {
+	class WP_Error {
+		public function __construct( private string $code = '', private string $message = '', private array $data = array() ) {}
+		public function get_error_code(): string { return $this->code; }
+		public function get_error_message(): string { return $this->message; }
+		public function get_error_data(): array { return $this->data; }
+	}
+}
+
+if ( ! class_exists( 'WP_REST_Request' ) ) {
+	class WP_REST_Request {
+		public function __construct( private array $params = array(), private array $json = array() ) {}
+		public function get_param( string $key ) { return $this->params[ $key ] ?? null; }
+		public function get_json_params(): array { return $this->json; }
+	}
+}
+
+if ( ! function_exists( 'get_current_user_id' ) ) {
+	function get_current_user_id(): int {
+		return (int) $GLOBALS['__agents_api_smoke_current_user_id'];
+	}
+}
+
+if ( ! function_exists( 'current_user_can' ) ) {
+	function current_user_can( string $capability ): bool {
+		unset( $capability );
+		return (bool) $GLOBALS['__agents_api_smoke_can_manage'];
+	}
+} else {
+	add_filter(
+		'user_has_cap',
+		static function ( array $allcaps ): array {
+			$allcaps['manage_options'] = (bool) $GLOBALS['__agents_api_smoke_can_manage'];
+			return $allcaps;
+		}
+	);
+}
+
+agents_api_smoke_require_module();
+
+$access_store = new class() implements WP_Agent_Access_Store, WP_Agent_Principal_Access_Store {
+	public function grant_access( WP_Agent_Access_Grant $grant ): WP_Agent_Access_Grant { return $grant; }
+	public function revoke_access( string $agent_id, int $user_id, ?string $workspace_id = null ): bool { return false; }
+	public function get_access( string $agent_id, int $user_id, ?string $workspace_id = null ): ?WP_Agent_Access_Grant { return null; }
+	public function get_agent_ids_for_user( int $user_id, ?string $minimum_role = null, ?string $workspace_id = null ): array { return array(); }
+	public function get_users_for_agent( string $agent_id, ?string $workspace_id = null ): array { return array(); }
+	public function get_access_for_principal( string $agent_id, AgentsAPI\AI\WP_Agent_Execution_Principal $principal, ?string $workspace_id = null ): ?WP_Agent_Access_Grant {
+		$role = $GLOBALS['__agents_api_smoke_chat_role'];
+		if ( ! is_string( $role ) || 'support-agent' !== $agent_id || 'audience:public' !== $principal->audience_id || 'site:42' !== $workspace_id ) {
+			return null;
+		}
+
+		return new WP_Agent_Access_Grant( $agent_id, 0, $role, $workspace_id, null, null, null, array(), 'audience:public' );
+	}
+	public function get_agent_ids_for_principal( AgentsAPI\AI\WP_Agent_Execution_Principal $principal, ?string $minimum_role = null, ?string $workspace_id = null ): array {
+		unset( $minimum_role );
+		return 'audience:public' === $principal->audience_id && 'site:42' === $workspace_id ? array( 'support-agent' ) : array();
+	}
+};
+
+add_filter(
+	'wp_agent_access_store',
+	static fn( $store ) => $store instanceof WP_Agent_Access_Store ? $store : $access_store
+);
+
+$direct_input = array(
+	'agent'        => 'support-agent',
+	'message'      => 'Hello',
+	'workspace_id' => 'site:42',
+	'client_id'    => 'native-1',
+);
+$rest_request = new WP_REST_Request(
+	array(
+		'agent'        => 'support-agent',
+		'message'      => 'Hello',
+		'workspace_id' => 'site:42',
+		'client_id'    => 'browser-1',
+	)
+);
+$jsonrpc_request = new WP_REST_Request(
+	array(
+		'agent_id'     => 'support-agent',
+		'workspace_id' => 'site:42',
+		'client_id'    => 'rpc-1',
+	),
+	array(
+		'jsonrpc' => '2.0',
+		'id'      => 'permission-check',
+		'method'  => 'message/send',
+		'params'  => array(
+			'id'      => 'permission-check',
+			'message' => array(
+				'role'  => 'user',
+				'parts' => array( array( 'type' => 'text', 'text' => 'Hello' ) ),
+			),
+		),
+	)
+);
+
+$is_allowed = static fn( $result ): bool => true === $result;
+$assert_matrix = static function ( string $label, bool $expected ) use ( &$failures, &$passes, $direct_input, $rest_request, $jsonrpc_request, $is_allowed ): void {
+	agents_api_smoke_assert_equals( $expected, AgentsAPI\AI\Channels\agents_chat_permission( $direct_input ), $label . ' direct ability permission', $failures, $passes );
+	agents_api_smoke_assert_equals( $expected, $is_allowed( AgentsAPI\AI\Channels\agents_frontend_chat_rest_permission( $rest_request ) ), $label . ' REST permission', $failures, $passes );
+	agents_api_smoke_assert_equals( $expected, $is_allowed( AgentsAPI\AI\Channels\agents_chat_jsonrpc_permission( $jsonrpc_request ) ), $label . ' JSON-RPC permission', $failures, $passes );
+};
+
+$GLOBALS['__agents_api_smoke_chat_role'] = WP_Agent_Access_Grant::ROLE_OPERATOR;
+$assert_matrix( 'operator', true );
+
+$GLOBALS['__agents_api_smoke_chat_role'] = WP_Agent_Access_Grant::ROLE_VIEWER;
+$assert_matrix( 'viewer', false );
+
+$GLOBALS['__agents_api_smoke_chat_role'] = null;
+$assert_matrix( 'ungranted principal', false );
+
+$GLOBALS['__agents_api_smoke_can_manage'] = true;
+$assert_matrix( 'administrator', true );
+
+$GLOBALS['__agents_api_smoke_can_manage'] = false;
+$GLOBALS['__agents_api_smoke_chat_role']  = WP_Agent_Access_Grant::ROLE_OPERATOR;
+$runtime_principal = AgentsAPI\AI\WP_Agent_Execution_Principal::runtime( 'runtime-1', 'support-agent' )->to_array();
+agents_api_smoke_assert_equals( false, AgentsAPI\AI\Channels\agents_chat_permission( $direct_input + array( 'principal' => $runtime_principal ) ), 'operator grant cannot attest a caller-supplied runtime principal', $failures, $passes );
+add_filter( 'agents_chat_runtime_principal_permission', static fn() => true );
+agents_api_smoke_assert_equals( true, AgentsAPI\AI\Channels\agents_chat_permission( $direct_input + array( 'principal' => $runtime_principal ) ), 'runtime principal filter can attest an explicit runtime principal', $failures, $passes );
+
+$GLOBALS['__agents_api_smoke_chat_role'] = null;
+add_filter( 'agents_chat_permission', static fn() => true );
+$assert_matrix( 'host filter', true );
+
+add_filter( 'agents_frontend_chat_rest_permission', static fn() => false );
+add_filter( 'agents_chat_jsonrpc_permission', static fn() => false );
+agents_api_smoke_assert_equals( true, AgentsAPI\AI\Channels\agents_chat_permission( $direct_input ), 'canonical host grant remains allowed', $failures, $passes );
+agents_api_smoke_assert_equals( false, $is_allowed( AgentsAPI\AI\Channels\agents_frontend_chat_rest_permission( $rest_request ) ), 'REST filter can narrow canonical permission', $failures, $passes );
+agents_api_smoke_assert_equals( false, $is_allowed( AgentsAPI\AI\Channels\agents_chat_jsonrpc_permission( $jsonrpc_request ) ), 'JSON-RPC filter can narrow canonical permission', $failures, $passes );
+
+agents_api_smoke_finish( 'chat permission parity', $failures, $passes );

--- a/tests/frontend-chat-rest-smoke.php
+++ b/tests/frontend-chat-rest-smoke.php
@@ -152,8 +152,8 @@ add_filter(
 );
 add_filter(
 	'agents_chat_permission',
-	static function (): bool {
-		return (bool) $GLOBALS['__agents_api_smoke_allow_chat'];
+	static function ( bool $allowed ): bool {
+		return $allowed || (bool) $GLOBALS['__agents_api_smoke_allow_chat'];
 	}
 );
 
@@ -181,7 +181,10 @@ $ability  = new class( $captured ) {
 		$this->captured =& $captured;
 	}
 
-	public function execute( array $input ): array {
+	public function execute( array $input ) {
+		if ( ! AgentsAPI\AI\Channels\agents_chat_permission( $input ) ) {
+			return new WP_Error( 'ability_invalid_permissions', 'Ability permission denied.' );
+		}
 		$this->captured = $input;
 		return array(
 			'session_id' => 's-1',
@@ -230,9 +233,7 @@ $request = agents_api_smoke_rest_request(
 $permission = AgentsAPI\AI\Channels\agents_frontend_chat_rest_permission( $request );
 agents_api_smoke_assert_equals( true, $permission, 'permission allows operator grant', $failures, $passes );
 
-$GLOBALS['__agents_api_smoke_allow_chat'] = true;
 $response = AgentsAPI\AI\Channels\agents_frontend_chat_rest_dispatch( $request );
-$GLOBALS['__agents_api_smoke_allow_chat'] = false;
 $response_data = $response instanceof WP_REST_Response && method_exists( $response, 'get_data' ) ? $response->get_data() : ( $response->data ?? null );
 agents_api_smoke_assert_equals( true, $response instanceof WP_REST_Response, 'dispatch returns REST response', $failures, $passes );
 agents_api_smoke_assert_equals( 'hello from adapter', $response_data['reply'] ?? null, 'dispatch returns ability reply', $failures, $passes );
@@ -241,6 +242,8 @@ agents_api_smoke_assert_equals( 'rest-source-item-1', $response_data['metadata']
 agents_api_smoke_assert_equals( 'support-agent', $captured['agent'] ?? null, 'dispatch sanitizes agent slug', $failures, $passes );
 agents_api_smoke_assert_equals( 'Hi there', $captured['message'] ?? null, 'dispatch forwards message', $failures, $passes );
 agents_api_smoke_assert_equals( 'rest', $captured['client_context']['source'] ?? null, 'dispatch marks REST source', $failures, $passes );
+agents_api_smoke_assert_equals( 'site:42', $captured['workspace_id'] ?? null, 'dispatch preserves canonical access workspace', $failures, $passes );
+agents_api_smoke_assert_equals( 'browser-1', $captured['client_id'] ?? null, 'dispatch preserves canonical access client', $failures, $passes );
 agents_api_smoke_assert_equals( 'block-chat', $captured['client_context']['client_name'] ?? null, 'dispatch preserves client name', $failures, $passes );
 agents_api_smoke_assert_equals( 'selected-material-123', $captured['client_context']['host_context']['opaque_id'] ?? null, 'dispatch preserves caller-owned context metadata', $failures, $passes );
 	agents_api_smoke_assert_equals( array( 'current-item' ), $captured['client_context']['host_context']['hints'] ?? null, 'dispatch preserves nested caller-owned context metadata', $failures, $passes );
@@ -265,7 +268,13 @@ add_filter( 'agents_frontend_chat_rest_permission', static fn() => true );
 $filtered = AgentsAPI\AI\Channels\agents_frontend_chat_rest_permission(
 	agents_api_smoke_rest_request( array( 'agent' => 'other-agent', 'message' => 'Allowed by host' ) )
 );
-agents_api_smoke_assert_equals( true, $filtered, 'permission is filterable for hosts', $failures, $passes );
+agents_api_smoke_assert_equals( true, $filtered instanceof WP_Error, 'transport filter cannot widen canonical permission', $failures, $passes );
+$GLOBALS['__agents_api_smoke_allow_chat'] = true;
+$filtered = AgentsAPI\AI\Channels\agents_frontend_chat_rest_permission(
+	agents_api_smoke_rest_request( array( 'agent' => 'other-agent', 'message' => 'Allowed by canonical host policy' ) )
+);
+$GLOBALS['__agents_api_smoke_allow_chat'] = false;
+agents_api_smoke_assert_equals( true, $filtered, 'canonical permission filter remains host extension seam', $failures, $passes );
 
 $invalid = AgentsAPI\AI\Channels\agents_frontend_chat_rest_dispatch( agents_api_smoke_rest_request( array( 'agent' => '', 'message' => '' ) ) );
 agents_api_smoke_assert_equals( true, $invalid instanceof WP_Error, 'dispatch rejects empty input', $failures, $passes );


### PR DESCRIPTION
## Summary
- make `agents_chat_permission()` the single authorization decision for direct ability, frontend REST, synchronous JSON-RPC, and streaming JSON-RPC chat
- recognize canonical operator grants in the ability permission callback while requiring explicit runtime principals to be host-attested
- carry `workspace_id` and `client_id` through canonical chat input so route and ability checks resolve the same scoped grant
- cache normalized JSON-RPC input per request so permission and streaming execution cannot observe different filtered contexts

## Authorization contract
- administrators, operator-granted principals, attested runtime principals, and hosts using `agents_chat_permission` can authorize chat
- viewer grants remain read-only
- caller-supplied execution principals are never authorized by an ambient operator grant
- transport-specific permission filters remain available as narrowing hooks, but can no longer widen past the canonical ability decision; hosts that currently widen `agents_frontend_chat_rest_permission` or `agents_chat_jsonrpc_permission` should move that policy to `agents_chat_permission`

## Verification
- `composer test`
- `composer phpstan`
- focused direct/REST/JSON-RPC role matrix covering operator, viewer, ungranted, administrator, runtime-principal, and host-filter paths
- JSON-RPC cache and malformed-request framing regressions
- `git diff --check`

Closes #493