### PR TITLE
Add principal memory layer vocabulary

### DIFF
--- a/src/Context/class-wp-agent-memory-layer.php
+++ b/src/Context/class-wp-agent-memory-layer.php
@@ -16,6 +16,7 @@ if ( ! class_exists( 'WP_Agent_Memory_Layer' ) ) {
 		public const WORKSPACE = 'workspace';
 		public const AGENT     = 'agent';
 		public const USER      = 'user';
+		public const PRINCIPAL = 'principal';
 		public const NETWORK   = 'network';
 		public const SHARED    = 'shared';
 
@@ -29,6 +30,7 @@ if ( ! class_exists( 'WP_Agent_Memory_Layer' ) ) {
 				self::WORKSPACE,
 				self::AGENT,
 				self::USER,
+				self::PRINCIPAL,
 				self::NETWORK,
 				self::SHARED,
 			);

--- a/src/Memory/class-wp-agent-memory-scope.php
+++ b/src/Memory/class-wp-agent-memory-scope.php
@@ -34,11 +34,11 @@ final class WP_Agent_Memory_Scope {
 	public readonly string $filename;
 
 	/**
-	 * @param string $layer          Memory layer identifier (for example shared, agent, user, or network).
+	 * @param string $layer          Memory layer identifier (for example shared, agent, user, principal, or network).
 	 * @param string $workspace_type Generic workspace kind.
 	 * @param string $workspace_id   Stable workspace identifier within the workspace type.
-	 * @param int    $user_id        Effective WordPress user ID. 0 = shared / no user.
-	 * @param int    $agent_id       Agent ID for direct resolution. 0 = resolve from user_id.
+	 * @param int    $user_id        Effective WordPress user ID. 0 = shared / no user. Principal memory requires a user.
+	 * @param int    $agent_id       Agent ID for direct resolution. 0 = resolve from user_id. Principal memory requires an agent.
 	 * @param string $filename       Filename or relative path within the layer
 	 *                               (e.g. 'MEMORY.md', 'contexts/chat.md', 'daily/2026/04/17.md').
 	 */

--- a/tests/workspace-scope-smoke.php
+++ b/tests/workspace-scope-smoke.php
@@ -59,6 +59,14 @@ agents_api_smoke_assert_equals(
 	$failures,
 	$passes
 );
+agents_api_smoke_assert_equals( 'principal', WP_Agent_Memory_Layer::normalize( 'principal' ), 'principal memory is a canonical additive layer', $failures, $passes );
+agents_api_smoke_assert_equals(
+	array( 'workspace', 'agent', 'user', 'principal', 'network', 'shared' ),
+	WP_Agent_Memory_Layer::values(),
+	'layer vocabulary preserves existing values and adds principal scope',
+	$failures,
+	$passes
+);
 
 echo "\n[3] Conversation requests carry workspace identity for transcript persisters:\n";
 


### PR DESCRIPTION
## Summary

- add `principal` to the canonical memory-layer vocabulary
- document the existing scope tuple requirements for principal memory
- prove existing layer normalization remains compatible

This stays storage- and policy-agnostic. Consumers combine the existing workspace, user, agent, and filename fields to implement principal-scoped persistence and authorization.

Closes #503.

## Verification

- `php tests/workspace-scope-smoke.php` (21 assertions)
- `composer validate --no-check-publish`
- PHP syntax checks for all changed files

## AI Assistance

OpenAI `gpt-5.6-sol` via OpenCode audited the Agents API, Data Machine, and North contracts, implemented the additive vocabulary change, and ran the listed verification. Chris Huber directed and reviewed the architecture and remains responsible for the change.
