### PR TITLE
Expose resolved host dispatch model context

### DIFF
--- a/docs/runtime-and-tools.md
+++ b/docs/runtime-and-tools.md
@@ -22,13 +22,13 @@ Consumers own provider/model dispatch, prompt assembly, concrete tools, durable 
 
 ## Provider-turn dispatch
 
-`WP_Agent_Default_Provider_Turn_Adapter` uses the bare wp-ai-client prompt builder by default. A caller may inject `dispatch_provider` through the constructor options or `set_dispatch_provider()`; that explicit callable is authoritative. When no explicit dispatcher exists, the adapter applies `wp_agent_provider_turn_dispatch` with `null` and the `WP_Agent_Provider_Turn_Request`. A host can return a callable, preserving an earlier callable when present so multiple host integrations arbitrate predictably:
+`WP_Agent_Default_Provider_Turn_Adapter` uses the bare wp-ai-client prompt builder by default. A caller may inject `dispatch_provider` through the constructor options or `set_dispatch_provider()`; that explicit callable is authoritative. When no explicit dispatcher exists, the adapter applies `wp_agent_provider_turn_dispatch` with `null`, the `WP_Agent_Provider_Turn_Request`, and the effective provider/model IDs after request metadata has been resolved against constructor defaults. A host can return a callable, preserving an earlier callable when present so multiple host integrations arbitrate predictably:
 
 ```php
 add_filter(
 	'wp_agent_provider_turn_dispatch',
-	static function ( $dispatcher, WP_Agent_Provider_Turn_Request $request ) {
-		if ( null !== $dispatcher || 'example-provider' !== ( $request->model()['provider_id'] ?? '' ) ) {
+	static function ( $dispatcher, WP_Agent_Provider_Turn_Request $request, string $provider_id, string $model_id ) {
+		if ( null !== $dispatcher || 'example-provider' !== $provider_id ) {
 			return $dispatcher;
 		}
 
@@ -37,11 +37,11 @@ add_filter(
 		};
 	},
 	10,
-	2
+	4
 );
 ```
 
-Returning `null` or any non-callable value retains the exact bare-builder path. The discovered callable receives one normalized payload array with `provider_id`, `model_id`, `system_prompt`, canonical `messages`, mapped `prompt_parts`, mapped `history`, mapped `function_declarations`, adapter `options`, and the full `request`. The adapter retains generic retry behavior and result normalization for both explicit and discovered dispatchers.
+Returning `null` or any non-callable value retains the exact bare-builder path. The additive provider/model filter arguments let selective hosts make the same routing decision whether those values came from request metadata or adapter defaults; existing callbacks that accept only the first two arguments remain compatible. The discovered callable receives one normalized payload array with `provider_id`, `model_id`, `system_prompt`, canonical `messages`, mapped `prompt_parts`, mapped `history`, mapped `function_declarations`, adapter `options`, and the full `request`. The adapter retains generic retry behavior and result normalization for both explicit and discovered dispatchers.
 
 ## Task execution targets
 

--- a/src/Runtime/class-wp-agent-default-provider-turn-adapter.php
+++ b/src/Runtime/class-wp-agent-default-provider-turn-adapter.php
@@ -265,7 +265,7 @@ class WP_Agent_Default_Provider_Turn_Adapter implements WP_Agent_Provider_Turn_A
 		$prompt_context        = self::split_prompt_context( $messages );
 		$function_declarations = self::function_declarations( $request->toolDeclarations() );
 
