### PR TITLE
fix: emit provider-safe host tool names

### DIFF
--- a/src/Runtime/class-wp-agent-default-provider-turn-adapter.php
+++ b/src/Runtime/class-wp-agent-default-provider-turn-adapter.php
@@ -1194,10 +1194,29 @@ class WP_Agent_Default_Provider_Turn_Adapter implements WP_Agent_Provider_Turn_A
 
 		$declarations = array();
 		foreach ( $tool_declarations as $name => $tool ) {
-			$tool_name = is_string( $tool['name'] ?? null ) && '' !== $tool['name'] ? $tool['name'] : (string) $name;
-			if ( '' === $tool_name ) {
+			$canonical_name = is_string( $tool['name'] ?? null ) && '' !== $tool['name'] ? $tool['name'] : (string) $name;
+			if ( '' === $canonical_name ) {
 				continue;
 			}
+
+			/*
+			 * Send the provider-safe alias, not the canonical name.
+			 *
+			 * Canonical tool names are namespaced (`namespace/tool`), and provider
+			 * tool-name validation rejects the slash — the same constraint #320
+			 * addressed for client runtime tool declarations. Host tools derived
+			 * from abilities cannot avoid it: the Abilities API requires a
+			 * namespaced name, so every ability-backed declaration carries one.
+			 *
+			 * `normalizeForConversationRequest()` already records the alias on any
+			 * declaration that needs one, and WP_Agent_Tool_Execution_Core maps the
+			 * provider's emitted name back through
+			 * `canonicalNameForProviderToolName()`, so mediation still resolves the
+			 * canonical declaration.
+			 */
+			$tool_name = is_string( $tool['provider_safe_name'] ?? null ) && '' !== $tool['provider_safe_name']
+				? $tool['provider_safe_name']
+				: $canonical_name;
 
 			$description = is_string( $tool['description'] ?? null ) ? $tool['description'] : '';
 			$parameters  = is_array( $tool['parameters'] ?? null ) ? $tool['parameters'] : array();

--- a/tests/default-provider-turn-adapter-smoke.php
+++ b/tests/default-provider-turn-adapter-smoke.php
@@ -399,7 +399,7 @@ namespace {
 	agents_api_smoke_assert_equals( 1, count( $GLOBALS['__adapter_smoke']['prompt_parts'] ?? array() ), 'run_turn sends the latest user turn as the current prompt', $failures, $passes );
 	agents_api_smoke_assert_equals( 2, count( $GLOBALS['__adapter_smoke']['history'] ?? array() ), 'run_turn sends earlier turns as history', $failures, $passes );
 	agents_api_smoke_assert_equals( 1, count( $GLOBALS['__adapter_smoke']['declarations'] ?? array() ), 'run_turn maps tool declarations to function declarations', $failures, $passes );
-	agents_api_smoke_assert_equals( 'client/lookup', $GLOBALS['__adapter_smoke']['declarations'][0]->name ?? '', 'function declaration carries the logical tool name', $failures, $passes );
+	agents_api_smoke_assert_equals( 'client__lookup', $GLOBALS['__adapter_smoke']['declarations'][0]->name ?? '', 'function declaration carries the provider-safe tool name', $failures, $passes );
 	$model_parameters = $GLOBALS['__adapter_smoke']['declarations'][0]->parameters ?? array();
 	agents_api_smoke_assert_equals( false, array_key_exists( 'scope_id', $model_parameters['properties'] ?? array() ), 'function declaration excludes authoritative parameters from model input', $failures, $passes );
 	agents_api_smoke_assert_equals( array( 'query' ), $model_parameters['required'] ?? array(), 'function declaration excludes authoritative parameters from model requirements', $failures, $passes );
@@ -865,7 +865,7 @@ namespace {
 	agents_api_smoke_assert_equals( 1, count( $dispatch_payload['prompt_parts'] ?? array() ), 'dispatch payload carries the current-prompt message parts', $failures, $passes );
 	agents_api_smoke_assert_equals( 2, count( $dispatch_payload['history'] ?? array() ), 'dispatch payload carries the history messages', $failures, $passes );
 	agents_api_smoke_assert_equals( 1, count( $dispatch_payload['function_declarations'] ?? array() ), 'dispatch payload carries the function declarations', $failures, $passes );
-	agents_api_smoke_assert_equals( 'client/lookup', $dispatch_payload['function_declarations'][0]->name ?? '', 'dispatch payload function declaration carries the logical tool name', $failures, $passes );
+	agents_api_smoke_assert_equals( 'client__lookup', $dispatch_payload['function_declarations'][0]->name ?? '', 'dispatch payload function declaration carries the provider-safe tool name', $failures, $passes );
 	agents_api_smoke_assert_equals( 0.5, $dispatch_payload['options']['temperature'] ?? null, 'dispatch payload carries adapter options (temperature)', $failures, $passes );
 	agents_api_smoke_assert_equals( 256, $dispatch_payload['options']['max_tokens'] ?? null, 'dispatch payload carries adapter options (max_tokens)', $failures, $passes );
 	agents_api_smoke_assert_equals( true, ( $dispatch_payload['request'] ?? null ) instanceof AgentsAPI\AI\WP_Agent_Provider_Turn_Request, 'dispatch payload carries the WP_Agent_Provider_Turn_Request', $failures, $passes );
@@ -1143,11 +1143,38 @@ namespace {
 	agents_api_smoke_assert_equals( true, false !== strpos( $wrapped_empty, '"parameters":{' ), 'wrapped tool payload contains "parameters":{ (an object)', $failures, $passes );
 	agents_api_smoke_assert_equals( false, false !== strpos( $wrapped_empty, '"parameters":[' ), 'wrapped tool payload never contains "parameters":[ (the OpenAI 400 shape)', $failures, $passes );
 
-	// The real-schema tool: object stays an object and the declared schema is preserved verbatim.
-	$real_json = json_encode( $decls_by_name['client/lookup']->parameters ?? null );
+	// The real-schema tool: object stays an object and the declared schema is preserved
+	// verbatim. Keyed by the provider-safe alias, because that is the name the
+	// declaration is emitted under (see the provider-safe assertions below).
+	$real_json = json_encode( $decls_by_name['client__lookup']->parameters ?? null );
 	agents_api_smoke_assert_equals( true, '{' === substr( $real_json, 0, 1 ), 'real-schema tool parameters remain a JSON object', $failures, $passes );
 	agents_api_smoke_assert_equals( true, false !== strpos( $real_json, '"query"' ), 'real-schema tool preserves its declared properties unchanged', $failures, $passes );
-	agents_api_smoke_assert_equals( 'object', $decls_by_name['client/lookup']->parameters['type'] ?? '', 'real-schema tool keeps its declared type', $failures, $passes );
+	agents_api_smoke_assert_equals( 'object', $decls_by_name['client__lookup']->parameters['type'] ?? '', 'real-schema tool keeps its declared type', $failures, $passes );
+
+	/*
+	 * Provider-safe tool names.
+	 *
+	 * Provider tool-name validation rejects the `/` in a canonical namespaced
+	 * name — the same constraint #320 addressed for client runtime declarations.
+	 * Host tools derived from abilities cannot dodge it, because the Abilities API
+	 * requires a namespaced name, so the alias has to be what reaches the provider.
+	 * Mediation still resolves the canonical declaration, because
+	 * WP_Agent_Tool_Execution_Core maps the emitted name back through
+	 * canonicalNameForProviderToolName().
+	 */
+	agents_api_smoke_assert_equals( true, isset( $decls_by_name['client__lookup'] ), 'namespaced tool is emitted under its provider-safe alias', $failures, $passes );
+	agents_api_smoke_assert_equals( false, isset( $decls_by_name['client/lookup'] ), 'namespaced tool is never emitted under its canonical name', $failures, $passes );
+	agents_api_smoke_assert_equals( true, isset( $decls_by_name['workspace_show'] ), 'an already provider-safe name is emitted unchanged', $failures, $passes );
+
+	foreach ( array_keys( $decls_by_name ) as $emitted_name ) {
+		agents_api_smoke_assert_equals(
+			1,
+			preg_match( '/^[a-zA-Z0-9_-]{1,128}$/', (string) $emitted_name ),
+			sprintf( 'emitted tool name "%s" satisfies provider tool-name validation', $emitted_name ),
+			$failures,
+			$passes
+		);
+	}
 
 	agents_api_smoke_finish( 'Agents API default provider-turn adapter', $failures, $passes );
 }


### PR DESCRIPTION
## Summary
- emit `provider_safe_name` for host tool declarations in `WP_Agent_Default_Provider_Turn_Adapter::function_declarations()`
- update the default provider-turn adapter smoke coverage, including three assertions whose expectation changes

## Why

Host tool declarations reach the provider under their canonical namespaced name, and provider tool-name validation rejects the `/`. This is the same constraint #320 fixed for client runtime declarations — on the half #320 did not cover.

Client runtime tools could sidestep it, because the consumer picks the name and can simply declare `filesystem_write`. Host tools cannot: they are derived from abilities, and the Abilities API **requires** a namespaced `namespace/name` and refuses to register anything else. So every ability-backed declaration carries a `/`.

Observed against a live OpenAI-compatible endpoint, using the shipped default chat handler with an ability-backed toolset:

```
tools.0.custom.name: String should match pattern '^[a-zA-Z0-9_-]{1,128}$'
```

The same request succeeds with this patch applied, executes the ability, and reports the **canonical** name back in `tool_observability`.

For what it is worth, this is not specific to one connector: `FunctionDeclaration` stores the name verbatim, `AbstractOpenAiCompatibleTextGenerationModel::prepareToolsParam()` emits it verbatim, and the official `ai-provider-for-anthropic` connector does the same (`'name' => $functionDeclaration->getName()`). Nothing between the declaration and the wire sanitizes it.

## What was already in place

Only the outbound mapping was missing:

- `normalizeForConversationRequest()` already records `provider_safe_name` whenever the canonical name is not provider-safe
- `WP_Agent_Provider_Turn_Request` normalizes declarations on construction, so the alias is present by the time the adapter maps them
- `WP_Agent_Tool_Execution_Core` already resolves the provider's emitted name back via `canonicalNameForProviderToolName()`, so mediation still matches the canonical declaration

## Review note

Three existing assertions **change expectation** rather than being added to, and they are the ones worth a close look:

| Assertion | Was | Now |
|---|---|---|
| `function declaration carries the … tool name` | `client/lookup` | `client__lookup` |
| `dispatch payload function declaration carries the … tool name` | `client/lookup` | `client__lookup` |
| real-schema parameter assertions | keyed `client/lookup` | keyed `client__lookup` |

They asserted that the canonical namespaced name is what reaches the provider, which is the behaviour this corrects. If that was load-bearing intent rather than recorded behaviour, this PR is the wrong shape and I would rather know.

The suite could not have caught this on its own: every provider result in it is stubbed via `$make_result()`, so no test sends a tool name to anything that validates one. Added assertions now check every emitted name against `^[a-zA-Z0-9_-]{1,128}$`.

## Testing
- `composer phpstan` — no errors
- `composer smoke` — all suites pass (`default-provider-turn-adapter-smoke.php`: 116 assertions)
- verified end to end against a live OpenAI-compatible provider with an ability-backed toolset, before and after

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Opus 5)
- **Used for:** Root-cause investigation, the change, smoke coverage, and local verification. Aaron Ware remains responsible for the contents of this PR.