### PR TITLE
Fix Composer discovery for public package classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ composer require wordpress/agents-api:^0.1
 
 Composer autoloads `agents-api.php` through the package `files` autoload entry. The consuming project must load Composer's generated `vendor/autoload.php` during WordPress bootstrap. After that, the same public API is available as in the plugin activation path.
 
+Public agent package definitions are classmapped, so Composer-aware IDEs and static analyzers discover their concrete types without executing the WordPress runtime bootstrap.
+
 Pin released tags (`^0.1`, `0.1.x`, or an exact `0.1.0` tag) for reproducible production installs. Track `main` only for active substrate development.
 
 ## Consumer Integration

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,10 @@
   "autoload": {
     "files": [
       "agents-api.php"
+    ],
+    "classmap": [
+      "src/Registry/class-wp-agent.php",
+      "src/Packages/"
     ]
   },
   "suggest": {
@@ -24,8 +28,10 @@
   },
   "scripts": {
     "phpstan": "phpstan analyse --no-progress --memory-limit=2G",
+    "phpstan-consumer": "phpstan analyse --no-progress --memory-limit=1G -c tests/fixtures/phpstan-consumer.neon",
     "smoke": [
       "php tests/composer-autoload-smoke.php",
+      "@phpstan-consumer",
       "php tests/bootstrap-version-skew-smoke.php",
       "php tests/bootstrap-smoke.php",
       "php tests/message-envelope-smoke.php",

--- a/tests/composer-autoload-smoke.php
+++ b/tests/composer-autoload-smoke.php
@@ -9,11 +9,22 @@
 
 echo "agents-api-composer-autoload-smoke\n";
 
-require dirname( __DIR__ ) . '/vendor/autoload.php';
+$loader = require dirname( __DIR__ ) . '/vendor/autoload.php';
 
 if ( defined( 'AGENTS_API_LOADED' ) ) {
 	fwrite( STDERR, "FAIL: Composer autoload initialized Agents API outside WordPress.\n" );
 	exit( 1 );
 }
 
-echo "PASS: Composer autoload returns without WordPress.\n";
+$package_file = $loader->findFile( 'WP_Agent_Package' );
+if ( ! is_string( $package_file ) || ! str_ends_with( str_replace( '\\', '/', $package_file ), '/src/Packages/class-wp-agent-package.php' ) ) {
+	fwrite( STDERR, "FAIL: Composer classmap does not expose WP_Agent_Package.\n" );
+	exit( 1 );
+}
+
+if ( class_exists( 'WP_Agent_Package', false ) ) {
+	fwrite( STDERR, "FAIL: Composer autoload eagerly loaded WP_Agent_Package outside WordPress.\n" );
+	exit( 1 );
+}
+
+echo "PASS: Composer autoload returns without WordPress and exposes package classmaps lazily.\n";

--- a/tests/fixtures/phpstan-consumer.neon
+++ b/tests/fixtures/phpstan-consumer.neon
@@ -1,0 +1,6 @@
+parameters:
+	level: 7
+	paths:
+		- phpstan-consumer.php
+	bootstrapFiles:
+		- ../../vendor/autoload.php

--- a/tests/fixtures/phpstan-consumer.php
+++ b/tests/fixtures/phpstan-consumer.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Consumer fixture proving Composer exposes guarded package contracts to PHPStan.
+ *
+ * @package AgentsAPI\Tests
+ */
+
+/**
+ * Exercise package types without loading the WordPress runtime bootstrap.
+ *
+ * @param WP_Agent_Package $package Package contract.
+ * @return array<int,mixed>
+ */
+function agents_api_phpstan_consume_package( WP_Agent_Package $package ): array {
+	$report = WP_Agent_Package_Capability_Checker::check( $package, array() );
+
+	return array(
+		$package->get_slug(),
+		$report->to_array(),
+		WP_Agent_Package_Artifact_Status::classify( 'installed', 'current' ),
+		WP_Agent_Package_Artifact_Hasher::hash( array() ),
+	);
+}


### PR DESCRIPTION
## Summary
- classmap `WP_Agent` and the public package definition directory through Agents API's Composer metadata
- keep `agents-api.php` as the idempotent runtime bootstrap while exposing public package types lazily
- add a consumer-only PHPStan fixture that resolves package, capability, artifact-status, and hashing contracts with no custom include or handwritten stubs

## Why
Guarded WordPress-style global classes were invisible to Composer-aware static analysis because `agents-api.php` deliberately returns under PHPStan. Downstream projects had to scan Agents API's internal source paths themselves.

The package now owns discovery directly. Consumers only load normal Composer autoload; no opt-in NEON, internal path knowledge, or runtime bootstrap execution is required.

## Verification
- consumer-only PHPStan fixture: passed at level 7 with no custom dependency config
- Agents API max-level PHPStan: passed
- complete `composer smoke` suite: passed, including the consumer fixture
- Composer autoload outside WordPress remains inert and package classes remain lazily loaded
- normal WordPress bootstrap: passed
- version-skew symbol top-up: passed
- Homeboy changed-file lint: passed
- Homeboy architecture audit: no introduced findings
- production package build and PHP syntax validation: passed
- Composer validation and `git diff --check`: passed

Closes #524