### PR TITLE
Stream default chat provider deltas

### DIFF
--- a/src/Channels/register-agents-chat-ability.php
+++ b/src/Channels/register-agents-chat-ability.php
@@ -467,6 +467,11 @@ function agents_chat_input_schema(): array {
 				'type'        => array( 'string', 'null' ),
 				'description' => 'Optional client-supplied idempotency/run key. If omitted, the dispatcher provides an opaque run ID to the runtime and response.',
 			),
+			'token_streaming'       => array(
+				'type'        => 'boolean',
+				'description' => 'Whether a streaming transport should expose provider-token deltas when the selected provider dispatcher supports them.',
+				'default'     => false,
+			),
 			'principal'             => agents_chat_principal_schema(),
 			'session_owner'         => agents_chat_session_owner_schema(),
 			'attachments'           => array(

--- a/src/Channels/register-default-agents-chat-handler.php
+++ b/src/Channels/register-default-agents-chat-handler.php
@@ -81,6 +81,29 @@ class WP_Agent_Default_Chat_Handler {
 	 */
 	public static function register(): void {
 		register_chat_handler( array( self::class, 'execute' ), self::FALLBACK_PRIORITY );
+		add_filter(
+			'wp_agent_chat_stream_handler',
+			static function ( $existing, array $input ) {
+				unset( $input );
+				return null === $existing ? array( self::class, 'execute_stream' ) : $existing;
+			},
+			self::FALLBACK_PRIORITY,
+			2
+		);
+	}
+
+	/**
+	 * Execute one canonical streaming chat turn through the native runtime.
+	 *
+	 * Provider deltas are emitted only when canonical input explicitly requests
+	 * token streaming. The terminal output always matches execute().
+	 *
+	 * @param array<string,mixed> $input Canonical agents/chat input.
+	 * @param callable            $emit  Canonical provider delta sink.
+	 * @return array<string,mixed>|\WP_Error Canonical agents/chat output, or WP_Error.
+	 */
+	public static function execute_stream( array $input, callable $emit ) {
+		return self::execute_native( $input, true === ( $input['token_streaming'] ?? false ) ? $emit : null );
 	}
 
 	/**
@@ -90,6 +113,17 @@ class WP_Agent_Default_Chat_Handler {
 	 * @return array<string,mixed>|\WP_Error Canonical agents/chat output, or WP_Error.
 	 */
 	public static function execute( array $input ) {
+		return self::execute_native( $input );
+	}
+
+	/**
+	 * Execute one canonical chat turn with an optional provider delta sink.
+	 *
+	 * @param array<string,mixed> $input      Canonical agents/chat input.
+	 * @param callable|null       $delta_sink Request-scoped provider delta sink.
+	 * @return array<string,mixed>|\WP_Error Canonical agents/chat output, or WP_Error.
+	 */
+	private static function execute_native( array $input, ?callable $delta_sink = null ) {
 		$message = is_string( $input['message'] ?? null ) ? trim( $input['message'] ) : '';
 		if ( '' === $message ) {
 			return new \WP_Error( 'agents_chat_empty_message', 'Message cannot be empty.', array( 'status' => 400 ) );
@@ -213,6 +247,9 @@ class WP_Agent_Default_Chat_Handler {
 			// before a required commit, and a completion block until the commit
 			// tool runs — so the guarantee is the runtime's, not a prompt's.
 			$loop_options['tool_call_rules'] = $tool_call_rules;
+		}
+		if ( null !== $delta_sink ) {
+			$loop_options['on_provider_delta'] = $delta_sink;
 		}
 
 		$result = WP_Agent_Conversation_Loop::run_conversation(

--- a/src/Runtime/class-wp-agent-conversation-loop.php
+++ b/src/Runtime/class-wp-agent-conversation-loop.php
@@ -84,6 +84,7 @@ class WP_Agent_Conversation_Loop {
 	 * - `transcript_persister` (WP_Agent_Transcript_Persister|null): Transcript persister.
 	 * - `runtime_tool_request_store` (WP_Agent_Runtime_Tool_Request_Store|null): Optional durable store for pending runtime-tool requests.
 	 * - `on_event` (callable|null): Caller-owned lifecycle event sink `fn(string $event, array $payload)`.
+	 * - `on_provider_delta` (callable|null): Request-scoped provider delta sink `fn(array $delta)`.
 	 *
 	 * @param array<int, array<string, mixed>> $messages    Initial transcript messages.
 	 * @param callable|null                    $turn_runner Caller-owned turn adapter.
@@ -1844,8 +1845,9 @@ class WP_Agent_Conversation_Loop {
 			throw new \InvalidArgumentException( 'invalid_agent_conversation_loop: provider_turn_adapter must implement WP_Agent_Provider_Turn_Adapter or be callable' );
 		}
 		$mediation_enabled = self::resolve_tool_executor( $options ) instanceof WP_Agent_Tool_Executor && ! empty( $tool_declarations );
+		$delta_sink        = is_callable( $options['on_provider_delta'] ?? null ) ? $options['on_provider_delta'] : null;
 
-		return static function ( array $messages, array $context ) use ( $adapter, $options, $tool_declarations, $run_id, $session_id, $request, $budgets, $mediation_enabled ): array {
+		return static function ( array $messages, array $context ) use ( $adapter, $options, $tool_declarations, $run_id, $session_id, $request, $budgets, $mediation_enabled, $delta_sink ): array {
 			$context          = self::normalize_assoc_array( $context );
 			$provider_request = new WP_Agent_Provider_Turn_Request(
 				$messages,
@@ -1856,7 +1858,8 @@ class WP_Agent_Conversation_Loop {
 				self::provider_turn_budget_metadata( $budgets ),
 				$run_id,
 				$session_id,
-				$request->metadata()
+				$request->metadata(),
+				$delta_sink
 			);
 
 			$raw_result = call_user_func( $adapter, $provider_request );

--- a/src/Runtime/class-wp-agent-default-provider-turn-adapter.php
+++ b/src/Runtime/class-wp-agent-default-provider-turn-adapter.php
@@ -276,7 +276,7 @@ class WP_Agent_Default_Provider_Turn_Adapter implements WP_Agent_Provider_Turn_A
 			};
 		}
 
-		$result = $this->dispatch_with_retry( $dispatch, $provider_id, $model_id );
+		$result = $this->dispatch_with_retry( $dispatch, $provider_id, $model_id, array( $request, 'hasEmittedDeltas' ) );
 
 		if ( function_exists( 'is_wp_error' ) && is_wp_error( $result ) ) {
 			throw new \RuntimeException( 'wp-ai-client request failed: ' . $result->get_error_message() );
@@ -324,9 +324,10 @@ class WP_Agent_Default_Provider_Turn_Adapter implements WP_Agent_Provider_Turn_A
 	 *                                 GenerativeAiResult or WP_Error (or throwing).
 	 * @param string      $provider_id Resolved provider id (retry policy context + event).
 	 * @param string      $model_id    Resolved model id (retry policy context + event).
+	 * @param callable|null $has_emitted_deltas Reports whether the current attempt emitted client-visible deltas.
 	 * @return mixed The successful result, or the last non-retryable / exhausted WP_Error.
 	 */
-	private function dispatch_with_retry( callable $dispatch, string $provider_id, string $model_id ) {
+	private function dispatch_with_retry( callable $dispatch, string $provider_id, string $model_id, ?callable $has_emitted_deltas = null ) {
 		$policy       = $this->resolve_retry_policy( $provider_id, $model_id );
 		$max_attempts = $policy['max_attempts'];
 		$attempt      = 1;
@@ -359,7 +360,9 @@ class WP_Agent_Default_Provider_Turn_Adapter implements WP_Agent_Provider_Turn_A
 				}
 			}
 
-			if ( $attempt >= $max_attempts ) {
+			// Retrying after exposing a partial response would duplicate or reorder
+			// client-visible content. Surface that attempt's failure unchanged.
+			if ( ( null !== $has_emitted_deltas && true === call_user_func( $has_emitted_deltas ) ) || $attempt >= $max_attempts ) {
 				// Budget exhausted: surface the original transient failure unchanged.
 				if ( null !== $caught ) {
 					throw $caught;

--- a/src/Runtime/class-wp-agent-provider-turn-request.php
+++ b/src/Runtime/class-wp-agent-provider-turn-request.php
@@ -45,6 +45,12 @@ class WP_Agent_Provider_Turn_Request {
 	/** @var array<string, mixed> Caller-owned metadata. */
 	private array $metadata;
 
+	/** @var callable|null Request-scoped provider delta sink. */
+	private $delta_sink;
+
+	/** Whether this provider turn has emitted at least one delta. */
+	private bool $deltas_emitted = false;
+
 	/**
 	 * @param array<mixed>         $messages          Canonical transcript messages.
 	 * @param array<mixed>         $tool_declarations Tool declarations keyed by name.
@@ -55,8 +61,9 @@ class WP_Agent_Provider_Turn_Request {
 	 * @param string               $run_id            Run identifier.
 	 * @param string               $session_id        Session identifier.
 	 * @param array<string, mixed> $metadata          Caller-owned metadata.
+	 * @param callable|null        $delta_sink        Request-scoped provider delta sink.
 	 */
-	public function __construct( array $messages, array $tool_declarations = array(), array $model = array(), array $runtime = array(), array $context = array(), array $budgets = array(), string $run_id = '', string $session_id = '', array $metadata = array() ) {
+	public function __construct( array $messages, array $tool_declarations = array(), array $model = array(), array $runtime = array(), array $context = array(), array $budgets = array(), string $run_id = '', string $session_id = '', array $metadata = array(), ?callable $delta_sink = null ) {
 		$this->messages          = WP_Agent_Message::normalize_many( $messages );
 		$this->tool_declarations = self::normalize_tool_declarations( $tool_declarations );
 		$this->model             = self::normalize_json_array( $model, 'model' );
@@ -66,6 +73,7 @@ class WP_Agent_Provider_Turn_Request {
 		$this->run_id            = $run_id;
 		$this->session_id        = $session_id;
 		$this->metadata          = self::normalize_json_array( $metadata, 'metadata' );
+		$this->delta_sink        = $delta_sink;
 	}
 
 	/** @return array<int, array<string, mixed>> Canonical transcript messages. */
@@ -111,6 +119,30 @@ class WP_Agent_Provider_Turn_Request {
 	/** @return array<string, mixed> Caller-owned metadata. */
 	public function metadata(): array {
 		return $this->metadata;
+	}
+
+	/** Whether this provider turn can emit request-scoped deltas. */
+	public function supportsStreaming(): bool {
+		return is_callable( $this->delta_sink );
+	}
+
+	/** Whether this provider turn has already emitted a delta. */
+	public function hasEmittedDeltas(): bool {
+		return $this->deltas_emitted;
+	}
+
+	/**
+	 * Emit one canonical provider delta when a sink is available.
+	 *
+	 * @param array<string, mixed> $delta Canonical provider delta.
+	 */
+	public function emitDelta( array $delta ): void {
+		if ( ! is_callable( $this->delta_sink ) ) {
+			return;
+		}
+
+		$this->deltas_emitted = true;
+		call_user_func( $this->delta_sink, self::normalize_json_array( $delta, 'delta' ) );
 	}
 
 	/**

--- a/tests/agents-chat-jsonrpc-route-smoke.php
+++ b/tests/agents-chat-jsonrpc-route-smoke.php
@@ -186,6 +186,7 @@ agents_api_smoke_assert_equals( true, $input['token_streaming'] ?? null, 'input 
 $input_schema = agents_chat_input_schema();
 $source_enum  = $input_schema['properties']['client_context']['properties']['source']['enum'] ?? array();
 agents_api_smoke_assert_equals( true, in_array( $input['client_context']['source'] ?? null, $source_enum, true ), 'input source is accepted by agents/chat schema', $failures, $passes );
+agents_api_smoke_assert_equals( 'boolean', $input_schema['properties']['token_streaming']['type'] ?? null, 'canonical agents/chat schema declares token streaming', $failures, $passes );
 agents_api_smoke_assert_equals( 'a.png', $input['attachments'][0]['name'] ?? null, 'input extracts file parts as attachments', $failures, $passes );
 
 $empty = agents_chat_jsonrpc_input_from_params( array( 'message' => array( 'parts' => array() ) ), 'support-agent' );

--- a/tests/default-agents-chat-handler-smoke.php
+++ b/tests/default-agents-chat-handler-smoke.php
@@ -479,6 +479,7 @@ namespace {
 
 	use function AgentsAPI\AI\Channels\agents_chat_dispatch;
 	use function AgentsAPI\AI\Channels\register_chat_handler;
+	use function AgentsAPI\AI\Channels\register_chat_stream_handler;
 
 	// Mark `init` as fired so the registry can be read, then register an agent
 	// directly. This mirrors a runtime-bundle import that registered an agent
@@ -839,7 +840,60 @@ namespace {
 	$no_model = AgentsAPI\AI\Channels\WP_Agent_Default_Chat_Handler::execute( array( 'agent' => 'no-model-brain', 'message' => 'hi' ) );
 	agents_api_smoke_assert_equals( 'agents_chat_model_required', $no_model instanceof WP_Error ? $no_model->get_error_code() : '', 'missing model is rejected', $failures, $passes );
 
-	echo "\n[4] The default handler is a fallback: an explicit consumer runtime wins:\n";
+	echo "\n[4] Default streaming threads requested provider deltas through native execution:\n";
+	$registry->register(
+		'stream-brain',
+		array(
+			'label'          => 'Stream Brain',
+			'default_config' => array( 'provider' => 'fake-provider', 'model' => 'fake-model' ),
+		)
+	);
+	$streaming_support = array();
+	add_filter(
+		'wp_agent_provider_turn_dispatch',
+		static function ( $dispatcher, $request ) use ( $make_result, &$streaming_support ) {
+			if ( ! $request instanceof \AgentsAPI\AI\WP_Agent_Provider_Turn_Request || 'stream-brain' !== ( $request->context()['agent_slug'] ?? '' ) ) {
+				return $dispatcher;
+			}
+
+			return static function ( array $payload ) use ( $request, $make_result, &$streaming_support ) {
+				unset( $payload );
+				$streaming_support[] = $request->supportsStreaming();
+				$request->emitDelta( array( 'type' => 'content', 'text' => 'All ' ) );
+				$request->emitDelta( array( 'type' => 'content', 'text' => 'set.' ) );
+				return $make_result( 'All set.', array(), array( 2, 2, 4 ) );
+			};
+		},
+		20,
+		2
+	);
+
+	$default_stream_handler = apply_filters( 'wp_agent_chat_stream_handler', null, array( 'agent' => 'stream-brain' ) );
+	agents_api_smoke_assert_equals( true, is_callable( $default_stream_handler ), 'default handler registers a fallback streaming sibling', $failures, $passes );
+	$streamed_deltas        = array();
+	$streamed_output        = call_user_func(
+		$default_stream_handler,
+		array( 'agent' => 'stream-brain', 'message' => 'stream', 'token_streaming' => true ),
+		static function ( array $delta ) use ( &$streamed_deltas ): void {
+			$streamed_deltas[] = $delta;
+		}
+	);
+	agents_api_smoke_assert_equals( array( 'All ', 'set.' ), array_column( $streamed_deltas, 'text' ), 'requested provider deltas retain emission order', $failures, $passes );
+	agents_api_smoke_assert_equals( 'All set.', $streamed_output['reply'] ?? '', 'streaming execution returns the same canonical terminal output', $failures, $passes );
+
+	$terminal_only_deltas = array();
+	$terminal_only_output = call_user_func(
+		$default_stream_handler,
+		array( 'agent' => 'stream-brain', 'message' => 'terminal only', 'token_streaming' => false ),
+		static function ( array $delta ) use ( &$terminal_only_deltas ): void {
+			$terminal_only_deltas[] = $delta;
+		}
+	);
+	agents_api_smoke_assert_equals( array( true, false ), $streaming_support, 'provider request exposes a sink only when token streaming is requested', $failures, $passes );
+	agents_api_smoke_assert_equals( array(), $terminal_only_deltas, 'token_streaming false suppresses provider deltas', $failures, $passes );
+	agents_api_smoke_assert_equals( 'All set.', $terminal_only_output['reply'] ?? '', 'terminal-only streaming still completes through native execution', $failures, $passes );
+
+	echo "\n[5] The default handlers are fallbacks: explicit consumer runtimes win:\n";
 	// A consumer registers at the default priority (10); the default sits at 1000.
 	register_chat_handler(
 		static function ( array $input ): array {
@@ -853,12 +907,17 @@ namespace {
 	$dispatched = agents_chat_dispatch( array( 'agent' => 'kitchen-brain', 'message' => 'who answers?' ) );
 	agents_api_smoke_assert_equals( 'consumer reply', $dispatched['reply'] ?? null, 'an explicit consumer handler overrides the default fallback', $failures, $passes );
 	agents_api_smoke_assert_equals( 0, count( $GLOBALS['__chat_handler_ability_calls'] ), 'the default loop did not run when a consumer handler is present', $failures, $passes );
+	$consumer_stream_handler = static fn( array $input, callable $emit ): array => array( 'reply' => 'consumer stream' );
+	register_chat_stream_handler( $consumer_stream_handler, 10 );
+	agents_api_smoke_assert_equals( $consumer_stream_handler, apply_filters( 'wp_agent_chat_stream_handler', null, array() ), 'an explicit consumer stream handler overrides the default fallback', $failures, $passes );
 
-	echo "\n[5] With no consumer registered, dispatch resolves to the default native handler:\n";
+	echo "\n[6] With no consumer registered, dispatch resolves to the default native handlers:\n";
 	if ( function_exists( 'remove_all_filters' ) ) {
 		remove_all_filters( 'wp_agent_chat_handler' );
+		remove_all_filters( 'wp_agent_chat_stream_handler' );
 	} else {
 		unset( $GLOBALS['__agents_api_smoke_actions']['wp_agent_chat_handler'] );
+		unset( $GLOBALS['__agents_api_smoke_actions']['wp_agent_chat_stream_handler'] );
 	}
 	// Re-register only the default (module load already did, but filters were just cleared).
 	AgentsAPI\AI\Channels\WP_Agent_Default_Chat_Handler::register();
@@ -868,6 +927,7 @@ namespace {
 	agents_api_smoke_assert_equals( false, $dispatched_default instanceof WP_Error, 'dispatch resolves to the default native handler with no consumer present', $failures, $passes );
 	agents_api_smoke_assert_equals( 'All set, chef.', $dispatched_default['reply'] ?? null, 'the default native handler answers through agents/chat dispatch', $failures, $passes );
 	agents_api_smoke_assert_equals( 1, count( $GLOBALS['__chat_handler_ability_calls'] ), 'the default native loop mediated the tool call via dispatch', $failures, $passes );
+	agents_api_smoke_assert_equals( true, is_callable( apply_filters( 'wp_agent_chat_stream_handler', null, array() ) ), 'default registration restores the native streaming sibling', $failures, $passes );
 
 	agents_api_smoke_finish( 'Agents API default agents/chat handler', $failures, $passes );
 }

--- a/tests/default-provider-turn-adapter-smoke.php
+++ b/tests/default-provider-turn-adapter-smoke.php
@@ -688,6 +688,51 @@ namespace {
 	$GLOBALS['__agents_api_smoke_actions']['agents_api_provider_turn_retry']             = array();
 	$GLOBALS['__agents_api_smoke_actions']['agents_api_provider_turn_retry_max_attempts'] = array();
 
+	echo "\n[3g] A transient failure is not retried after client-visible deltas were emitted:\n";
+	$stream_retry_attempts = 0;
+	$stream_retry_sleeps   = array();
+	$stream_retry_deltas   = array();
+	$stream_retry_adapter  = new AgentsAPI\AI\WP_Agent_Default_Provider_Turn_Adapter(
+		'fake-provider',
+		'fake-model',
+		'sys',
+		array(
+			'dispatch_provider' => static function ( array $payload ) use ( &$stream_retry_attempts ) {
+				++$stream_retry_attempts;
+				$payload['request']->emitDelta( array( 'type' => 'content', 'text' => 'partial' ) );
+				return new WP_Error( 'prompt_upstream_server_error', 'Service Unavailable (503)', array( 'status' => 503 ) );
+			},
+			'retry_sleeper'    => static function ( $seconds ) use ( &$stream_retry_sleeps ) {
+				$stream_retry_sleeps[] = $seconds;
+			},
+		)
+	);
+	$stream_retry_threw = false;
+	try {
+		$stream_retry_adapter->run_turn(
+			new AgentsAPI\AI\WP_Agent_Provider_Turn_Request(
+				array( array( 'role' => 'user', 'content' => 'stream then fail' ) ),
+				array(),
+				array(),
+				array(),
+				array(),
+				array(),
+				'',
+				'',
+				array(),
+				static function ( array $delta ) use ( &$stream_retry_deltas ): void {
+					$stream_retry_deltas[] = $delta;
+				}
+			)
+		);
+	} catch ( \RuntimeException $error ) {
+		$stream_retry_threw = false !== strpos( $error->getMessage(), '503' );
+	}
+	agents_api_smoke_assert_equals( true, $stream_retry_threw, 'the transient failure remains visible after partial output', $failures, $passes );
+	agents_api_smoke_assert_equals( 1, $stream_retry_attempts, 'provider dispatch is not repeated after exposing a partial response', $failures, $passes );
+	agents_api_smoke_assert_equals( array(), $stream_retry_sleeps, 'no retry backoff occurs after exposing a partial response', $failures, $passes );
+	agents_api_smoke_assert_equals( array( 'partial' ), array_column( $stream_retry_deltas, 'text' ), 'client receives the partial delta exactly once', $failures, $passes );
+
 	echo "\n[4] run_conversation() drives the loop end-to-end through the default adapter:\n";
 	$turn = 0;
 	$GLOBALS['__adapter_smoke'] = array();

--- a/tests/provider-turn-adapter-smoke.php
+++ b/tests/provider-turn-adapter-smoke.php
@@ -67,6 +67,7 @@ $executor = new class() implements AgentsAPI\AI\Tools\WP_Agent_Tool_Executor {
 };
 
 echo "\n[1] Provider-turn request and result contracts normalize neutral fields:\n";
+$request_deltas = array();
 $request = new AgentsAPI\AI\WP_Agent_Provider_Turn_Request(
 	array( array( 'role' => 'user', 'content' => 'hello' ) ),
 	$tools,
@@ -76,7 +77,10 @@ $request = new AgentsAPI\AI\WP_Agent_Provider_Turn_Request(
 	array( 'turns' => array( 'current' => 0, 'limit' => 3 ) ),
 	'run-123',
 	'session-456',
-	array( 'trace_id' => 'trace-789' )
+	array( 'trace_id' => 'trace-789' ),
+	static function ( array $delta ) use ( &$request_deltas ): void {
+		$request_deltas[] = $delta;
+	}
 );
 
 agents_api_smoke_assert_equals( AgentsAPI\AI\WP_Agent_Message::SCHEMA, $request->messages()[0]['schema'], 'provider request messages normalize to canonical envelopes', $failures, $passes );
@@ -89,6 +93,12 @@ agents_api_smoke_assert_equals( 'fake-provider', $request->model()['provider_id'
 agents_api_smoke_assert_equals( 'fake-runtime', $request->runtime()['runtime_id'], 'provider request carries runtime metadata', $failures, $passes );
 agents_api_smoke_assert_equals( 'run-123', $request->runId(), 'provider request carries run id', $failures, $passes );
 agents_api_smoke_assert_equals( 'session-456', $request->sessionId(), 'provider request carries session id', $failures, $passes );
+agents_api_smoke_assert_equals( true, $request->supportsStreaming(), 'provider request reports an available delta sink', $failures, $passes );
+agents_api_smoke_assert_equals( false, $request->hasEmittedDeltas(), 'provider request starts without emitted deltas', $failures, $passes );
+$request->emitDelta( array( 'type' => 'content', 'text' => 'mise' ) );
+agents_api_smoke_assert_equals( array( array( 'type' => 'content', 'text' => 'mise' ) ), $request_deltas, 'provider request emits normalized deltas to its request-scoped sink', $failures, $passes );
+agents_api_smoke_assert_equals( true, $request->hasEmittedDeltas(), 'provider request records that client-visible output started', $failures, $passes );
+agents_api_smoke_assert_equals( false, array_key_exists( 'delta_sink', $request->to_array() ), 'provider request serialization excludes the executable delta sink', $failures, $passes );
 
 $host_tool = AgentsAPI\AI\Tools\WP_Agent_Tool_Declaration::normalizeForConversationRequest(
 	array(
@@ -201,6 +211,7 @@ agents_api_smoke_assert_equals( 1, count( $deduped_turn['tool_calls'] ), 'fallba
 
 echo "\n[2] Conversation loop can run through a fake provider-turn adapter without product runtime coupling:\n";
 $adapter_calls = array();
+$provider_deltas = array();
 $adapter       = new class( $adapter_calls ) implements AgentsAPI\AI\WP_Agent_Provider_Turn_Adapter {
 	/** @var array<int, array<string, mixed>> Captured requests. */
 	public array $requests = array();
@@ -215,6 +226,7 @@ $adapter       = new class( $adapter_calls ) implements AgentsAPI\AI\WP_Agent_Pr
 	public function run_turn( AgentsAPI\AI\WP_Agent_Provider_Turn_Request $request ): array {
 		$this->requests[] = $request->to_array();
 		$turn             = (int) ( $request->context()['turn'] ?? 0 );
+		$request->emitDelta( array( 'type' => 'content', 'text' => 'turn-' . $turn ) );
 
 		if ( 1 === $turn ) {
 			return array(
@@ -257,10 +269,14 @@ $result = AgentsAPI\AI\WP_Agent_Conversation_Loop::run(
 			'model_id'     => 'fake-model',
 			'request_kind' => 'smoke',
 		),
+		'on_provider_delta'     => static function ( array $delta ) use ( &$provider_deltas ): void {
+			$provider_deltas[] = $delta;
+		},
 	)
 );
 
 agents_api_smoke_assert_equals( 2, count( $adapter->requests ), 'loop called provider adapter for tool and final turns', $failures, $passes );
+agents_api_smoke_assert_equals( array( 'turn-1', 'turn-2' ), array_column( $provider_deltas, 'text' ), 'loop supplies the request-scoped delta sink to every provider turn', $failures, $passes );
 agents_api_smoke_assert_equals( 'fake-provider', $adapter->requests[0]['model']['provider_id'], 'provider adapter receives model metadata', $failures, $passes );
 agents_api_smoke_assert_equals( 'smoke', $adapter->requests[0]['runtime']['request_kind'], 'provider adapter receives runtime metadata', $failures, $passes );
 agents_api_smoke_assert_equals( 'run-loop-1', $adapter->requests[0]['run_id'], 'provider adapter receives run id', $failures, $passes );


### PR DESCRIPTION
## Summary

- Register a fallback streaming sibling for the default native `agents/chat` runtime.
- Thread a request-scoped provider-delta sink through every native conversation-loop turn.
- Let host provider dispatchers emit canonical content and tool deltas without replacing the native loop.
- Keep the executable sink out of serialized provider-turn data.
- Stop transient retries after client-visible output begins, preventing duplicated or reordered partial responses.
- Declare `token_streaming` in the canonical chat input schema and retain terminal-only behavior when it is false or unsupported.

Fixes #507.

## Verification

- `composer smoke`
- `composer phpstan`
- `composer validate --strict`
- Focused provider-turn, default-provider, default-chat-handler, and JSON-RPC smoke suites
- `git diff --check`

Coverage proves sink propagation across multi-turn execution, delta ordering, explicit true/false behavior, fallback precedence, terminal output parity, non-serialization, and no retry after partial output.

## AI assistance

OpenAI `openai/gpt-5.6-sol` via OpenCode was used to trace the streaming and retry contracts, implement the generic runtime seam, add deterministic coverage, and run verification. Chris Huber reviewed and is responsible for every line.
