### PR TITLE
Resolve runtime profiles in default chat

### DIFF
--- a/src/Channels/register-default-agents-chat-handler.php
+++ b/src/Channels/register-default-agents-chat-handler.php
@@ -40,6 +40,7 @@ namespace AgentsAPI\AI\Channels;
 use AgentsAPI\AI\WP_Agent_Conversation_Loop;
 use AgentsAPI\AI\WP_Agent_Execution_Principal;
 use AgentsAPI\AI\WP_Agent_Message;
+use AgentsAPI\AI\WP_Agent_Runtime_Profile;
 use AgentsAPI\AI\Tools\WP_Agent_Ability_Tool_Executor;
 use AgentsAPI\AI\Tools\WP_Agent_Tool_Declaration;
 use AgentsAPI\AI\Tools\WP_Agent_Tool_Executor_Registry;
@@ -101,9 +102,11 @@ class WP_Agent_Default_Chat_Handler {
 		}
 
 		$config = ( $agent instanceof \WP_Agent ) ? $agent->get_default_config() : array();
+		$runtime_profile = self::resolve_runtime_profile( $agent, $input, $config );
 
 		$provider = self::first_non_empty(
 			is_string( $input['provider'] ?? null ) ? $input['provider'] : '',
+			$runtime_profile instanceof WP_Agent_Runtime_Profile ? $runtime_profile->provider_id() : '',
 			is_string( $config['provider'] ?? null ) ? $config['provider'] : '',
 			is_string( $config['provider_id'] ?? null ) ? $config['provider_id'] : ''
 		);
@@ -117,6 +120,7 @@ class WP_Agent_Default_Chat_Handler {
 
 		$model = self::first_non_empty(
 			is_string( $input['model'] ?? null ) ? $input['model'] : '',
+			$runtime_profile instanceof WP_Agent_Runtime_Profile ? $runtime_profile->model_id() : '',
 			is_string( $config['model'] ?? null ) ? $config['model'] : '',
 			is_string( $config['model_id'] ?? null ) ? $config['model_id'] : ''
 		);
@@ -153,10 +157,11 @@ class WP_Agent_Default_Chat_Handler {
 		}
 
 		$runtime_context = array(
-			'agent'      => $agent,
-			'agent_slug' => $agent_slug,
-			'session_id' => $session_id,
-			'run_id'     => is_string( $input['run_id'] ?? null ) ? trim( $input['run_id'] ) : '',
+			'agent'           => $agent,
+			'agent_slug'      => $agent_slug,
+			'session_id'      => $session_id,
+			'run_id'          => is_string( $input['run_id'] ?? null ) ? trim( $input['run_id'] ) : '',
+			'runtime_profile' => $runtime_profile instanceof WP_Agent_Runtime_Profile ? $runtime_profile->to_array() : null,
 		);
 		$executor_registry = WP_Agent_Tool_Executor_Registry::fromFilters( $runtime_context );
 		$tool_declarations = self::resolve_tool_declarations( $config, self::runtime_tool_declarations( $agent, $runtime_context ), $executor_registry );
@@ -189,6 +194,7 @@ class WP_Agent_Default_Chat_Handler {
 				'principal'              => $input['principal'] ?? null,
 				'conversation_store'     => $store,
 				'tool_executor_registry' => $executor_registry,
+				'runtime_profile'        => $runtime_context['runtime_profile'],
 			),
 		);
 		if ( ! empty( $tool_declarations ) ) {
@@ -225,7 +231,44 @@ class WP_Agent_Default_Chat_Handler {
 			);
 		}
 
