### PR TITLE
Add structured provider output

### DIFF
--- a/agents-api.php
+++ b/agents-api.php
@@ -243,6 +243,8 @@ require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-run-outcome.php';
 require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-runtime-package-run-request.php';
 require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-runtime-package-run-result.php';
 require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-conversation-result.php';
+require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-structured-output-request.php';
+require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-structured-output-capability-exception.php';
 require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-chat-run-control.php';
 require_once AGENTS_API_PATH . 'src/Tasks/class-wp-agent-task-run-control.php';
 require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-conversation-loop.php';

--- a/src/Channels/register-agents-chat-ability.php
+++ b/src/Channels/register-agents-chat-ability.php
@@ -730,6 +730,7 @@ function agents_chat_output_schema(): array {
 				'description' => 'Whether the agent considers this turn complete (true) or expects further work (false, e.g. tool approvals pending).',
 			),
 			'structured_output' => array(
+				'type'        => array( 'object', 'array', 'string', 'number', 'integer', 'boolean', 'null' ),
 				'description' => 'Parsed JSON value returned for a structured-output request. The key is present even when the valid value is null.',
 			),
 			'status'     => agents_chat_status_schema(),

--- a/src/Channels/register-agents-chat-ability.php
+++ b/src/Channels/register-agents-chat-ability.php
@@ -491,6 +491,16 @@ function agents_chat_input_schema(): array {
 				'description' => 'Whether a streaming transport should expose provider-token deltas when the selected provider dispatcher supports them.',
 				'default'     => false,
 			),