-		$dispatcher = $this->resolve_dispatch_provider( $request );
+		$dispatcher = $this->resolve_dispatch_provider( $request, $provider_id, $model_id );
 		if ( null !== $dispatcher ) {
 			$dispatch = function () use ( $dispatcher, $request, $provider_id, $model_id, $system_prompt, $messages, $prompt_context, $function_declarations ) {
 				return $this->dispatch_via_provider( $dispatcher, $request, $provider_id, $model_id, $system_prompt, $messages, $prompt_context, $function_declarations );
@@ -835,10 +835,12 @@ class WP_Agent_Default_Provider_Turn_Adapter implements WP_Agent_Provider_Turn_A
 	 * hosts may provide a callable through `wp_agent_provider_turn_dispatch`.
 	 * Returning null or a non-callable preserves the bare-builder default.
 	 *
-	 * @param WP_Agent_Provider_Turn_Request $request Provider-turn request passed to host discovery.
+	 * @param WP_Agent_Provider_Turn_Request $request     Provider-turn request passed to host discovery.
+	 * @param string                         $provider_id Effective provider identifier.
+	 * @param string                         $model_id    Effective model identifier.
 	 * @return callable|null Dispatch provider, when available.
 	 */
-	private function resolve_dispatch_provider( WP_Agent_Provider_Turn_Request $request ): ?callable {
+	private function resolve_dispatch_provider( WP_Agent_Provider_Turn_Request $request, string $provider_id, string $model_id ): ?callable {
 		if ( null !== $this->dispatch_provider ) {
 			return $this->dispatch_provider;
 		}
@@ -857,8 +859,10 @@ class WP_Agent_Default_Provider_Turn_Adapter implements WP_Agent_Provider_Turn_A
 		 *
 		 * @param callable|null                   $dispatcher Host dispatch provider, or null for the default path.
 		 * @param WP_Agent_Provider_Turn_Request $request    Full provider-turn request for host routing context.
+		 * @param string                          $provider_id Effective provider identifier after request/default resolution.
+		 * @param string                          $model_id    Effective model identifier after request/default resolution.
 		 */
-		$dispatcher = apply_filters( 'wp_agent_provider_turn_dispatch', null, $request );
+		$dispatcher = apply_filters( 'wp_agent_provider_turn_dispatch', null, $request, $provider_id, $model_id );
 
 		return is_callable( $dispatcher ) ? $dispatcher : null;
 	}

--- a/tests/default-provider-turn-adapter-smoke.php
+++ b/tests/default-provider-turn-adapter-smoke.php
@@ -903,6 +903,7 @@ namespace {
 	echo "\n[9] Host dispatch discovery uses request context, preserves explicit precedence, and falls back safely:\n";
 	$host_dispatch_payload = null;
 	$host_filter_initial   = 'not-called';
+	$host_resolved_model   = null;
 	$host_dispatch_request = new AgentsAPI\AI\WP_Agent_Provider_Turn_Request(
 		array( array( 'role' => 'user', 'content' => 'host dispatch' ) ),
 		array(),
@@ -912,8 +913,9 @@ namespace {
 	);
 	add_filter(
 		'wp_agent_provider_turn_dispatch',
-		static function ( $dispatcher, $request ) use ( &$host_dispatch_payload, &$host_filter_initial, $make_result ) {
+		static function ( $dispatcher, $request, $provider_id, $model_id ) use ( &$host_dispatch_payload, &$host_filter_initial, &$host_resolved_model, $make_result ) {
 			$host_filter_initial = $dispatcher;
+			$host_resolved_model = array( $provider_id, $model_id );
 			$GLOBALS['__adapter_smoke']['host_dispatch_request'] = $request;
 			return static function ( array $payload ) use ( &$host_dispatch_payload, $make_result ) {
 				$host_dispatch_payload = $payload;
@@ -921,16 +923,34 @@ namespace {
 			};
 		},
 		10,
-		2
+		4
 	);
 	$GLOBALS['__adapter_smoke']          = array();
 	$host_raw = ( new AgentsAPI\AI\WP_Agent_Default_Provider_Turn_Adapter( 'fallback-provider', 'fallback-model', 'sys' ) )->run_turn( $host_dispatch_request );
 	agents_api_smoke_assert_equals( null, $host_filter_initial, 'host dispatch filter starts with null when no dispatcher is explicit', $failures, $passes );
 	agents_api_smoke_assert_equals( 'host dispatched', $host_raw['content'], 'host-discovered dispatcher drives the shared normalization tail', $failures, $passes );
 	agents_api_smoke_assert_equals( $host_dispatch_request, $GLOBALS['__adapter_smoke']['host_dispatch_request'] ?? null, 'host dispatch filter receives the exact provider-turn request context', $failures, $passes );
+	agents_api_smoke_assert_equals( array( 'host-provider', 'host-model' ), $host_resolved_model, 'host dispatch filter receives effective request model overrides', $failures, $passes );
 	agents_api_smoke_assert_equals( 'host-provider', $host_dispatch_payload['provider_id'] ?? '', 'host-discovered dispatcher receives normalized provider payload', $failures, $passes );
 	agents_api_smoke_assert_equals( $host_dispatch_request, $host_dispatch_payload['request'] ?? null, 'host-discovered dispatcher payload retains the full request', $failures, $passes );
 	agents_api_smoke_assert_equals( false, isset( $GLOBALS['__adapter_smoke']['model'] ), 'host-discovered dispatcher bypasses the bare builder', $failures, $passes );
+	$GLOBALS['__agents_api_smoke_actions']['wp_agent_provider_turn_dispatch'] = array();
+
+	$fallback_resolved_model = null;
+	add_filter(
+		'wp_agent_provider_turn_dispatch',
+		static function ( $dispatcher, $request, $provider_id, $model_id ) use ( &$fallback_resolved_model, $make_result ) {
+			unset( $dispatcher, $request );
+			$fallback_resolved_model = array( $provider_id, $model_id );
+			return static fn ( array $payload ) => $make_result( 'fallback ids dispatched', array(), array( 1, 1, 2 ) );
+		},
+		10,
+		4
+	);
+	$fallback_discovery_request = new AgentsAPI\AI\WP_Agent_Provider_Turn_Request( array( array( 'role' => 'user', 'content' => 'constructor defaults' ) ) );
+	$fallback_discovery_result  = ( new AgentsAPI\AI\WP_Agent_Default_Provider_Turn_Adapter( 'fallback-provider', 'fallback-model', 'sys' ) )->run_turn( $fallback_discovery_request );
+	agents_api_smoke_assert_equals( 'fallback ids dispatched', $fallback_discovery_result['content'], 'host dispatcher can claim a request whose effective model comes from constructor defaults', $failures, $passes );
+	agents_api_smoke_assert_equals( array( 'fallback-provider', 'fallback-model' ), $fallback_resolved_model, 'host dispatch filter receives effective constructor fallback ids', $failures, $passes );
 	$GLOBALS['__agents_api_smoke_actions']['wp_agent_provider_turn_dispatch'] = array();
 
 	$discovery_calls = 0;


### PR DESCRIPTION
## Summary

- pass effective provider/model IDs to `wp_agent_provider_turn_dispatch` after request/default resolution
- preserve the original request and compatibility with existing two-argument callbacks
- cover request overrides and constructor fallback IDs in the dispatch smoke
- document selective host routing against the resolved arguments

Closes #497.

## Verification

- `composer test`
- `git diff --check`

## AI assistance

GPT-5.6-sol via OpenCode was used to trace the host-dispatch lifecycle, identify the constructor-fallback visibility gap, implement the additive filter contract, and run the repository test suite. Chris Huber reviewed and is responsible for every line.