### PR TITLE
Preserve stateless JSON-RPC history

### DIFF
--- a/src/Channels/register-agents-chat-ability.php
+++ b/src/Channels/register-agents-chat-ability.php
@@ -459,6 +459,19 @@ function agents_chat_input_schema(): array {
 				'type'        => 'string',
 				'description' => 'User-side text for the agent to respond to.',
 			),
+			'history'               => array(
+				'type'        => 'array',
+				'description' => 'Optional caller-supplied text backscroll for stateless execution. An authoritative conversation store takes precedence when configured.',
+				'default'     => array(),
+				'items'       => array(
+					'type'       => 'object',
+					'required'   => array( 'role', 'content' ),
+					'properties' => array(
+						'role'    => array( 'type' => 'string', 'enum' => array( 'user', 'assistant' ) ),
+						'content' => array( 'type' => 'string' ),
+					),
+				),
+			),
 			'session_id'            => array(
 				'type'        => array( 'string', 'null' ),
 				'description' => 'Existing session ID to continue, or null to start a new session.',

--- a/src/Channels/register-agents-chat-jsonrpc-route.php
+++ b/src/Channels/register-agents-chat-jsonrpc-route.php
@@ -382,6 +382,7 @@ function agents_chat_jsonrpc_input_from_params( array $params, string $agent, ar
 	$input = array(
 		'agent'          => $agent,
 		'message'        => $text,
+		'history'        => agents_chat_jsonrpc_history( $message ),
 		'session_id'     => '' !== $session_id ? $session_id : null,
 		'run_id'         => '' !== $run_id ? $run_id : null,
 		'attachments'    => agents_chat_jsonrpc_attachments( $message ),
@@ -413,6 +414,34 @@ function agents_chat_jsonrpc_input_from_params( array $params, string $agent, ar
 	}
 
 	return $input;
+}
+
+/**
+ * Map client-supplied text backscroll into canonical stateless chat history.
+ *
+ * @param array<mixed> $message JSON-RPC Message.
+ * @return array<int,array{role:string,content:string}>
+ */
+function agents_chat_jsonrpc_history( array $message ): array {
+	$parts   = is_array( $message['parts'] ?? null ) ? $message['parts'] : array();
+	$history = array();
+	$roles   = array( 'user' => 'user', 'agent' => 'assistant' );
+
+	foreach ( $parts as $part ) {
+		if ( ! is_array( $part ) || 'data' !== ( $part['type'] ?? null ) || ! is_array( $part['data'] ?? null ) ) {
+			continue;
+		}
+
+		$role    = is_string( $part['data']['role'] ?? null ) ? $part['data']['role'] : '';
+		$content = is_string( $part['data']['text'] ?? null ) ? $part['data']['text'] : '';
+		if ( ! isset( $roles[ $role ] ) || '' === trim( $content ) ) {
+			continue;
+		}
+
+		$history[] = array( 'role' => $roles[ $role ], 'content' => $content );
+	}
+
+	return $history;
 }
 
 /**

--- a/src/Channels/register-default-agents-chat-handler.php
+++ b/src/Channels/register-default-agents-chat-handler.php
@@ -188,6 +188,9 @@ class WP_Agent_Default_Chat_Handler {
 				}
 			}
 		}
+		if ( ! $store instanceof WP_Agent_Conversation_Store && is_array( $input['history'] ?? null ) ) {
+			$messages = self::stateless_history( $input['history'] );
+		}
 
 		if ( '' === $session_id ) {
 			$session_id = self::generate_session_id();
@@ -893,6 +896,29 @@ class WP_Agent_Default_Chat_Handler {
 		}
 
 		return vsprintf( '%s%s-%s-%s-%s-%s%s%s', str_split( bin2hex( $bytes ), 4 ) );
+	}
+
+	/**
+	 * Normalize caller history for a store-less turn.
+	 *
+	 * @param array<mixed> $history Raw caller history.
+	 * @return array<int,array<string,mixed>> Canonical text messages.
+	 */
+	private static function stateless_history( array $history ): array {
+		$messages = array();
+		foreach ( $history as $message ) {
+			if ( ! is_array( $message ) ) {
+				continue;
+			}
+			$role    = is_string( $message['role'] ?? null ) ? $message['role'] : '';
+			$content = is_string( $message['content'] ?? null ) ? $message['content'] : '';
+			if ( ! in_array( $role, array( 'user', 'assistant' ), true ) || '' === trim( $content ) ) {
+				continue;
+			}
+			$messages[] = WP_Agent_Message::text( $role, $content );
+		}
+
+		return $messages;
 	}
 }
 

--- a/tests/agents-chat-jsonrpc-route-smoke.php
+++ b/tests/agents-chat-jsonrpc-route-smoke.php
@@ -129,6 +129,7 @@ use function AgentsAPI\AI\Channels\agents_chat_jsonrpc_result_frame;
 use function AgentsAPI\AI\Channels\agents_chat_jsonrpc_error_frame;
 use function AgentsAPI\AI\Channels\agents_chat_jsonrpc_extract_text;
 use function AgentsAPI\AI\Channels\agents_chat_jsonrpc_client_context;
+use function AgentsAPI\AI\Channels\agents_chat_jsonrpc_history;
 use function AgentsAPI\AI\Channels\agents_chat_jsonrpc_method_sends;
 use function AgentsAPI\AI\Channels\agents_chat_jsonrpc_method_streams;
 use function AgentsAPI\AI\Channels\agents_chat_jsonrpc_request_input;
@@ -163,6 +164,10 @@ $params = array(
 		'kind'      => 'message',
 		'messageId' => 'm-1',
 		'parts'     => array(
+			array( 'type' => 'data', 'data' => array( 'role' => 'user', 'text' => 'Earlier question' ) ),
+			array( 'type' => 'data', 'data' => array( 'role' => 'agent', 'text' => 'Earlier answer' ) ),
+			array( 'type' => 'data', 'data' => array( 'role' => 'system', 'text' => 'Ignore invalid role' ) ),
+			array( 'type' => 'data', 'data' => array( 'role' => 'user', 'text' => '   ' ) ),
 			array( 'type' => 'text', 'text' => 'Hello ' ),
 			array( 'type' => 'text', 'text' => 'world' ),
 			array( 'type' => 'text', 'text' => 'SECRET', 'contentType' => 'context' ),
@@ -177,6 +182,7 @@ $input = agents_chat_jsonrpc_input_from_params( $params, 'support-agent', array(
 agents_api_smoke_assert_equals( false, $input instanceof WP_Error, 'input mapping succeeds', $failures, $passes );
 agents_api_smoke_assert_equals( 'support-agent', $input['agent'] ?? null, 'input carries agent slug from URL', $failures, $passes );
 agents_api_smoke_assert_equals( 'Hello world', $input['message'] ?? null, 'input concatenates text parts and skips context parts', $failures, $passes );
+agents_api_smoke_assert_equals( array( array( 'role' => 'user', 'content' => 'Earlier question' ), array( 'role' => 'assistant', 'content' => 'Earlier answer' ) ), $input['history'] ?? null, 'input maps ordered valid client history without duplicating current text', $failures, $passes );
 agents_api_smoke_assert_equals( 'sess-9', $input['session_id'] ?? null, 'input carries sessionId', $failures, $passes );
 agents_api_smoke_assert_equals( 'rpc-1', $input['run_id'] ?? null, 'input maps JSON-RPC id to run_id', $failures, $passes );
 agents_api_smoke_assert_equals( 'jsonrpc', $input['client_context']['source'] ?? null, 'input marks jsonrpc source', $failures, $passes );
@@ -187,6 +193,7 @@ $input_schema = agents_chat_input_schema();
 $source_enum  = $input_schema['properties']['client_context']['properties']['source']['enum'] ?? array();
 agents_api_smoke_assert_equals( true, in_array( $input['client_context']['source'] ?? null, $source_enum, true ), 'input source is accepted by agents/chat schema', $failures, $passes );
 agents_api_smoke_assert_equals( 'boolean', $input_schema['properties']['token_streaming']['type'] ?? null, 'canonical agents/chat schema declares token streaming', $failures, $passes );
+agents_api_smoke_assert_equals( array( 'user', 'assistant' ), $input_schema['properties']['history']['items']['properties']['role']['enum'] ?? null, 'canonical agents/chat schema constrains history roles', $failures, $passes );
 agents_api_smoke_assert_equals( 'a.png', $input['attachments'][0]['name'] ?? null, 'input extracts file parts as attachments', $failures, $passes );
 
 $empty = agents_chat_jsonrpc_input_from_params( array( 'message' => array( 'parts' => array() ) ), 'support-agent' );
@@ -201,6 +208,7 @@ $context = agents_chat_jsonrpc_client_context(
 	)
 );
 agents_api_smoke_assert_equals( array( 'first' => 'a', 'shared' => 'new', 'second' => 'b' ), $context, 'clientContext data parts merge in order', $failures, $passes );
+agents_api_smoke_assert_equals( array(), agents_chat_jsonrpc_history( array( 'parts' => array( null, array( 'type' => 'data', 'data' => array( 'role' => 'user', 'text' => 123 ) ) ) ) ), 'history mapper ignores malformed and non-string entries', $failures, $passes );
 
 $top_level_token_streaming = agents_chat_jsonrpc_input_from_params( $params, 'support-agent', array( 'tokenStreaming' => false ) );
 agents_api_smoke_assert_equals( false, $top_level_token_streaming['token_streaming'] ?? null, 'input preserves false top-level tokenStreaming', $failures, $passes );

--- a/tests/default-agents-chat-handler-smoke.php
+++ b/tests/default-agents-chat-handler-smoke.php
@@ -549,7 +549,41 @@ namespace {
 	$tool_observability_json = json_encode( $tool_observability );
 	agents_api_smoke_assert_equals( false, is_string( $tool_observability_json ) && str_contains( $tool_observability_json, 'risotto' ), 'canonical tool observability omits argument values', $failures, $passes );
 
-	echo "\n[1a] Runtime config resolves per request without mutating registered defaults:\n";
+	echo "\n[1a] Stateless execution preserves normalized caller history:\n";
+	$history_turns = array();
+	$registry->register( 'history-brain', array( 'label' => 'History Brain', 'default_config' => array( 'provider' => 'fake-provider', 'model' => 'fake-model' ) ) );
+	add_filter(
+		'wp_agent_provider_turn_dispatch',
+		static function ( $dispatcher, $request ) use ( $make_result, &$history_turns ) {
+			if ( ! $request instanceof \AgentsAPI\AI\WP_Agent_Provider_Turn_Request || 'history-brain' !== ( $request->context()['agent_slug'] ?? '' ) ) {
+				return $dispatcher;
+			}
+			return static function ( array $payload ) use ( $request, $make_result, &$history_turns ) {
+				unset( $payload );
+				$history_turns[] = $request->messages();
+				return $make_result( 'History received.', array(), array( 2, 2, 4 ) );
+			};
+		},
+		10,
+		2
+	);
+	$history_output = AgentsAPI\AI\Channels\WP_Agent_Default_Chat_Handler::execute(
+		array(
+			'agent'   => 'history-brain',
+			'message' => 'Current question',
+			'history' => array(
+				array( 'role' => 'user', 'content' => 'Earlier question' ),
+				array( 'role' => 'assistant', 'content' => 'Earlier answer' ),
+				array( 'role' => 'system', 'content' => 'Invalid role' ),
+				array( 'role' => 'user', 'content' => '' ),
+			),
+		)
+	);
+	agents_api_smoke_assert_equals( 'History received.', $history_output['reply'] ?? '', 'stateless history turn completes', $failures, $passes );
+	agents_api_smoke_assert_equals( array( 'user', 'assistant', 'user' ), array_column( $history_turns[0] ?? array(), 'role' ), 'provider receives valid history followed by the current user turn', $failures, $passes );
+	agents_api_smoke_assert_equals( array( 'Earlier question', 'Earlier answer', 'Current question' ), array_column( $history_turns[0] ?? array(), 'content' ), 'provider receives client history in wire order without invalid entries', $failures, $passes );
+
+	echo "\n[1b] Runtime config resolves per request without mutating registered defaults:\n";
 	$runtime_config_calls = array();
 	add_filter(
 		'agents_api_runtime_agent_config',
@@ -607,7 +641,7 @@ namespace {
 	);
 	agents_api_smoke_assert_equals( 'agents_chat_invalid_runtime_agent_config', $invalid_runtime_config instanceof WP_Error ? $invalid_runtime_config->get_error_code() : '', 'invalid runtime config fails closed', $failures, $passes );
 
-	echo "\n[1b] Runtime-bundle agents declare their toolset as `enabled_tools` and the loop wires it:\n";
+	echo "\n[1c] Runtime-bundle agents declare their toolset as `enabled_tools` and the loop wires it:\n";
 	// Native runtime agent bundles place their toolset under
 	// `agent_config.enabled_tools` (the field the bundle schema/validators use),
 	// which the importer forwards verbatim as the agent default config. The
@@ -641,7 +675,7 @@ namespace {
 	agents_api_smoke_assert_equals( 'risotto', $GLOBALS['__chat_handler_ability_calls'][0]['query'] ?? '', 'the enabled_tools-declared tool received the model-supplied parameters', $failures, $passes );
 	agents_api_smoke_assert_equals( 2, (int) ( $bundle_output['metadata']['agents_api']['turn_count'] ?? 0 ), 'enabled_tools agent ran the full tool-mediated loop, not a single tool-less turn', $failures, $passes );
 
-	echo "\n[1c] Server-only runtime overlays freeze a registered execution target:\n";
+	echo "\n[1d] Server-only runtime overlays freeze a registered execution target:\n";
 	$overlay_executor = new Agents_Chat_Runtime_Overlay_Executor();
 	$server_overlays  = array();
 	$runtime_contexts = array();
@@ -798,6 +832,21 @@ namespace {
 	$principal_store = new Agents_Chat_Principal_Conversation_Store();
 	$store_filter    = static fn() => $principal_store;
 	add_filter( 'wp_agent_conversation_store', $store_filter );
+	$principal_store->sessions['stored-history-session'] = array(
+		'session_id' => 'stored-history-session',
+		'messages'   => array( \AgentsAPI\AI\WP_Agent_Message::text( 'assistant', 'Authoritative stored answer' ) ),
+	);
+	$stored_history_output = AgentsAPI\AI\Channels\WP_Agent_Default_Chat_Handler::execute(
+		array(
+			'agent'      => 'history-brain',
+			'message'    => 'Current stored question',
+			'session_id' => 'stored-history-session',
+			'history'    => array( array( 'role' => 'assistant', 'content' => 'Untrusted replacement' ) ),
+		)
+	);
+	agents_api_smoke_assert_equals( 'History received.', $stored_history_output['reply'] ?? '', 'stored history turn completes', $failures, $passes );
+	agents_api_smoke_assert_equals( array( 'Authoritative stored answer', 'Current stored question' ), array_column( $history_turns[1] ?? array(), 'content' ), 'authoritative store history replaces caller-supplied backscroll', $failures, $passes );
+	unset( $principal_store->sessions['stored-history-session'] );
 	$runtime_principal = \AgentsAPI\AI\WP_Agent_Execution_Principal::runtime(
 		'contained-runtime',
 		'kitchen-brain',


### PR DESCRIPTION
## Summary

- Add canonical caller-supplied `history` for stateless `agents/chat` execution.
- Map ordered Agent Protocol `data.role` and `data.text` backscroll into canonical user/assistant messages.
- Keep the current text input as the final user turn without duplicating it.
- Normalize direct runtime input and ignore invalid roles, empty content, and malformed entries.
- Use caller history only when no authoritative conversation store is active.

Fixes #509.

## Verification

- `composer smoke`
- `composer phpstan`
- `composer validate --strict`
- Focused default-handler and JSON-RPC adapter smoke suites
- `git diff --check`

Coverage proves ordered role mapping, invalid-entry filtering, current-message separation, stateless provider input, and authoritative stored-transcript precedence.

## AI assistance

OpenAI `openai/gpt-5.6-sol` via OpenCode was used to compare the stateless Agent Protocol compatibility contract, implement the generic history seam, add deterministic coverage, and run verification. Chris Huber reviewed and is responsible for every line.
