### PR TITLE
fix(routines): annotate prepared wpdb queries for phpcs

### DIFF
--- a/src/Routines/class-wp-agent-routine-action-scheduler-bridge.php
+++ b/src/Routines/class-wp-agent-routine-action-scheduler-bridge.php
@@ -660,6 +660,7 @@ final class WP_Agent_Routine_Action_Scheduler_Bridge implements WP_Agent_Routine
 		if ( ! is_string( $query ) ) {
 			return 0;
 		}
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- $query is built by $wpdb->prepare() above.
 		$deleted = $wpdb->query( $query );
 
 		if ( function_exists( 'wp_cache_supports' ) && function_exists( 'wp_cache_flush_group' ) && wp_cache_supports( 'flush_group' ) ) {

--- a/src/Routines/class-wp-agent-routine-registry.php
+++ b/src/Routines/class-wp-agent-routine-registry.php
@@ -453,6 +453,7 @@ final class WP_Agent_Routine_Registry {
 			return false;
 		}
 
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- $query is built by $wpdb->prepare() above.
 		$affected = $wpdb->query( $query );
 
 		self::flush_reconcile_lock_cache();
@@ -468,6 +469,7 @@ final class WP_Agent_Routine_Registry {
 
 		$query = $wpdb->prepare( 'DELETE FROM %i WHERE option_name = %s', $wpdb->options, self::RECONCILE_LOCK_OPTION );
 		if ( is_string( $query ) ) {
+			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- $query is built by $wpdb->prepare() above.
 			$wpdb->query( $query );
 		}
 


### PR DESCRIPTION
Follow-up to #555. `homeboy release` preflight lint flags three `WordPress.DB.PreparedSQL.NotPrepared` findings on `$wpdb->query( $query )` calls where `$query` is produced by `$wpdb->prepare()` two lines above — the sniff can't trace through the variable. Adds the standard phpcs:ignore annotation with justification; no behavior change.

Unblocks the agents-api release needed to ship the 2026-09-12 outage fix to extrachill.com.