### PR TITLE
Expose host provider-turn dispatch through the default adapter

### DIFF
--- a/docs/runtime-and-tools.md
+++ b/docs/runtime-and-tools.md
@@ -20,6 +20,29 @@ Agents API owns reusable runtime mechanics:
 
 Consumers own provider/model dispatch, prompt assembly, concrete tools, durable storage, streaming UX, product-specific continuation policy, and final business semantics.
 
+## Provider-turn dispatch
+
+`WP_Agent_Default_Provider_Turn_Adapter` uses the bare wp-ai-client prompt builder by default. A caller may inject `dispatch_provider` through the constructor options or `set_dispatch_provider()`; that explicit callable is authoritative. When no explicit dispatcher exists, the adapter applies `wp_agent_provider_turn_dispatch` with `null` and the `WP_Agent_Provider_Turn_Request`. A host can return a callable, preserving an earlier callable when present so multiple host integrations arbitrate predictably:
+
+```php
+add_filter(
+	'wp_agent_provider_turn_dispatch',
+	static function ( $dispatcher, WP_Agent_Provider_Turn_Request $request ) {
+		if ( null !== $dispatcher || 'example-provider' !== ( $request->model()['provider_id'] ?? '' ) ) {
+			return $dispatcher;
+		}
+
+		return static function ( array $payload ) {
+			return example_provider_dispatch( $payload );
+		};
+	},
+	10,
+	2
+);
+```
+
+Returning `null` or any non-callable value retains the exact bare-builder path. The discovered callable receives one normalized payload array with `provider_id`, `model_id`, `system_prompt`, canonical `messages`, mapped `prompt_parts`, mapped `history`, mapped `function_declarations`, adapter `options`, and the full `request`. The adapter retains generic retry behavior and result normalization for both explicit and discovered dispatchers.
+
 ## Task execution targets
 
 Agents API also exposes product-neutral task execution plumbing for work that is

--- a/src/Runtime/class-wp-agent-default-provider-turn-adapter.php
+++ b/src/Runtime/class-wp-agent-default-provider-turn-adapter.php
@@ -38,12 +38,15 @@ defined( 'ABSPATH' ) || exit;
  * authenticated, transport-tuned, cached, model-config-aware, or vision-capable
  * request cannot influence the bare builder this adapter constructs by default.
  * For that case the adapter exposes a second injectable "dispatch provider"