-		return self::to_canonical_output( $session_id, $result );
+		return self::to_canonical_output( $session_id, $result, $runtime_profile );
+	}
+
+	/**
+	 * Resolve the registered agent's provider/model binding for this chat turn.
+	 *
+	 * Only canonical, normalized request context is forwarded. Runtime overrides
+	 * remain server-owned through the agent and resolver contracts.
+	 *
+	 * @param \WP_Agent|null      $agent  Selected agent, or null for an agent-less turn.
+	 * @param array<string,mixed> $input  Canonical agents/chat input.
+	 * @param array<string,mixed> $config Agent default config.
+	 * @return WP_Agent_Runtime_Profile|null Resolved profile, or null without an agent/binding.
+	 */
+	private static function resolve_runtime_profile( ?\WP_Agent $agent, array $input, array $config ): ?WP_Agent_Runtime_Profile {
+		if ( ! $agent instanceof \WP_Agent || ! function_exists( 'wp_resolve_agent_runtime_profile' ) ) {
+			return null;
+		}
+
+		$context = array(
+			'mode'           => 'chat',
+			'agent_config'   => $config,
+			'principal'      => $input['principal'] ?? null,
+			'workspace'      => self::workspace_from_input( $input ),
+			'workspace_id'   => is_string( $input['workspace_id'] ?? null ) ? trim( $input['workspace_id'] ) : '',
+			'client_id'      => is_string( $input['client_id'] ?? null ) ? trim( $input['client_id'] ) : '',
+			'client_context' => is_array( $input['client_context'] ?? null ) ? $input['client_context'] : array(),
+		);
+
+		if ( is_string( $input['provider'] ?? null ) ) {
+			$context['provider_id'] = trim( $input['provider'] );
+		}
+		if ( is_string( $input['model'] ?? null ) ) {
+			$context['model_id'] = trim( $input['model'] );
+		}
+
+		$profile = wp_resolve_agent_runtime_profile( $agent, $context );
+		return $profile instanceof WP_Agent_Runtime_Profile ? $profile : null;
 	}
 
 	/**
@@ -602,11 +645,12 @@ class WP_Agent_Default_Chat_Handler {
 	/**
 	 * Project the loop result to the canonical `agents/chat` output shape.
 	 *
-	 * @param string              $session_id Session id to thread further turns under.
-	 * @param array<string,mixed> $result     Conversation loop result.
+	 * @param string                        $session_id      Session id to thread further turns under.
+	 * @param array<string,mixed>           $result          Conversation loop result.
+	 * @param WP_Agent_Runtime_Profile|null $runtime_profile Resolved runtime profile.
 	 * @return array<string,mixed>
 	 */