+			'structured_output'     => array(
+				'type'        => array( 'object', 'null' ),
+				'description' => 'Optional JSON Schema structured-output request. Structured turns run without tools or token streaming.',
+				'properties'  => array(
+					'format' => array( 'type' => 'string', 'enum' => array( 'json_schema' ) ),
+					'name'   => array( 'type' => array( 'string', 'null' ) ),
+					'schema' => array( 'type' => 'object' ),
+					'strict' => array( 'type' => 'boolean' ),
+				),
+			),
 			'principal'             => agents_chat_principal_schema(),
 			'session_owner'         => agents_chat_session_owner_schema(),
 			'attachments'           => array(
@@ -718,6 +728,9 @@ function agents_chat_output_schema(): array {
 			'completed'  => array(
 				'type'        => 'boolean',
 				'description' => 'Whether the agent considers this turn complete (true) or expects further work (false, e.g. tool approvals pending).',
+			),
+			'structured_output' => array(
+				'description' => 'Parsed JSON value returned for a structured-output request. The key is present even when the valid value is null.',
 			),
 			'status'     => agents_chat_status_schema(),
 			'runtime_tool_pending' => agents_chat_runtime_tool_pending_schema(),

--- a/src/Channels/register-default-agents-chat-handler.php
+++ b/src/Channels/register-default-agents-chat-handler.php
@@ -174,6 +174,14 @@ class WP_Agent_Default_Chat_Handler {
 		$system_prompt   = self::resolve_system_prompt( $config );
 		$max_turns       = self::resolve_max_turns( $input, $config );
 		$tool_call_rules = self::resolve_tool_call_rules( $config );
+		$structured_output = $input['structured_output'] ?? $config['structured_output'] ?? null;
+		if ( null !== $structured_output ) {
+			try {
+				$structured_output = $structured_output instanceof \AgentsAPI\AI\WP_Agent_Structured_Output_Request ? $structured_output : \AgentsAPI\AI\WP_Agent_Structured_Output_Request::from_array( $structured_output );
+			} catch ( \InvalidArgumentException $error ) {
+				return new \WP_Error( 'agents_chat_invalid_structured_output', $error->getMessage(), array( 'status' => 400 ) );
+			}
+		}
 
 		$store      = WP_Agent_Conversation_Sessions::get_store( $input );
 		$session_id = is_string( $input['session_id'] ?? null ) ? trim( $input['session_id'] ) : '';
@@ -230,6 +238,9 @@ class WP_Agent_Default_Chat_Handler {
 				'runtime_tools' => $trusted_runtime_tools,
 			)
 		);
+		if ( null !== $structured_output && ( ! empty( $tool_declarations ) || null !== $delta_sink ) ) {
+			return new \WP_Error( 'agents_chat_structured_output_incompatible', 'Structured output requires a no-tools, non-streaming turn.', array( 'status' => 400 ) );
+		}
 
 		$messages   = array_merge( $messages, $input_messages );
 		$messages   = WP_Agent_Message::normalize_many( $messages );
@@ -250,6 +261,9 @@ class WP_Agent_Default_Chat_Handler {
 				'runtime_profile'        => $runtime_context['runtime_profile'],
 			),
 		);
+		if ( null !== $structured_output ) {
+			$loop_options['structured_output'] = $structured_output;
+		}
 		if ( ! empty( $tool_declarations ) ) {
 			// Default executor: dispatch tool calls through registered abilities.
 			// The loop also consults the #377 per-target executor registry
@@ -857,6 +871,12 @@ class WP_Agent_Default_Chat_Handler {
 		}
 		if ( is_array( $result['run_outcome'] ?? null ) ) {
 			$output['run_outcome'] = $result['run_outcome'];
+		}
+		if ( array_key_exists( 'structured_output', $result ) ) {
+			$output['structured_output'] = $result['structured_output'];
+			if ( ! empty( $result['structured_output_diagnostics'] ) && is_array( $result['structured_output_diagnostics'] ) ) {
+				$output['metadata']['agents_api']['structured_output'] = $result['structured_output_diagnostics'];
+			}
 		}
 
 		return $output;

--- a/src/Runtime/class-wp-agent-conversation-loop.php
+++ b/src/Runtime/class-wp-agent-conversation-loop.php
@@ -99,6 +99,14 @@ class WP_Agent_Conversation_Loop {
 		$tool_executor         = self::resolve_tool_executor( $options );
 		$rejected_declarations = array();
 		$tool_declarations     = self::resolve_tool_declarations( $options, $rejected_declarations );
+		if ( array_key_exists( 'structured_output', $options ) && null !== $options['structured_output'] ) {
+			if ( ! $options['structured_output'] instanceof WP_Agent_Structured_Output_Request ) {
+				WP_Agent_Structured_Output_Request::from_array( $options['structured_output'] );
+			}
+			if ( ! empty( $tool_declarations ) || is_callable( $options['on_provider_delta'] ?? null ) ) {
+				throw new \InvalidArgumentException( 'invalid_agent_structured_output_request: structured output requires a no-tools, non-streaming turn' );
+			}
+		}
 		$should_continue       = self::resolve_should_continue( $options, $tool_executor, $tool_declarations );
 		$completion_policy     = self::resolve_completion_policy( $options );
 		$transcript_persister  = self::resolve_transcript_persister( $options );
@@ -169,6 +177,9 @@ class WP_Agent_Conversation_Loop {
 		$result_metadata      = array();
 		$request_metadata     = array();
 		$provider_diagnostics = array();
+		$structured_output     = null;
+		$structured_output_set = false;
+		$structured_diagnostics = array();
 
 		if ( null !== $transcript_lock && '' !== $lock_session_id ) {
 			$lock_token = $transcript_lock->acquire_session_lock( $lock_session_id, $lock_ttl );
@@ -320,6 +331,11 @@ class WP_Agent_Conversation_Loop {
 				if ( isset( $result['metadata'] ) && is_array( $result['metadata'] ) ) {
 					$result_metadata = array_merge( $result_metadata, self::normalize_assoc_array( $result['metadata'] ) );
 				}
+				if ( isset( $result['structured_output'] ) && is_array( $result['structured_output'] ) && array_key_exists( 'parsed', $result['structured_output'] ) ) {
+					$structured_output     = $result['structured_output']['parsed'];
+					$structured_output_set = true;
+					$structured_diagnostics = is_array( $result['structured_output']['diagnostics'] ?? null ) ? self::structured_output_diagnostics( $result['structured_output']['diagnostics'] ) : array();
+				}
 
 				// When mediation is enabled, the turn runner returns tool_calls
 				// and the loop handles execution. Otherwise, the caller-managed path applies.
@@ -405,7 +421,7 @@ class WP_Agent_Conversation_Loop {
 					}
 				} else {
 					// Caller-managed path: turn runner handles everything internally.
-					$result       = self::normalize_conversation_result( $result );
+					$result       = self::normalize_conversation_result( self::normalize_assoc_array( $result ) );
 					$messages     = self::normalize_messages( is_array( $result['messages'] ?? null ) ? $result['messages'] : array() );
 					$tool_results = array_merge( $tool_results, self::normalize_array_list( $result['tool_execution_results'] ) );
 					if ( isset( $result['tool_audit_events'] ) && is_array( $result['tool_audit_events'] ) ) {
@@ -506,8 +522,12 @@ class WP_Agent_Conversation_Loop {
 				'usage'                  => $total_usage,
 				'request_metadata'       => $request_metadata,
 				'provider_diagnostics'   => $provider_diagnostics,
+				'structured_output_diagnostics' => $structured_diagnostics,
 				'completed'              => true,
 			);
+			if ( $structured_output_set ) {
+				$final_result_data['structured_output'] = $structured_output;
+			}
 
 			if ( null !== $exceeded_budget ) {
 				$final_result_data['status']    = 'budget_exceeded';
@@ -1849,6 +1869,13 @@ class WP_Agent_Conversation_Loop {
 
 		return static function ( array $messages, array $context ) use ( $adapter, $options, $tool_declarations, $run_id, $session_id, $request, $budgets, $mediation_enabled, $delta_sink ): array {
 			$context          = self::normalize_assoc_array( $context );
+			$structured_output = null;
+			if ( array_key_exists( 'structured_output', $options ) && null !== $options['structured_output'] ) {
+				$structured_output = $options['structured_output'] instanceof WP_Agent_Structured_Output_Request ? $options['structured_output'] : WP_Agent_Structured_Output_Request::from_array( $options['structured_output'] );
+				if ( ! empty( $tool_declarations ) || null !== $delta_sink ) {
+					throw new \InvalidArgumentException( 'invalid_agent_structured_output_request: structured output requires a no-tools, non-streaming turn' );
+				}
+			}
 			$provider_request = new WP_Agent_Provider_Turn_Request(
 				$messages,
 				$tool_declarations,
@@ -1859,7 +1886,8 @@ class WP_Agent_Conversation_Loop {
 				$run_id,
 				$session_id,
 				$request->metadata(),
-				$delta_sink
+				$delta_sink,
+				$structured_output
 			);
 
 			$raw_result = call_user_func( $adapter, $provider_request );
@@ -2807,10 +2835,25 @@ class WP_Agent_Conversation_Loop {
 	}
 
 	/**
-	 * Normalize a conversation result while preserving the public return shape.
+	 * Project structured-output diagnostics without exposing provider response data.
 	 *
-	 * @param array<mixed> $result Raw conversation result.
-	 * @return array<string, mixed> Normalized conversation result.
+	 * @param array<mixed> $diagnostics Provider or parser diagnostics.
+	 * @return array<string,mixed>
+	 */
+	private static function structured_output_diagnostics( array $diagnostics ): array {
+		$diagnostics = self::normalize_assoc_array( $diagnostics );
+		$public      = array();
+		foreach ( array( 'status', 'code', 'parser', 'valid' ) as $key ) {
+			if ( array_key_exists( $key, $diagnostics ) && ( is_string( $diagnostics[ $key ] ) || is_bool( $diagnostics[ $key ] ) || is_int( $diagnostics[ $key ] ) ) ) {
+				$public[ $key ] = $diagnostics[ $key ];
+			}
+		}
+		return $public;
+	}
+
+	/**
+	 * @param array<string,mixed> $result Raw conversation result.
+	 * @return array<string,mixed> Normalized conversation result.
 	 */
 	private static function normalize_conversation_result( array $result ): array {
 		return self::normalize_assoc_array( WP_Agent_Conversation_Result::normalize( $result ) );

--- a/src/Runtime/class-wp-agent-conversation-result.php
+++ b/src/Runtime/class-wp-agent-conversation-result.php
@@ -38,8 +38,8 @@ class WP_Agent_Conversation_Result {
 	 * `tool_execution_results` is optional because a valid no-tool response has
 	 * no tool output; when omitted it normalizes to an empty list.
 	 *
-	 * @param array<mixed> $result Raw loop result.
-	 * @return array<mixed> Normalized loop result.
+	 * @param array<string,mixed> $result Raw loop result.
+	 * @return array<string,mixed> Normalized loop result.
 	 * @throws \InvalidArgumentException When the result shape is invalid.
 	 */
 	public static function normalize( array $result ): array {
@@ -227,6 +227,14 @@ class WP_Agent_Conversation_Result {
 
 		if ( array_key_exists( 'provider_diagnostics', $result ) && ! is_array( $result['provider_diagnostics'] ) ) {
 			throw self::invalid( 'provider_diagnostics', 'must be an array when present' );
+		}
+
+		if ( array_key_exists( 'structured_output', $result ) && false === wp_json_encode( $result['structured_output'], JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ) ) {
+			throw self::invalid( 'structured_output', 'must be JSON serializable' );
+		}
+
+		if ( array_key_exists( 'structured_output_diagnostics', $result ) && ! is_array( $result['structured_output_diagnostics'] ) ) {
+			throw self::invalid( 'structured_output_diagnostics', 'must be an array when present' );
 		}
 
 		if ( array_key_exists( 'completed', $result ) && ! is_bool( $result['completed'] ) ) {

--- a/src/Runtime/class-wp-agent-default-provider-turn-adapter.php
+++ b/src/Runtime/class-wp-agent-default-provider-turn-adapter.php
@@ -266,13 +266,14 @@ class WP_Agent_Default_Provider_Turn_Adapter implements WP_Agent_Provider_Turn_A
 		$function_declarations = self::function_declarations( $request->toolDeclarations() );
 
 		$dispatcher = $this->resolve_dispatch_provider( $request, $provider_id, $model_id );
+		$structured_output = $request->structuredOutput();
 		if ( null !== $dispatcher ) {
 			$dispatch = function () use ( $dispatcher, $request, $provider_id, $model_id, $system_prompt, $messages, $prompt_context, $function_declarations ) {
 				return $this->dispatch_via_provider( $dispatcher, $request, $provider_id, $model_id, $system_prompt, $messages, $prompt_context, $function_declarations );
 			};
 		} else {
-			$dispatch = function () use ( $provider_id, $model_id, $system_prompt, $prompt_context, $function_declarations ) {
-				return $this->dispatch_via_bare_builder( $provider_id, $model_id, $system_prompt, $prompt_context, $function_declarations );
+			$dispatch = function () use ( $provider_id, $model_id, $system_prompt, $prompt_context, $function_declarations, $structured_output ) {
+				return $this->dispatch_via_bare_builder( $provider_id, $model_id, $system_prompt, $prompt_context, $function_declarations, $structured_output );
 			};
 		}
 
@@ -282,7 +283,7 @@ class WP_Agent_Default_Provider_Turn_Adapter implements WP_Agent_Provider_Turn_A
 			throw new \RuntimeException( 'wp-ai-client request failed: ' . $result->get_error_message() );
 		}
 
-		return array(
+		$normalized = array(
 			'content'          => WP_Agent_Provider_Turn_Result::result_text( $result ),
 			'tool_calls'       => WP_Agent_Provider_Turn_Result::extract_tool_calls( $result ),
 			'usage'            => WP_Agent_Provider_Turn_Result::result_usage( $result ),
@@ -291,6 +292,17 @@ class WP_Agent_Default_Provider_Turn_Adapter implements WP_Agent_Provider_Turn_A
 				'model_id'    => $model_id,
 			),
 		);
+		if ( null !== $structured_output ) {
+			$parsed = self::parse_structured_output( WP_Agent_Provider_Turn_Result::result_text( $result ) );
+			if ( ! $parsed['valid'] ) {
+				return array(
+					'failure' => array( 'type' => 'structured_output_invalid_json', 'message' => 'Provider returned invalid JSON for the requested structured output.' ),
+					'provider_diagnostics' => array( 'structured_output' => array( 'status' => 'invalid_json' ) ),
+				);
+			}
+			$normalized['structured_output'] = array( 'parsed' => $parsed['value'], 'diagnostics' => array( 'status' => 'parsed' ) );
+		}
+		return $normalized;
 	}
 
 	/**
@@ -639,7 +651,7 @@ class WP_Agent_Default_Provider_Turn_Adapter implements WP_Agent_Provider_Turn_A
 	 * @param array<int,object>                                               $function_declarations Mapped function declarations.
 	 * @return mixed wp-ai-client GenerativeAiResult or WP_Error.
 	 */
-	private function dispatch_via_bare_builder( string $provider_id, string $model_id, string $system_prompt, array $prompt_context, array $function_declarations ) {
+	private function dispatch_via_bare_builder( string $provider_id, string $model_id, string $system_prompt, array $prompt_context, array $function_declarations, ?WP_Agent_Structured_Output_Request $structured_output = null ) {
 		if ( ! function_exists( 'wp_ai_client_prompt' ) ) {
 			throw new \RuntimeException( 'wp-ai-client is unavailable: wp_ai_client_prompt() is not defined.' );
 		}
@@ -695,9 +707,28 @@ class WP_Agent_Default_Provider_Turn_Adapter implements WP_Agent_Provider_Turn_A
 			$builder = $builder->using_function_declarations( ...$function_declarations );
 		}
 
+		if ( null !== $structured_output ) {
+			if ( ! is_callable( array( $builder, 'as_output_mime_type' ) ) || ! is_callable( array( $builder, 'as_output_schema' ) ) ) {
+				throw new WP_Agent_Structured_Output_Capability_Exception( 'The installed wp-ai-client does not support JSON Schema output. Upgrade wp-ai-client or provide a host provider-turn dispatcher.' );
+			}
+			// The public wp-ai-client builder is fluent; keep the original typed builder
+			// reference so its magic proxy remains compatible across client versions.
+			$builder->as_output_mime_type( 'application/json' );
+			$builder->as_output_schema( $structured_output->schema() );
+		}
+
 		$builder = $this->apply_request_timeout( $builder );
 
 		return $builder->generate_text_result();
+	}
+
+	/** @return array{valid:bool,value:mixed} */
+	private static function parse_structured_output( string $text ): array {
+		$value = json_decode( $text, true );
+		return array(
+			'valid' => JSON_ERROR_NONE === json_last_error(),
+			'value' => $value,
+		);
 	}
 
 	/**
@@ -899,6 +930,9 @@ class WP_Agent_Default_Provider_Turn_Adapter implements WP_Agent_Provider_Turn_A
 			'options'               => $this->options,
 			'request'               => $request,
 		);
+		if ( null !== $request->structuredOutput() ) {
+			$payload['structured_output'] = $request->structuredOutput()->to_array();
+		}
 
 		return call_user_func( $dispatcher, $payload );
 	}

--- a/src/Runtime/class-wp-agent-default-provider-turn-adapter.php
+++ b/src/Runtime/class-wp-agent-default-provider-turn-adapter.php
@@ -300,6 +300,13 @@ class WP_Agent_Default_Provider_Turn_Adapter implements WP_Agent_Provider_Turn_A
 					'provider_diagnostics' => array( 'structured_output' => array( 'status' => 'invalid_json' ) ),
 				);
 			}
+			$validation_failure = $structured_output->strict() ? $structured_output->validate( $parsed['value'] ) : null;
+			if ( null !== $validation_failure ) {
+				return array(
+					'failure' => array( 'type' => 'structured_output_schema_mismatch', 'message' => 'Provider structured output does not match the requested schema.' ),
+					'provider_diagnostics' => array( 'structured_output' => array( 'status' => 'schema_mismatch', 'code' => $validation_failure ) ),
+				);
+			}
 			$normalized['structured_output'] = array( 'parsed' => $parsed['value'], 'diagnostics' => array( 'status' => 'parsed' ) );
 		}
 		return $normalized;
@@ -724,11 +731,11 @@ class WP_Agent_Default_Provider_Turn_Adapter implements WP_Agent_Provider_Turn_A
 
 	/** @return array{valid:bool,value:mixed} */
 	private static function parse_structured_output( string $text ): array {
-		$value = json_decode( $text, true );
-		return array(
-			'valid' => JSON_ERROR_NONE === json_last_error(),
-			'value' => $value,
-		);
+		try {
+			return array( 'valid' => true, 'value' => json_decode( $text, false, 512, JSON_THROW_ON_ERROR ) );
+		} catch ( \JsonException $error ) {
+			return array( 'valid' => false, 'value' => null );
+		}
 	}
 
 	/**

--- a/src/Runtime/class-wp-agent-provider-turn-request.php
+++ b/src/Runtime/class-wp-agent-provider-turn-request.php
@@ -48,6 +48,9 @@ class WP_Agent_Provider_Turn_Request {
 	/** @var callable|null Request-scoped provider delta sink. */
 	private $delta_sink;
 
+	/** @var WP_Agent_Structured_Output_Request|null Requested structured output. */
+	private ?WP_Agent_Structured_Output_Request $structured_output;
+
 	/** Whether this provider turn has emitted at least one delta. */
 	private bool $deltas_emitted = false;
 
@@ -63,7 +66,7 @@ class WP_Agent_Provider_Turn_Request {
 	 * @param array<string, mixed> $metadata          Caller-owned metadata.
 	 * @param callable|null        $delta_sink        Request-scoped provider delta sink.
 	 */
-	public function __construct( array $messages, array $tool_declarations = array(), array $model = array(), array $runtime = array(), array $context = array(), array $budgets = array(), string $run_id = '', string $session_id = '', array $metadata = array(), ?callable $delta_sink = null ) {
+	public function __construct( array $messages, array $tool_declarations = array(), array $model = array(), array $runtime = array(), array $context = array(), array $budgets = array(), string $run_id = '', string $session_id = '', array $metadata = array(), ?callable $delta_sink = null, ?WP_Agent_Structured_Output_Request $structured_output = null ) {
 		$this->messages          = WP_Agent_Message::normalize_many( $messages );
 		$this->tool_declarations = self::normalize_tool_declarations( $tool_declarations );
 		$this->model             = self::normalize_json_array( $model, 'model' );
@@ -74,6 +77,7 @@ class WP_Agent_Provider_Turn_Request {
 		$this->session_id        = $session_id;
 		$this->metadata          = self::normalize_json_array( $metadata, 'metadata' );
 		$this->delta_sink        = $delta_sink;
+		$this->structured_output = $structured_output;
 	}
 
 	/** @return array<int, array<string, mixed>> Canonical transcript messages. */
@@ -121,6 +125,11 @@ class WP_Agent_Provider_Turn_Request {
 		return $this->metadata;
 	}
 
+	/** @return WP_Agent_Structured_Output_Request|null */
+	public function structuredOutput(): ?WP_Agent_Structured_Output_Request {
+		return $this->structured_output;
+	}
+
 	/** Whether this provider turn can emit request-scoped deltas. */
 	public function supportsStreaming(): bool {
 		return is_callable( $this->delta_sink );
@@ -151,7 +160,7 @@ class WP_Agent_Provider_Turn_Request {
 	 * @return array<string, mixed>
 	 */
 	public function to_array(): array {
-		return array(
+		$result = array(
 			'messages'          => $this->messages,
 			'tool_declarations' => $this->tool_declarations,
 			'model'             => $this->model,
@@ -162,6 +171,10 @@ class WP_Agent_Provider_Turn_Request {
 			'session_id'        => $this->session_id,
 			'metadata'          => $this->metadata,
 		);
+		if ( null !== $this->structured_output ) {
+			$result['structured_output'] = $this->structured_output->to_array();
+		}
+		return $result;
 	}
 
 	/**

--- a/src/Runtime/class-wp-agent-provider-turn-result.php
+++ b/src/Runtime/class-wp-agent-provider-turn-result.php
@@ -72,6 +72,20 @@ class WP_Agent_Provider_Turn_Result {
 			$normalized['failure'] = $failure;
 		}
 
+		if ( array_key_exists( 'structured_output', $result ) ) {
+			if ( ! is_array( $result['structured_output'] ) || ! array_key_exists( 'parsed', $result['structured_output'] ) ) {
+				throw self::invalid( 'structured_output', 'must be an array with a parsed key' );
+			}
+			$structured = array( 'parsed' => $result['structured_output']['parsed'] );
+			if ( false === wp_json_encode( $structured['parsed'], JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ) ) {
+				throw self::invalid( 'structured_output.parsed', 'must be JSON serializable' );
+			}
+			if ( isset( $result['structured_output']['diagnostics'] ) ) {
+				$structured['diagnostics'] = self::assoc_array( $result['structured_output']['diagnostics'], 'structured_output.diagnostics' );
+			}
+			$normalized['structured_output'] = $structured;
+		}
+
 		return $normalized;
 	}
 

--- a/src/Runtime/class-wp-agent-structured-output-capability-exception.php
+++ b/src/Runtime/class-wp-agent-structured-output-capability-exception.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * Structured-output capability failure.
+ *
+ * @package AgentsAPI
+ */
+
+namespace AgentsAPI\AI;
+
+defined( 'ABSPATH' ) || exit;
+
+/** Raised when a selected adapter cannot preserve the requested output contract. */
+class WP_Agent_Structured_Output_Capability_Exception extends \RuntimeException {}

--- a/src/Runtime/class-wp-agent-structured-output-request.php
+++ b/src/Runtime/class-wp-agent-structured-output-request.php
@@ -11,6 +11,10 @@ defined( 'ABSPATH' ) || exit;
 
 /**
  * Immutable, provider-neutral JSON Schema output request.
+ *
+ * Strict local validation supports `type`, `enum`, object `properties`,
+ * `required`, `additionalProperties`, and array `items`. Providers still receive
+ * the complete schema unchanged.
  */
 // phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Validation exceptions are not rendered output.
 class WP_Agent_Structured_Output_Request {
@@ -96,6 +100,94 @@ class WP_Agent_Structured_Output_Request {
 
 	/** @return array<string,mixed> */
 	public function schema(): array { return $this->schema; }
+
+	public function format(): string { return $this->format; }
+
+	public function name(): ?string { return $this->name; }
+
+	public function strict(): bool { return $this->strict; }
+
+	/**
+	 * Validate a parsed JSON value against the supported strict schema subset.
+	 *
+	 * @param mixed $value Parsed JSON value.
+	 * @return string|null Stable failure code, or null when valid.
+	 */
+	public function validate( $value ): ?string {
+		return self::validate_value( $value, $this->schema );
+	}
+
+	/**
+	 * @param mixed $value
+	 * @param array<mixed> $schema
+	 */
+	private static function validate_value( $value, array $schema ): ?string {
+		if ( isset( $schema['type'] ) && ! self::matches_type( $value, $schema['type'] ) ) {
+			return 'type_mismatch';
+		}
+		if ( isset( $schema['enum'] ) && is_array( $schema['enum'] ) && ! in_array( $value, $schema['enum'], true ) ) {
+			return 'enum_mismatch';
+		}
+		if ( $value instanceof \stdClass ) {
+			$properties = get_object_vars( $value );
+			if ( isset( $schema['required'] ) && is_array( $schema['required'] ) ) {
+				foreach ( $schema['required'] as $name ) {
+					if ( ! is_string( $name ) || ! array_key_exists( $name, $properties ) ) {
+						return 'required_property_missing';
+					}
+				}
+			}
+			$property_schemas = is_array( $schema['properties'] ?? null ) ? $schema['properties'] : array();
+			foreach ( $properties as $name => $property ) {
+				$property_schema = $property_schemas[ $name ] ?? null;
+				if ( is_array( $property_schema ) ) {
+					$failure = self::validate_value( $property, self::schema_object( $property_schema ) );
+					if ( null !== $failure ) {
+						return $failure;
+					}
+				} elseif ( false === ( $schema['additionalProperties'] ?? true ) ) {
+					return 'additional_property_forbidden';
+				}
+			}
+		}
+		if ( is_array( $value ) && array_is_list( $value ) && isset( $schema['items'] ) && is_array( $schema['items'] ) ) {
+			foreach ( $value as $item ) {
+				$failure = self::validate_value( $item, self::schema_object( $schema['items'] ) );
+				if ( null !== $failure ) {
+					return $failure;
+				}
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * @param mixed $value
+	 * @param mixed $type
+	 */
+	private static function matches_type( $value, $type ): bool {
+		$types = is_array( $type ) ? $type : array( $type );
+		foreach ( $types as $candidate ) {
+			if ( ( 'object' === $candidate && $value instanceof \stdClass ) || ( 'array' === $candidate && is_array( $value ) && array_is_list( $value ) ) || ( 'string' === $candidate && is_string( $value ) ) || ( 'number' === $candidate && ( is_int( $value ) || is_float( $value ) ) ) || ( 'integer' === $candidate && is_int( $value ) ) || ( 'boolean' === $candidate && is_bool( $value ) ) || ( 'null' === $candidate && null === $value ) ) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * @param array<mixed> $schema
+	 * @return array<string,mixed>
+	 */
+	private static function schema_object( array $schema ): array {
+		$normalized = array();
+		foreach ( $schema as $key => $value ) {
+			if ( is_string( $key ) ) {
+				$normalized[ $key ] = $value;
+			}
+		}
+		return $normalized;
+	}
 
 	private static function invalid( string $path, string $reason ): \InvalidArgumentException {
 		return new \InvalidArgumentException( 'invalid_agent_structured_output_request: ' . $path . ' ' . $reason );

--- a/src/Runtime/class-wp-agent-structured-output-request.php
+++ b/src/Runtime/class-wp-agent-structured-output-request.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * Structured provider-output request contract.
+ *
+ * @package AgentsAPI
+ */
+
+namespace AgentsAPI\AI;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Immutable, provider-neutral JSON Schema output request.
+ */
+// phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Validation exceptions are not rendered output.
+class WP_Agent_Structured_Output_Request {
+
+	public const FORMAT_JSON_SCHEMA = 'json_schema';
+
+	private string $format;
+
+	private ?string $name;
+
+	/** @var array<string,mixed> */
+	private array $schema;
+
+	private bool $strict;
+
+	/**
+	 * @param array<string,mixed> $schema JSON Schema object.
+	 */
+	public function __construct( array $schema, ?string $name = null, bool $strict = true, string $format = self::FORMAT_JSON_SCHEMA ) {
+		if ( self::FORMAT_JSON_SCHEMA !== $format ) {
+			throw self::invalid( 'format', 'must be json_schema' );
+		}
+		if ( false === wp_json_encode( $schema, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ) ) {
+			throw self::invalid( 'schema', 'must be JSON serializable' );
+		}
+
+		$name = null === $name ? null : trim( $name );
+		if ( null !== $name && ( '' === $name || ! preg_match( '/^[A-Za-z][A-Za-z0-9_-]{0,63}$/', $name ) ) ) {
+			throw self::invalid( 'name', 'must match /^[A-Za-z][A-Za-z0-9_-]{0,63}$/' );
+		}
+
+		$this->format = $format;
+		$this->name   = $name;
+		$this->schema = $schema;
+		$this->strict = $strict;
+	}
+
+	/**
+	 * @param mixed $value Raw request configuration.
+	 */
+	public static function from_array( $value ): self {
+		if ( ! is_array( $value ) ) {
+			throw self::invalid( 'structured_output', 'must be an array' );
+		}
+		if ( ! array_key_exists( 'schema', $value ) || ! is_array( $value['schema'] ) ) {
+			throw self::invalid( 'schema', 'must be an array' );
+		}
+		if ( array_key_exists( 'name', $value ) && ! is_string( $value['name'] ) && null !== $value['name'] ) {
+			throw self::invalid( 'name', 'must be a string or null' );
+		}
+		if ( array_key_exists( 'strict', $value ) && ! is_bool( $value['strict'] ) ) {
+			throw self::invalid( 'strict', 'must be a boolean' );
+		}
+		if ( array_key_exists( 'format', $value ) && ! is_string( $value['format'] ) ) {
+			throw self::invalid( 'format', 'must be a string' );
+		}
+
+		$schema = array();
+		foreach ( $value['schema'] as $key => $item ) {
+			if ( is_string( $key ) ) {
+				$schema[ $key ] = $item;
+			}
+		}
+		$name   = isset( $value['name'] ) && is_string( $value['name'] ) ? $value['name'] : null;
+		$strict = isset( $value['strict'] ) && is_bool( $value['strict'] ) ? $value['strict'] : true;
+		$format = isset( $value['format'] ) && is_string( $value['format'] ) ? $value['format'] : self::FORMAT_JSON_SCHEMA;
+
+		return new self( $schema, $name, $strict, $format );
+	}
+
+	/** @return array<string,mixed> */
+	public function to_array(): array {
+		$result = array(
+			'format' => $this->format,
+			'schema' => $this->schema,
+			'strict' => $this->strict,
+		);
+		if ( null !== $this->name ) {
+			$result['name'] = $this->name;
+		}
+		return $result;
+	}
+
+	/** @return array<string,mixed> */
+	public function schema(): array { return $this->schema; }
+
+	private static function invalid( string $path, string $reason ): \InvalidArgumentException {
+		return new \InvalidArgumentException( 'invalid_agent_structured_output_request: ' . $path . ' ' . $reason );
+	}
+}

--- a/tests/agents-chat-ability-smoke.php
+++ b/tests/agents-chat-ability-smoke.php
@@ -222,6 +222,7 @@ smoke_assert( true, agents_chat_permission( array() ), 'permission_filter_widens
 $in = agents_chat_input_schema();
 smoke_assert( array( 'agent' ), $in['required'] ?? array(), 'input_schema_required_fields', $failures, $passes );
 smoke_assert( true, isset( $in['properties']['input_messages'] ), 'input_schema_has_canonical_input_messages', $failures, $passes );
+smoke_assert( true, isset( $in['properties']['structured_output']['properties']['schema'] ), 'input_schema_has_structured_output', $failures, $passes );
 smoke_assert( true, isset( $in['properties']['client_context'] ), 'input_schema_has_client_context', $failures, $passes );
 smoke_assert( true, isset( $in['properties']['workspace']['properties']['workspace_type'] ), 'input_schema_has_canonical_workspace', $failures, $passes );
 smoke_assert( true, isset( $in['properties']['session_owner'] ), 'input_schema_has_session_owner', $failures, $passes );
@@ -246,6 +247,7 @@ smoke_assert( true, isset( $in['properties']['principal']['properties']['auth_so
 
 $out_schema = agents_chat_output_schema();
 smoke_assert( array( 'session_id', 'reply' ), $out_schema['required'] ?? array(), 'output_schema_required_fields', $failures, $passes );
+smoke_assert( true, array_key_exists( 'structured_output', $out_schema['properties'] ?? array() ), 'output_schema_has_additive_structured_output', $failures, $passes );
 smoke_assert( array( 1 ), $out_schema['properties']['metadata']['properties']['agents_api']['properties']['tool_observability']['properties']['version']['enum'] ?? array(), 'output_schema_documents_tool_observability_v1', $failures, $passes );
 smoke_assert( array( 'pending', 'succeeded', 'failed', 'rejected' ), $out_schema['properties']['metadata']['properties']['agents_api']['properties']['tool_observability']['properties']['calls']['items']['properties']['status']['enum'] ?? array(), 'output_schema_documents_tool_statuses', $failures, $passes );
 smoke_assert( AgentsAPI\AI\WP_Agent_Run_Outcome::statuses(), $out_schema['properties']['status']['enum'] ?? array(), 'output_schema_documents_canonical_statuses', $failures, $passes );

--- a/tests/default-provider-turn-adapter-smoke.php
+++ b/tests/default-provider-turn-adapter-smoke.php
@@ -418,12 +418,49 @@ namespace {
 	$GLOBALS['__adapter_smoke']['next_result'] = $make_result( '{"items":[1,2]}', array(), array( 1, 1, 2 ) );
 	$structured_request = new AgentsAPI\AI\WP_Agent_Provider_Turn_Request(
 		array( array( 'role' => 'user', 'content' => 'return JSON' ) ), array(), array(), array(), array(), array(), '', '', array(), null,
-		new AgentsAPI\AI\WP_Agent_Structured_Output_Request( array( 'type' => 'object', 'properties' => array( 'items' => array( 'type' => 'array' ) ) ), 'result', true )
+		new AgentsAPI\AI\WP_Agent_Structured_Output_Request( array( 'type' => 'object', 'required' => array( 'items' ), 'properties' => array( 'items' => array( 'type' => 'array' ) ) ), 'result', true )
 	);
 	$structured_result = $adapter->run_turn( $structured_request );
 	agents_api_smoke_assert_equals( 'application/json', $GLOBALS['__adapter_smoke']['output_mime_type'] ?? '', 'structured output selects JSON MIME output through the public builder API', $failures, $passes );
 	agents_api_smoke_assert_equals( 'object', $GLOBALS['__adapter_smoke']['output_schema']['type'] ?? '', 'structured output maps the requested JSON Schema through the public builder API', $failures, $passes );
-	agents_api_smoke_assert_equals( array( 1, 2 ), $structured_result['structured_output']['parsed']['items'] ?? null, 'structured output parses the provider JSON response', $failures, $passes );
+	agents_api_smoke_assert_equals( array( 1, 2 ), $structured_result['structured_output']['parsed']->items ?? null, 'structured output parses the provider JSON response as an object', $failures, $passes );
+
+	$shape_request = new AgentsAPI\AI\WP_Agent_Provider_Turn_Request(
+		array( array( 'role' => 'user', 'content' => 'return JSON' ) ), array(), array(), array(), array(), array(), '', '', array(), null,
+		new AgentsAPI\AI\WP_Agent_Structured_Output_Request( array( 'type' => 'object' ), null, false )
+	);
+	foreach ( array( '{}' => 'object', '[]' => 'array', '{"key":"value"}' => 'object', '[1,2]' => 'array', '"text"' => 'string', '42' => 'integer', 'true' => 'boolean', 'null' => 'NULL' ) as $json => $expected_type ) {
+		$GLOBALS['__adapter_smoke']['next_result'] = $make_result( $json, array(), array( 1, 1, 2 ) );
+		$value = $adapter->run_turn( $shape_request )['structured_output']['parsed'];
+		$actual_type = $value instanceof \stdClass ? 'object' : ( is_array( $value ) ? 'array' : gettype( $value ) );
+		agents_api_smoke_assert_equals( $expected_type, $actual_type, 'structured output preserves JSON ' . $expected_type . ' shape', $failures, $passes );
+	}
+
+	$GLOBALS['__adapter_smoke']['next_result'] = $make_result( '{"wrong":true}', array(), array( 1, 1, 2 ) );
+	$mismatch = $adapter->run_turn( $structured_request );
+	agents_api_smoke_assert_equals( 'structured_output_schema_mismatch', $mismatch['failure']['type'] ?? '', 'strict structured output returns a typed schema mismatch', $failures, $passes );
+	agents_api_smoke_assert_equals( false, str_contains( wp_json_encode( $mismatch ), 'wrong' ), 'strict schema mismatch does not expose raw provider output', $failures, $passes );
+
+	$permissive_request = new AgentsAPI\AI\WP_Agent_Provider_Turn_Request(
+		array( array( 'role' => 'user', 'content' => 'return JSON' ) ), array(), array(), array(), array(), array(), '', '', array(), null,
+		new AgentsAPI\AI\WP_Agent_Structured_Output_Request( array( 'type' => 'object', 'required' => array( 'required' ) ), null, false )
+	);
+	$GLOBALS['__adapter_smoke']['next_result'] = $make_result( '{"wrong":true}', array(), array( 1, 1, 2 ) );
+	$permissive = $adapter->run_turn( $permissive_request );
+	agents_api_smoke_assert_equals( true, isset( $permissive['structured_output'] ), 'non-strict structured output preserves parse-only behavior', $failures, $passes );
+
+	$GLOBALS['__adapter_smoke']['next_result'] = $make_result( '{bad', array(), array( 1, 1, 2 ) );
+	$invalid_json = $adapter->run_turn( $structured_request );
+	agents_api_smoke_assert_equals( 'structured_output_invalid_json', $invalid_json['failure']['type'] ?? '', 'invalid JSON returns a typed structured-output failure', $failures, $passes );
+
+	$host_payload = null;
+	$host_adapter = new AgentsAPI\AI\WP_Agent_Default_Provider_Turn_Adapter( 'fake-provider', 'fake-model', '', array( 'dispatch_provider' => static function ( array $payload ) use ( &$host_payload, $make_result ) {
+		$host_payload = $payload;
+		return $make_result( '{"items":[]}', array(), array( 1, 1, 2 ) );
+	} ) );
+	$host_result = $host_adapter->run_turn( $structured_request );
+	agents_api_smoke_assert_equals( 'json_schema', $host_payload['structured_output']['format'] ?? '', 'host dispatch payload includes normalized structured output', $failures, $passes );
+	agents_api_smoke_assert_equals( true, $host_result['structured_output']['parsed'] instanceof \stdClass, 'host dispatch result follows the shared structured parse tail', $failures, $passes );
 
 	echo "\n[1b] request timeout is configurable and honors a caller-supplied override + filter:\n";
 	$GLOBALS['__adapter_smoke']                = array();

--- a/tests/default-provider-turn-adapter-smoke.php
+++ b/tests/default-provider-turn-adapter-smoke.php
@@ -287,6 +287,14 @@ namespace {
 			$GLOBALS['__adapter_smoke']['declarations'] = $declarations;
 			return $this;
 		}
+		public function as_output_mime_type( string $mime_type ): self {
+			$GLOBALS['__adapter_smoke']['output_mime_type'] = $mime_type;
+			return $this;
+		}
+		public function as_output_schema( array $schema ): self {
+			$GLOBALS['__adapter_smoke']['output_schema'] = $schema;
+			return $this;
+		}
 		public function using_request_options( \WordPress\AiClient\Providers\Http\DTO\RequestOptions $options ): self {
 			$GLOBALS['__adapter_smoke']['request_timeout'] = $options->getTimeout();
 			return $this;
@@ -404,6 +412,18 @@ namespace {
 	agents_api_smoke_assert_equals( false, array_key_exists( 'scope_id', $model_parameters['properties'] ?? array() ), 'function declaration excludes authoritative parameters from model input', $failures, $passes );
 	agents_api_smoke_assert_equals( array( 'query' ), $model_parameters['required'] ?? array(), 'function declaration excludes authoritative parameters from model requirements', $failures, $passes );
 	agents_api_smoke_assert_equals( 600.0, $GLOBALS['__adapter_smoke']['request_timeout'] ?? null, 'run_turn applies the raised 600s agentic per-request timeout to the builder by default', $failures, $passes );
+
+	echo "\n[1a] Structured output maps through the installed public wp-ai-client APIs:\n";
+	$GLOBALS['__adapter_smoke']                = array();
+	$GLOBALS['__adapter_smoke']['next_result'] = $make_result( '{"items":[1,2]}', array(), array( 1, 1, 2 ) );
+	$structured_request = new AgentsAPI\AI\WP_Agent_Provider_Turn_Request(
+		array( array( 'role' => 'user', 'content' => 'return JSON' ) ), array(), array(), array(), array(), array(), '', '', array(), null,
+		new AgentsAPI\AI\WP_Agent_Structured_Output_Request( array( 'type' => 'object', 'properties' => array( 'items' => array( 'type' => 'array' ) ) ), 'result', true )
+	);
+	$structured_result = $adapter->run_turn( $structured_request );
+	agents_api_smoke_assert_equals( 'application/json', $GLOBALS['__adapter_smoke']['output_mime_type'] ?? '', 'structured output selects JSON MIME output through the public builder API', $failures, $passes );
+	agents_api_smoke_assert_equals( 'object', $GLOBALS['__adapter_smoke']['output_schema']['type'] ?? '', 'structured output maps the requested JSON Schema through the public builder API', $failures, $passes );
+	agents_api_smoke_assert_equals( array( 1, 2 ), $structured_result['structured_output']['parsed']['items'] ?? null, 'structured output parses the provider JSON response', $failures, $passes );
 
 	echo "\n[1b] request timeout is configurable and honors a caller-supplied override + filter:\n";
 	$GLOBALS['__adapter_smoke']                = array();

--- a/tests/provider-turn-adapter-smoke.php
+++ b/tests/provider-turn-adapter-smoke.php
@@ -386,4 +386,54 @@ agents_api_smoke_assert_equals( AgentsAPI\AI\WP_Agent_Conversation_Result::OUTCO
 agents_api_smoke_assert_equals( AgentsAPI\AI\WP_Agent_Conversation_Result::OUTCOME_STOP_PROVIDER_ERROR, $failure_result['run_outcome']['stop_reason'] ?? '', 'provider failure run outcome stop reason is provider error', $failures, $passes );
 agents_api_smoke_assert_equals( 'rate_limit', $failure_result['run_outcome']['provider_error']['type'] ?? '', 'provider failure run outcome preserves provider error', $failures, $passes );
 
+echo "\n[6] Structured output normalizes and reaches the terminal result:\n";
+$structured_request = new AgentsAPI\AI\WP_Agent_Structured_Output_Request(
+	array( 'type' => 'object', 'properties' => array( 'value' => array( 'type' => 'string' ) ) ),
+	' normalized_result ',
+	true
+);
+agents_api_smoke_assert_equals( 'normalized_result', $structured_request->to_array()['name'] ?? '', 'structured-output request normalizes its optional name', $failures, $passes );
+$invalid_structured = false;
+try {
+	AgentsAPI\AI\WP_Agent_Structured_Output_Request::from_array( array( 'format' => 'text', 'schema' => array(), 'strict' => 'yes' ) );
+} catch ( \InvalidArgumentException $error ) {
+	$invalid_structured = true;
+}
+agents_api_smoke_assert_equals( true, $invalid_structured, 'structured-output request rejects malformed configuration deterministically', $failures, $passes );
+
+foreach ( array( array( 'object' => true ), array( 'first', 2 ), 'scalar', null ) as $index => $value ) {
+	$normalized_structured = AgentsAPI\AI\WP_Agent_Provider_Turn_Result::normalize( array( 'structured_output' => array( 'parsed' => $value ) ) );
+	agents_api_smoke_assert_equals( $value, $normalized_structured['structured_output']['parsed'], 'structured-output result preserves JSON value shape ' . $index, $failures, $passes );
+}
+$missing_parsed = false;
+try {
+	AgentsAPI\AI\WP_Agent_Provider_Turn_Result::normalize( array( 'structured_output' => array() ) );
+} catch ( \InvalidArgumentException $error ) {
+	$missing_parsed = true;
+}
+agents_api_smoke_assert_equals( true, $missing_parsed, 'structured-output result rejects a missing parsed value without conflating it with null', $failures, $passes );
+
+$structured_adapter = new class() implements AgentsAPI\AI\WP_Agent_Provider_Turn_Adapter {
+	public array $payload = array();
+	public function run_turn( AgentsAPI\AI\WP_Agent_Provider_Turn_Request $request ): array {
+		$this->payload = $request->to_array();
+		return array( 'content' => 'JSON reply', 'structured_output' => array( 'parsed' => null, 'diagnostics' => array( 'status' => 'parsed', 'raw_response' => 'private' ) ) );
+	}
+};
+$structured_loop = AgentsAPI\AI\WP_Agent_Conversation_Loop::run(
+	array( array( 'role' => 'user', 'content' => 'return null' ) ),
+	null,
+	array( 'provider_turn_adapter' => $structured_adapter, 'structured_output' => $structured_request )
+);
+agents_api_smoke_assert_equals( 'json_schema', $structured_adapter->payload['structured_output']['format'] ?? '', 'provider dispatch payload includes the normalized structured-output contract', $failures, $passes );
+agents_api_smoke_assert_equals( true, array_key_exists( 'structured_output', $structured_loop ) && null === $structured_loop['structured_output'], 'terminal loop result preserves a valid null structured value', $failures, $passes );
+agents_api_smoke_assert_equals( array( 'status' => 'parsed' ), $structured_loop['structured_output_diagnostics'] ?? null, 'terminal result strips raw structured-output diagnostics', $failures, $passes );
+$incompatible_structured = false;
+try {
+	AgentsAPI\AI\WP_Agent_Conversation_Loop::run( array( array( 'role' => 'user', 'content' => 'no' ) ), null, array( 'provider_turn_adapter' => $structured_adapter, 'structured_output' => $structured_request, 'tool_declarations' => $tools, 'tool_executor' => $executor ) );
+} catch ( \InvalidArgumentException $error ) {
+	$incompatible_structured = true;
+}
+agents_api_smoke_assert_equals( true, $incompatible_structured, 'structured output fails closed when tools are configured', $failures, $passes );
+
 agents_api_smoke_finish( 'Agents API provider-turn adapter', $failures, $passes );


### PR DESCRIPTION
## Summary
- add a normalized JSON Schema structured-output contract at the provider-turn boundary
- preserve parsed JSON object, list, scalar, and null shapes through the conversation and canonical chat results
- map bare wp-ai-client turns through its public JSON output APIs; strict mode validates the documented local schema subset and returns redacted typed failures
- fail closed for tool or streaming combinations and redact public diagnostics

## Verification
- `composer validate --no-check-publish`
- `composer phpstan`
- `composer smoke`
- focused provider-turn, default adapter, chat schema, and default chat handler smoke suites

Fixes #516

## AI assistance
OpenCode with `openai/gpt-5.6-sol` implemented and revised the provider-neutral contract, inspected the installed wp-ai-client APIs, and added focused tests. Chris Huber reviewed and remains responsible for the change.