- * strategy, symmetric with the prompt-input one. When a dispatcher is injected,
- * the adapter still owns the generic mapping (provider/model/system/messages/
+ * strategy, symmetric with the prompt-input one. An explicitly injected
+ * dispatcher takes precedence; otherwise a host can discover one through the
+ * `wp_agent_provider_turn_dispatch` filter. The adapter still owns the generic
+ * mapping (provider/model/system/messages/
  * declarations) and the generic tail (tool-call extraction, text/usage
  * normalization, result-shape assembly); the consumer owns only request
  * construction and dispatch, returning a wp-ai-client `GenerativeAiResult`. When
- * no dispatcher is injected the adapter builds and dispatches the bare
+ * no explicit or host-discovered dispatcher is available, the adapter builds and
+ * dispatches the bare
  * `wp_ai_client_prompt()` builder exactly as before — the seam is a pure
  * addition with no behavior change on the default path.
  */
@@ -130,7 +133,7 @@ class WP_Agent_Default_Provider_Turn_Adapter implements WP_Agent_Provider_Turn_A
 	/** @var callable|null Injectable prompt-input strategy, defaulting to identity. */
 	private $prompt_input_provider;
 
-	/** @var callable|null Injectable dispatch strategy, defaulting to the bare builder. */
+	/** @var callable|null Explicit dispatch strategy, taking precedence over host discovery. */
 	private $dispatch_provider;
 
 	/** @var callable|null Injectable sleep strategy, defaulting to usleep(). Replaced in tests with a non-sleeping spy. */
@@ -210,7 +213,8 @@ class WP_Agent_Default_Provider_Turn_Adapter implements WP_Agent_Provider_Turn_A
 	 * transport tuning, caching, model-config, multimodal parts, and the actual
 	 * dispatch call.
 	 *
-	 * Passing `null` restores the default bare-builder dispatch.
+	 * Passing `null` removes the explicit dispatcher, allowing host discovery and,
+	 * when none is discovered, the default bare-builder dispatch.
 	 *
 	 * The provider is called as `$dispatcher( array $payload )` and receives a
 	 * single associative array with these keys (the mapped builder inputs, not a
@@ -261,9 +265,10 @@ class WP_Agent_Default_Provider_Turn_Adapter implements WP_Agent_Provider_Turn_A
 		$prompt_context        = self::split_prompt_context( $messages );
 		$function_declarations = self::function_declarations( $request->toolDeclarations() );
 
-		if ( null !== $this->dispatch_provider ) {
-			$dispatch = function () use ( $request, $provider_id, $model_id, $system_prompt, $messages, $prompt_context, $function_declarations ) {
-				return $this->dispatch_via_provider( $request, $provider_id, $model_id, $system_prompt, $messages, $prompt_context, $function_declarations );
+		$dispatcher = $this->resolve_dispatch_provider( $request );
+		if ( null !== $dispatcher ) {
+			$dispatch = function () use ( $dispatcher, $request, $provider_id, $model_id, $system_prompt, $messages, $prompt_context, $function_declarations ) {
+				return $this->dispatch_via_provider( $dispatcher, $request, $provider_id, $model_id, $system_prompt, $messages, $prompt_context, $function_declarations );
 			};
 		} else {
 			$dispatch = function () use ( $provider_id, $model_id, $system_prompt, $prompt_context, $function_declarations ) {
@@ -291,7 +296,7 @@ class WP_Agent_Default_Provider_Turn_Adapter implements WP_Agent_Provider_Turn_A
 	/**
 	 * Dispatch one provider request with deterministic retry-on-transient backoff.
 	 *
-	 * Wraps the single provider-dispatch call (bare builder or injected dispatcher)
+	 * Wraps the single provider-dispatch call (bare builder or explicit/discovered dispatcher)
 	 * — NOT the whole loop turn — so a retry never re-runs the loop's mediated tool
 	 * execution and never duplicates tool side effects. The adapter's own turn has
 	 * no side effects beyond the model request, so re-dispatching is safe.
@@ -621,7 +626,8 @@ class WP_Agent_Default_Provider_Turn_Adapter implements WP_Agent_Provider_Turn_A
 	 *
 	 * This is the original, unmodified dispatch: it constructs a
 	 * `wp_ai_client_prompt()` builder from the mapped inputs and calls
-	 * `generate_text_result()`. It runs only when no dispatch provider is injected.
+	 * `generate_text_result()`. It runs only when neither an explicit nor a
+	 * host-discovered dispatch provider is available.
 	 *
 	 * @param string                                                          $provider_id           Resolved provider id.
 	 * @param string                                                          $model_id              Resolved model id.
@@ -823,7 +829,42 @@ class WP_Agent_Default_Provider_Turn_Adapter implements WP_Agent_Provider_Turn_A
 	}
 
 	/**
-	 * Delegate request construction and dispatch to the injected dispatch provider.
+	 * Resolve an explicit or host-discovered dispatch provider.
+	 *
+	 * Explicit constructor/setter injection is authoritative. When none exists,
+	 * hosts may provide a callable through `wp_agent_provider_turn_dispatch`.
+	 * Returning null or a non-callable preserves the bare-builder default.
+	 *
+	 * @param WP_Agent_Provider_Turn_Request $request Provider-turn request passed to host discovery.
+	 * @return callable|null Dispatch provider, when available.
+	 */
+	private function resolve_dispatch_provider( WP_Agent_Provider_Turn_Request $request ): ?callable {
+		if ( null !== $this->dispatch_provider ) {
+			return $this->dispatch_provider;
+		}
+
+		if ( ! function_exists( 'apply_filters' ) ) {
+			return null;
+		}
+
+		/**
+		 * Filters the host provider-turn dispatcher for the default adapter.
+		 *
+		 * Explicit `dispatch_provider` constructor/setter injection takes precedence,
+		 * so this filter runs only when no explicit dispatcher exists. Return a
+		 * callable that accepts the documented normalized dispatch payload, or return
+		 * the incoming null to retain the default wp-ai-client builder path.
+		 *
+		 * @param callable|null                   $dispatcher Host dispatch provider, or null for the default path.
+		 * @param WP_Agent_Provider_Turn_Request $request    Full provider-turn request for host routing context.
+		 */
+		$dispatcher = apply_filters( 'wp_agent_provider_turn_dispatch', null, $request );
+
+		return is_callable( $dispatcher ) ? $dispatcher : null;
+	}
+
+	/**
+	 * Delegate request construction and dispatch to an explicit or discovered provider.
 	 *
 	 * The provider receives the mapped builder inputs (see {@see self::set_dispatch_provider()}
 	 * for the exact payload contract) and returns a wp-ai-client GenerativeAiResult
@@ -839,12 +880,7 @@ class WP_Agent_Default_Provider_Turn_Adapter implements WP_Agent_Provider_Turn_A
 	 * @param array<int,object>                                               $function_declarations Mapped function declarations.
 	 * @return mixed wp-ai-client GenerativeAiResult or WP_Error.
 	 */
-	private function dispatch_via_provider( WP_Agent_Provider_Turn_Request $request, string $provider_id, string $model_id, string $system_prompt, array $messages, array $prompt_context, array $function_declarations ) {
-		$dispatcher = $this->dispatch_provider;
-		if ( ! is_callable( $dispatcher ) ) {
-			throw new \RuntimeException( 'Dispatch provider is unavailable.' );
-		}
-
+	private function dispatch_via_provider( callable $dispatcher, WP_Agent_Provider_Turn_Request $request, string $provider_id, string $model_id, string $system_prompt, array $messages, array $prompt_context, array $function_declarations ) {
 		$payload = array(
 			'provider_id'           => $provider_id,
 			'model_id'              => $model_id,

--- a/tests/default-provider-turn-adapter-smoke.php
+++ b/tests/default-provider-turn-adapter-smoke.php
@@ -900,7 +900,74 @@ namespace {
 	agents_api_smoke_assert_equals( 'bare again', $restore_raw['content'], 'set_dispatch_provider(null) falls back to the bare builder', $failures, $passes );
 	agents_api_smoke_assert_equals( true, ( $GLOBALS['__adapter_smoke']['model'] ?? null ) instanceof \WordPress\AiClient\Providers\Models\Contracts\ModelInterface, 'restored bare path drives the wp_ai_client builder again with a resolved ModelInterface', $failures, $passes );
 
-	echo "\n[9] Public result normalization helpers on WP_Agent_Provider_Turn_Result:\n";
+	echo "\n[9] Host dispatch discovery uses request context, preserves explicit precedence, and falls back safely:\n";
+	$host_dispatch_payload = null;
+	$host_filter_initial   = 'not-called';
+	$host_dispatch_request = new AgentsAPI\AI\WP_Agent_Provider_Turn_Request(
+		array( array( 'role' => 'user', 'content' => 'host dispatch' ) ),
+		array(),
+		array( 'provider_id' => 'host-provider', 'model_id' => 'host-model' ),
+		array(),
+		array( 'host_route' => 'primary' )
+	);
+	add_filter(
+		'wp_agent_provider_turn_dispatch',
+		static function ( $dispatcher, $request ) use ( &$host_dispatch_payload, &$host_filter_initial, $make_result ) {
+			$host_filter_initial = $dispatcher;
+			$GLOBALS['__adapter_smoke']['host_dispatch_request'] = $request;
+			return static function ( array $payload ) use ( &$host_dispatch_payload, $make_result ) {
+				$host_dispatch_payload = $payload;
+				return $make_result( 'host dispatched', array(), array( 2, 3, 5 ) );
+			};
+		},
+		10,
+		2
+	);
+	$GLOBALS['__adapter_smoke']          = array();
+	$host_raw = ( new AgentsAPI\AI\WP_Agent_Default_Provider_Turn_Adapter( 'fallback-provider', 'fallback-model', 'sys' ) )->run_turn( $host_dispatch_request );
+	agents_api_smoke_assert_equals( null, $host_filter_initial, 'host dispatch filter starts with null when no dispatcher is explicit', $failures, $passes );
+	agents_api_smoke_assert_equals( 'host dispatched', $host_raw['content'], 'host-discovered dispatcher drives the shared normalization tail', $failures, $passes );
+	agents_api_smoke_assert_equals( $host_dispatch_request, $GLOBALS['__adapter_smoke']['host_dispatch_request'] ?? null, 'host dispatch filter receives the exact provider-turn request context', $failures, $passes );
+	agents_api_smoke_assert_equals( 'host-provider', $host_dispatch_payload['provider_id'] ?? '', 'host-discovered dispatcher receives normalized provider payload', $failures, $passes );
+	agents_api_smoke_assert_equals( $host_dispatch_request, $host_dispatch_payload['request'] ?? null, 'host-discovered dispatcher payload retains the full request', $failures, $passes );
+	agents_api_smoke_assert_equals( false, isset( $GLOBALS['__adapter_smoke']['model'] ), 'host-discovered dispatcher bypasses the bare builder', $failures, $passes );
+	$GLOBALS['__agents_api_smoke_actions']['wp_agent_provider_turn_dispatch'] = array();
+
+	$discovery_calls = 0;
+	$explicit_calls  = 0;
+	add_filter(
+		'wp_agent_provider_turn_dispatch',
+		static function ( $dispatcher ) use ( &$discovery_calls, $make_result ) {
+			++$discovery_calls;
+			return static fn ( array $payload ) => $make_result( 'discovered should not run', array(), array( 0, 0, 0 ) );
+		}
+	);
+	$explicit_adapter = new AgentsAPI\AI\WP_Agent_Default_Provider_Turn_Adapter( 'fake-provider', 'fake-model', 'sys' );
+	$explicit_adapter->set_dispatch_provider(
+		static function ( array $payload ) use ( &$explicit_calls, $make_result ) {
+			++$explicit_calls;
+			return $make_result( 'explicit dispatched', array(), array( 1, 1, 2 ) );
+		}
+	);
+	agents_api_smoke_assert_equals( 'explicit dispatched', $explicit_adapter->run_turn( $host_dispatch_request )['content'], 'explicit dispatcher takes precedence over host discovery', $failures, $passes );
+	agents_api_smoke_assert_equals( 1, $explicit_calls, 'explicit dispatcher runs when configured', $failures, $passes );
+	agents_api_smoke_assert_equals( 0, $discovery_calls, 'explicit dispatcher prevents host discovery from running', $failures, $passes );
+	$GLOBALS['__agents_api_smoke_actions']['wp_agent_provider_turn_dispatch'] = array();
+
+	$GLOBALS['__adapter_smoke']                = array();
+	$GLOBALS['__adapter_smoke']['next_result'] = $make_result( 'invalid filter fallback', array(), array( 1, 1, 2 ) );
+	add_filter( 'wp_agent_provider_turn_dispatch', static fn () => 'not a callable' );
+	$invalid_raw = ( new AgentsAPI\AI\WP_Agent_Default_Provider_Turn_Adapter( 'fake-provider', 'fake-model', 'sys' ) )->run_turn( $host_dispatch_request );
+	agents_api_smoke_assert_equals( 'invalid filter fallback', $invalid_raw['content'], 'invalid host dispatch filter value falls back to the bare builder', $failures, $passes );
+	agents_api_smoke_assert_equals( true, ( $GLOBALS['__adapter_smoke']['model'] ?? null ) instanceof \WordPress\AiClient\Providers\Models\Contracts\ModelInterface, 'invalid host dispatch filter value preserves bare-builder behavior', $failures, $passes );
+	$GLOBALS['__agents_api_smoke_actions']['wp_agent_provider_turn_dispatch'] = array();
+
+	$GLOBALS['__adapter_smoke']                = array();
+	$GLOBALS['__adapter_smoke']['next_result'] = $make_result( 'no host fallback', array(), array( 1, 1, 2 ) );
+	$no_host_raw = ( new AgentsAPI\AI\WP_Agent_Default_Provider_Turn_Adapter( 'fake-provider', 'fake-model', 'sys' ) )->run_turn( $host_dispatch_request );
+	agents_api_smoke_assert_equals( 'no host fallback', $no_host_raw['content'], 'no host dispatcher retains the bare-builder fallback', $failures, $passes );
+
+	echo "\n[10] Public result normalization helpers on WP_Agent_Provider_Turn_Result:\n";
 	$helper_result = $make_result( 'helper text', array(), array( 4, 6, 10 ) );
 	agents_api_smoke_assert_equals( 'helper text', AgentsAPI\AI\WP_Agent_Provider_Turn_Result::result_text( $helper_result ), 'public result_text() extracts assistant text', $failures, $passes );
 	$helper_usage = AgentsAPI\AI\WP_Agent_Provider_Turn_Result::result_usage( $helper_result );
@@ -910,7 +977,7 @@ namespace {
 	$tool_only_result = $make_result( '', array( array( 'name' => 'client/lookup', 'parameters' => array( 'q' => 'x' ), 'id' => 'tc-1' ) ), array( 1, 0, 1 ) );
 	agents_api_smoke_assert_equals( '', AgentsAPI\AI\WP_Agent_Provider_Turn_Result::result_text( $tool_only_result ), 'public result_text() returns empty for a tool-only turn', $failures, $passes );
 
-	echo "\n[10] Regression: a STRING model id is resolved to a ModelInterface and the turn dispatches (no TypeError):\n";
+	echo "\n[11] Regression: a STRING model id is resolved to a ModelInterface and the turn dispatches (no TypeError):\n";
 	$GLOBALS['__adapter_smoke']                = array();
 	$GLOBALS['__adapter_smoke']['next_result'] = $make_result( 'resolved-and-dispatched', array(), array( 1, 2, 3 ) );
 
@@ -929,7 +996,7 @@ namespace {
 	agents_api_smoke_assert_equals( 'gpt-5.5', $regression_model->model_id ?? '', 'the resolved ModelInterface carries the requested string model id', $failures, $passes );
 	agents_api_smoke_assert_equals( 'resolved-and-dispatched', $regression_raw['content'], 'the turn dispatches and produces content (no TypeError, no empty completion)', $failures, $passes );
 
-	echo "\n[11] Regression: an unresolvable model id surfaces a clear RuntimeException, not a TypeError:\n";
+	echo "\n[12] Regression: an unresolvable model id surfaces a clear RuntimeException, not a TypeError:\n";
 	$GLOBALS['__adapter_smoke']                = array();
 	$GLOBALS['__adapter_smoke']['next_result'] = $make_result( 'unused', array(), array( 0, 0, 0 ) );
 	$bad_model_adapter                         = new AgentsAPI\AI\WP_Agent_Default_Provider_Turn_Adapter( 'fake-provider', 'fake-model', 'sys' );
@@ -948,7 +1015,7 @@ namespace {
 	agents_api_smoke_assert_equals( true, false !== strpos( $bad_model_message, 'Unable to resolve model' ), 'an unresolvable model id throws an actionable RuntimeException (not a TypeError)', $failures, $passes );
 	agents_api_smoke_assert_equals( true, false !== strpos( $bad_model_message, '__unregistered__' ), 'the resolution error names the unresolvable model id', $failures, $passes );
 
-	echo "\n[12] Regression: a no-parameter tool's function declaration serializes 'parameters' as a JSON OBJECT, never an array:\n";
+	echo "\n[13] Regression: a no-parameter tool's function declaration serializes 'parameters' as a JSON OBJECT, never an array:\n";
 	$GLOBALS['__adapter_smoke']                = array();
 	$GLOBALS['__adapter_smoke']['next_result'] = $make_result( 'ok', array(), array( 1, 1, 2 ) );
 


### PR DESCRIPTION
## Summary

- discover a host provider-turn dispatcher through `wp_agent_provider_turn_dispatch` when no explicit dispatcher is injected
- preserve explicit constructor/setter precedence and the unchanged bare wp-ai-client fallback
- document the normalized payload contract and add deterministic coverage for discovery, precedence, invalid values, request context, and fallback

Closes #495.

## Testing

1. `composer test`
2. `php tests/default-provider-turn-adapter-smoke.php` (104 assertions)
3. `git diff --check`

## Compatibility

Existing callers are unchanged unless a host registers the new filter. Explicit `dispatch_provider` injection remains authoritative. Null or non-callable filter values retain the previous bare-builder behavior.

## AI assistance

OpenAI `openai/gpt-5.6-sol` via an OpenCode general coding subagent implemented the change and ran the test suite. OpenCode then reviewed the diff and repeated verification with Chris Huber responsible for every line.