-	private static function to_canonical_output( string $session_id, array $result ): array {
+	private static function to_canonical_output( string $session_id, array $result, ?WP_Agent_Runtime_Profile $runtime_profile = null ): array {
 		$metadata = array_filter(
 			array(
 				'status'             => is_string( $result['status'] ?? null ) ? $result['status'] : null,
@@ -614,6 +658,7 @@ class WP_Agent_Default_Chat_Handler {
 				'usage'              => is_array( $result['usage'] ?? null ) ? $result['usage'] : null,
 				'run_outcome'        => is_array( $result['run_outcome'] ?? null ) ? $result['run_outcome'] : null,
 				'tool_observability' => is_array( $result['tool_observability'] ?? null ) ? $result['tool_observability'] : null,
+				'runtime_profile'    => $runtime_profile instanceof WP_Agent_Runtime_Profile ? self::runtime_profile_metadata( $runtime_profile ) : null,
 			),
 			static fn( $value ): bool => null !== $value
 		);
@@ -624,6 +669,57 @@ class WP_Agent_Default_Chat_Handler {
 			'messages'   => self::to_canonical_messages( is_array( $result['messages'] ?? null ) ? array_values( $result['messages'] ) : array() ),
 			'completed'  => (bool) ( $result['completed'] ?? true ),
 			'metadata'   => array( 'agents_api' => $metadata ),
+		);
+	}
+
+	/**
+	 * Project a runtime profile to public diagnostics without identity payloads.
+	 *
+	 * @return array<string,mixed>
+	 */
+	private static function runtime_profile_metadata( WP_Agent_Runtime_Profile $profile ): array {
+		return array(
+			'agent_slug'  => $profile->agent_slug(),
+			'provider_id' => $profile->provider_id(),
+			'model_id'    => $profile->model_id(),
+			'provenance'  => self::runtime_profile_provenance_metadata( $profile->provenance() ),
+		);
+	}
+
+	/**
+	 * Restrict public provenance to its documented source/path diagnostics.
+	 *
+	 * @param array<string,mixed> $provenance Internal profile provenance.
+	 * @return array<string,mixed>
+	 */
+	private static function runtime_profile_provenance_metadata( array $provenance ): array {
+		$public = array();
+		foreach ( array( 'provider_id', 'model_id' ) as $field ) {
+			if ( is_array( $provenance[ $field ] ?? null ) ) {
+				$public[ $field ] = self::runtime_profile_provenance_entry( $provenance[ $field ] );
+			}
+		}
+
+		if ( is_array( $provenance['config_sources'] ?? null ) ) {
+			$public['config_sources'] = array_values(
+				array_map(
+					static fn( array $entry ): array => self::runtime_profile_provenance_entry( $entry ),
+					array_filter( $provenance['config_sources'], 'is_array' )
+				)
+			);
+		}
+
+		return $public;
+	}
+
+	/**
+	 * @param array<mixed> $entry Internal provenance entry.
+	 * @return array{source:string,path:string}
+	 */
+	private static function runtime_profile_provenance_entry( array $entry ): array {
+		return array(
+			'source' => is_string( $entry['source'] ?? null ) ? $entry['source'] : '',
+			'path'   => is_string( $entry['path'] ?? null ) ? $entry['path'] : '',
 		);
 	}
 

--- a/tests/default-agents-chat-handler-smoke.php
+++ b/tests/default-agents-chat-handler-smoke.php
@@ -363,6 +363,29 @@ namespace {
 	require_once __DIR__ . '/class-agents-api-memory-atomic-run-control-store.php';
 	\AgentsAPI\AI\WP_Agent_Run_Control::set_store( new \Agents_API_Memory_Atomic_Run_Control_Store() );
 
+	class Agents_Chat_Runtime_Profile_Provider implements \AgentsAPI\AI\WP_Agent_Runtime_Profile_Provider {
+		/** @var array<int,array<string,mixed>> */
+		public array $contexts = array();
+
+		public function resolve_agent_runtime_profile( \WP_Agent $agent, array $context ): ?\AgentsAPI\AI\WP_Agent_Runtime_Profile {
+			if ( 'profile-brain' !== $agent->get_slug() ) {
+				return null;
+			}
+
+			$this->contexts[] = $context;
+			return new \AgentsAPI\AI\WP_Agent_Runtime_Profile(
+				$agent->get_slug(),
+				'profile-provider',
+				'profile-model',
+				array( 'private_token' => 'never-expose-this' ),
+				array(
+					'provider_id' => array( 'source' => 'host-profile', 'path' => 'provider_id', 'private_token' => 'never-expose-provenance' ),
+					'model_id'    => array( 'source' => 'host-profile', 'path' => 'model_id' ),
+				)
+			);
+		}
+	}
+
 	class Agents_Chat_Runtime_Overlay_Executor implements \AgentsAPI\AI\Tools\WP_Agent_Tool_Executor {
 		/** @var array<int,array<string,mixed>> */
 		public array $calls = array();
@@ -622,7 +645,74 @@ namespace {
 	agents_api_smoke_assert_equals( false, $mandatory_output instanceof WP_Error, 'mandatory tool overlay runs successfully', $failures, $passes );
 	agents_api_smoke_assert_equals( 1, count( $overlay_executor->calls ), 'mandatory tool bypasses allow_only after overlay', $failures, $passes );
 
-	echo "\n[2] Provider/model fall back to the request when the agent config omits them:\n";
+	echo "\n[2] Native chat resolves host runtime profiles and publishes safe provenance:\n";
+	$profile_provider = new Agents_Chat_Runtime_Profile_Provider();
+	$profile_turn_contexts = array();
+	add_filter(
+		'agents_api_runtime_profile_providers',
+		static function ( array $providers ) use ( $profile_provider ): array {
+			$providers[] = $profile_provider;
+			return $providers;
+		}
+	);
+	add_filter(
+		'wp_agent_provider_turn_dispatch',
+		static function ( $dispatcher, $request ) use ( &$profile_turn_contexts ) {
+			$context = $request instanceof \AgentsAPI\AI\WP_Agent_Provider_Turn_Request ? $request->context() : array();
+			if ( 'profile-brain' === ( $context['agent_slug'] ?? '' ) ) {
+				$profile_turn_contexts[] = $context;
+			}
+			return $dispatcher;
+		},
+		10,
+		2
+	);
+	$registry->register(
+		'profile-brain',
+		array(
+			'label'          => 'Profile Brain',
+			'default_config' => array( 'system_prompt' => 'You are profile-driven.' ),
+		)
+	);
+	$reset_provider();
+	$profile_output = AgentsAPI\AI\Channels\WP_Agent_Default_Chat_Handler::execute(
+		array(
+			'agent'          => 'profile-brain',
+			'message'        => 'use the host profile',
+			'workspace_id'   => 'site-42',
+			'client_context' => array( 'source' => 'channel' ),
+		)
+	);
+	$profile_model = $GLOBALS['__adapter_smoke']['model'] ?? null;
+	$profile_metadata = $profile_output['metadata']['agents_api']['runtime_profile'] ?? array();
+	agents_api_smoke_assert_equals( false, $profile_output instanceof WP_Error, 'host-profile turn returns canonical output', $failures, $passes );
+	agents_api_smoke_assert_equals( 'profile-provider', $profile_model->provider_id ?? '', 'host profile selects the dispatch provider', $failures, $passes );
+	agents_api_smoke_assert_equals( 'profile-model', $profile_model->model_id ?? '', 'host profile selects the dispatch model', $failures, $passes );
+	agents_api_smoke_assert_equals( 'host-profile', $profile_metadata['provenance']['provider_id']['source'] ?? '', 'canonical metadata exposes provider provenance', $failures, $passes );
+	agents_api_smoke_assert_equals( 'chat', $profile_provider->contexts[0]['mode'] ?? '', 'host profile receives canonical chat mode', $failures, $passes );
+	agents_api_smoke_assert_equals( 'site-42', $profile_provider->contexts[0]['workspace_id'] ?? '', 'host profile receives normalized workspace context', $failures, $passes );
+	agents_api_smoke_assert_equals( 'never-expose-this', $profile_turn_contexts[0]['runtime_profile']['identity']['private_token'] ?? '', 'resolved profile identity remains available to internal provider dispatch', $failures, $passes );
+	$profile_metadata_json = json_encode( $profile_metadata );
+	agents_api_smoke_assert_equals( false, is_string( $profile_metadata_json ) && str_contains( $profile_metadata_json, 'never-expose-this' ), 'canonical metadata excludes private profile identity', $failures, $passes );
+	agents_api_smoke_assert_equals( false, is_string( $profile_metadata_json ) && str_contains( $profile_metadata_json, 'never-expose-provenance' ), 'canonical metadata allowlists public provenance fields', $failures, $passes );
+
+	echo "\n[2a] Explicit provider/model remain authoritative over a host profile:\n";
+	$reset_provider();
+	$explicit_profile_output = AgentsAPI\AI\Channels\WP_Agent_Default_Chat_Handler::execute(
+		array(
+			'agent'    => 'profile-brain',
+			'message'  => 'use explicit binding',
+			'provider' => 'explicit-provider',
+			'model'    => 'explicit-model',
+		)
+	);
+	$explicit_profile_model = $GLOBALS['__adapter_smoke']['model'] ?? null;
+	$explicit_profile_metadata = $explicit_profile_output['metadata']['agents_api']['runtime_profile'] ?? array();
+	agents_api_smoke_assert_equals( 'explicit-provider', $explicit_profile_model->provider_id ?? '', 'explicit provider overrides the host profile', $failures, $passes );
+	agents_api_smoke_assert_equals( 'explicit-model', $explicit_profile_model->model_id ?? '', 'explicit model overrides the host profile', $failures, $passes );
+	agents_api_smoke_assert_equals( 'context', $explicit_profile_metadata['provenance']['provider_id']['source'] ?? '', 'explicit provider provenance remains observable', $failures, $passes );
+
+	echo "\n[2b] Provider/model fall back to the request when the agent config omits them:\n";
 	$registry->register(
 		'bare-brain',
 		array(
@@ -645,7 +735,7 @@ namespace {
 	agents_api_smoke_assert_equals( 'request-provider', $request_model->provider_id ?? '', 'request provider overrides/supplies the dispatch provider', $failures, $passes );
 	agents_api_smoke_assert_equals( 'request-model', $request_model->model_id ?? '', 'request model overrides/supplies the dispatch model', $failures, $passes );
 
-	echo "\n[2b] Principal-owned turns create an authoritative session before run control finalizes:\n";
+	echo "\n[2c] Principal-owned turns create an authoritative session before run control finalizes:\n";
 	$principal_store = new Agents_Chat_Principal_Conversation_Store();
 	$store_filter    = static fn() => $principal_store;
 	add_filter( 'wp_agent_conversation_store', $store_filter );


### PR DESCRIPTION
## Summary

- resolve registered agent provider/model bindings through the runtime-profile contract in the canonical default chat handler
- preserve explicit input precedence, legacy default-config aliases, agent-less behavior, and existing provider dispatch
- carry full profiles only in internal runtime context while exposing allowlisted, identity-free provenance in canonical metadata
- add deterministic coverage for host profiles, explicit overrides, internal identity handoff, redaction, and compatibility

Fixes #499.

## Verification

- `composer smoke`
- `composer phpstan`
- `composer validate --strict`
- `php -l src/Channels/register-default-agents-chat-handler.php`
- `php -l tests/default-agents-chat-handler-smoke.php`
- `git diff --check`

## AI assistance

GPT-5.6-sol via OpenCode traced the existing runtime-profile and canonical chat contracts, implemented the integration and deterministic coverage, and ran the repository verification gates. Chris Huber reviewed and is responsible for every line.