### PR TITLE
Fix Composer discovery for all public classes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,7 @@
       "agents-api.php"
     ],
     "classmap": [
-      "src/Registry/class-wp-agent.php",
-      "src/Packages/"
+      "src/"
     ]
   },
   "suggest": {

--- a/tests/composer-autoload-smoke.php
+++ b/tests/composer-autoload-smoke.php
@@ -22,9 +22,20 @@ if ( ! is_string( $package_file ) || ! str_ends_with( str_replace( '\\', '/', $p
 	exit( 1 );
 }
 
+$outcome_file = $loader->findFile( 'AgentsAPI\\AI\\WP_Agent_Run_Outcome' );
+if ( ! is_string( $outcome_file ) || ! str_ends_with( str_replace( '\\', '/', $outcome_file ), '/src/Runtime/class-wp-agent-run-outcome.php' ) ) {
+	fwrite( STDERR, "FAIL: Composer classmap does not expose WP_Agent_Run_Outcome.\n" );
+	exit( 1 );
+}
+
 if ( class_exists( 'WP_Agent_Package', false ) ) {
 	fwrite( STDERR, "FAIL: Composer autoload eagerly loaded WP_Agent_Package outside WordPress.\n" );
 	exit( 1 );
 }
 
-echo "PASS: Composer autoload returns without WordPress and exposes package classmaps lazily.\n";
+if ( class_exists( 'AgentsAPI\\AI\\WP_Agent_Run_Outcome', false ) ) {
+	fwrite( STDERR, "FAIL: Composer autoload eagerly loaded WP_Agent_Run_Outcome outside WordPress.\n" );
+	exit( 1 );
+}
+
+echo "PASS: Composer autoload returns without WordPress and exposes public classmaps lazily.\n";

--- a/tests/fixtures/phpstan-consumer.php
+++ b/tests/fixtures/phpstan-consumer.php
@@ -5,6 +5,12 @@
  * @package AgentsAPI\Tests
  */
 
+use AgentsAPI\AI\Tools\WP_Agent_Tool_Executor;
+use AgentsAPI\AI\WP_Agent_Conversation_Completion_Policy;
+use AgentsAPI\AI\WP_Agent_Run_Outcome;
+use AgentsAPI\AI\WP_Agent_Runtime_Tool_Request;
+use AgentsAPI\AI\WP_Agent_Transcript_Persister;
+
 /**
  * Exercise package types without loading the WordPress runtime bootstrap.
  *
@@ -19,5 +25,35 @@ function agents_api_phpstan_consume_package( WP_Agent_Package $package ): array 
 		$report->to_array(),
 		WP_Agent_Package_Artifact_Status::classify( 'installed', 'current' ),
 		WP_Agent_Package_Artifact_Hasher::hash( array() ),
+	);
+}
+
+/**
+ * Exercise conversation/runtime contracts from a Composer consumer.
+ *
+ * @param WP_Agent_Conversation_Completion_Policy $policy    Completion policy.
+ * @param WP_Agent_Transcript_Persister           $persister Transcript persister.
+ * @param WP_Agent_Tool_Executor                  $executor  Tool executor.
+ * @return array<int,mixed>
+ */
+function agents_api_phpstan_consume_runtime(
+	WP_Agent_Conversation_Completion_Policy $policy,
+	WP_Agent_Transcript_Persister $persister,
+	WP_Agent_Tool_Executor $executor
+): array {
+	return array(
+		$policy,
+		$persister,
+		$executor,
+		WP_Agent_Run_Outcome::normalize( null, array( 'completed' => true ) ),
+		WP_Agent_Runtime_Tool_Request::normalize(
+			array(
+				'id'           => 'request-1',
+				'tool_call_id' => 'call-1',
+				'tool_name'    => 'example/tool',
+				'parameters'   => array(),
+				'status'       => WP_Agent_Runtime_Tool_Request::STATUS_PENDING,
+			)
+		),
 	);
 }


### PR DESCRIPTION
## Summary
- extend the package-owned lazy Composer classmap from package contracts to the complete public `src/` type surface
- keep procedural registration and runtime bootstrap owned by `agents-api.php`
- prove conversation, run-outcome, runtime-tool, transcript, and tool-executor contracts resolve in a consumer-only PHPStan fixture

## Verification
- consumer-only PHPStan: passed with no custom config or stubs
- Agents API max-level PHPStan: passed
- Composer autoload outside WordPress remains inert and public classes remain lazy
- normal bootstrap: passed
- version-skew bootstrap: passed
- complete source vocabulary/bootstrap assertions: passed

Closes #526