### PR TITLE
Return typed workflow errors for run-control contention

### DIFF
--- a/agents-api.php
+++ b/agents-api.php
@@ -63,6 +63,9 @@ if ( defined( 'AGENTS_API_LOADED' ) ) {
 			if ( ! in_array( $token[0], array( T_CLASS, T_INTERFACE, T_TRAIT ), true ) ) {
 				continue;
 			}
+			if ( T_CLASS === $token[0] && T_DOUBLE_COLON === ( $tokens[ $index - 1 ][0] ?? null ) ) {
+				continue;
+			}
 
 			for ( ++$index; $index < $count; ++$index ) {
 				$symbol_token = $tokens[ $index ];

--- a/agents-api.php
+++ b/agents-api.php
@@ -237,6 +237,7 @@ require_once AGENTS_API_PATH . 'src/Runtime/interface-wp-agent-run-control-store
 require_once AGENTS_API_PATH . 'src/Runtime/interface-wp-agent-workspace-run-control-store.php';
 require_once AGENTS_API_PATH . 'src/Runtime/interface-wp-agent-atomic-run-control-store.php';
 require_once AGENTS_API_PATH . 'src/Runtime/interface-wp-agent-atomic-workspace-run-control-store.php';
+require_once AGENTS_API_PATH . 'src/Runtime/interface-wp-agent-exclusive-run-control-store.php';
 require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-run-control-store-exception.php';
 require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-option-run-control-store.php';
 require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-run-control.php';

--- a/agents-api.php
+++ b/agents-api.php
@@ -234,6 +234,7 @@ require_once AGENTS_API_PATH . 'src/Runtime/interface-wp-agent-run-control-store
 require_once AGENTS_API_PATH . 'src/Runtime/interface-wp-agent-workspace-run-control-store.php';
 require_once AGENTS_API_PATH . 'src/Runtime/interface-wp-agent-atomic-run-control-store.php';
 require_once AGENTS_API_PATH . 'src/Runtime/interface-wp-agent-atomic-workspace-run-control-store.php';
+require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-run-control-store-exception.php';
 require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-option-run-control-store.php';
 require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-run-control.php';
 require_once AGENTS_API_PATH . 'src/Runtime/class-wp-agent-run-result-envelope.php';

--- a/composer.json
+++ b/composer.json
@@ -116,6 +116,7 @@
       "php tests/conversation-loop-budgets-smoke.php",
       "php tests/runtime-package-run-contract-smoke.php",
       "php tests/run-control-normalization-smoke.php",
+      "php tests/run-control-option-store-failures-smoke.php",
       "php tests/canonical-run-lifecycle-smoke.php",
       "php tests/channels-smoke.php",
       "php tests/chat-run-control-smoke.php",

--- a/src/Runtime/class-wp-agent-option-run-control-store.php
+++ b/src/Runtime/class-wp-agent-option-run-control-store.php
@@ -14,6 +14,9 @@ defined( 'ABSPATH' ) || exit;
 if ( ! interface_exists( WP_Agent_Atomic_Workspace_Run_Control_Store::class ) ) {
 	require_once __DIR__ . '/interface-wp-agent-atomic-workspace-run-control-store.php';
 }
+if ( ! interface_exists( WP_Agent_Exclusive_Run_Control_Store::class ) ) {
+	require_once __DIR__ . '/interface-wp-agent-exclusive-run-control-store.php';
+}
 if ( ! class_exists( __NAMESPACE__ . '\\WP_Agent_Run_Control_Store_Exception', false ) ) {
 	require_once __DIR__ . '/class-wp-agent-run-control-store-exception.php';
 }
@@ -21,13 +24,15 @@ if ( ! class_exists( __NAMESPACE__ . '\\WP_Agent_Run_Control_Store_Exception', f
 /**
  * Persists run-control state in WordPress options.
  */
-class WP_Agent_Option_Run_Control_Store implements WP_Agent_Atomic_Workspace_Run_Control_Store {
+class WP_Agent_Option_Run_Control_Store implements WP_Agent_Atomic_Workspace_Run_Control_Store, WP_Agent_Exclusive_Run_Control_Store {
 
 	private const LOCK_PREFIX       = '_agents_api_run_lock_';
 	private const LOCK_WAIT_SECONDS = 5.0;
 	private const LOCK_TTL_SECONDS  = 15.0;
 
 	private ?\wpdb $database;
+	/** @var array<string,true> */
+	private array $active_claims = array();
 
 	public function __construct( ?\wpdb $database = null ) {
 		$this->database = $database;
@@ -67,8 +72,10 @@ class WP_Agent_Option_Run_Control_Store implements WP_Agent_Atomic_Workspace_Run
 		}
 		$db      = $this->wordpress_database();
 		$updated = $this->write_wordpress_option( $db, static fn() => update_option( $store_key, $state, false ) );
-		if ( ! $updated && $state !== $this->read_wordpress_option( $db, static fn() => get_option( $store_key, array() ) ) ) {
-			throw new WP_Agent_Run_Control_Store_Exception( 'Run-control state write failed.' );
+		if ( ! $updated && null !== $db ) {
+			// False also represents unchanged values and intentional filter vetoes.
+			// The direct read verifies DB availability without consulting API caches.
+			$this->read_option_state( $db, $db->options, $store_key );
 		}
 	}
 
@@ -143,8 +150,46 @@ class WP_Agent_Option_Run_Control_Store implements WP_Agent_Atomic_Workspace_Run
 		$option_key = $this->workspace_option_key( $store_key, $workspace );
 		$db         = $this->wordpress_database();
 		$updated    = $this->write_wordpress_option( $db, static fn() => update_site_option( $option_key, $state ) );
-		if ( ! $updated && $state !== $this->read_wordpress_option( $db, static fn() => get_site_option( $option_key, array() ) ) ) {
-			throw new WP_Agent_Run_Control_Store_Exception( 'Workspace run-control state write failed.' );
+		if ( ! $updated && null !== $db ) {
+			$this->read_workspace_state( $db, $option_key );
+		}
+	}
+
+	public function execute_claimed( string $claim_key, callable $callback ): bool {
+		$db        = $this->database();
+		$lock_name = 'agents-api:' . substr( hash( 'sha256', $claim_key ), 0, 53 );
+		if ( isset( $this->active_claims[ $lock_name ] ) ) {
+			return false;
+		}
+
+		$acquired = $this->get_var( $db, $db->prepare( 'SELECT GET_LOCK(%s, 0)', $lock_name ) );
+		if ( 0 === $acquired || '0' === $acquired ) {
+			return false;
+		}
+		if ( 1 !== $acquired && '1' !== $acquired ) {
+			throw new WP_Agent_Run_Control_Store_Exception( 'Run-control claim acquisition failed.' );
+		}
+
+		$this->active_claims[ $lock_name ] = true;
+		$primary_error = null;
+		try {
+			$callback();
+			return true;
+		} catch ( \Throwable $error ) {
+			$primary_error = $error;
+			throw $error;
+		} finally {
+			unset( $this->active_claims[ $lock_name ] );
+			try {
+				$released = $this->get_var( $db, $db->prepare( 'SELECT RELEASE_LOCK(%s)', $lock_name ) );
+				if ( 1 !== $released && '1' !== $released ) {
+					throw new WP_Agent_Run_Control_Store_Exception( 'Run-control claim release failed.' );
+				}
+			} catch ( \Throwable $release_error ) {
+				if ( null === $primary_error ) {
+					throw $release_error;
+				}
+			}
 		}
 	}
 
@@ -478,10 +523,19 @@ class WP_Agent_Option_Run_Control_Store implements WP_Agent_Atomic_Workspace_Run
 	}
 
 	private function read_wordpress_option( ?\wpdb $db, callable $read ): mixed {
+		global $wpdb;
+		$previous_database = $wpdb ?? null;
 		if ( null !== $db ) {
 			$db->last_error = '';
+			$wpdb = $db;
 		}
-		$value = $read();
+		try {
+			$value = $read();
+		} finally {
+			if ( null !== $db ) {
+				$wpdb = $previous_database;
+			}
+		}
 		if ( $this->database_has_error( $db ) ) {
 			throw new WP_Agent_Run_Control_Store_Exception( 'Run-control state read failed.' );
 		}
@@ -489,10 +543,19 @@ class WP_Agent_Option_Run_Control_Store implements WP_Agent_Atomic_Workspace_Run
 	}
 
 	private function write_wordpress_option( ?\wpdb $db, callable $write ): bool {
+		global $wpdb;
+		$previous_database = $wpdb ?? null;
 		if ( null !== $db ) {
 			$db->last_error = '';
+			$wpdb = $db;
 		}
-		$written = $write();
+		try {
+			$written = $write();
+		} finally {
+			if ( null !== $db ) {
+				$wpdb = $previous_database;
+			}
+		}
 		if ( $this->database_has_error( $db ) ) {
 			throw new WP_Agent_Run_Control_Store_Exception( 'Run-control state write failed.' );
 		}

--- a/src/Runtime/class-wp-agent-option-run-control-store.php
+++ b/src/Runtime/class-wp-agent-option-run-control-store.php
@@ -38,7 +38,11 @@ class WP_Agent_Option_Run_Control_Store implements WP_Agent_Atomic_Workspace_Run
 	 * @return array{runs:array<string,array<string,mixed>>,queues:array<string,array<int,array<string,mixed>>>,events:array<string,array<int,array<string,mixed>>>}
 	 */
 	public function get_state( string $store_key ): array {
-		$state = function_exists( 'get_option' ) ? get_option( $store_key, array() ) : array();
+		if ( ! function_exists( 'get_option' ) ) {
+			return array( 'runs' => array(), 'queues' => array(), 'events' => array() );
+		}
+		$db    = $this->wordpress_database();
+		$state = $this->read_wordpress_option( $db, static fn() => get_option( $store_key, array() ) );
 		if ( ! is_array( $state ) ) {
 			$state = array();
 		}
@@ -55,8 +59,16 @@ class WP_Agent_Option_Run_Control_Store implements WP_Agent_Atomic_Workspace_Run
 	 * @param array{runs:array<string,array<string,mixed>>,queues:array<string,array<int,array<string,mixed>>>,events:array<string,array<int,array<string,mixed>>>} $state State envelope.
 	 */
 	public function save_state( string $store_key, array $state ): void {
-		if ( function_exists( 'update_option' ) ) {
-			update_option( $store_key, $state, false );
+		if ( ! function_exists( 'update_option' ) ) {
+			return;
+		}
+		if ( ! function_exists( 'get_option' ) ) {
+			throw new \RuntimeException( 'The run-control store requires a readable WordPress options API.' );
+		}
+		$db      = $this->wordpress_database();
+		$updated = $this->write_wordpress_option( $db, static fn() => update_option( $store_key, $state, false ) );
+		if ( ! $updated && $state !== $this->read_wordpress_option( $db, static fn() => get_option( $store_key, array() ) ) ) {
+			throw new WP_Agent_Run_Control_Store_Exception( 'Run-control state write failed.' );
 		}
 	}
 
@@ -66,6 +78,7 @@ class WP_Agent_Option_Run_Control_Store implements WP_Agent_Atomic_Workspace_Run
 		$lock_key   = $this->lock_option_key( 'site:' . $table . ':' . $store_key );
 		$lock_value = $this->acquire_lock( $db, $table, $lock_key );
 
+		$primary_error = null;
 		try {
 			$state   = $this->read_option_state( $db, $table, $store_key );
 			$mutated = $this->mutation_result( $mutation( $state ) );
@@ -78,8 +91,17 @@ class WP_Agent_Option_Run_Control_Store implements WP_Agent_Atomic_Workspace_Run
 			);
 			$this->refresh_site_cache( $store_key, $mutated['state'] );
 			return $mutated['result'];
+		} catch ( \Throwable $error ) {
+			$primary_error = $error;
+			throw $error;
 		} finally {
-			$this->release_lock( $db, $table, $lock_key, $lock_value );
+			try {
+				$this->release_lock( $db, $table, $lock_key, $lock_value );
+			} catch ( \Throwable $release_error ) {
+				if ( null === $primary_error ) {
+					throw $release_error;
+				}
+			}
 		}
 	}
 
@@ -95,7 +117,8 @@ class WP_Agent_Option_Run_Control_Store implements WP_Agent_Atomic_Workspace_Run
 			throw new \RuntimeException( 'The run-control store cannot share explicit workspace state.' );
 		}
 
-		$state = get_site_option( $this->workspace_option_key( $store_key, $workspace ), array() );
+		$db    = $this->wordpress_database();
+		$state = $this->read_wordpress_option( $db, fn() => get_site_option( $this->workspace_option_key( $store_key, $workspace ), array() ) );
 		if ( ! is_array( $state ) ) {
 			$state = array();
 		}
@@ -113,11 +136,16 @@ class WP_Agent_Option_Run_Control_Store implements WP_Agent_Atomic_Workspace_Run
 	 * @param array{runs:array<string,array<string,mixed>>,queues:array<string,array<int,array<string,mixed>>>,events:array<string,array<int,array<string,mixed>>>} $state State envelope.
 	 */
 	public function save_workspace_state( string $store_key, WP_Agent_Workspace_Scope $workspace, array $state ): void {
-		if ( ! function_exists( 'update_site_option' ) ) {
+		if ( ! function_exists( 'update_site_option' ) || ! function_exists( 'get_site_option' ) ) {
 			throw new \RuntimeException( 'The run-control store cannot share explicit workspace state.' );
 		}
 
-		update_site_option( $this->workspace_option_key( $store_key, $workspace ), $state );
+		$option_key = $this->workspace_option_key( $store_key, $workspace );
+		$db         = $this->wordpress_database();
+		$updated    = $this->write_wordpress_option( $db, static fn() => update_site_option( $option_key, $state ) );
+		if ( ! $updated && $state !== $this->read_wordpress_option( $db, static fn() => get_site_option( $option_key, array() ) ) ) {
+			throw new WP_Agent_Run_Control_Store_Exception( 'Workspace run-control state write failed.' );
+		}
 	}
 
 	public function mutate_workspace_state( string $store_key, WP_Agent_Workspace_Scope $workspace, callable $mutation ): mixed {
@@ -130,6 +158,7 @@ class WP_Agent_Option_Run_Control_Store implements WP_Agent_Atomic_Workspace_Run
 		$lock_key   = $this->lock_option_key( 'workspace:' . $db->sitemeta . ':' . $this->network_id( $db ) . ':' . $option_key );
 		$lock_value = $this->acquire_lock( $db, $lock_table, $lock_key );
 
+		$primary_error = null;
 		try {
 			$state   = $this->read_workspace_state( $db, $option_key );
 			$mutated = $this->mutation_result( $mutation( $state ) );
@@ -142,8 +171,17 @@ class WP_Agent_Option_Run_Control_Store implements WP_Agent_Atomic_Workspace_Run
 			);
 			$this->refresh_workspace_cache( $this->network_id( $db ), $option_key, $mutated['state'] );
 			return $mutated['result'];
+		} catch ( \Throwable $error ) {
+			$primary_error = $error;
+			throw $error;
 		} finally {
-			$this->release_lock( $db, $lock_table, $lock_key, $lock_value );
+			try {
+				$this->release_lock( $db, $lock_table, $lock_key, $lock_value );
+			} catch ( \Throwable $release_error ) {
+				if ( null === $primary_error ) {
+					throw $release_error;
+				}
+			}
 		}
 	}
 
@@ -162,6 +200,15 @@ class WP_Agent_Option_Run_Control_Store implements WP_Agent_Atomic_Workspace_Run
 		}
 
 		return $wpdb;
+	}
+
+	private function wordpress_database(): ?\wpdb {
+		if ( $this->database instanceof \wpdb ) {
+			return $this->database;
+		}
+
+		global $wpdb;
+		return $wpdb instanceof \wpdb ? $wpdb : null;
 	}
 
 	private function main_options_table( \wpdb $db ): string {
@@ -189,8 +236,7 @@ class WP_Agent_Option_Run_Control_Store implements WP_Agent_Atomic_Workspace_Run
 				return $lock_value;
 			}
 			if ( false === $created ) {
-				usleep( 50000 );
-				continue;
+				throw new WP_Agent_Run_Control_Store_Exception( 'Atomic run-control lock creation failed.' );
 			}
 
 			$current = $this->get_var( $db, $db->prepare( 'SELECT option_value FROM %i WHERE option_name = %s LIMIT 1', $table, $lock_key ) );
@@ -200,8 +246,7 @@ class WP_Agent_Option_Run_Control_Store implements WP_Agent_Atomic_Workspace_Run
 					return $lock_value;
 				}
 				if ( false === $replaced ) {
-					usleep( 50000 );
-					continue;
+					throw new WP_Agent_Run_Control_Store_Exception( 'Atomic run-control lock takeover failed.' );
 				}
 			}
 
@@ -214,7 +259,7 @@ class WP_Agent_Option_Run_Control_Store implements WP_Agent_Atomic_Workspace_Run
 	private function release_lock( \wpdb $db, string $table, string $lock_key, string $lock_value ): void {
 		$released = $this->query( $db, $db->prepare( 'DELETE FROM %i WHERE option_name = %s AND option_value = %s', $table, $lock_key, $lock_value ) );
 		if ( false === $released ) {
-			throw new \RuntimeException( 'Atomic run-control lock release failed.' );
+			throw new WP_Agent_Run_Control_Store_Exception( 'Atomic run-control lock release failed.' );
 		}
 	}
 
@@ -224,7 +269,7 @@ class WP_Agent_Option_Run_Control_Store implements WP_Agent_Atomic_Workspace_Run
 			throw new \RuntimeException( 'Atomic run-control lock token is invalid.' );
 		}
 		if ( false === $this->query( $db, 'START TRANSACTION' ) ) {
-			throw new \RuntimeException( 'Atomic run-control transaction could not start.' );
+			throw new WP_Agent_Run_Control_Store_Exception( 'Atomic run-control transaction could not start.' );
 		}
 		try {
 			$current = $this->get_var( $db, $db->prepare( 'SELECT option_value FROM %i WHERE option_name = %s FOR UPDATE', $table, $lock_key ) );
@@ -238,7 +283,7 @@ class WP_Agent_Option_Run_Control_Store implements WP_Agent_Atomic_Workspace_Run
 			}
 			$write();
 			if ( false === $this->query( $db, 'COMMIT' ) ) {
-				throw new \RuntimeException( 'Atomic run-control transaction could not commit.' );
+				throw new WP_Agent_Run_Control_Store_Exception( 'Atomic run-control transaction could not commit.' );
 			}
 			return $refreshed;
 		} catch ( \Throwable $error ) {
@@ -284,7 +329,7 @@ class WP_Agent_Option_Run_Control_Store implements WP_Agent_Atomic_Workspace_Run
 	private function write_option_state( \wpdb $db, string $table, string $store_key, array $state ): void {
 		$written = $this->query( $db, $db->prepare( "INSERT INTO %i (option_name, option_value, autoload) VALUES (%s, %s, 'no') ON DUPLICATE KEY UPDATE option_value = VALUES(option_value), autoload = 'no'", $table, $store_key, $this->serialize_value( $state ) ) );
 		if ( false === $written ) {
-			throw new \RuntimeException( 'Atomic run-control state write failed.' );
+			throw new WP_Agent_Run_Control_Store_Exception( 'Atomic run-control state write failed.' );
 		}
 	}
 
@@ -299,7 +344,7 @@ class WP_Agent_Option_Run_Control_Store implements WP_Agent_Atomic_Workspace_Run
 		$value   = $this->serialize_value( $state );
 		$updated = $this->query( $db, $db->prepare( 'UPDATE %i SET meta_value = %s WHERE site_id = %d AND meta_key = %s', $db->sitemeta, $value, $this->network_id( $db ), $option_key ) );
 		if ( false === $updated ) {
-			throw new \RuntimeException( 'Atomic workspace run-control state write failed.' );
+			throw new WP_Agent_Run_Control_Store_Exception( 'Atomic workspace run-control state write failed.' );
 		}
 		if ( 0 === $updated ) {
 			$existing = $this->get_var( $db, $db->prepare( 'SELECT meta_id FROM %i WHERE site_id = %d AND meta_key = %s LIMIT 1', $db->sitemeta, $this->network_id( $db ), $option_key ) );
@@ -307,6 +352,9 @@ class WP_Agent_Option_Run_Control_Store implements WP_Agent_Atomic_Workspace_Run
 				return;
 			}
 			$inserted = $this->query( $db, $db->prepare( 'INSERT INTO %i (site_id, meta_key, meta_value) VALUES (%d, %s, %s)', $db->sitemeta, $this->network_id( $db ), $option_key, $value ) );
+			if ( false === $inserted ) {
+				throw new WP_Agent_Run_Control_Store_Exception( 'Atomic workspace run-control state creation failed.' );
+			}
 			if ( 1 !== $inserted ) {
 				throw new \RuntimeException( 'Atomic workspace run-control state creation failed.' );
 			}
@@ -421,11 +469,38 @@ class WP_Agent_Option_Run_Control_Store implements WP_Agent_Atomic_Workspace_Run
 		if ( ! is_string( $query ) ) {
 			throw new \RuntimeException( 'Atomic run-control query preparation failed.' );
 		}
+		$db->last_error = '';
 		$value = $db->get_var( $query );
-		if ( '' !== $db->last_error ) {
-			throw new \RuntimeException( 'Atomic run-control state read failed: ' . $db->last_error );
+		if ( $this->database_has_error( $db ) ) {
+			throw new WP_Agent_Run_Control_Store_Exception( 'Atomic run-control state read failed.' );
 		}
 		return $value;
+	}
+
+	private function read_wordpress_option( ?\wpdb $db, callable $read ): mixed {
+		if ( null !== $db ) {
+			$db->last_error = '';
+		}
+		$value = $read();
+		if ( $this->database_has_error( $db ) ) {
+			throw new WP_Agent_Run_Control_Store_Exception( 'Run-control state read failed.' );
+		}
+		return $value;
+	}
+
+	private function write_wordpress_option( ?\wpdb $db, callable $write ): bool {
+		if ( null !== $db ) {
+			$db->last_error = '';
+		}
+		$written = $write();
+		if ( $this->database_has_error( $db ) ) {
+			throw new WP_Agent_Run_Control_Store_Exception( 'Run-control state write failed.' );
+		}
+		return (bool) $written;
+	}
+
+	private function database_has_error( ?\wpdb $db ): bool {
+		return null !== $db && '' !== $db->last_error;
 	}
 
 	/** @return int|bool */

--- a/src/Runtime/class-wp-agent-option-run-control-store.php
+++ b/src/Runtime/class-wp-agent-option-run-control-store.php
@@ -14,6 +14,9 @@ defined( 'ABSPATH' ) || exit;
 if ( ! interface_exists( WP_Agent_Atomic_Workspace_Run_Control_Store::class ) ) {
 	require_once __DIR__ . '/interface-wp-agent-atomic-workspace-run-control-store.php';
 }
+if ( ! class_exists( __NAMESPACE__ . '\\WP_Agent_Run_Control_Store_Exception', false ) ) {
+	require_once __DIR__ . '/class-wp-agent-run-control-store-exception.php';
+}
 
 /**
  * Persists run-control state in WordPress options.
@@ -205,7 +208,7 @@ class WP_Agent_Option_Run_Control_Store implements WP_Agent_Atomic_Workspace_Run
 			usleep( 50000 );
 		} while ( microtime( true ) < $deadline );
 
-		throw new \RuntimeException( 'Atomic run-control lock acquisition timed out.' );
+		throw new WP_Agent_Run_Control_Store_Exception( 'Atomic run-control lock acquisition timed out.' );
 	}
 
 	private function release_lock( \wpdb $db, string $table, string $lock_key, string $lock_value ): void {
@@ -226,12 +229,12 @@ class WP_Agent_Option_Run_Control_Store implements WP_Agent_Atomic_Workspace_Run
 		try {
 			$current = $this->get_var( $db, $db->prepare( 'SELECT option_value FROM %i WHERE option_name = %s FOR UPDATE', $table, $lock_key ) );
 			if ( ! is_string( $current ) || ! hash_equals( $lock_value, $current ) ) {
-				throw new \RuntimeException( 'Atomic run-control lock ownership was lost before state write.' );
+				throw new WP_Agent_Run_Control_Store_Exception( 'Atomic run-control lock ownership was lost before state write.' );
 			}
 			$refreshed = $this->lock_value( $decoded['token'] );
 			$updated   = $this->query( $db, $db->prepare( "UPDATE %i SET option_value = %s, autoload = 'no' WHERE option_name = %s AND option_value = %s", $table, $refreshed, $lock_key, $lock_value ) );
 			if ( 1 !== $updated ) {
-				throw new \RuntimeException( 'Atomic run-control lock ownership was lost before state write.' );
+				throw new WP_Agent_Run_Control_Store_Exception( 'Atomic run-control lock ownership was lost before state write.' );
 			}
 			$write();
 			if ( false === $this->query( $db, 'COMMIT' ) ) {

--- a/src/Runtime/class-wp-agent-run-control-store-exception.php
+++ b/src/Runtime/class-wp-agent-run-control-store-exception.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Temporary run-control storage failure.
+ *
+ * @package AgentsAPI
+ */
+
+namespace AgentsAPI\AI;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Identifies storage failures that callers may safely retry.
+ */
+class WP_Agent_Run_Control_Store_Exception extends \RuntimeException {}

--- a/src/Runtime/class-wp-agent-run-control.php
+++ b/src/Runtime/class-wp-agent-run-control.php
@@ -423,7 +423,7 @@ class WP_Agent_Run_Control {
 	/**
 	 * Serialize a read-modify-write mutation through the registered store.
 	 *
-	 * @param callable(array{runs:array<string,array<string,mixed>>,queues:array<string,array<int,array<string,mixed>>>,events:array<string,array<int,array<string,mixed>>>,idempotency?:array<string,string>}):array{state:array{runs:array<string,array<string,mixed>>,queues:array<string,array<int,array<string,mixed>>>,events:array<string,array<int,array<string,mixed>>>,idempotency?:array<string,string>},result:mixed} $mutation State mutation.
+	 * @param callable(array{runs:array<string,array<string,mixed>>,queues:array<string,array<int,array<string,mixed>>>,events:array<string,array<int,array<string,mixed>>>}):array{state:array{runs:array<string,array<string,mixed>>,queues:array<string,array<int,array<string,mixed>>>,events:array<string,array<int,array<string,mixed>>>},result:mixed} $mutation State mutation.
 	 * @return mixed Mutation result.
 	 */
 	public static function mutate_state( string $store_key, callable $mutation, ?WP_Agent_Workspace_Scope $workspace = null ): mixed {

--- a/src/Runtime/interface-wp-agent-atomic-run-control-store.php
+++ b/src/Runtime/interface-wp-agent-atomic-run-control-store.php
@@ -19,7 +19,7 @@ if ( ! interface_exists( __NAMESPACE__ . '\\WP_Agent_Run_Control_Store' ) ) {
 interface WP_Agent_Atomic_Run_Control_Store extends WP_Agent_Run_Control_Store {
 
 	/**
-	 * @param callable(array{runs:array<string,array<string,mixed>>,queues:array<string,array<int,array<string,mixed>>>,events:array<string,array<int,array<string,mixed>>>,idempotency?:array<string,string>}):array{state:array{runs:array<string,array<string,mixed>>,queues:array<string,array<int,array<string,mixed>>>,events:array<string,array<int,array<string,mixed>>>,idempotency?:array<string,string>},result:mixed} $mutation State mutation.
+	 * @param callable(array{runs:array<string,array<string,mixed>>,queues:array<string,array<int,array<string,mixed>>>,events:array<string,array<int,array<string,mixed>>>}):array{state:array{runs:array<string,array<string,mixed>>,queues:array<string,array<int,array<string,mixed>>>,events:array<string,array<int,array<string,mixed>>>},result:mixed} $mutation State mutation.
 	 * @return mixed Mutation result.
 	 * @throws WP_Agent_Run_Control_Store_Exception When storage is temporarily unavailable.
 	 */

--- a/src/Runtime/interface-wp-agent-atomic-run-control-store.php
+++ b/src/Runtime/interface-wp-agent-atomic-run-control-store.php
@@ -21,6 +21,7 @@ interface WP_Agent_Atomic_Run_Control_Store extends WP_Agent_Run_Control_Store {
 	/**
 	 * @param callable(array{runs:array<string,array<string,mixed>>,queues:array<string,array<int,array<string,mixed>>>,events:array<string,array<int,array<string,mixed>>>,idempotency?:array<string,string>}):array{state:array{runs:array<string,array<string,mixed>>,queues:array<string,array<int,array<string,mixed>>>,events:array<string,array<int,array<string,mixed>>>,idempotency?:array<string,string>},result:mixed} $mutation State mutation.
 	 * @return mixed Mutation result.
+	 * @throws WP_Agent_Run_Control_Store_Exception When storage is temporarily unavailable.
 	 */
 	public function mutate_state( string $store_key, callable $mutation ): mixed;
 }

--- a/src/Runtime/interface-wp-agent-atomic-workspace-run-control-store.php
+++ b/src/Runtime/interface-wp-agent-atomic-workspace-run-control-store.php
@@ -26,6 +26,7 @@ interface WP_Agent_Atomic_Workspace_Run_Control_Store extends WP_Agent_Atomic_Ru
 	/**
 	 * @param callable(array{runs:array<string,array<string,mixed>>,queues:array<string,array<int,array<string,mixed>>>,events:array<string,array<int,array<string,mixed>>>}):array{state:array{runs:array<string,array<string,mixed>>,queues:array<string,array<int,array<string,mixed>>>,events:array<string,array<int,array<string,mixed>>>},result:mixed} $mutation State mutation.
 	 * @return mixed Mutation result.
+	 * @throws WP_Agent_Run_Control_Store_Exception When storage is temporarily unavailable.
 	 */
 	public function mutate_workspace_state( string $store_key, WP_Agent_Workspace_Scope $workspace, callable $mutation ): mixed;
 }

--- a/src/Runtime/interface-wp-agent-exclusive-run-control-store.php
+++ b/src/Runtime/interface-wp-agent-exclusive-run-control-store.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Process-lifetime run-control claim capability.
+ *
+ * @package AgentsAPI
+ */
+
+namespace AgentsAPI\AI;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Optional capability for work that must not overlap while a worker is alive.
+ */
+interface WP_Agent_Exclusive_Run_Control_Store {
+
+	/**
+	 * Execute while holding a claim released automatically when the connection dies.
+	 *
+	 * @return bool Whether the claim was acquired and the callback executed.
+	 * @throws WP_Agent_Run_Control_Store_Exception When claim acquisition or release fails.
+	 */
+	public function execute_claimed( string $claim_key, callable $callback ): bool;
+}

--- a/src/Runtime/interface-wp-agent-run-control-store.php
+++ b/src/Runtime/interface-wp-agent-run-control-store.php
@@ -19,6 +19,7 @@ interface WP_Agent_Run_Control_Store {
 	 *
 	 * @param string $store_key Store key.
 	 * @return array{runs:array<string,array<string,mixed>>,queues:array<string,array<int,array<string,mixed>>>,events:array<string,array<int,array<string,mixed>>>}
+	 * @throws WP_Agent_Run_Control_Store_Exception When storage is temporarily unavailable.
 	 */
 	public function get_state( string $store_key ): array;
 
@@ -27,6 +28,7 @@ interface WP_Agent_Run_Control_Store {
 	 *
 	 * @param string $store_key Store key.
 	 * @param array{runs:array<string,array<string,mixed>>,queues:array<string,array<int,array<string,mixed>>>,events:array<string,array<int,array<string,mixed>>>} $state State envelope.
+	 * @throws WP_Agent_Run_Control_Store_Exception When storage is temporarily unavailable.
 	 */
 	public function save_state( string $store_key, array $state ): void;
 }

--- a/src/Runtime/interface-wp-agent-workspace-run-control-store.php
+++ b/src/Runtime/interface-wp-agent-workspace-run-control-store.php
@@ -22,11 +22,13 @@ interface WP_Agent_Workspace_Run_Control_Store extends WP_Agent_Run_Control_Stor
 
 	/**
 	 * @return array{runs:array<string,array<string,mixed>>,queues:array<string,array<int,array<string,mixed>>>,events:array<string,array<int,array<string,mixed>>>}
+	 * @throws WP_Agent_Run_Control_Store_Exception When storage is temporarily unavailable.
 	 */
 	public function get_workspace_state( string $store_key, WP_Agent_Workspace_Scope $workspace ): array;
 
 	/**
 	 * @param array{runs:array<string,array<string,mixed>>,queues:array<string,array<int,array<string,mixed>>>,events:array<string,array<int,array<string,mixed>>>} $state State envelope.
+	 * @throws WP_Agent_Run_Control_Store_Exception When storage is temporarily unavailable.
 	 */
 	public function save_workspace_state( string $store_key, WP_Agent_Workspace_Scope $workspace, array $state ): void;
 }

--- a/src/Workflows/class-wp-agent-workflow-request-controller.php
+++ b/src/Workflows/class-wp-agent-workflow-request-controller.php
@@ -7,6 +7,7 @@
 
 namespace AgentsAPI\AI\Workflows;
 
+use AgentsAPI\AI\WP_Agent_Exclusive_Run_Control_Store;
 use AgentsAPI\AI\WP_Agent_Run_Control;
 use AgentsAPI\AI\WP_Agent_Run_Control_Store_Exception;
 
@@ -24,7 +25,7 @@ final class WP_Agent_Workflow_Request_Controller {
 	public const SCHEMA = 'agents-api/workflow-request-controller/v1';
 	private const DEFAULT_ADVANCE_TIME_LIMIT_MS = 5000;
 	private const DEFAULT_ADVANCE_ACTION_LIMIT = 25;
-	private const TERMINAL_DELIVERY_LEASE_SECONDS = 60;
+	private const TERMINAL_DELIVERY_CLAIM_VERSION = 2;
 	private const MAX_TERMINAL_EVIDENCE_BYTES = 65536;
 
 	/** @var callable|null */
@@ -262,7 +263,9 @@ final class WP_Agent_Workflow_Request_Controller {
 					$phase = 'read_terminal';
 					$entry = $this->get( $operation_id ) ?? $entry;
 				}
-				return $this->response( $operation_id, $entry, false );
+				$stored_lease = $this->array_value( $entry['lease'] ?? array() );
+				$rejected     = $lease !== $this->string_value( $stored_lease['token'] ?? '' ) && $this->lease_is_active( $entry );
+				return $this->response( $operation_id, $entry, $rejected );
 			} catch ( \Throwable $error ) {
 				$primary_error = $error;
 				throw $error;
@@ -339,52 +342,80 @@ final class WP_Agent_Workflow_Request_Controller {
 
 	/** @param array<string,mixed> $entry */
 	private function deliver_terminal_once( string $operation_id, array $entry, WP_Agent_Workflow_Run_Result $result ): void {
-		$token   = bin2hex( random_bytes( 12 ) );
-		$claimed = WP_Agent_Run_Control::mutate_state( $this->store_key, function ( array $state ) use ( $operation_id, $token ) {
-			$stored = $this->array_value( $state['runs'][ $operation_id ] ?? array() );
-			$disposition = $this->string_value( $stored['disposition'] ?? '' );
-			$reclaimable = 'delivering' === $disposition && $this->int_value( $stored['delivery_expires_at'] ?? 0 ) <= $this->int_value( ( $this->clock )() );
-			if ( ! in_array( $disposition, array( 'pending', 'callback_failed' ), true ) && ! $reclaimable ) {
-				return array( 'state' => $state, 'result' => false );
-			}
-			$stored['disposition']        = 'delivering';
-			$stored['delivery_token']     = $token;
-			$stored['delivery_expires_at'] = $this->int_value( ( $this->clock )() ) + self::TERMINAL_DELIVERY_LEASE_SECONDS;
-			$stored['terminal_cleanup']   = true;
-			$stored['lease']              = array();
-			$state['runs'][ $operation_id ] = $stored;
-			return array( 'state' => $state, 'result' => $token );
-		} );
-		if ( $token !== $claimed ) {
+		if ( null === $this->terminal_action && null === $this->terminal_cleanup ) {
+			WP_Agent_Run_Control::mutate_state( $this->store_key, function ( array $state ) use ( $operation_id ) {
+				$stored = $this->array_value( $state['runs'][ $operation_id ] ?? array() );
+				if ( in_array( $stored['disposition'] ?? '', array( 'pending', 'callback_failed' ), true ) ) {
+					$stored['disposition']            = 'delivered';
+					$stored['terminal_cleanup']       = true;
+					$stored['lease']                  = array();
+					$state['runs'][ $operation_id ]   = $stored;
+				}
+				return array( 'state' => $state, 'result' => null );
+			} );
 			return;
 		}
-		$delivered = true;
-		try {
-			if ( null !== $this->terminal_action ) {
-				call_user_func( $this->terminal_action, $operation_id, $result, $entry );
+
+		$store = WP_Agent_Run_Control::store();
+		if ( ! $store instanceof WP_Agent_Exclusive_Run_Control_Store ) {
+			throw new \RuntimeException( 'Terminal callbacks require a run-control store with exclusive claim support.' );
+		}
+		$disposition = $this->string_value( $entry['disposition'] ?? '' );
+		if ( 'delivering' === $disposition && self::TERMINAL_DELIVERY_CLAIM_VERSION !== $this->int_value( $entry['delivery_claim_version'] ?? 0 ) ) {
+			// A pre-upgrade worker may still be executing, and its fixed lease cannot
+			// prove process death. Avoid an unsafe automatic replay.
+			return;
+		}
+
+		$store->execute_claimed( $this->store_key . "\0terminal\0" . $operation_id, function () use ( $operation_id, $entry, $result ): void {
+			$token   = bin2hex( random_bytes( 12 ) );
+			$claimed = WP_Agent_Run_Control::mutate_state( $this->store_key, function ( array $state ) use ( $operation_id, $token ) {
+				$stored      = $this->array_value( $state['runs'][ $operation_id ] ?? array() );
+				$disposition = $this->string_value( $stored['disposition'] ?? '' );
+				$recoverable = 'delivering' === $disposition && self::TERMINAL_DELIVERY_CLAIM_VERSION === $this->int_value( $stored['delivery_claim_version'] ?? 0 );
+				if ( ! in_array( $disposition, array( 'pending', 'callback_failed' ), true ) && ! $recoverable ) {
+					return array( 'state' => $state, 'result' => false );
+				}
+				$stored['disposition']            = 'delivering';
+				$stored['delivery_token']         = $token;
+				$stored['delivery_claim_version'] = self::TERMINAL_DELIVERY_CLAIM_VERSION;
+				$stored['terminal_cleanup']       = true;
+				$stored['lease']                  = array();
+				$state['runs'][ $operation_id ]   = $stored;
+				return array( 'state' => $state, 'result' => $token );
+			} );
+			if ( $token !== $claimed ) {
+				return;
 			}
-		} catch ( \Throwable $error ) {
-			$delivered = false;
-			unset( $error );
-		} finally {
-			// Callback consumers must tolerate retry after an interrupted delivery.
-			if ( null !== $this->terminal_cleanup ) {
-				try {
-					call_user_func( $this->terminal_cleanup, $operation_id, $result, $entry );
-				} catch ( \Throwable $error ) {
-					$delivered = false;
-					unset( $error );
+
+			$delivered = true;
+			try {
+				if ( null !== $this->terminal_action ) {
+					call_user_func( $this->terminal_action, $operation_id, $result, $entry );
+				}
+			} catch ( \Throwable $error ) {
+				$delivered = false;
+				unset( $error );
+			} finally {
+				// Callback consumers must tolerate retry after an interrupted delivery.
+				if ( null !== $this->terminal_cleanup ) {
+					try {
+						call_user_func( $this->terminal_cleanup, $operation_id, $result, $entry );
+					} catch ( \Throwable $error ) {
+						$delivered = false;
+						unset( $error );
+					}
 				}
 			}
-		}
-		WP_Agent_Run_Control::mutate_state( $this->store_key, function ( array $state ) use ( $operation_id, $delivered, $token ) {
-			$stored = $this->array_value( $state['runs'][ $operation_id ] ?? array() );
-			if ( 'delivering' === ( $stored['disposition'] ?? '' ) && $token === ( $stored['delivery_token'] ?? '' ) ) {
-				$stored['disposition'] = $delivered ? 'delivered' : 'callback_failed';
-				unset( $stored['delivery_token'], $stored['delivery_expires_at'] );
-				$state['runs'][ $operation_id ] = $stored;
-			}
-			return array( 'state' => $state, 'result' => null );
+			WP_Agent_Run_Control::mutate_state( $this->store_key, function ( array $state ) use ( $operation_id, $delivered, $token ) {
+				$stored = $this->array_value( $state['runs'][ $operation_id ] ?? array() );
+				if ( 'delivering' === ( $stored['disposition'] ?? '' ) && $token === ( $stored['delivery_token'] ?? '' ) ) {
+					$stored['disposition'] = $delivered ? 'delivered' : 'callback_failed';
+					unset( $stored['delivery_token'], $stored['delivery_claim_version'] );
+					$state['runs'][ $operation_id ] = $stored;
+				}
+				return array( 'state' => $state, 'result' => null );
+			} );
 		} );
 	}
 

--- a/src/Workflows/class-wp-agent-workflow-request-controller.php
+++ b/src/Workflows/class-wp-agent-workflow-request-controller.php
@@ -24,6 +24,7 @@ final class WP_Agent_Workflow_Request_Controller {
 	public const SCHEMA = 'agents-api/workflow-request-controller/v1';
 	private const DEFAULT_ADVANCE_TIME_LIMIT_MS = 5000;
 	private const DEFAULT_ADVANCE_ACTION_LIMIT = 25;
+	private const TERMINAL_DELIVERY_LEASE_SECONDS = 60;
 	private const MAX_TERMINAL_EVIDENCE_BYTES = 65536;
 
 	/** @var callable|null */
@@ -165,13 +166,6 @@ final class WP_Agent_Workflow_Request_Controller {
 					return array( 'state' => $state, 'result' => null );
 				}
 				$run_id = 'workflow_request_' . substr( hash( 'sha256', $this->store_key . "\0" . $operation_id ), 0, 32 );
-				// The idempotency mapping and authoritative run identity share this atomic write.
-				$idempotency = array();
-				foreach ( $this->array_value( $state['idempotency'] ?? array() ) as $key => $value ) {
-					$idempotency[ $key ] = $this->string_value( $value );
-				}
-				$idempotency[ $operation_id ] = $run_id;
-				$state['idempotency'] = $idempotency;
 				$state['runs'][ $operation_id ] = array(
 					'run_id'      => $run_id,
 					'spec'        => $spec->to_array(),
@@ -210,9 +204,26 @@ final class WP_Agent_Workflow_Request_Controller {
 			if ( null === $lease ) {
 				$phase = 'read_status';
 				$entry = $this->get( $operation_id );
-				return null === $entry ? new \WP_Error( 'agents_workflow_operation_not_found', 'No workflow operation was found for the requested operation_id.' ) : $this->response( $operation_id, $entry, true );
+				if ( null === $entry ) {
+					return new \WP_Error( 'agents_workflow_operation_not_found', 'No workflow operation was found for the requested operation_id.' );
+				}
+				if ( ! empty( $entry['terminal'] ) ) {
+					$result = $this->recorder->find( $this->string_value( $entry['run_id'] ?? '' ) );
+					if ( null !== $result ) {
+						if ( 'delivered' !== ( $entry['disposition'] ?? '' ) ) {
+							$this->cleanup_operation_actions( $result->get_run_id() );
+						}
+						$phase = 'deliver_terminal';
+						$this->deliver_terminal_once( $operation_id, $entry, $result );
+						$phase = 'read_terminal';
+						$entry = $this->get( $operation_id ) ?? $entry;
+					}
+					return $this->response( $operation_id, $entry, false );
+				}
+				return $this->response( $operation_id, $entry, true );
 			}
 
+			$primary_error = null;
 			try {
 				$phase = 'read_operation';
 				$entry = $this->get( $operation_id );
@@ -243,7 +254,7 @@ final class WP_Agent_Workflow_Request_Controller {
 				}
 
 				$phase = 'record_terminal';
-				$entry = $this->record_terminal( $operation_id, $result );
+				$entry = $this->record_terminal( $operation_id, $result, $lease );
 				if ( ! empty( $entry['terminal'] ) ) {
 					$this->cleanup_operation_actions( $result->get_run_id() );
 					$phase = 'deliver_terminal';
@@ -252,10 +263,19 @@ final class WP_Agent_Workflow_Request_Controller {
 					$entry = $this->get( $operation_id ) ?? $entry;
 				}
 				return $this->response( $operation_id, $entry, false );
+			} catch ( \Throwable $error ) {
+				$primary_error = $error;
+				throw $error;
 			} finally {
 				$active_phase = $phase;
 				$phase        = 'release_lease';
-				$this->release_lease( $operation_id, $lease );
+				try {
+					$this->release_lease( $operation_id, $lease );
+				} catch ( \Throwable $release_error ) {
+					if ( null === $primary_error ) {
+						throw $release_error;
+					}
+				}
 				$phase = $active_phase;
 			}
 		} catch ( WP_Agent_Run_Control_Store_Exception $error ) {
@@ -298,9 +318,12 @@ final class WP_Agent_Workflow_Request_Controller {
 	}
 
 	/** @return array<string,mixed> */
-	private function record_terminal( string $operation_id, WP_Agent_Workflow_Run_Result $result ): array {
-		$stored = WP_Agent_Run_Control::mutate_state( $this->store_key, function ( array $state ) use ( $operation_id, $result ) {
+	private function record_terminal( string $operation_id, WP_Agent_Workflow_Run_Result $result, ?string $lease_token = null ): array {
+		$stored = WP_Agent_Run_Control::mutate_state( $this->store_key, function ( array $state ) use ( $operation_id, $result, $lease_token ) {
 			$entry = $this->array_value( $state['runs'][ $operation_id ] ?? array() );
+			if ( null !== $lease_token && $lease_token !== $this->string_value( $this->array_value( $entry['lease'] ?? array() )['token'] ?? '' ) ) {
+				return array( 'state' => $state, 'result' => $entry );
+			}
 			if ( $this->is_terminal( $result ) && empty( $entry['terminal'] ) ) {
 				$entry['terminal']        = true;
 				$entry['terminal_status'] = $result->get_status();
@@ -316,18 +339,23 @@ final class WP_Agent_Workflow_Request_Controller {
 
 	/** @param array<string,mixed> $entry */
 	private function deliver_terminal_once( string $operation_id, array $entry, WP_Agent_Workflow_Run_Result $result ): void {
-		$claimed = WP_Agent_Run_Control::mutate_state( $this->store_key, function ( array $state ) use ( $operation_id ) {
+		$token   = bin2hex( random_bytes( 12 ) );
+		$claimed = WP_Agent_Run_Control::mutate_state( $this->store_key, function ( array $state ) use ( $operation_id, $token ) {
 			$stored = $this->array_value( $state['runs'][ $operation_id ] ?? array() );
-			if ( ! in_array( $stored['disposition'] ?? '', array( 'pending', 'callback_failed' ), true ) ) {
+			$disposition = $this->string_value( $stored['disposition'] ?? '' );
+			$reclaimable = 'delivering' === $disposition && $this->int_value( $stored['delivery_expires_at'] ?? 0 ) <= $this->int_value( ( $this->clock )() );
+			if ( ! in_array( $disposition, array( 'pending', 'callback_failed' ), true ) && ! $reclaimable ) {
 				return array( 'state' => $state, 'result' => false );
 			}
-			$stored['disposition']       = 'delivering';
-			$stored['terminal_cleanup']  = true;
-			$stored['lease']             = array();
+			$stored['disposition']        = 'delivering';
+			$stored['delivery_token']     = $token;
+			$stored['delivery_expires_at'] = $this->int_value( ( $this->clock )() ) + self::TERMINAL_DELIVERY_LEASE_SECONDS;
+			$stored['terminal_cleanup']   = true;
+			$stored['lease']              = array();
 			$state['runs'][ $operation_id ] = $stored;
-			return array( 'state' => $state, 'result' => true );
+			return array( 'state' => $state, 'result' => $token );
 		} );
-		if ( true !== $claimed ) {
+		if ( $token !== $claimed ) {
 			return;
 		}
 		$delivered = true;
@@ -349,10 +377,11 @@ final class WP_Agent_Workflow_Request_Controller {
 				}
 			}
 		}
-		WP_Agent_Run_Control::mutate_state( $this->store_key, function ( array $state ) use ( $operation_id, $delivered ) {
+		WP_Agent_Run_Control::mutate_state( $this->store_key, function ( array $state ) use ( $operation_id, $delivered, $token ) {
 			$stored = $this->array_value( $state['runs'][ $operation_id ] ?? array() );
-			if ( 'delivering' === ( $stored['disposition'] ?? '' ) ) {
+			if ( 'delivering' === ( $stored['disposition'] ?? '' ) && $token === ( $stored['delivery_token'] ?? '' ) ) {
 				$stored['disposition'] = $delivered ? 'delivered' : 'callback_failed';
+				unset( $stored['delivery_token'], $stored['delivery_expires_at'] );
 				$state['runs'][ $operation_id ] = $stored;
 			}
 			return array( 'state' => $state, 'result' => null );

--- a/src/Workflows/class-wp-agent-workflow-request-controller.php
+++ b/src/Workflows/class-wp-agent-workflow-request-controller.php
@@ -8,6 +8,7 @@
 namespace AgentsAPI\AI\Workflows;
 
 use AgentsAPI\AI\WP_Agent_Run_Control;
+use AgentsAPI\AI\WP_Agent_Run_Control_Store_Exception;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -61,8 +62,13 @@ final class WP_Agent_Workflow_Request_Controller {
 			return new \WP_Error( 'agents_workflow_operation_required', 'operation_id must be a non-empty string.' );
 		}
 
-		$this->reserve( $operation_id, $spec, $inputs, $options );
-		return $this->advance( $operation_id, $options );
+		try {
+			$this->reserve( $operation_id, $spec, $inputs, $options );
+		} catch ( WP_Agent_Run_Control_Store_Exception $error ) {
+			unset( $error );
+			return $this->storage_unavailable( 'start', 'reserve' );
+		}
+		return $this->advance_operation( $operation_id, $options, 'start' );
 	}
 
 	/**
@@ -73,7 +79,7 @@ final class WP_Agent_Workflow_Request_Controller {
 	 * @return array<string,mixed>|\WP_Error
 	 */
 	public function reconnect( string $operation_id, array $options = array() ): array|\WP_Error {
-		return $this->advance( trim( $operation_id ), $options );
+		return $this->advance_operation( trim( $operation_id ), $options, 'reconnect' );
 	}
 
 	/**
@@ -83,7 +89,12 @@ final class WP_Agent_Workflow_Request_Controller {
 	 */
 	public function get_status( string $operation_id ): array|\WP_Error {
 		$operation_id = trim( $operation_id );
-		$entry        = $this->get( $operation_id );
+		try {
+			$entry = $this->get( $operation_id );
+		} catch ( WP_Agent_Run_Control_Store_Exception $error ) {
+			unset( $error );
+			return $this->storage_unavailable( 'get_status', 'read' );
+		}
 		if ( null === $entry ) {
 			return new \WP_Error( 'agents_workflow_operation_not_found', 'No workflow operation was found for the requested operation_id.' );
 		}
@@ -98,29 +109,41 @@ final class WP_Agent_Workflow_Request_Controller {
 	 */
 	public function cancel( string $operation_id ): array|\WP_Error {
 		$operation_id = trim( $operation_id );
-		$entry        = $this->get( $operation_id );
-		if ( '' === $operation_id || null === $entry ) {
-			return new \WP_Error( 'agents_workflow_operation_not_found', 'No workflow operation was found for the requested operation_id.' );
-		}
+		$phase        = 'read';
+		try {
+			$entry = $this->get( $operation_id );
+			if ( '' === $operation_id || null === $entry ) {
+				return new \WP_Error( 'agents_workflow_operation_not_found', 'No workflow operation was found for the requested operation_id.' );
+			}
 
-		$run_id = $this->string_value( $entry['run_id'] ?? '' );
-		WP_Agent_Run_Control::request_cancel( WP_Agent_Workflow_Runner::RUN_CONTROL_STORE, $run_id );
-		$result = $this->recorder->find( $run_id );
-		if ( null !== $result && ! $this->is_terminal( $result ) ) {
-			$result = $result->with( array(
-				'status'   => WP_Agent_Workflow_Run_Result::STATUS_CANCELLED,
-				'error'    => array( 'code' => 'cancel_requested', 'message' => 'Workflow operation cancellation was requested.' ),
-				'ended_at' => $this->int_value( ( $this->clock )() ),
-			) );
-			$this->recorder->update( $result );
+			$run_id = $this->string_value( $entry['run_id'] ?? '' );
+			$phase  = 'request_cancel';
+			WP_Agent_Run_Control::request_cancel( WP_Agent_Workflow_Runner::RUN_CONTROL_STORE, $run_id );
+			$result = $this->recorder->find( $run_id );
+			if ( null !== $result && ! $this->is_terminal( $result ) ) {
+				$result = $result->with( array(
+					'status'   => WP_Agent_Workflow_Run_Result::STATUS_CANCELLED,
+					'error'    => array( 'code' => 'cancel_requested', 'message' => 'Workflow operation cancellation was requested.' ),
+					'ended_at' => $this->int_value( ( $this->clock )() ),
+				) );
+				$this->recorder->update( $result );
+			}
+			if ( null === $result ) {
+				$phase = 'read_status';
+				$entry = $this->get( $operation_id );
+				return null === $entry ? new \WP_Error( 'agents_workflow_operation_not_found', 'No workflow operation was found for the requested operation_id.' ) : $this->response( $operation_id, $entry, $this->lease_is_active( $entry ) );
+			}
+			$phase = 'record_terminal';
+			$entry = $this->record_terminal( $operation_id, $result );
+			$this->cleanup_operation_actions( $run_id );
+			$phase = 'deliver_terminal';
+			$this->deliver_terminal_once( $operation_id, $entry, $result );
+			$phase = 'read_terminal';
+			return $this->response( $operation_id, $this->get( $operation_id ) ?? $entry, false );
+		} catch ( WP_Agent_Run_Control_Store_Exception $error ) {
+			unset( $error );
+			return $this->storage_unavailable( 'cancel', $phase );
 		}
-		if ( null === $result ) {
-			return $this->get_status( $operation_id );
-		}
-		$entry = $this->record_terminal( $operation_id, $result );
-		$this->cleanup_operation_actions( $run_id );
-		$this->deliver_terminal_once( $operation_id, $entry, $result );
-		return $this->response( $operation_id, $this->get( $operation_id ) ?? $entry, false );
 	}
 
 	/** @return array<string,mixed>|null */
@@ -168,51 +191,76 @@ final class WP_Agent_Workflow_Request_Controller {
 	 * @return array<string,mixed>|\WP_Error
 	 */
 	public function advance( string $operation_id, array $options = array() ): array|\WP_Error {
+		return $this->advance_operation( $operation_id, $options, 'advance' );
+	}
+
+	/**
+	 * @param array<string,mixed> $options
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	private function advance_operation( string $operation_id, array $options, string $operation ): array|\WP_Error {
 		if ( '' === $operation_id ) {
 			return new \WP_Error( 'agents_workflow_operation_required', 'operation_id must be a non-empty string.' );
 		}
-		$await_options = $this->bounded_await_options( $options );
-		$lease_seconds = max( $this->int_value( $options['lease_seconds'] ?? 0 ), (int) ceil( $this->int_value( $await_options['time_limit_ms'] ) / 1000 ) + 2, 1 );
-		$lease = $this->claim_lease( $operation_id, $lease_seconds, $this->string_value( $options['worker_id'] ?? '' ) );
-		if ( null === $lease ) {
-			$entry = $this->get( $operation_id );
-			return null === $entry ? new \WP_Error( 'agents_workflow_operation_not_found', 'No workflow operation was found for the requested operation_id.' ) : $this->response( $operation_id, $entry, true );
-		}
-
+		$phase = 'claim_lease';
 		try {
-			$entry = $this->get( $operation_id );
-			if ( null === $entry ) {
-				return new \WP_Error( 'agents_workflow_operation_not_found', 'No workflow operation was found for the requested operation_id.' );
-			}
-			$result = $this->recorder->find( $this->string_value( $entry['run_id'] ?? '' ) );
-			if ( null === $result ) {
-				$spec = WP_Agent_Workflow_Spec::from_array( is_array( $entry['spec'] ?? null ) ? $entry['spec'] : array() );
-				if ( is_wp_error( $spec ) ) {
-					return $spec;
-				}
-				$run_options           = is_array( $entry['options'] ?? null ) ? $entry['options'] : array();
-				$run_options['run_id'] = $this->string_value( $entry['run_id'] ?? '' );
-				$result                = $this->runner->run( $spec, is_array( $entry['inputs'] ?? null ) ? $entry['inputs'] : array(), $run_options );
+			$await_options = $this->bounded_await_options( $options );
+			$lease_seconds = max( $this->int_value( $options['lease_seconds'] ?? 0 ), (int) ceil( $this->int_value( $await_options['time_limit_ms'] ) / 1000 ) + 2, 1 );
+			$lease = $this->claim_lease( $operation_id, $lease_seconds, $this->string_value( $options['worker_id'] ?? '' ) );
+			if ( null === $lease ) {
+				$phase = 'read_status';
+				$entry = $this->get( $operation_id );
+				return null === $entry ? new \WP_Error( 'agents_workflow_operation_not_found', 'No workflow operation was found for the requested operation_id.' ) : $this->response( $operation_id, $entry, true );
 			}
 
-			if ( $result->is_suspended() ) {
-				$this->renew_lease( $operation_id, $lease, $lease_seconds );
-				$awaited = $this->awaiter->await( $result->get_run_id(), $this->recorder, $await_options );
-				if ( is_wp_error( $awaited ) ) {
-					return $awaited;
+			try {
+				$phase = 'read_operation';
+				$entry = $this->get( $operation_id );
+				if ( null === $entry ) {
+					return new \WP_Error( 'agents_workflow_operation_not_found', 'No workflow operation was found for the requested operation_id.' );
 				}
-				$result = $this->recorder->find( $result->get_run_id() ) ?? $result;
-			}
+				$result = $this->recorder->find( $this->string_value( $entry['run_id'] ?? '' ) );
+				if ( null === $result ) {
+					$spec = WP_Agent_Workflow_Spec::from_array( is_array( $entry['spec'] ?? null ) ? $entry['spec'] : array() );
+					if ( is_wp_error( $spec ) ) {
+						return $spec;
+					}
+					$run_options           = is_array( $entry['options'] ?? null ) ? $entry['options'] : array();
+					$run_options['run_id'] = $this->string_value( $entry['run_id'] ?? '' );
+					$phase                  = 'run';
+					$result                 = $this->runner->run( $spec, is_array( $entry['inputs'] ?? null ) ? $entry['inputs'] : array(), $run_options );
+				}
 
-			$entry = $this->record_terminal( $operation_id, $result );
-			if ( ! empty( $entry['terminal'] ) ) {
-				$this->cleanup_operation_actions( $result->get_run_id() );
-				$this->deliver_terminal_once( $operation_id, $entry, $result );
-				$entry = $this->get( $operation_id ) ?? $entry;
+				if ( $result->is_suspended() ) {
+					$phase = 'renew_lease';
+					$this->renew_lease( $operation_id, $lease, $lease_seconds );
+					$phase   = 'await';
+					$awaited = $this->awaiter->await( $result->get_run_id(), $this->recorder, $await_options );
+					if ( is_wp_error( $awaited ) ) {
+						return $awaited;
+					}
+					$result = $this->recorder->find( $result->get_run_id() ) ?? $result;
+				}
+
+				$phase = 'record_terminal';
+				$entry = $this->record_terminal( $operation_id, $result );
+				if ( ! empty( $entry['terminal'] ) ) {
+					$this->cleanup_operation_actions( $result->get_run_id() );
+					$phase = 'deliver_terminal';
+					$this->deliver_terminal_once( $operation_id, $entry, $result );
+					$phase = 'read_terminal';
+					$entry = $this->get( $operation_id ) ?? $entry;
+				}
+				return $this->response( $operation_id, $entry, false );
+			} finally {
+				$active_phase = $phase;
+				$phase        = 'release_lease';
+				$this->release_lease( $operation_id, $lease );
+				$phase = $active_phase;
 			}
-			return $this->response( $operation_id, $entry, false );
-		} finally {
-			$this->release_lease( $operation_id, $lease );
+		} catch ( WP_Agent_Run_Control_Store_Exception $error ) {
+			unset( $error );
+			return $this->storage_unavailable( $operation, $phase );
 		}
 	}
 
@@ -348,6 +396,19 @@ final class WP_Agent_Workflow_Request_Controller {
 			'busy'          => $busy,
 			'status'        => $terminal ? $this->string_value( $entry['terminal_status'] ?? '' ) : 'running',
 			'result'        => $terminal ? ( $entry['result'] ?? null ) : null,
+		);
+	}
+
+	private function storage_unavailable( string $operation, string $phase ): \WP_Error {
+		return new \WP_Error(
+			'agents_workflow_run_control_unavailable',
+			'Workflow run-control storage is temporarily unavailable. Retry the operation.',
+			array(
+				'status'    => 503,
+				'retryable' => true,
+				'operation' => $operation,
+				'phase'     => $phase,
+			)
 		);
 	}
 

--- a/tests/run-control-option-store-failures-smoke.php
+++ b/tests/run-control-option-store-failures-smoke.php
@@ -13,6 +13,10 @@ if ( ! class_exists( 'wpdb' ) ) {
 		public array $rows = array();
 		/** @var array<string,mixed> */
 		public array $api_options = array();
+		public bool $veto_option_write = false;
+		public bool $veto_site_option_write = false;
+		/** @var array<string,true> */
+		public array $claims = array();
 		private string $fault = '';
 		/** @var array<string,array{query:string,args:array<int,mixed>}> */
 		private array $prepared = array();
@@ -53,9 +57,12 @@ if ( ! class_exists( 'wpdb' ) ) {
 		}
 		public function get_var( string $query ): mixed {
 			$prepared = $this->prepared[ $query ]; $sql = $prepared['query']; $args = $prepared['args'];
+			if ( str_starts_with( $sql, 'SELECT GET_LOCK' ) ) { if ( false === $this->result( 'claim_acquire', 1 ) ) { return null; } $key = (string) $args[0]; if ( isset( $this->claims[ $key ] ) ) { return 0; } $this->claims[ $key ] = true; return 1; }
+			if ( str_starts_with( $sql, 'SELECT RELEASE_LOCK' ) ) { if ( false === $this->result( 'claim_release', 1 ) ) { return null; } unset( $this->claims[ (string) $args[0] ] ); return 1; }
 			$operation = str_contains( $sql, 'option_value' ) && str_starts_with( (string) $args[1], '_agents_api_run_lock_' ) ? 'lock_read' : 'state_read';
 			if ( false === $this->result( $operation, 1 ) ) { return null; }
-			return $this->rows[ (string) $args[1] ] ?? null;
+			$key = str_contains( $sql, 'meta_value' ) ? (string) $args[2] : (string) $args[1];
+			return $this->rows[ $key ] ?? null;
 		}
 		public function suppress_errors( bool $suppress ): bool { unset( $suppress ); return false; }
 		public function get_blog_prefix( int $blog_id = 1 ): string { unset( $blog_id ); return 'wp_'; }
@@ -68,32 +75,37 @@ if ( ! class_exists( 'wpdb' ) ) {
 	}
 }
 
-$GLOBALS['option_store_db'] = null;
 function get_option( string $key, mixed $default = false ): mixed {
-	$db = $GLOBALS['option_store_db'];
+	global $wpdb; $db = $wpdb;
 	if ( false === $db->api_result( 'option_read', true ) ) { return $default; }
 	return $db->api_options[ $key ] ?? $default;
 }
 function update_option( string $key, mixed $value, mixed $autoload = null ): bool {
-	unset( $autoload ); $db = $GLOBALS['option_store_db'];
+	global $wpdb; unset( $autoload ); $db = $wpdb;
 	if ( false === $db->api_result( 'option_write', true ) ) { return false; }
+	if ( $db->veto_option_write ) { return false; }
 	if ( array_key_exists( $key, $db->api_options ) && $value === $db->api_options[ $key ] ) { return false; }
-	$db->api_options[ $key ] = $value; return true;
+	$db->api_options[ $key ] = $value; $db->rows[ $key ] = serialize( $value ); return true;
 }
+function get_site_option( string $key, mixed $default = false ): mixed { return get_option( $key, $default ); }
+function update_site_option( string $key, mixed $value ): bool { global $wpdb; if ( $wpdb->veto_site_option_write ) { return false; } return update_option( $key, $value ); }
 
 require_once __DIR__ . '/../src/Runtime/interface-wp-agent-run-control-store.php';
 require_once __DIR__ . '/../src/Runtime/interface-wp-agent-workspace-run-control-store.php';
 require_once __DIR__ . '/../src/Runtime/interface-wp-agent-atomic-run-control-store.php';
 require_once __DIR__ . '/../src/Runtime/interface-wp-agent-atomic-workspace-run-control-store.php';
+require_once __DIR__ . '/../src/Runtime/interface-wp-agent-exclusive-run-control-store.php';
 require_once __DIR__ . '/../src/Runtime/class-wp-agent-run-control-store-exception.php';
+require_once __DIR__ . '/../src/Workspace/class-wp-agent-workspace-scope.php';
 require_once __DIR__ . '/../src/Runtime/class-wp-agent-option-run-control-store.php';
 
 use AgentsAPI\AI\WP_Agent_Option_Run_Control_Store;
 use AgentsAPI\AI\WP_Agent_Run_Control_Store_Exception;
+use AgentsAPI\Core\Workspace\WP_Agent_Workspace_Scope;
 
 $fails = array(); $passes = 0;
 function option_store_assert( bool $ok, string $name ): void { global $fails, $passes; if ( $ok ) { ++$passes; echo "  PASS $name\n"; } else { $fails[] = $name; echo "  FAIL $name\n"; } }
-function option_store_fixture(): array { $db = new wpdb(); $GLOBALS['option_store_db'] = $db; return array( $db, new WP_Agent_Option_Run_Control_Store( $db ) ); }
+function option_store_fixture(): array { $db = new wpdb(); $GLOBALS['wpdb'] = $db; return array( $db, new WP_Agent_Option_Run_Control_Store( $db ) ); }
 function option_store_mutation( array $state ): array { $state['runs']['operation'] = array( 'run_id' => 'deterministic-run' ); return array( 'state' => $state, 'result' => 'stored' ); }
 
 echo "run-control-option-store-failures-smoke\n";
@@ -111,6 +123,24 @@ $state = array( 'runs' => array(), 'queues' => array(), 'events' => array() );
 $store->save_state( 'unchanged', $state ); $store->save_state( 'unchanged', $state );
 option_store_assert( $state === $store->get_state( 'unchanged' ), 'unchanged update_option false is preserved as a successful no-op' );
 
+list( $db, $store ) = option_store_fixture();
+$db->veto_option_write = true;
+$store->save_state( 'vetoed', $state );
+option_store_assert( array() === $db->api_options, 'intentional update_option veto is not classified as a temporary database outage' );
+
+list( $db, $store ) = option_store_fixture();
+$db->veto_site_option_write = true;
+$store->save_workspace_state( 'vetoed', WP_Agent_Workspace_Scope::from_parts( 'site', '1' ), $state );
+option_store_assert( array() === $db->api_options, 'intentional update_site_option veto is not classified as a temporary database outage' );
+
+$injected = new wpdb(); $global = new wpdb();
+$injected->api_options['authority'] = array( 'runs' => array( 'injected' => array( 'run_id' => 'injected' ) ), 'queues' => array(), 'events' => array() );
+$global->api_options['authority'] = array( 'runs' => array( 'global' => array( 'run_id' => 'global' ) ), 'queues' => array(), 'events' => array() );
+$global->last_error = 'Unrelated connection error.'; $GLOBALS['wpdb'] = $global;
+$authority_store = new WP_Agent_Option_Run_Control_Store( $injected );
+$authority_state = $authority_store->get_state( 'authority' );
+option_store_assert( isset( $authority_state['runs']['injected'] ) && ! isset( $authority_state['runs']['global'] ) && $global === $GLOBALS['wpdb'], 'injected connection is the coherent option API and error authority' );
+
 foreach ( array( 'lock_insert', 'state_read', 'start', 'state_write', 'commit', 'lock_release' ) as $operation ) {
 	list( $db, $store ) = option_store_fixture(); $db->fail_next( $operation );
 	try { $store->mutate_state( 'atomic-state', 'option_store_mutation' ); $typed = false; } catch ( WP_Agent_Run_Control_Store_Exception $error ) { $typed = true; }
@@ -125,6 +155,18 @@ try {
 	$primary_preserved = 'Primary mutation bug.' === $error->getMessage();
 }
 option_store_assert( $primary_preserved, 'lock release failure does not replace an in-flight programmer exception' );
+
+list( $db, $store ) = option_store_fixture();
+$nested_claimed = true;
+$claimed = $store->execute_claimed( 'terminal-operation', static function () use ( $store, &$nested_claimed ): void { $nested_claimed = $store->execute_claimed( 'terminal-operation', static function (): void {} ); } );
+$recovered_claim = $store->execute_claimed( 'terminal-operation', static function (): void {} );
+option_store_assert( $claimed && ! $nested_claimed && $recovered_claim, 'connection-lifetime claim rejects live overlap and is recoverable after release' );
+
+foreach ( array( 'claim_acquire', 'claim_release' ) as $operation ) {
+	list( $db, $store ) = option_store_fixture(); $db->fail_next( $operation );
+	try { $store->execute_claimed( 'failed-claim', static function (): void {} ); $typed = false; } catch ( WP_Agent_Run_Control_Store_Exception $error ) { $typed = true; }
+	option_store_assert( $typed, "{$operation} failure uses the retryable store exception" );
+}
 
 list( $db, $store ) = option_store_fixture();
 $stored = $store->mutate_state( 'normalized-state', static function ( array $state ): array { $state['runs']['operation'] = array( 'run_id' => 'deterministic-run' ); $state['idempotency'] = array( 'operation' => 'other-run' ); return array( 'state' => $state, 'result' => null ); } );

--- a/tests/run-control-option-store-failures-smoke.php
+++ b/tests/run-control-option-store-failures-smoke.php
@@ -1,0 +1,136 @@
+<?php
+/** Run with: php tests/run-control-option-store-failures-smoke.php */
+
+defined( 'ABSPATH' ) || define( 'ABSPATH', __DIR__ . '/' );
+
+if ( ! class_exists( 'wpdb' ) ) {
+	class wpdb {
+		public string $options = 'wp_options';
+		public string $sitemeta = 'wp_sitemeta';
+		public int $siteid = 1;
+		public string $last_error = '';
+		/** @var array<string,string> */
+		public array $rows = array();
+		/** @var array<string,mixed> */
+		public array $api_options = array();
+		private string $fault = '';
+		/** @var array<string,array{query:string,args:array<int,mixed>}> */
+		private array $prepared = array();
+
+		public function fail_next( string $operation ): void { $this->fault = $operation; }
+		public function prepare( string $query, ...$args ): string {
+			$key = 'prepared:' . count( $this->prepared );
+			$this->prepared[ $key ] = array( 'query' => $query, 'args' => $args );
+			return $key;
+		}
+		public function query( string $query ): int|bool {
+			if ( 'START TRANSACTION' === $query ) { return $this->result( 'start', 1 ); }
+			if ( 'COMMIT' === $query ) { return $this->result( 'commit', 1 ); }
+			if ( 'ROLLBACK' === $query ) { return 1; }
+			$prepared = $this->prepared[ $query ]; $sql = $prepared['query']; $args = $prepared['args'];
+			if ( str_starts_with( $sql, 'INSERT IGNORE' ) ) {
+				if ( false === $this->result( 'lock_insert', 1 ) ) { return false; }
+				if ( isset( $this->rows[ (string) $args[1] ] ) ) { return 0; }
+				$this->rows[ (string) $args[1] ] = (string) $args[2]; return 1;
+			}
+			if ( str_starts_with( $sql, 'UPDATE %i SET option_value' ) ) {
+				if ( false === $this->result( 'lock_update', 1 ) ) { return false; }
+				$key = (string) $args[2];
+				if ( ! isset( $this->rows[ $key ] ) || (string) $args[3] !== $this->rows[ $key ] ) { return 0; }
+				$this->rows[ $key ] = (string) $args[1]; return 1;
+			}
+			if ( str_starts_with( $sql, 'DELETE FROM' ) ) {
+				if ( false === $this->result( 'lock_release', 1 ) ) { return false; }
+				$key = (string) $args[1];
+				if ( isset( $this->rows[ $key ] ) && (string) $args[2] === $this->rows[ $key ] ) { unset( $this->rows[ $key ] ); return 1; }
+				return 0;
+			}
+			if ( str_starts_with( $sql, 'INSERT INTO %i (option_name' ) ) {
+				if ( false === $this->result( 'state_write', 1 ) ) { return false; }
+				$this->rows[ (string) $args[1] ] = (string) $args[2]; return 1;
+			}
+			throw new RuntimeException( 'Unexpected test query: ' . $sql );
+		}
+		public function get_var( string $query ): mixed {
+			$prepared = $this->prepared[ $query ]; $sql = $prepared['query']; $args = $prepared['args'];
+			$operation = str_contains( $sql, 'option_value' ) && str_starts_with( (string) $args[1], '_agents_api_run_lock_' ) ? 'lock_read' : 'state_read';
+			if ( false === $this->result( $operation, 1 ) ) { return null; }
+			return $this->rows[ (string) $args[1] ] ?? null;
+		}
+		public function suppress_errors( bool $suppress ): bool { unset( $suppress ); return false; }
+		public function get_blog_prefix( int $blog_id = 1 ): string { unset( $blog_id ); return 'wp_'; }
+		public function api_result( string $operation, mixed $success ): mixed { return $this->result( $operation, $success ); }
+		private function result( string $operation, mixed $success ): mixed {
+			$this->last_error = '';
+			if ( $operation === $this->fault ) { $this->fault = ''; $this->last_error = 'Injected database failure.'; return false; }
+			return $success;
+		}
+	}
+}
+
+$GLOBALS['option_store_db'] = null;
+function get_option( string $key, mixed $default = false ): mixed {
+	$db = $GLOBALS['option_store_db'];
+	if ( false === $db->api_result( 'option_read', true ) ) { return $default; }
+	return $db->api_options[ $key ] ?? $default;
+}
+function update_option( string $key, mixed $value, mixed $autoload = null ): bool {
+	unset( $autoload ); $db = $GLOBALS['option_store_db'];
+	if ( false === $db->api_result( 'option_write', true ) ) { return false; }
+	if ( array_key_exists( $key, $db->api_options ) && $value === $db->api_options[ $key ] ) { return false; }
+	$db->api_options[ $key ] = $value; return true;
+}
+
+require_once __DIR__ . '/../src/Runtime/interface-wp-agent-run-control-store.php';
+require_once __DIR__ . '/../src/Runtime/interface-wp-agent-workspace-run-control-store.php';
+require_once __DIR__ . '/../src/Runtime/interface-wp-agent-atomic-run-control-store.php';
+require_once __DIR__ . '/../src/Runtime/interface-wp-agent-atomic-workspace-run-control-store.php';
+require_once __DIR__ . '/../src/Runtime/class-wp-agent-run-control-store-exception.php';
+require_once __DIR__ . '/../src/Runtime/class-wp-agent-option-run-control-store.php';
+
+use AgentsAPI\AI\WP_Agent_Option_Run_Control_Store;
+use AgentsAPI\AI\WP_Agent_Run_Control_Store_Exception;
+
+$fails = array(); $passes = 0;
+function option_store_assert( bool $ok, string $name ): void { global $fails, $passes; if ( $ok ) { ++$passes; echo "  PASS $name\n"; } else { $fails[] = $name; echo "  FAIL $name\n"; } }
+function option_store_fixture(): array { $db = new wpdb(); $GLOBALS['option_store_db'] = $db; return array( $db, new WP_Agent_Option_Run_Control_Store( $db ) ); }
+function option_store_mutation( array $state ): array { $state['runs']['operation'] = array( 'run_id' => 'deterministic-run' ); return array( 'state' => $state, 'result' => 'stored' ); }
+
+echo "run-control-option-store-failures-smoke\n";
+
+list( $db, $store ) = option_store_fixture();
+$db->fail_next( 'option_read' );
+try { $store->get_state( 'state' ); $typed_read = false; } catch ( WP_Agent_Run_Control_Store_Exception $error ) { $typed_read = true; }
+option_store_assert( $typed_read, 'options API database read failure uses the retryable store exception' );
+
+list( $db, $store ) = option_store_fixture();
+$db->fail_next( 'option_write' );
+try { $store->save_state( 'state', array( 'runs' => array(), 'queues' => array(), 'events' => array() ) ); $typed_write = false; } catch ( WP_Agent_Run_Control_Store_Exception $error ) { $typed_write = true; }
+option_store_assert( $typed_write, 'options API database write failure is not silently ignored' );
+$state = array( 'runs' => array(), 'queues' => array(), 'events' => array() );
+$store->save_state( 'unchanged', $state ); $store->save_state( 'unchanged', $state );
+option_store_assert( $state === $store->get_state( 'unchanged' ), 'unchanged update_option false is preserved as a successful no-op' );
+
+foreach ( array( 'lock_insert', 'state_read', 'start', 'state_write', 'commit', 'lock_release' ) as $operation ) {
+	list( $db, $store ) = option_store_fixture(); $db->fail_next( $operation );
+	try { $store->mutate_state( 'atomic-state', 'option_store_mutation' ); $typed = false; } catch ( WP_Agent_Run_Control_Store_Exception $error ) { $typed = true; }
+	option_store_assert( $typed, "atomic {$operation} failure uses the retryable store exception" );
+}
+
+list( $db, $store ) = option_store_fixture();
+try {
+	$store->mutate_state( 'primary-error', static function ( array $state ) use ( $db ): array { unset( $state ); $db->fail_next( 'lock_release' ); throw new LogicException( 'Primary mutation bug.' ); } );
+	$primary_preserved = false;
+} catch ( LogicException $error ) {
+	$primary_preserved = 'Primary mutation bug.' === $error->getMessage();
+}
+option_store_assert( $primary_preserved, 'lock release failure does not replace an in-flight programmer exception' );
+
+list( $db, $store ) = option_store_fixture();
+$stored = $store->mutate_state( 'normalized-state', static function ( array $state ): array { $state['runs']['operation'] = array( 'run_id' => 'deterministic-run' ); $state['idempotency'] = array( 'operation' => 'other-run' ); return array( 'state' => $state, 'result' => null ); } );
+unset( $stored );
+$normalized = $store->mutate_state( 'normalized-state', static fn( array $state ): array => array( 'state' => $state, 'result' => $state ) );
+option_store_assert( 'deterministic-run' === ( $normalized['runs']['operation']['run_id'] ?? '' ) && ! isset( $normalized['idempotency'] ), 'production normalization relies on the authoritative operation record, not a false idempotency map' );
+
+echo 'Passed: ' . $passes . ', Failed: ' . count( $fails ) . "\n";
+exit( empty( $fails ) ? 0 : 1 );

--- a/tests/workflow-request-controller-smoke.php
+++ b/tests/workflow-request-controller-smoke.php
@@ -12,6 +12,7 @@ if ( ! function_exists( 'is_wp_error' ) ) { function is_wp_error( $value ): bool
 
 require_once __DIR__ . '/../src/Runtime/interface-wp-agent-run-control-store.php';
 require_once __DIR__ . '/../src/Runtime/interface-wp-agent-atomic-run-control-store.php';
+require_once __DIR__ . '/../src/Runtime/interface-wp-agent-exclusive-run-control-store.php';
 require_once __DIR__ . '/../src/Runtime/class-wp-agent-run-control-store-exception.php';
 require_once __DIR__ . '/../src/Runtime/class-wp-agent-run-control.php';
 require_once __DIR__ . '/../src/Workflows/class-wp-agent-workflow-spec-validator.php';
@@ -36,6 +37,7 @@ if ( ! function_exists( 'as_unschedule_all_actions' ) ) {
 }
 
 use AgentsAPI\AI\WP_Agent_Atomic_Run_Control_Store;
+use AgentsAPI\AI\WP_Agent_Exclusive_Run_Control_Store;
 use AgentsAPI\AI\WP_Agent_Run_Control;
 use AgentsAPI\AI\WP_Agent_Run_Control_Store_Exception;
 use AgentsAPI\AI\Workflows\WP_Agent_Workflow_Request_Controller;
@@ -45,11 +47,13 @@ use AgentsAPI\AI\Workflows\WP_Agent_Workflow_Run_Result;
 use AgentsAPI\AI\Workflows\WP_Agent_Workflow_Runner;
 use AgentsAPI\AI\Workflows\WP_Agent_Workflow_Spec;
 
-class Controller_Memory_Store implements WP_Agent_Atomic_Run_Control_Store {
+class Controller_Memory_Store implements WP_Agent_Atomic_Run_Control_Store, WP_Agent_Exclusive_Run_Control_Store {
 	public array $states = array();
+	private array $claims = array();
 	public function get_state( string $key ): array { return $this->states[ $key ] ?? array( 'runs' => array(), 'queues' => array(), 'events' => array() ); }
 	public function save_state( string $key, array $state ): void { $this->states[ $key ] = $state; }
 	public function mutate_state( string $key, callable $mutation ): mixed { $out = $mutation( $this->get_state( $key ) ); $this->save_state( $key, $out['state'] ); return $out['result']; }
+	public function execute_claimed( string $key, callable $callback ): bool { if ( isset( $this->claims[ $key ] ) ) { return false; } $this->claims[ $key ] = true; try { $callback(); return true; } finally { unset( $this->claims[ $key ] ); } }
 }
 final class Controller_Failing_Store extends Controller_Memory_Store {
 	private string $failure = '';
@@ -198,11 +202,22 @@ $terminal_runner->after_run = static function () use ( $terminal_store ): void {
 $claim_error = $terminal_controller->start( 'claim-uncertain', $spec, array( 'status' => 'succeeded' ) );
 $terminal_runner->after_run = null;
 controller_assert( $claim_error instanceof WP_Error && 'deliver_terminal' === ( $claim_error->get_error_data()['phase'] ?? '' ), 'uncertain delivery-claim commit returns a retryable public error' );
-$terminal_controller->reconnect( 'claim-uncertain' );
-controller_assert( array() === $terminal_deliveries, 'retry does not duplicate an unexpired uncertain delivery claim' );
-$clock += 61;
 $claim_retry = $terminal_controller->reconnect( 'claim-uncertain' );
-controller_assert( $claim_retry['terminal'] && array( 'claim-uncertain' ) === $terminal_deliveries && 'delivered' === ( $terminal_controller->get( 'claim-uncertain' )['disposition'] ?? '' ), 'expired delivery claim is reclaimed and token-fenced to completion' );
+controller_assert( $claim_retry['terminal'] && array( 'claim-uncertain' ) === $terminal_deliveries && 'delivered' === ( $terminal_controller->get( 'claim-uncertain' )['disposition'] ?? '' ), 'delivery resumes after an interrupted worker releases its process-lifetime claim' );
+
+$terminal_deliveries = array(); $nested_delivery = null;
+$slow_controller = null;
+$slow_controller = new WP_Agent_Workflow_Request_Controller( $terminal_runner, $terminal_recorder, $terminal_awaiter, 'controller-slow-terminal', static function ( $id ) use ( &$terminal_deliveries, &$nested_delivery, &$slow_controller, &$clock ) { $terminal_deliveries[] = $id; $clock += 600; $nested_delivery = $slow_controller->reconnect( $id ); }, null, static function () use ( &$clock ): int { return $clock; } );
+$slow_result = $slow_controller->start( 'slow-callback', $spec, array( 'status' => 'succeeded' ) );
+controller_assert( $slow_result['terminal'] && is_array( $nested_delivery ) && array( 'slow-callback' ) === $terminal_deliveries, 'slow live terminal callback is not reclaimed after an arbitrary elapsed interval' );
+
+$legacy_state = $terminal_store->get_state( 'controller-slow-terminal' );
+$legacy_state['runs']['slow-callback']['disposition'] = 'delivering';
+$legacy_state['runs']['slow-callback']['delivery_expires_at'] = 1;
+$terminal_store->save_state( 'controller-slow-terminal', $legacy_state );
+$terminal_deliveries = array();
+$slow_controller->reconnect( 'slow-callback' );
+controller_assert( array() === $terminal_deliveries && 'delivering' === ( $slow_controller->get( 'slow-callback' )['disposition'] ?? '' ), 'pre-upgrade delivering records are not replayed without proof that the old worker died' );
 
 $stale_store = new Controller_Memory_Store();
 WP_Agent_Run_Control::set_store( $stale_store );
@@ -214,7 +229,7 @@ $stale_runner->after_run = static function () use ( $stale_store ): void {
 	$stale_store->save_state( 'controller-stale-terminal', $state );
 };
 $stale_result = $stale_controller->start( 'stale-worker', $spec, array( 'status' => 'succeeded' ) );
-controller_assert( ! $stale_result['terminal'] && 'replacement-worker' === ( $stale_controller->get( 'stale-worker' )['lease']['token'] ?? '' ) && array() === $stale_deliveries, 'expired worker cannot terminalize or deliver after another worker reclaims its lease' );
+controller_assert( ! $stale_result['terminal'] && $stale_result['busy'] && 'replacement-worker' === ( $stale_controller->get( 'stale-worker' )['lease']['token'] ?? '' ) && array() === $stale_deliveries, 'stale worker rejection reports the active replacement owner as busy' );
 
 $release_store = new Controller_Failing_Store();
 WP_Agent_Run_Control::set_store( $release_store );

--- a/tests/workflow-request-controller-smoke.php
+++ b/tests/workflow-request-controller-smoke.php
@@ -3,12 +3,16 @@
 defined( 'ABSPATH' ) || define( 'ABSPATH', __DIR__ . '/' );
 
 if ( ! class_exists( 'WP_Error' ) ) {
-	class WP_Error { public function __construct( public string $code = '', public string $message = '' ) {} }
+	class WP_Error {
+		public function __construct( public string $code = '', public string $message = '', public mixed $data = array() ) {}
+		public function get_error_data(): mixed { return $this->data; }
+	}
 }
 if ( ! function_exists( 'is_wp_error' ) ) { function is_wp_error( $value ): bool { return $value instanceof WP_Error; } }
 
 require_once __DIR__ . '/../src/Runtime/interface-wp-agent-run-control-store.php';
 require_once __DIR__ . '/../src/Runtime/interface-wp-agent-atomic-run-control-store.php';
+require_once __DIR__ . '/../src/Runtime/class-wp-agent-run-control-store-exception.php';
 require_once __DIR__ . '/../src/Runtime/class-wp-agent-run-control.php';
 require_once __DIR__ . '/../src/Workflows/class-wp-agent-workflow-spec-validator.php';
 require_once __DIR__ . '/../src/Workflows/class-wp-agent-workflow-spec.php';
@@ -33,6 +37,7 @@ if ( ! function_exists( 'as_unschedule_all_actions' ) ) {
 
 use AgentsAPI\AI\WP_Agent_Atomic_Run_Control_Store;
 use AgentsAPI\AI\WP_Agent_Run_Control;
+use AgentsAPI\AI\WP_Agent_Run_Control_Store_Exception;
 use AgentsAPI\AI\Workflows\WP_Agent_Workflow_Request_Controller;
 use AgentsAPI\AI\Workflows\WP_Agent_Workflow_Run_Awaiter;
 use AgentsAPI\AI\Workflows\WP_Agent_Workflow_Run_Recorder;
@@ -40,11 +45,26 @@ use AgentsAPI\AI\Workflows\WP_Agent_Workflow_Run_Result;
 use AgentsAPI\AI\Workflows\WP_Agent_Workflow_Runner;
 use AgentsAPI\AI\Workflows\WP_Agent_Workflow_Spec;
 
-final class Controller_Memory_Store implements WP_Agent_Atomic_Run_Control_Store {
+class Controller_Memory_Store implements WP_Agent_Atomic_Run_Control_Store {
 	public array $states = array();
 	public function get_state( string $key ): array { return $this->states[ $key ] ?? array( 'runs' => array(), 'queues' => array(), 'events' => array() ); }
 	public function save_state( string $key, array $state ): void { $this->states[ $key ] = $state; }
 	public function mutate_state( string $key, callable $mutation ): mixed { $out = $mutation( $this->get_state( $key ) ); $this->save_state( $key, $out['state'] ); return $out['result']; }
+}
+final class Controller_Failing_Store extends Controller_Memory_Store {
+	private string $failure = '';
+	private bool $after_commit = false;
+	public function fail_next( string $failure = 'storage', bool $after_commit = false ): void { $this->failure = $failure; $this->after_commit = $after_commit; }
+	public function get_state( string $key ): array { if ( '' !== $this->failure ) { $this->fail(); } return parent::get_state( $key ); }
+	public function mutate_state( string $key, callable $mutation ): mixed {
+		$failure = $this->failure; $after_commit = $this->after_commit; $this->failure = ''; $this->after_commit = false;
+		if ( '' === $failure ) { return parent::mutate_state( $key, $mutation ); }
+		if ( ! $after_commit ) { $this->throw_failure( $failure ); }
+		$result = parent::mutate_state( $key, $mutation );
+		$this->throw_failure( $failure );
+	}
+	private function fail(): never { $failure = $this->failure; $this->failure = ''; $this->after_commit = false; $this->throw_failure( $failure ); }
+	private function throw_failure( string $failure ): never { if ( 'programmer' === $failure ) { throw new RuntimeException( 'Injected programmer failure.' ); } throw new WP_Agent_Run_Control_Store_Exception( 'Injected secret storage detail.' ); }
 }
 final class Controller_Recorder implements WP_Agent_Workflow_Run_Recorder {
 	public array $runs = array();
@@ -116,5 +136,41 @@ controller_assert( false === $reclaimed['busy'], 'expired worker lane is reclaim
 $cancelled_operation = $controller->cancel( 'two' );
 controller_assert( true === $cancelled_operation['terminal'] && 'cancelled' === $cancelled_operation['status'], 'public cancel atomically records a terminal disposition' );
 controller_assert( isset( WP_Agent_Run_Control::state( 'controller-test' )['idempotency']['two'] ), 'idempotency key and authoritative run identity are persisted together' );
+
+$failure_store = new Controller_Failing_Store();
+WP_Agent_Run_Control::set_store( $failure_store );
+$failure_recorder = new Controller_Recorder(); $failure_runner = new Controller_Runner( $failure_recorder ); $failure_awaiter = new Controller_Awaiter( $failure_recorder );
+$failure_controller = new WP_Agent_Workflow_Request_Controller( $failure_runner, $failure_recorder, $failure_awaiter, 'controller-failures' );
+
+$failure_store->fail_next( 'storage', true );
+$contended_start = $failure_controller->start( 'retry-start', $spec );
+$start_data = $contended_start instanceof WP_Error ? $contended_start->get_error_data() : array();
+controller_assert( $contended_start instanceof WP_Error && 'agents_workflow_run_control_unavailable' === $contended_start->code, 'post-commit start storage failure returns the typed public error' );
+controller_assert( array( 'start', 'reserve', true, 503 ) === array( $start_data['operation'] ?? '', $start_data['phase'] ?? '', $start_data['retryable'] ?? false, $start_data['status'] ?? 0 ), 'start error carries retryable operation and phase evidence' );
+controller_assert( ! str_contains( $contended_start->message, 'secret' ), 'storage error does not expose store details' );
+$retried_start = $failure_controller->start( 'retry-start', $spec );
+controller_assert( 1 === $failure_runner->starts && isset( $retried_start['run_id'] ), 'retry after uncertain reservation commit starts exactly one durable run' );
+
+$failure_store->fail_next();
+$reconnect_error = $failure_controller->reconnect( 'retry-start' );
+$reconnect_data = $reconnect_error instanceof WP_Error ? $reconnect_error->get_error_data() : array();
+controller_assert( array( 'reconnect', 'claim_lease' ) === array( $reconnect_data['operation'] ?? '', $reconnect_data['phase'] ?? '' ), 'reconnect normalizes lease contention with operation evidence' );
+$failure_store->fail_next();
+$status_error = $failure_controller->get_status( 'retry-start' );
+$status_data = $status_error instanceof WP_Error ? $status_error->get_error_data() : array();
+controller_assert( array( 'get_status', 'read' ) === array( $status_data['operation'] ?? '', $status_data['phase'] ?? '' ), 'status normalizes temporary read failure with operation evidence' );
+$failure_store->fail_next();
+$cancel_error = $failure_controller->cancel( 'retry-start' );
+$cancel_data = $cancel_error instanceof WP_Error ? $cancel_error->get_error_data() : array();
+controller_assert( array( 'cancel', 'read' ) === array( $cancel_data['operation'] ?? '', $cancel_data['phase'] ?? '' ), 'cancel normalizes temporary read failure with operation evidence' );
+$failure_store->fail_next();
+$advance_error = $failure_controller->advance( 'retry-start' );
+$advance_data = $advance_error instanceof WP_Error ? $advance_error->get_error_data() : array();
+controller_assert( array( 'advance', 'claim_lease' ) === array( $advance_data['operation'] ?? '', $advance_data['phase'] ?? '' ), 'advance normalizes lease contention with operation evidence' );
+
+$failure_store->fail_next( 'programmer' );
+$programmer_error_visible = false;
+try { $failure_controller->advance( 'retry-start' ); } catch ( RuntimeException $error ) { $programmer_error_visible = 'Injected programmer failure.' === $error->getMessage(); }
+controller_assert( $programmer_error_visible, 'unexpected programmer errors are not normalized' );
 echo "Passed: $passes, Failed: " . count( $fails ) . "\n";
 exit( empty( $fails ) ? 0 : 1 );

--- a/tests/workflow-request-controller-smoke.php
+++ b/tests/workflow-request-controller-smoke.php
@@ -54,9 +54,13 @@ class Controller_Memory_Store implements WP_Agent_Atomic_Run_Control_Store {
 final class Controller_Failing_Store extends Controller_Memory_Store {
 	private string $failure = '';
 	private bool $after_commit = false;
+	private int $mutation_countdown = 0;
 	public function fail_next( string $failure = 'storage', bool $after_commit = false ): void { $this->failure = $failure; $this->after_commit = $after_commit; }
+	public function fail_on_mutation( int $countdown, string $failure = 'storage', bool $after_commit = false ): void { $this->mutation_countdown = $countdown; $this->failure = $failure; $this->after_commit = $after_commit; }
 	public function get_state( string $key ): array { if ( '' !== $this->failure ) { $this->fail(); } return parent::get_state( $key ); }
 	public function mutate_state( string $key, callable $mutation ): mixed {
+		if ( $this->mutation_countdown > 1 ) { --$this->mutation_countdown; $failure = $this->failure; $after_commit = $this->after_commit; $this->failure = ''; $this->after_commit = false; $result = parent::mutate_state( $key, $mutation ); $this->failure = $failure; $this->after_commit = $after_commit; return $result; }
+		$this->mutation_countdown = 0;
 		$failure = $this->failure; $after_commit = $this->after_commit; $this->failure = ''; $this->after_commit = false;
 		if ( '' === $failure ) { return parent::mutate_state( $key, $mutation ); }
 		if ( ! $after_commit ) { $this->throw_failure( $failure ); }
@@ -75,11 +79,14 @@ final class Controller_Recorder implements WP_Agent_Workflow_Run_Recorder {
 }
 final class Controller_Runner extends WP_Agent_Workflow_Runner {
 	public int $starts = 0;
+	public $after_run = null;
 	public function __construct( private Controller_Recorder $test_recorder ) {}
 	public function run( WP_Agent_Workflow_Spec $spec, array $inputs = array(), array $options = array() ): WP_Agent_Workflow_Run_Result {
 		++$this->starts; $status = $inputs['status'] ?? WP_Agent_Workflow_Run_Result::STATUS_SUSPENDED;
 		$r = new WP_Agent_Workflow_Run_Result( $options['run_id'], $spec->get_id(), $status, $inputs, array(), array(), array(), 1, 'suspended' === $status ? 0 : 2, array() );
-		$this->test_recorder->start( $r ); return $r;
+		$this->test_recorder->start( $r );
+		if ( is_callable( $this->after_run ) ) { ( $this->after_run )(); }
+		return $r;
 	}
 }
 final class Controller_Awaiter extends WP_Agent_Workflow_Run_Awaiter {
@@ -135,7 +142,7 @@ $reclaimed = $controller->advance( 'two', array( 'worker_id' => 'worker-b' ) );
 controller_assert( false === $reclaimed['busy'], 'expired worker lane is reclaimed deterministically' );
 $cancelled_operation = $controller->cancel( 'two' );
 controller_assert( true === $cancelled_operation['terminal'] && 'cancelled' === $cancelled_operation['status'], 'public cancel atomically records a terminal disposition' );
-controller_assert( isset( WP_Agent_Run_Control::state( 'controller-test' )['idempotency']['two'] ), 'idempotency key and authoritative run identity are persisted together' );
+controller_assert( 'workflow_request_' . substr( hash( 'sha256', "controller-test\0two" ), 0, 32 ) === $cancelled_operation['run_id'], 'operation identity deterministically supplies idempotent run identity' );
 
 $failure_store = new Controller_Failing_Store();
 WP_Agent_Run_Control::set_store( $failure_store );
@@ -172,5 +179,50 @@ $failure_store->fail_next( 'programmer' );
 $programmer_error_visible = false;
 try { $failure_controller->advance( 'retry-start' ); } catch ( RuntimeException $error ) { $programmer_error_visible = 'Injected programmer failure.' === $error->getMessage(); }
 controller_assert( $programmer_error_visible, 'unexpected programmer errors are not normalized' );
+
+$clock = 1000;
+$terminal_store = new Controller_Failing_Store();
+WP_Agent_Run_Control::set_store( $terminal_store );
+$terminal_recorder = new Controller_Recorder(); $terminal_runner = new Controller_Runner( $terminal_recorder ); $terminal_awaiter = new Controller_Awaiter( $terminal_recorder ); $terminal_deliveries = array(); $terminal_cleanups = array();
+$terminal_controller = new WP_Agent_Workflow_Request_Controller( $terminal_runner, $terminal_recorder, $terminal_awaiter, 'controller-terminal-recovery', static function ( $id ) use ( &$terminal_deliveries ) { $terminal_deliveries[] = $id; }, static function ( $id ) use ( &$terminal_cleanups ) { $terminal_cleanups[] = $id; }, static function () use ( &$clock ): int { return $clock; } );
+
+$terminal_runner->after_run = static function () use ( $terminal_store ): void { $terminal_store->fail_next( 'storage', true ); };
+$record_error = $terminal_controller->start( 'record-uncertain', $spec, array( 'status' => 'succeeded' ) );
+$terminal_runner->after_run = null;
+controller_assert( $record_error instanceof WP_Error && 'record_terminal' === ( $record_error->get_error_data()['phase'] ?? '' ), 'uncertain terminal-record commit returns a retryable public error' );
+$record_retry = $terminal_controller->reconnect( 'record-uncertain' );
+controller_assert( $record_retry['terminal'] && array( 'record-uncertain' ) === $terminal_deliveries && array( 'record-uncertain' ) === $terminal_cleanups, 'public retry resumes terminal delivery and cleanup from durable pending state' );
+
+$terminal_deliveries = array(); $terminal_cleanups = array();
+$terminal_runner->after_run = static function () use ( $terminal_store ): void { $terminal_store->fail_on_mutation( 2, 'storage', true ); };
+$claim_error = $terminal_controller->start( 'claim-uncertain', $spec, array( 'status' => 'succeeded' ) );
+$terminal_runner->after_run = null;
+controller_assert( $claim_error instanceof WP_Error && 'deliver_terminal' === ( $claim_error->get_error_data()['phase'] ?? '' ), 'uncertain delivery-claim commit returns a retryable public error' );
+$terminal_controller->reconnect( 'claim-uncertain' );
+controller_assert( array() === $terminal_deliveries, 'retry does not duplicate an unexpired uncertain delivery claim' );
+$clock += 61;
+$claim_retry = $terminal_controller->reconnect( 'claim-uncertain' );
+controller_assert( $claim_retry['terminal'] && array( 'claim-uncertain' ) === $terminal_deliveries && 'delivered' === ( $terminal_controller->get( 'claim-uncertain' )['disposition'] ?? '' ), 'expired delivery claim is reclaimed and token-fenced to completion' );
+
+$stale_store = new Controller_Memory_Store();
+WP_Agent_Run_Control::set_store( $stale_store );
+$stale_recorder = new Controller_Recorder(); $stale_runner = new Controller_Runner( $stale_recorder ); $stale_awaiter = new Controller_Awaiter( $stale_recorder ); $stale_deliveries = array();
+$stale_controller = new WP_Agent_Workflow_Request_Controller( $stale_runner, $stale_recorder, $stale_awaiter, 'controller-stale-terminal', static function ( $id ) use ( &$stale_deliveries ) { $stale_deliveries[] = $id; }, null, static fn(): int => 2000 );
+$stale_runner->after_run = static function () use ( $stale_store ): void {
+	$state = $stale_store->get_state( 'controller-stale-terminal' );
+	$state['runs']['stale-worker']['lease'] = array( 'token' => 'replacement-worker', 'worker_id' => 'replacement-worker', 'expires_at' => 2100 );
+	$stale_store->save_state( 'controller-stale-terminal', $state );
+};
+$stale_result = $stale_controller->start( 'stale-worker', $spec, array( 'status' => 'succeeded' ) );
+controller_assert( ! $stale_result['terminal'] && 'replacement-worker' === ( $stale_controller->get( 'stale-worker' )['lease']['token'] ?? '' ) && array() === $stale_deliveries, 'expired worker cannot terminalize or deliver after another worker reclaims its lease' );
+
+$release_store = new Controller_Failing_Store();
+WP_Agent_Run_Control::set_store( $release_store );
+$release_recorder = new Controller_Recorder(); $release_runner = new Controller_Runner( $release_recorder ); $release_awaiter = new Controller_Awaiter( $release_recorder );
+$release_controller = new WP_Agent_Workflow_Request_Controller( $release_runner, $release_recorder, $release_awaiter, 'controller-release-primary' );
+$release_runner->after_run = static function () use ( $release_store ): void { $release_store->fail_next(); throw new RuntimeException( 'Primary programmer failure.' ); };
+$primary_visible = false;
+try { $release_controller->start( 'programmer-primary', $spec ); } catch ( RuntimeException $error ) { $primary_visible = 'Primary programmer failure.' === $error->getMessage(); }
+controller_assert( $primary_visible, 'lease-release storage failure does not replace an in-flight programmer exception' );
 echo "Passed: $passes, Failed: " . count( $fails ) . "\n";
 exit( empty( $fails ) ? 0 : 1 );


### PR DESCRIPTION
## Summary

- return typed retryable workflow errors when run-control storage is temporarily unavailable
- classify option-store read, write, transaction, lock, and release failures without swallowing programmer or policy errors
- preserve idempotent request identity across uncertain commits and safely resume terminal delivery through exclusive connection-lifetime claims
- keep stale workers and duplicate live callbacks fenced with truthful public status

Closes #528

## Verification

- `php tests/workflow-request-controller-smoke.php` (35 passed)
- `php tests/run-control-option-store-failures-smoke.php` (17 passed)
- `composer smoke`
- `composer phpstan`
- `git diff --check origin/main...HEAD`

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode general coding and review subagents was used to reproduce the live Intelligence failure, trace the Agents API ownership boundary, implement and independently review the typed-error and recovery contracts, find and correct uncertain-commit and callback-claim edge cases, and run verification. Chris Huber directed the orchestration and remains responsible for the submitted change.
