### PR TITLE
fix: preserve normalized pending mediation requests

### DIFF
--- a/src/Runtime/class-wp-agent-conversation-loop.php
+++ b/src/Runtime/class-wp-agent-conversation-loop.php
@@ -1364,12 +1364,24 @@ class WP_Agent_Conversation_Loop {
 				$runtime
 			);
 		} elseif ( 'pending' === $action ) {
-			$runtime      = self::associative_array_or_null( $decision['runtime'] ?? null ) ?? array();
-			$metadata     = self::associative_array_or_null( $decision['metadata'] ?? null ) ?? array();
-			$tool_call_id = is_string( $context['tool_call_id'] ?? null ) ? $context['tool_call_id'] : '';
-			$parameters   = is_array( $context['parameters'] ?? null ) ? $context['parameters'] : array();
-			$turn_context = self::normalize_assoc_array( $context['turn_context'] ?? array() );
-			$request      = self::associative_array_or_null( $decision['runtime_tool_request'] ?? ( $decision['request'] ?? ( $decision['result'] ?? null ) ) ) ?? array();
+			$normalized_result = self::associative_array_or_null( $decision['result'] ?? null );
+			$is_normalized     = isset( $normalized_result['runtime_tool_request'] ) && is_array( $normalized_result['runtime_tool_request'] );
+			$runtime           = self::associative_array_or_null( $decision['runtime'] ?? ( $is_normalized ? ( $normalized_result['runtime'] ?? null ) : null ) ) ?? array();
+			$metadata          = self::associative_array_or_null( $decision['metadata'] ?? ( $is_normalized ? ( $normalized_result['metadata'] ?? null ) : null ) ) ?? array();
+			$pending_error     = $decision['error'] ?? ( $is_normalized ? ( $normalized_result['error'] ?? null ) : null );
+			$tool_call_id      = is_string( $context['tool_call_id'] ?? null ) ? $context['tool_call_id'] : '';
+			$parameters        = is_array( $context['parameters'] ?? null ) ? $context['parameters'] : array();
+			$turn_context      = self::normalize_assoc_array( $context['turn_context'] ?? array() );
+			if ( isset( $decision['runtime_tool_request'] ) ) {
+				$request = $decision['runtime_tool_request'];
+			} elseif ( isset( $decision['request'] ) ) {
+				$request = $decision['request'];
+			} elseif ( $is_normalized ) {
+				$request = $normalized_result['runtime_tool_request'];
+			} else {
+				$request = $decision['result'] ?? null;
+			}
+			$request = self::associative_array_or_null( $request ) ?? array();
 
 			try {
 				$request = WP_Agent_Runtime_Tool_Request::normalize( array_merge(
@@ -1394,7 +1406,7 @@ class WP_Agent_Conversation_Loop {
 				'success'              => false,
 				'tool_name'            => $tool_name,
 				'status'               => WP_Agent_Runtime_Tool_Request::STATUS_PENDING,
-				'error'                => is_string( $decision['error'] ?? null ) && '' !== trim( $decision['error'] ) ? trim( $decision['error'] ) : 'Waiting for external runtime tool result.',
+				'error'                => is_string( $pending_error ) && '' !== trim( $pending_error ) ? trim( $pending_error ) : 'Waiting for external runtime tool result.',
 				'metadata'             => $metadata,
 				'runtime'              => $runtime,
 				'runtime_tool_request' => $request,

--- a/tests/conversation-loop-tool-execution-smoke.php
+++ b/tests/conversation-loop-tool-execution-smoke.php
@@ -768,6 +768,70 @@ agents_api_smoke_assert_equals( true, isset( $loop_runtime_tool_store->requests[
 agents_api_smoke_assert_equals( 1, did_action( 'agents_api_runtime_tool_request_created' ), 'loop persistence emits generic runtime tool created event', $failures, $passes );
 agents_api_smoke_assert_equals( 1, $loop_runtime_tool_store->requests[ $stored_request_id ]['metadata']['turn_count'] ?? 0, 'stored pending request records generic turn metadata for replay', $failures, $passes );
 
+echo "\n[Option-provided pending decisions remain stable through a no-op filter (#521):\n";
+
+$pending_noop_filter_called = false;
+add_filter(
+	'agents_api_pre_tool_call_decision',
+	static function ( array $decision, array $context ) use ( &$pending_noop_filter_called ): array {
+		if ( 'call_option_pending' === ( $context['tool_call_id'] ?? '' ) ) {
+			$pending_noop_filter_called = true;
+		}
+
+		return $decision;
+	},
+	10,
+	2
+);
+
+$executor->executed    = array();
+$option_pending_result = AgentsAPI\AI\WP_Agent_Conversation_Loop::run(
+	array( array( 'role' => 'user', 'content' => 'pending via option' ) ),
+	static function ( array $messages ): array {
+		return array(
+			'messages'   => $messages,
+			'tool_calls' => array(
+				array(
+					'id'         => 'call_option_pending',
+					'name'       => 'client/summarize',
+					'parameters' => array( 'text' => 'needs host runtime' ),
+				),
+			),
+		);
+	},
+	array(
+		'max_turns'                  => 3,
+		'tool_executor'              => $executor,
+		'tool_declarations'          => $tools,
+		'runtime_tool_request_store' => $loop_runtime_tool_store,
+		'pre_tool_mediator'          => static function (): array {
+			return array(
+				'action'               => 'pending',
+				'runtime_tool_request' => array(
+					'request_id'   => 'runtime_tool_521',
+					'tool_name'    => 'client/summarize',
+					'tool_call_id' => 'call_option_pending',
+					'parameters'   => array( 'text' => 'needs host runtime' ),
+					'run_id'       => 'run-option-pending',
+					'timeout_at'   => '2026-08-23T12:00:00Z',
+					'runtime'      => array( 'completion_signal' => 'external_result' ),
+					'metadata'     => array( 'transport' => 'host' ),
+				),
+			);
+		},
+	)
+);
+
+$option_pending_request = $option_pending_result['runtime_tool_pending'] ?? array();
+agents_api_smoke_assert_equals( true, $pending_noop_filter_called, 'option-provided pending decision passes through the active no-op filter', $failures, $passes );
+agents_api_smoke_assert_equals( 0, count( $executor->executed ), 'option-provided pending decision prevents executor call', $failures, $passes );
+agents_api_smoke_assert_equals( 'runtime_tool_521', $option_pending_request['request_id'] ?? '', 'returned pending request preserves the host-provided request ID', $failures, $passes );
+agents_api_smoke_assert_equals( 'runtime_tool_521', $loop_runtime_tool_store->requests['runtime_tool_521']['request_id'] ?? '', 'persisted pending request preserves the host-provided request ID', $failures, $passes );
+agents_api_smoke_assert_equals( $option_pending_request, $loop_runtime_tool_store->requests['runtime_tool_521'] ?? array(), 'returned and persisted pending requests retain the same canonical request', $failures, $passes );
+agents_api_smoke_assert_equals( '2026-08-23T12:00:00Z', $option_pending_request['timeout_at'] ?? '', 'pending normalization preserves the canonical timeout', $failures, $passes );
+agents_api_smoke_assert_equals( 'external_result', $option_pending_request['runtime']['completion_signal'] ?? '', 'pending normalization preserves canonical runtime metadata', $failures, $passes );
+agents_api_smoke_assert_equals( 'host', $option_pending_request['metadata']['transport'] ?? '', 'pending normalization preserves canonical host metadata', $failures, $passes );
+
 echo "\n[Pre-tool filter hook allows, rejects, or pauses external runtime tools (#259):\n";
 
 $filter_contexts = array();


### PR DESCRIPTION
## Summary

- make pending pre-tool mediation normalization idempotent when an option-provided decision passes unchanged through `agents_api_pre_tool_call_decision`
- preserve the canonical runtime-tool request and its host-provided identity when re-normalizing the pending tool-result envelope
- add focused coverage for a no-op filter, custom request ID, and runtime-tool store

## Root cause

`pre_tool_mediation_decision()` normalized the option mediator's pending decision before applying `agents_api_pre_tool_call_decision`, then normalized the filter result again. On that second pass, `normalize_pre_tool_mediation_decision()` treated the already-normalized `decision['result']` tool-result envelope as though it were the pending request itself. Because the actual request was nested under `result.runtime_tool_request`, request normalization could not see the host-provided `request_id` and generated a replacement hash ID.

The pending branch now recognizes an already-normalized tool-result envelope, unwraps its canonical `runtime_tool_request`, and retains the envelope's runtime, metadata, and error fields. Existing compatibility is preserved: explicit top-level `runtime_tool_request` remains first priority, the `request` alias remains second, and legacy raw requests supplied through `result` continue to normalize as before.

## Verification

- `php tests/conversation-loop-tool-execution-smoke.php` (123 assertions passed)
- `php -l src/Runtime/class-wp-agent-conversation-loop.php` (no syntax errors)
- `php -l tests/conversation-loop-tool-execution-smoke.php` (no syntax errors)
- `composer phpstan` (no errors)
- `git diff --check` (clean)

Fixes #521